### PR TITLE
Make MissingActionException use 404 error code.

### DIFF
--- a/src/Controller/Exception/MissingActionException.php
+++ b/src/Controller/Exception/MissingActionException.php
@@ -14,14 +14,19 @@ declare(strict_types=1);
  */
 namespace Cake\Controller\Exception;
 
-use Cake\Core\Exception\CakeException;
+use Cake\Http\Exception\HttpException;
 
 /**
  * Missing Action exception - used when a controller action
  * cannot be found, or when the controller's isAction() method returns false.
  */
-class MissingActionException extends CakeException
+class MissingActionException extends HttpException
 {
+    /**
+     * @inheritDoc
+     */
+    protected int $_defaultCode = 404;
+
     /**
      * @inheritDoc
      */


### PR DESCRIPTION
This exception is generally caused by invalid URLs which should cause a 4xx error page not a 5xx error page.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
