### PR TITLE
Fix creation of new entity for the shadow table.

### DIFF
--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -421,7 +421,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
         if ($translation) {
             $translation->set($values);
         } else {
-            $translation = $this->translationTable->newEntity(
+            $translation = new ($this->translationTable->getEntityClass())(
                 $where + $values,
                 [
                     'useSetters' => false,

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -57,6 +57,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
             'setLocale' => 'setLocale',
             'getLocale' => 'getLocale',
             'translationField' => 'translationField',
+            'getStrategy' => 'getStrategy',
         ],
         'fields' => [],
         'defaultLocale' => null,

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -23,6 +23,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\I18n\I18n;
 use Cake\ORM\Behavior\Translate\ShadowTableStrategy;
 use Cake\ORM\Behavior\TranslateBehavior;
+use Cake\ORM\Entity;
 use Cake\Utility\Hash;
 use TestApp\Model\Entity\TranslateArticle;
 use TestApp\Model\Entity\TranslateBakedArticle;
@@ -939,6 +940,37 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $entity = $result->first();
         $this->assertSame('Title EN', $entity->title);
         $this->assertSame('Body EN', $entity->body);
+    }
+
+    /**
+     * Tests adding new translation to a record
+     */
+    public function testInsertNewTranslations(): void
+    {
+        parent::testInsertNewTranslations();
+
+        $shadowEntity = new class extends Entity {
+            protected function _setComment($value)
+            {
+                return $value . ' modified';
+            }
+        };
+
+        $table = $this->getTableLocator()->get('Comments');
+        $table->addBehavior('Translate', ['fields' => ['comment']]);
+        $table->setLocale('spa');
+        $table->getStrategy()->getTranslationTable()->setEntityClass($shadowEntity::class);
+
+        $entity = $table->get(1);
+        $entity->comment = 'New Comment';
+        $table->save($entity);
+
+        $entity = $table->get(1);
+        $this->assertSame(
+            'New Comment',
+            $entity->get('comment'),
+            'New translation should not be modified'
+        );
     }
 
     /**


### PR DESCRIPTION
Incorrect options were being passed for the `newEntity()` call.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
