### PR TITLE
Allow setting default view blocks.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -78,6 +78,7 @@ class FormHelper extends Helper
         'idPrefix' => null,
         // Deprecated option, use templates.errorClass intead.
         'errorClass' => null,
+        'defaultPostLinkBlock' => null,
         'typeMap' => [
             'string' => 'text',
             'text' => 'textarea',
@@ -1893,7 +1894,7 @@ class FormHelper extends Helper
      */
     public function postLink(string $title, array|string|null $url = null, array $options = []): string
     {
-        $options += ['block' => null, 'confirm' => null];
+        $options += ['block' => $this->getConfig('defaultPostLinkBlock'), 'confirm' => null];
 
         $requestMethod = 'POST';
         if (!empty($options['method'])) {

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -47,6 +47,9 @@ class HtmlHelper extends Helper
      * @var array<string, mixed>
      */
     protected array $_defaultConfig = [
+        'defaultScriptBlock' => null,
+        'defaultCssBlock' => null,
+        'defaultMetaBlock' => null,
         'templates' => [
             'meta' => '<meta{{attrs}}>',
             'metalink' => '<link href="{{url}}"{{attrs}}>',
@@ -177,7 +180,7 @@ class HtmlHelper extends Helper
             }
         }
 
-        $options += $type + ['block' => null];
+        $options += $type + ['block' => $this->getConfig('defaultMetaBlock')];
         $out = '';
 
         if (isset($options['link'])) {
@@ -385,7 +388,7 @@ class HtmlHelper extends Helper
     {
         $options += [
             'once' => true,
-            'block' => null,
+            'block' => $this->getConfig('defaultCssBlock'),
             'rel' => 'stylesheet',
             'nonce' => $this->_View->getRequest()->getAttribute('cspStyleNonce'),
         ];
@@ -484,7 +487,7 @@ class HtmlHelper extends Helper
     public function script(array|string $url, array $options = []): ?string
     {
         $defaults = [
-            'block' => null,
+            'block' => $this->getConfig('defaultScriptBlock'),
             'once' => true,
             'nonce' => $this->_View->getRequest()->getAttribute('cspScriptNonce'),
         ];
@@ -542,7 +545,10 @@ class HtmlHelper extends Helper
      */
     public function scriptBlock(string $script, array $options = []): ?string
     {
-        $options += ['block' => null, 'nonce' => $this->_View->getRequest()->getAttribute('cspScriptNonce')];
+        $options += [
+            'block' => $this->getConfig('defaultScriptBlock'),
+            'nonce' => $this->_View->getRequest()->getAttribute('cspScriptNonce'),
+        ];
 
         $out = $this->formatTemplate('javascriptblock', [
             'attrs' => $this->templater()->formatAttributes($options, ['block']),

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7489,6 +7489,28 @@ class FormHelperTest extends TestCase
             '/form',
         ];
         $this->assertHtml($expected, $result);
+
+        $this->Form->setConfig('defaultPostLinkBlock', 'foobaz');
+        $result = $this->Form->postLink('Delete', '/posts/delete/4');
+        $expected = [
+            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.submit\(\); event\.returnValue = false; return false;/'],
+            'Delete',
+            '/a',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->View->fetch('foobaz');
+        $expected = [
+            'form' => [
+                'method' => 'post', 'action' => '/posts/delete/4',
+                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+            ],
+            'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
+            '/form',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $this->Form->setConfig('defaultPostLinkBlock', null);
     }
 
     /**

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -638,12 +638,22 @@ class HtmlHelperTest extends TestCase
         $this->assertHtml($expected, $result[1]);
         $this->assertCount(2, $result);
 
-        $this->View->expects($this->exactly(2))
+        $result = $this->Html->css('import-screen', ['rel' => 'import']);
+        $expected = [
+            '<style',
+            'preg:/@import url\(.*css\/import-screen\.css\);/',
+            '/style',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $this->View->expects($this->exactly(4))
             ->method('append')
             ->with(
                 ...self::withConsecutive(
                     ['css', $this->matchesRegularExpression('/css_in_head.css/')],
                     ['css', $this->matchesRegularExpression('/more_css_in_head.css/')],
+                    ['css', $this->matchesRegularExpression('/css_in_head_2.css/')],
+                    ['css', $this->matchesRegularExpression('/more_css_in_head_2.css/')],
                 ),
             );
 
@@ -653,13 +663,15 @@ class HtmlHelperTest extends TestCase
         $result = $this->Html->css('more_css_in_head', ['block' => true]);
         $this->assertNull($result);
 
-        $result = $this->Html->css('import-screen', ['rel' => 'import']);
-        $expected = [
-            '<style',
-            'preg:/@import url\(.*css\/import-screen\.css\);/',
-            '/style',
-        ];
-        $this->assertHtml($expected, $result);
+        $this->Html->setConfig('defaultCssBlock', true);
+        $result = $this->Html->css('css_in_head_2');
+        $this->assertNull($result);
+
+        $this->Html->setConfig('defaultCssBlock', 'css');
+        $result = $this->Html->css('more_css_in_head_2');
+        $this->assertNull($result);
+
+        $this->Html->setConfig('defaultCssBlock', null);
     }
 
     /**
@@ -1118,12 +1130,14 @@ class HtmlHelperTest extends TestCase
      */
     public function testScriptWithBlocks(): void
     {
-        $this->View->expects($this->exactly(2))
+        $this->View->expects($this->exactly(4))
             ->method('append')
             ->with(
                 ...self::withConsecutive(
                     ['script', $this->matchesRegularExpression('/script_in_head.js/')],
                     ['headScripts', $this->matchesRegularExpression('/second_script.js/')],
+                    ['script', $this->matchesRegularExpression('/script_in_head_2.js/')],
+                    ['headScripts', $this->matchesRegularExpression('/second_script_2.js/')],
                 ),
             );
 
@@ -1132,6 +1146,16 @@ class HtmlHelperTest extends TestCase
 
         $result = $this->Html->script('second_script', ['block' => 'headScripts']);
         $this->assertNull($result);
+
+        $this->Html->setConfig('defaultScriptBlock', true);
+        $result = $this->Html->script('script_in_head_2');
+        $this->assertNull($result);
+
+        $this->Html->setConfig('defaultScriptBlock', 'headScripts');
+        $result = $this->Html->script('second_script_2');
+        $this->assertNull($result);
+
+        $this->Html->setConfig('defaultScriptBlock', null);
     }
 
     /**
@@ -1210,12 +1234,22 @@ class HtmlHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        $this->View->expects($this->exactly(2))
+        $result = $this->Html->scriptBlock('window.foo = 2;', ['encoding' => 'utf-8']);
+        $expected = [
+            'script' => ['encoding' => 'utf-8'],
+            'window.foo = 2;',
+            '/script',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $this->View->expects($this->exactly(4))
             ->method('append')
             ->with(
                 ...self::withConsecutive(
                     ['script', $this->matchesRegularExpression('/window\.foo\s\=\s2;/')],
-                    ['scriptTop', $this->stringContains('alert(')],
+                    ['scriptTop', $this->stringContains('alert("hi")')],
+                    ['script', $this->matchesRegularExpression('/window\.foo\s\=\s3;/')],
+                    ['scriptTop', $this->stringContains('alert("his")')],
                 ),
             );
 
@@ -1225,13 +1259,13 @@ class HtmlHelperTest extends TestCase
         $result = $this->Html->scriptBlock('alert("hi")', ['block' => 'scriptTop']);
         $this->assertNull($result);
 
-        $result = $this->Html->scriptBlock('window.foo = 2;', ['encoding' => 'utf-8']);
-        $expected = [
-            'script' => ['encoding' => 'utf-8'],
-            'window.foo = 2;',
-            '/script',
-        ];
-        $this->assertHtml($expected, $result);
+        $this->Html->setConfig('defaultScriptBlock', true);
+        $result = $this->Html->scriptBlock('window.foo = 3;');
+        $this->assertNull($result);
+
+        $this->Html->setConfig('defaultScriptBlock', 'scriptTop');
+        $result = $this->Html->scriptBlock('alert("his")');
+        $this->assertNull($result);
     }
 
     /**
@@ -1583,6 +1617,18 @@ class HtmlHelperTest extends TestCase
             'meta' => ['name' => 'csrf-token', 'content' => 'test'],
         ];
         $this->assertHtml($expected, $result);
+
+        $this->View->expects($this->exactly(1))
+            ->method('append')
+            ->with(
+                'myMeta',
+                $this->matchesRegularExpression('/csrf-token/'),
+            );
+
+        $this->Html->setConfig('defaultMetaBlock', 'myMeta');
+        $this->assertNull($this->Html->meta('csrf-token'));
+        $this->assertHtml($expected, $result);
+        $this->Html->setConfig('defaultMetaBlock', null);
     }
 
     /**


### PR DESCRIPTION
This avoids having to use `['block' => true]` for all `Html->script()` calls for e.g. I personally always want scripts/script blocks to go into the view block and echo it at the bottom of the page.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
