### PR TITLE
Making I18n in Text Class optional

### DIFF
--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -891,7 +891,9 @@ class Text
      */
     public static function toList(array $list, ?string $and = null, string $separator = ', '): string
     {
-        $and ??= __d('cake', 'and');
+        $defaultAnd = function_exists('__d') ? __d('cake', 'and') : 'and';
+        $and ??= $defaultAnd;
+
         if (count($list) > 1) {
             return implode($separator, array_slice($list, 0, -1)) . ' ' . $and . ' ' . array_pop($list);
         }

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -51,6 +51,13 @@ class Text
     ];
 
     /**
+     * Whether to use I18n functions for translating default error messages
+     *
+     * @var bool
+     */
+    protected static bool $_useI18n;
+
+    /**
      * Generate a random UUID version 4
      *
      * Warning: This method should not be used as a random seed for any cryptographic operations.
@@ -891,8 +898,8 @@ class Text
      */
     public static function toList(array $list, ?string $and = null, string $separator = ', '): string
     {
-        $defaultAnd = function_exists('__d') ? __d('cake', 'and') : 'and';
-        $and ??= $defaultAnd;
+        static::$_useI18n ??= function_exists('__d') === true;
+        $and ??= (static::$_useI18n === true ? __d('cake', 'and') : 'and');
 
         if (count($list) > 1) {
             return implode($separator, array_slice($list, 0, -1)) . ' ' . $and . ' ' . array_pop($list);

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -898,8 +898,8 @@ class Text
      */
     public static function toList(array $list, ?string $and = null, string $separator = ', '): string
     {
-        static::$_useI18n ??= function_exists('__d') === true;
-        $and ??= (static::$_useI18n === true ? __d('cake', 'and') : 'and');
+        static::$_useI18n ??= function_exists('__d');
+        $and ??= static::$_useI18n ? __d('cake', 'and') : 'and';
 
         if (count($list) > 1) {
             return implode($separator, array_slice($list, 0, -1)) . ' ' . $and . ' ' . array_pop($list);

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -55,7 +55,7 @@ class Text
      *
      * @var bool
      */
-    protected static bool $_useI18n;
+    protected static bool $useI18n;
 
     /**
      * Generate a random UUID version 4
@@ -898,8 +898,8 @@ class Text
      */
     public static function toList(array $list, ?string $and = null, string $separator = ', '): string
     {
-        static::$_useI18n ??= function_exists('__d');
-        $and ??= static::$_useI18n ? __d('cake', 'and') : 'and';
+        static::$useI18n ??= function_exists('__d');
+        $and ??= static::$useI18n ? __d('cake', 'and') : 'and';
 
         if (count($list) > 1) {
             return implode($separator, array_slice($list, 0, -1)) . ' ' . $and . ' ' . array_pop($list);

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -898,7 +898,7 @@ class Text
      */
     public static function toList(array $list, ?string $and = null, string $separator = ', '): string
     {
-        static::$useI18n ??= function_exists('__d');
+        static::$useI18n ??= function_exists('Cake\I18n\__d');
         $and ??= static::$useI18n ? __d('cake', 'and') : 'and';
 
         if (count($list) > 1) {


### PR DESCRIPTION
I fixed this to avoid the `I18n` dependency in the `Text` Class (by the way not declared in [composer.json](https://github.com/cakephp/utility/blob/5.x/composer.json) of `cakephp/utility`)