### PR TITLE
5.2 - Move several schema reflection methods to Dialect 

### DIFF
--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -75,7 +75,22 @@ class CachedCollection implements CollectionInterface
     }
 
     /**
-     * @inheritDoc
+     * Get the column metadata for a table.
+     *
+     * The name can include a database schema name in the form 'schema.table'.
+     *
+     * Caching will be applied if `cacheMetadata` key is present in the Connection
+     * configuration options. Defaults to _cake_model_ when true.
+     *
+     * ### Options
+     *
+     * - `forceRefresh` - Set to true to force rebuilding the cached metadata.
+     *   Defaults to false.
+     *
+     * @param string $name The name of the table to describe.
+     * @param array<string, mixed> $options The options to use, see above.
+     * @return \Cake\Database\Schema\TableSchemaInterface Object with column metadata.
+     * @throws \Cake\Database\Exception\DatabaseException when table cannot be described.
      */
     public function describe(string $name, array $options = []): TableSchemaInterface
     {

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -17,14 +17,14 @@ declare(strict_types=1);
 namespace Cake\Database\Schema;
 
 use Cake\Database\Connection;
-use Cake\Database\Exception\DatabaseException;
-use PDOException;
 
 /**
  * Represents a database schema collection
  *
- * Used to access information about the tables,
- * and other data in a database.
+ * Gives a simple high-level schema reflection API that can be
+ * decorated or extended with additional behavior like caching.
+ *
+ * @see \Cake\Database\Schema\SchemaDialect For lower level schema reflection API
  */
 class Collection implements CollectionInterface
 {
@@ -60,14 +60,7 @@ class Collection implements CollectionInterface
      */
     public function listTablesWithoutViews(): array
     {
-        [$sql, $params] = $this->_dialect->listTablesWithoutViewsSql($this->_connection->getDriver()->config());
-        $result = [];
-        $statement = $this->_connection->execute($sql, $params);
-        while ($row = $statement->fetch()) {
-            $result[] = $row[0];
-        }
-
-        return $result;
+        return $this->_dialect->listTablesWithoutViews();
     }
 
     /**
@@ -77,14 +70,7 @@ class Collection implements CollectionInterface
      */
     public function listTables(): array
     {
-        [$sql, $params] = $this->_dialect->listTablesSql($this->_connection->getDriver()->config());
-        $result = [];
-        $statement = $this->_connection->execute($sql, $params);
-        while ($row = $statement->fetch()) {
-            $result[] = $row[0];
-        }
-
-        return $result;
+        return $this->_dialect->listTables();
     }
 
     /**
@@ -92,73 +78,13 @@ class Collection implements CollectionInterface
      *
      * The name can include a database schema name in the form 'schema.table'.
      *
-     * Caching will be applied if `cacheMetadata` key is present in the Connection
-     * configuration options. Defaults to _cake_model_ when true.
-     *
-     * ### Options
-     *
-     * - `forceRefresh` - Set to true to force rebuilding the cached metadata.
-     *   Defaults to false.
-     *
      * @param string $name The name of the table to describe.
-     * @param array<string, mixed> $options The options to use, see above.
+     * @param array<string, mixed> $options Unused
      * @return \Cake\Database\Schema\TableSchemaInterface Object with column metadata.
      * @throws \Cake\Database\Exception\DatabaseException when table cannot be described.
      */
     public function describe(string $name, array $options = []): TableSchemaInterface
     {
-        $config = $this->_connection->config();
-        if (str_contains($name, '.')) {
-            [$config['schema'], $name] = explode('.', $name);
-        }
-        $table = $this->_connection->getDriver()->newTableSchema($name);
-
-        $this->_reflect('Column', $name, $config, $table);
-        if ($table->columns() === []) {
-            throw new DatabaseException(sprintf('Cannot describe %s. It has 0 columns.', $name));
-        }
-
-        $this->_reflect('Index', $name, $config, $table);
-        $this->_reflect('ForeignKey', $name, $config, $table);
-        $this->_reflect('Options', $name, $config, $table);
-
-        return $table;
-    }
-
-    /**
-     * Helper method for running each step of the reflection process.
-     *
-     * @param string $stage The stage name.
-     * @param string $name The table name.
-     * @param array<string, mixed> $config The config data.
-     * @param \Cake\Database\Schema\TableSchemaInterface $schema The table schema instance.
-     * @return void
-     * @throws \Cake\Database\Exception\DatabaseException on query failure.
-     * @uses \Cake\Database\Schema\SchemaDialect::describeColumnSql
-     * @uses \Cake\Database\Schema\SchemaDialect::describeIndexSql
-     * @uses \Cake\Database\Schema\SchemaDialect::describeForeignKeySql
-     * @uses \Cake\Database\Schema\SchemaDialect::describeOptionsSql
-     * @uses \Cake\Database\Schema\SchemaDialect::convertColumnDescription
-     * @uses \Cake\Database\Schema\SchemaDialect::convertIndexDescription
-     * @uses \Cake\Database\Schema\SchemaDialect::convertForeignKeyDescription
-     * @uses \Cake\Database\Schema\SchemaDialect::convertOptionsDescription
-     */
-    protected function _reflect(string $stage, string $name, array $config, TableSchemaInterface $schema): void
-    {
-        $describeMethod = "describe{$stage}Sql";
-        $convertMethod = "convert{$stage}Description";
-
-        [$sql, $params] = $this->_dialect->{$describeMethod}($name, $config);
-        if (!$sql) {
-            return;
-        }
-        try {
-            $statement = $this->_connection->execute($sql, $params);
-        } catch (PDOException $e) {
-            throw new DatabaseException($e->getMessage(), 500, $e);
-        }
-        foreach ($statement->fetchAll('assoc') as $row) {
-            $this->_dialect->{$convertMethod}($schema, $row);
-        }
+        return $this->_dialect->describe($name);
     }
 }

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Schema;
 
 use Cake\Database\Driver;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Type\ColumnSchemaAwareInterface;
 use Cake\Database\TypeFactory;
 use InvalidArgumentException;
@@ -26,6 +27,11 @@ use InvalidArgumentException;
  *
  * This class contains methods that are common across
  * the various SQL dialects.
+ *
+ * Provides methods for performing schema reflection. Results
+ * will be in the form of structured arrays. The structure
+ * of each result will be documented in this class. Subclasses
+ * are free to include *additional* data that is not documented.
  *
  * @method array<mixed> listTablesWithoutViewsSql(array $config) Generate the SQL to list the tables, excluding all views.
  */
@@ -336,4 +342,90 @@ abstract class SchemaDialect
      * @return array SQL statements to truncate a table.
      */
     abstract public function truncateTableSql(TableSchema $schema): array;
+
+    /**
+     * Get the list of tables, excluding any views, available in the current connection.
+     *
+     * @return array<string> The list of tables in the connected database/schema.
+     */
+    public function listTablesWithoutViews(): array
+    {
+        [$sql, $params] = $this->listTablesWithoutViewsSql($this->_driver->config());
+        $result = [];
+        $statement = $this->_driver->execute($sql, $params);
+        while ($row = $statement->fetch()) {
+            $result[] = $row[0];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the list of tables and views available in the current connection.
+     *
+     * @return array<string> The list of tables and views in the connected database/schema.
+     */
+    public function listTables(): array
+    {
+        [$sql, $params] = $this->listTablesSql($this->_driver->config());
+        $result = [];
+        $statement = $this->_driver->execute($sql, $params);
+        while ($row = $statement->fetch()) {
+            $result[] = $row[0];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the column metadata for a table.
+     *
+     * The name can include a database schema name in the form 'schema.table'.
+     *
+     * @param string $name The name of the table to describe.
+     * @return \Cake\Database\Schema\TableSchemaInterface Object with column metadata.
+     * @throws \Cake\Database\Exception\DatabaseException when table cannot be described.
+     */
+    public function describe(string $name): TableSchemaInterface
+    {
+        $config = $this->_driver->config();
+        if (str_contains($name, '.')) {
+            [$config['schema'], $name] = explode('.', $name);
+        }
+        // This is kind of a lie, but the convert methods
+        // would have a breaking change to change their parameter type.
+        /** @var \Cake\Database\Schema\TableSchema $table */
+        $table = $this->_driver->newTableSchema($name);
+
+        [$sql, $params] = $this->describeColumnSql($name, $config);
+        $statement = $this->_driver->execute($sql, $params);
+        foreach ($statement->fetchAll('assoc') as $row) {
+            $this->convertColumnDescription($table, $row);
+        }
+        if ($table->columns() === []) {
+            throw new DatabaseException(sprintf('Cannot describe %s. It has 0 columns.', $name));
+        }
+
+        [$sql, $params] = $this->describeForeignKeySql($name, $config);
+        $statement = $this->_driver->execute($sql, $params);
+        foreach ($statement->fetchAll('assoc') as $row) {
+            $this->convertForeignKeyDescription($table, $row);
+        }
+
+        [$sql, $params] = $this->describeIndexSql($name, $config);
+        $statement = $this->_driver->execute($sql, $params);
+        foreach ($statement->fetchAll('assoc') as $row) {
+            $this->convertIndexDescription($table, $row);
+        }
+
+        [$sql, $params] = $this->describeOptionsSql($name, $config);
+        if ($sql) {
+            $statement = $this->_driver->execute($sql, $params);
+            foreach ($statement->fetchAll('assoc') as $row) {
+                $this->convertOptionsDescription($table, $row);
+            }
+        }
+
+        return $table;
+    }
 }

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -21,6 +21,7 @@ use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Type\ColumnSchemaAwareInterface;
 use Cake\Database\TypeFactory;
 use InvalidArgumentException;
+use PDOException;
 
 /**
  * Base class for schema implementations.
@@ -398,7 +399,11 @@ abstract class SchemaDialect
         $table = $this->_driver->newTableSchema($name);
 
         [$sql, $params] = $this->describeColumnSql($name, $config);
-        $statement = $this->_driver->execute($sql, $params);
+        try {
+            $statement = $this->_driver->execute($sql, $params);
+        } catch (PDOException $e) {
+            throw new DatabaseException($e->getMessage(), 500, $e);
+        }
         foreach ($statement->fetchAll('assoc') as $row) {
             $this->convertColumnDescription($table, $row);
         }

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -32,7 +32,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Test case for MySQL Schema Dialect.
  */
-class MysqlSchemaTest extends TestCase
+class MysqlSchemaDialectTest extends TestCase
 {
     protected PDO $pdo;
 

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -30,7 +30,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Postgres schema test case.
  */
-class PostgresSchemaTest extends TestCase
+class PostgresSchemaDialectTest extends TestCase
 {
     /**
      * Helper method for skipping tests that need a real connection.

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\Schema;
+
+use Cake\Database\Connection;
+use Cake\Database\Driver;
+use Cake\Database\Exception\DatabaseException;
+use Cake\Database\Schema\TableSchema;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+use Exception;
+use PDO;
+
+/**
+ * Test case for SchemaDialect methods
+ * that can pass tests across all drivers
+ */
+class SchemaDialectTest extends TestCase
+{
+    /**
+     * @var array<string>
+     */
+    protected array $fixtures = [
+        'core.Users',
+    ];
+
+    /**
+     * @var \Cake\Database\Schema\SchemaDialect
+     */
+    protected $dialect;
+
+    /**
+     * Setup function
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->dialect = ConnectionManager::get('test')->getDriver()->schemaDialect();
+    }
+
+    /**
+     * Test that describing nonexistent tables fails.
+     *
+     * Tests for positive describe() calls are in each platformSchema
+     * test case.
+     */
+    public function testDescribeIncorrectTable(): void
+    {
+        $this->expectException(DatabaseException::class);
+        $this->assertNull($this->dialect->describe('derp'));
+    }
+
+    public function testListTables(): void
+    {
+        $result = $this->dialect->listTables();
+        $this->assertNotEmpty($result);
+        $this->assertContains('users', $result);
+    }
+
+    public function testListTablesWithoutViews(): void
+    {
+        $result = $this->dialect->listTablesWithoutViews();
+        $this->assertNotEmpty($result);
+        $this->assertContains('users', $result);
+    }
+
+    public function testDescribe(): void
+    {
+        $result = $this->dialect->describe('users');
+        $this->assertNotEmpty($result);
+        $this->assertEquals('users', $result->name());
+        $this->assertTrue($result->hasColumn('username'));
+    }
+}

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -16,14 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Schema;
 
-use Cake\Database\Connection;
-use Cake\Database\Driver;
 use Cake\Database\Exception\DatabaseException;
-use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
-use Exception;
-use PDO;
 
 /**
  * Test case for SchemaDialect methods

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -30,7 +30,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Test case for Sqlite Schema Dialect.
  */
-class SqliteSchemaTest extends TestCase
+class SqliteSchemaDialectTest extends TestCase
 {
     protected PDO $pdo;
 

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -31,7 +31,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * SQL Server schema test case.
  */
-class SqlserverSchemaTest extends TestCase
+class SqlserverSchemaDialectTest extends TestCase
 {
     /**
      * Helper method for skipping tests that need a real connection.


### PR DESCRIPTION
I want to use cake's schema reflection more extensively in migrations.
This will let us reduce the number of schema reflection implementations
we need to maintain by one, and also give the framework an improved
schema reflection toolkit.

Refs https://github.com/cakephp/cakephp/issues/18123