### PR TITLE
Allow customizing the field which holds the junction table data

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -301,6 +301,29 @@ class BelongsToMany extends Association
     }
 
     /**
+     * Set the junction property name.
+     *
+     * @param string $junctionProperty Property name.
+     * @return $this
+     */
+    public function setJunctionProperty(string $junctionProperty)
+    {
+        $this->_junctionProperty = $junctionProperty;
+
+        return $this;
+    }
+
+    /**
+     * Get the junction property naeme.
+     *
+     * @return string
+     */
+    public function getJunctionProperty(): string
+    {
+        return $this->_junctionProperty;
+    }
+
+    /**
      * Generate reciprocal associations as necessary.
      *
      * Generates the following associations:
@@ -463,7 +486,7 @@ class BelongsToMany extends Association
 
         $includeFields = $options['includeFields'] ?? null;
 
-        // Attach the junction table as well we need it to populate _joinData.
+        // Attach the junction table as well we need it to populate junction property (_joinData).
         $assoc = $this->getTarget()->getAssociation($junction->getAlias());
         $newOptions = array_intersect_key($options, ['joinType' => 1, 'fields' => 1]);
         $newOptions += [
@@ -1511,6 +1534,11 @@ class BelongsToMany extends Association
         }
         if (isset($options['sort'])) {
             $this->setSort($options['sort']);
+        }
+        if (isset($options['junctionProperty'])) {
+            assert(is_string($options['junctionProperty']), '`junctionProperty` must be a string');
+
+            $this->_junctionProperty = $options['junctionProperty'];
         }
     }
 }

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -88,19 +88,24 @@ class Marshaller
                 $key = $nested;
                 $nested = [];
             }
+
+            $stringifiedKey = (string)$key;
             // If the key is not a special field like _ids or _joinData
             // it is a missing association that we should error on.
-            if (!$this->_table->hasAssociation((string)$key)) {
-                if (!str_starts_with((string)$key, '_')) {
+            if (!$this->_table->hasAssociation($stringifiedKey)) {
+                if (
+                    !str_starts_with($stringifiedKey, '_')
+                    && (!isset($options['junctionProperty']) || $options['junctionProperty'] !== $stringifiedKey)
+                ) {
                     throw new InvalidArgumentException(sprintf(
                         'Cannot marshal data for `%s` association. It is not associated with `%s`.',
-                        (string)$key,
+                        $stringifiedKey,
                         $this->_table->getAlias(),
                     ));
                 }
                 continue;
             }
-            $assoc = $this->_table->getAssociation((string)$key);
+            $assoc = $this->_table->getAssociation($stringifiedKey);
 
             if (isset($options['forceNew'])) {
                 $nested['forceNew'] = $options['forceNew'];
@@ -396,6 +401,8 @@ class Marshaller
         $records = [];
         $conditions = [];
         $primaryCount = count($primaryKey);
+        $junctionProperty = $assoc->getJunctionProperty();
+        $options += ['junctionProperty' => $junctionProperty];
 
         foreach ($data as $i => $row) {
             if (!is_array($row)) {
@@ -453,15 +460,15 @@ class Marshaller
         $jointMarshaller = $assoc->junction()->marshaller();
 
         $nested = [];
-        if (isset($associated['_joinData'])) {
-            $nested = (array)$associated['_joinData'];
+        if (isset($associated[$junctionProperty])) {
+            $nested = (array)$associated[$junctionProperty];
         }
 
         foreach ($records as $i => $record) {
-            // Update junction table data in _joinData.
-            if (isset($data[$i]['_joinData'])) {
-                $joinData = $jointMarshaller->one($data[$i]['_joinData'], $nested);
-                $record->set('_joinData', $joinData);
+            // Update junction table data in the junction property (_joinData).
+            if (isset($data[$i][$junctionProperty])) {
+                $joinData = $jointMarshaller->one($data[$i][$junctionProperty], $nested);
+                $record->set($junctionProperty, $joinData);
             }
         }
 
@@ -820,7 +827,8 @@ class Marshaller
             return [];
         }
 
-        if ($associated && !in_array('_joinData', $associated, true) && !isset($associated['_joinData'])) {
+        $junctionProperty = $assoc->getJunctionProperty();
+        if ($associated && !in_array($junctionProperty, $associated, true) && !isset($associated[$junctionProperty])) {
             return $this->mergeMany($original, $value, $options);
         }
 
@@ -828,7 +836,7 @@ class Marshaller
     }
 
     /**
-     * Merge the special _joinData property into the entity set.
+     * Merge the special junction property (_joinData) into the entity set.
      *
      * @param array<\Cake\Datasource\EntityInterface> $original The original entities list.
      * @param \Cake\ORM\Association\BelongsToMany $assoc The association to marshall
@@ -840,11 +848,12 @@ class Marshaller
     {
         $associated = $options['associated'] ?? [];
         $extra = [];
+        $junctionProperty = $assoc->getJunctionProperty();
         foreach ($original as $entity) {
             // Mark joinData as accessible so we can marshal it properly.
-            $entity->setAccess('_joinData', true);
+            $entity->setAccess($junctionProperty, true);
 
-            $joinData = $entity->get('_joinData');
+            $joinData = $entity->get($junctionProperty);
             if ($joinData instanceof EntityInterface) {
                 $extra[spl_object_hash($entity)] = $joinData;
             }
@@ -854,16 +863,16 @@ class Marshaller
         $marshaller = $joint->marshaller();
 
         $nested = [];
-        if (isset($associated['_joinData'])) {
-            $nested = (array)$associated['_joinData'];
+        if (isset($associated[$junctionProperty])) {
+            $nested = (array)$associated[$junctionProperty];
         }
 
-        $options['accessibleFields'] = ['_joinData' => true];
+        $options['accessibleFields'] = [$junctionProperty => true];
 
         $records = $this->mergeMany($original, $value, $options);
         foreach ($records as $record) {
             $hash = spl_object_hash($record);
-            $value = $record->get('_joinData');
+            $value = $record->get($junctionProperty);
 
             // Already an entity, no further marshalling required.
             if ($value instanceof EntityInterface) {
@@ -872,16 +881,16 @@ class Marshaller
 
             // Scalar data can't be handled
             if (!is_array($value)) {
-                $record->unset('_joinData');
+                $record->unset($junctionProperty);
                 continue;
             }
 
             // Marshal data into the old object, or make a new joinData object.
             if (isset($extra[$hash])) {
-                $record->set('_joinData', $marshaller->merge($extra[$hash], $value, $nested));
+                $record->set($junctionProperty, $marshaller->merge($extra[$hash], $value, $nested));
             } else {
                 $joinData = $marshaller->one($value, $nested);
-                $record->set('_joinData', $joinData);
+                $record->set($junctionProperty, $joinData);
             }
         }
 

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -21,6 +21,7 @@ use Cake\Collection\Collection;
 use Cake\Core\Exception\CakeException;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\InvalidPropertyInterface;
+use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Entity;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Table;
@@ -640,13 +641,10 @@ class EntityContext implements ContextInterface
         $table = $this->_tables[$this->_rootName];
         $assoc = null;
         foreach ($normalized as $part) {
-            if ($part === '_joinData') {
-                if ($assoc !== null) {
-                    /** @var \Cake\ORM\Association\BelongsToMany $assoc */
-                    $table = $assoc->junction();
-                    $assoc = null;
-                    continue;
-                }
+            if ($assoc instanceof BelongsToMany && $part === $assoc->getJunctionProperty()) {
+                $table = $assoc->junction();
+                $assoc = null;
+                continue;
             } else {
                 $associationCollection = $table->associations();
                 $assoc = $associationCollection->getByProperty($part);

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -219,6 +219,18 @@ class BelongsToManyTest extends TestCase
         $assoc->setStrategy(BelongsToMany::STRATEGY_JOIN);
     }
 
+    public function testJunctionProperty()
+    {
+        $assoc = new BelongsToMany('Test');
+        $this->assertSame('_joinData', $assoc->getJunctionProperty());
+
+        $assoc = new BelongsToMany('Test', ['junctionProperty' => 'junction']);
+        $this->assertSame('junction', $assoc->getJunctionProperty());
+
+        $assoc->setJunctionProperty('_pivot');
+        $this->assertSame('_pivot', $assoc->getJunctionProperty());
+    }
+
     /**
      * Tests the junction method
      */


### PR DESCRIPTION
On more than one occasion I had seen users ask in the support channels if the `_joinData` key can be changed. While one can re-key the results using `SelectQuery::formatResults()`, being able to configure it would be nice.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
