### PR TITLE
Use the entity class configured for the table instead of ORM\Entity.

### DIFF
--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -22,7 +22,6 @@ use Cake\Collection\CollectionInterface;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
-use Cake\ORM\Entity;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
@@ -314,9 +313,10 @@ class EavStrategy implements TranslateStrategyInterface
             $modified[$field] = $translation;
         }
 
+        $entityClass = $this->translationTable->getEntityClass();
         $new = array_diff_key($values, $modified);
         foreach ($new as $field => $content) {
-            $new[$field] = new Entity(compact('locale', 'field', 'content', 'model'), [
+            $new[$field] = new $entityClass(compact('locale', 'field', 'content', 'model'), [
                 'useSetters' => false,
                 'markNew' => true,
             ]);
@@ -424,9 +424,9 @@ class EavStrategy implements TranslateStrategyInterface
             }
             $grouped = new Collection($translations);
 
+            $entityClass = $this->table->getEntityClass();
             $result = [];
             foreach ($grouped->combine('field', 'content', 'locale') as $locale => $keys) {
-                $entityClass = $this->table->getEntityClass();
                 $translation = new $entityClass($keys + ['locale' => $locale], [
                     'markNew' => false,
                     'useSetters' => false,
@@ -466,6 +466,7 @@ class EavStrategy implements TranslateStrategyInterface
         $key = $entity->get((string)current($primaryKey));
         $find = [];
         $contents = [];
+        $entityClass = $this->translationTable->getEntityClass();
 
         foreach ($translations as $lang => $translation) {
             foreach ($fields as $field) {
@@ -473,7 +474,7 @@ class EavStrategy implements TranslateStrategyInterface
                     continue;
                 }
                 $find[] = ['locale' => $lang, 'field' => $field, 'foreign_key IS' => $key];
-                $contents[] = new Entity(['content' => $translation->get($field)], [
+                $contents[] = new $entityClass(['content' => $translation->get($field)], [
                     'useSetters' => false,
                 ]);
             }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -3137,7 +3137,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if ($context === null) {
             $context = $options;
         }
-        $entity = new Entity(
+        $entity = new ($this->getEntityClass())(
             $context['data'],
             [
                 'useSetters' => false,


### PR DESCRIPTION
A table could be using a custom implementation of EntityInterface instead of ORM\Entity.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
