### PR TITLE
PHPStan:  Offset 'uri' always exists

### DIFF
--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -157,7 +157,7 @@ class FormData implements Countable, Stringable
             if (stream_is_local($value)) {
                 $finfo = new finfo(FILEINFO_MIME);
                 $metadata = stream_get_meta_data($value);
-                $uri = $metadata['uri'] ?? '';
+                $uri = $metadata['uri'];
                 $contentType = (string)$finfo->file($uri);
                 $filename = basename($uri);
             }


### PR DESCRIPTION
I get locally (with php 8.3) using PHPStan always this error:
```
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Http/Client/FormData.php                                                                                                                                                                                            
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  160    Offset 'uri' on array{timed_out: bool, blocked: bool, eof: bool, unread_bytes: int, stream_type: string, wrapper_type: string, wrapper_data: mixed, mode: string, ...} on left side of ?? always exists and is not  
         nullable.                                                                                                                                                                                                           
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
```

I wonder if thats the case for all versions, and if not, what can be done to avoid this annoying issue.
Maybe we can set PHPStan to an expected (min) version to run for?