### PR TITLE
Set the `default` provider in Validator's constructor.

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -165,7 +165,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @var bool
      */
-    protected bool $_useI18n = false;
+    protected bool $_useI18n;
 
     /**
      * Contains the validation messages associated with checking the emptiness
@@ -194,8 +194,9 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function __construct()
     {
-        $this->_useI18n = function_exists('\Cake\I18n\__d');
+        $this->_useI18n ??= function_exists('\Cake\I18n\__d');
         $this->_providers = self::$_defaultProviders;
+        $this->_providers['default'] ??= Validation::class;
     }
 
     /**
@@ -323,16 +324,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function getProvider(string $name): object|string|null
     {
-        if (isset($this->_providers[$name])) {
-            return $this->_providers[$name];
-        }
-        if ($name !== 'default') {
-            return null;
-        }
-
-        $this->_providers[$name] = Validation::class;
-
-        return $this->_providers[$name];
+        return $this->_providers[$name] ?? null;
     }
 
     /**
@@ -3181,8 +3173,6 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     protected function _processRules(string $field, ValidationSet $rules, array $data, bool $newRecord): array
     {
         $errors = [];
-        // Loading default provider in case there is none
-        $this->getProvider('default');
 
         if (!$this->_useI18n) {
             $message = 'The provided value is invalid';

--- a/tests/TestCase/Validation/NoI18nValidator.php
+++ b/tests/TestCase/Validation/NoI18nValidator.php
@@ -11,11 +11,9 @@ use Cake\Validation\Validator;
 class NoI18nValidator extends Validator
 {
     /**
-     * Disable the usage of I18n functions
+     * Whether to use I18n functions for translating default error messages
+     *
+     * @var bool
      */
-    public function __construct()
-    {
-        $this->_useI18n = false;
-        $this->_providers = self::$_defaultProviders;
-    }
+    protected bool $_useI18n = false;
 }

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -356,7 +356,7 @@ class ValidatorTest extends TestCase
         $require = true;
         $validator->requirePresence('title', function ($context) use (&$require) {
             $this->assertEquals([], $context['data']);
-            $this->assertEquals([], $context['providers']);
+            $this->assertEquals(['default' => Validation::class], $context['providers']);
             $this->assertSame('title', $context['field']);
             $this->assertTrue($context['newRecord']);
 
@@ -1329,7 +1329,7 @@ class ValidatorTest extends TestCase
         $allow = true;
         $validator->allowEmptyString('title', null, function ($context) use (&$allow) {
             $this->assertEquals([], $context['data']);
-            $this->assertEquals([], $context['providers']);
+            $this->assertEquals(['default' => Validation::class], $context['providers']);
             $this->assertTrue($context['newRecord']);
 
             return $allow;
@@ -1350,7 +1350,7 @@ class ValidatorTest extends TestCase
         $prevent = true;
         $validator->notEmptyString('title', 'error message', function ($context) use (&$prevent) {
             $this->assertEquals([], $context['data']);
-            $this->assertEquals([], $context['providers']);
+            $this->assertEquals(['default' => Validation::class], $context['providers']);
             $this->assertFalse($context['newRecord']);
 
             return $prevent;
@@ -1833,7 +1833,7 @@ class ValidatorTest extends TestCase
 
         $result = $validator->__debugInfo();
         $expected = [
-            '_providers' => ['test'],
+            '_providers' => ['default', 'test'],
             '_fields' => [
                 'title' => [
                     'isPresenceRequired' => false,
@@ -2986,11 +2986,16 @@ class ValidatorTest extends TestCase
     public function testAddingDefaultProvider(): void
     {
         $validator = new Validator();
-        $this->assertEmpty($validator->providers(), 'Providers should be empty');
+        $this->assertSame(['default'], $validator->providers(), '`default` validator provider is missing');
+        $this->assertSame(Validation::class, $validator->getProvider('default'));
 
         Validator::addDefaultProvider('test-provider', 'MyNameSpace\Validation\MyProvider');
         $validator = new Validator();
-        $this->assertEquals($validator->providers(), ['test-provider'], 'Default provider `test-provider` is missing');
+        $this->assertEquals(
+            ['test-provider', 'default'],
+            $validator->providers(),
+            'Default provider `test-provider` is missing'
+        );
     }
 
     /**


### PR DESCRIPTION
This simplifies the Validator::getProvider() method.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
