### PR TITLE
Improve message from QueryException

### DIFF
--- a/src/Database/Exception/QueryException.php
+++ b/src/Database/Exception/QueryException.php
@@ -29,7 +29,9 @@ class QueryException extends PDOException
      */
     public function __construct(protected LoggedQuery|string $query, PDOException $previous)
     {
-        parent::__construct($previous->getMessage(), (int)$previous->getCode(), $previous);
+        $message = $previous->getMessage() . "\nQuery: " . $this->getQueryString();
+
+        parent::__construct($message, (int)$previous->getCode(), $previous);
     }
 
     /**


### PR DESCRIPTION
I hit an invalid query doing some goofy joins and had a hard time figuring out what I did wrong in my query. It would have been much easier to figure out the problem if the error contained the problem query, especially when we went to the trouble of collecting it.

