### PR TITLE
Make PaginatedInterface extend IteratorAggregrate instead of Traversable

### DIFF
--- a/src/Datasource/Paging/PaginatedInterface.php
+++ b/src/Datasource/Paging/PaginatedInterface.php
@@ -17,14 +17,17 @@ declare(strict_types=1);
 namespace Cake\Datasource\Paging;
 
 use Countable;
+use IteratorAggregate;
 use Traversable;
 
 /**
- * This interface describes the methods for pagination instance.
+ * This interface describes the methods for paginated instance.
  *
- * @template-extends \Traversable<mixed>
+ * @template TKey
+ * @template TValue
+ * @template-extends \IteratorAggregate<TKey, TValue>
  */
-interface PaginatedInterface extends Countable, Traversable
+interface PaginatedInterface extends Countable, IteratorAggregate
 {
     /**
      * Get current page number.
@@ -71,9 +74,9 @@ interface PaginatedInterface extends Countable, Traversable
     /**
      * Get paginated items.
      *
-     * @return iterable
+     * @return \Traversable<TKey, TValue>
      */
-    public function items(): iterable;
+    public function items(): Traversable;
 
     /**
      * Get paging param.

--- a/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
+++ b/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
@@ -25,6 +25,28 @@ use Cake\TestSuite\TestCase;
 
 class PaginatedResultSetTest extends TestCase
 {
+    public function testConstructor(): void
+    {
+        $array = ['a' => 'a', 'b' => 'b', 'c' => 'c'];
+        $paginatedResults = new PaginatedResultSet(
+            $array,
+            [],
+        );
+
+        $result = iterator_to_array($paginatedResults);
+        $this->assertsame($array, $result);
+        $this->assertSame(3, $paginatedResults->count());
+
+        $collection = new Collection($array);
+        $paginatedResults = new PaginatedResultSet(
+            $collection,
+            [],
+        );
+        $result = iterator_to_array($paginatedResults);
+        $this->assertsame($array, $result);
+        $this->assertSame(3, $paginatedResults->count());
+    }
+
     public function testItems(): void
     {
         $resultSet = new class ([]) extends ResultSet {


### PR DESCRIPTION
This makes it more inline with implementations which will usually wrap an existing collection/resultset.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
