### PR TITLE
5.2 Add SchemaDialect::describeColumns

### DIFF
--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -433,4 +433,32 @@ abstract class SchemaDialect
 
         return $table;
     }
+
+    /**
+     * Get a list of column metadata as a array
+     *
+     * Each item in the array will contain the following:
+     */
+    public function describeColumns(string $tableName): array
+    {
+        $config = $this->_driver->config();
+        if (str_contains($tableName, '.')) {
+            [$config['schema'], $tableName] = explode('.', $tableName);
+        }
+        /** @var \Cake\Database\Schema\TableSchema $table */
+        $table = $this->_driver->newTableSchema($tableName);
+        [$sql, $params] = $this->describeColumnSql($tableName, $config);
+        $statement = $this->_driver->execute($sql, $params);
+        foreach ($statement->fetchAll('assoc') as $row) {
+            $this->convertColumnDescription($table, $row);
+        }
+        $columns = [];
+        foreach ($table->columns() as $columnName) {
+            $column = $table->getColumn($columnName);
+            $column['name'] = $columnName;
+            $columns[] = $column;
+        }
+
+        return $columns;
+    }
 }

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -80,4 +80,29 @@ class SchemaDialectTest extends TestCase
         $this->assertEquals('users', $result->name());
         $this->assertTrue($result->hasColumn('username'));
     }
+
+    public function testDescribeColumns(): void
+    {
+        $result = $this->dialect->describeColumns('users');
+        $this->assertCount(5, $result);
+        foreach ($result as $column) {
+            // Validate the interface for column array shape
+            $this->assertArrayHasKey('name', $column);
+            $this->assertTrue(is_string($column['name']));
+
+            $this->assertArrayHasKey('type', $column);
+            $this->assertTrue(is_string($column['type']));
+
+            $this->assertArrayHasKey('length', $column);
+            $this->assertTrue(is_int($column['length']) || $column['length'] === null);
+
+            $this->assertArrayHasKey('default', $column);
+
+            $this->assertArrayHasKey('null', $column);
+            $this->assertTrue(is_bool($column['null']));
+
+            $this->assertArrayHasKey('comment', $column);
+            $this->assertTrue(is_string($column['comment']));
+        }
+    }
 }

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -102,7 +102,7 @@ class SchemaDialectTest extends TestCase
             $this->assertTrue(is_bool($column['null']));
 
             $this->assertArrayHasKey('comment', $column);
-            $this->assertTrue(is_string($column['comment']));
+            $this->assertTrue(is_string($column['comment']) || $column['comment'] === null);
         }
     }
 }


### PR DESCRIPTION
I don't want to break the abstract interface between dialect operations right now, so I'm using a `TableSchema` to shim operations together.

Refs #18123

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
