### PR TITLE
Update dependency constraints for the split packages.

### DIFF
--- a/src/Cache/composer.json
+++ b/src/Cache/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "cakephp/core": "^5.2",
+        "cakephp/core": "5.2.*@dev",
         "psr/simple-cache": "^2.0 || ^3.0"
     },
     "provide": {
@@ -34,6 +34,10 @@
             "Cake\\Cache\\": "."
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-5.next": "5.2.x-dev"
+        }
+    }
 }

--- a/src/Console/composer.json
+++ b/src/Console/composer.json
@@ -24,9 +24,9 @@
     },
     "require": {
         "php": ">=8.1",
-        "cakephp/core": "^5.2",
-        "cakephp/event": "^5.2",
-        "cakephp/log": "^5.2",
+        "cakephp/core": "5.2.*@dev",
+        "cakephp/event": "5.2.*@dev",
+        "cakephp/log": "5.2.*@dev",
         "cakephp/utility": "^5.2"
     },
     "suggest": {
@@ -38,6 +38,10 @@
             "Cake\\Console\\": "."
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-5.next": "5.2.x-dev"
+        }
+    }
 }

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "cakephp/utility": "^5.2",
+        "cakephp/utility": "5.2.*@dev",
         "league/container": "^4.2",
         "psr/container": "^1.1 || ^2.0"
     },
@@ -43,6 +43,10 @@
         "cakephp/cache": "To use Configure::store() and restore().",
         "league/container": "To use Container and ServiceProvider classes"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-5.next": "5.2.x-dev"
+        }
+    }
 }

--- a/src/Database/composer.json
+++ b/src/Database/composer.json
@@ -25,13 +25,13 @@
     },
     "require": {
         "php": ">=8.1",
-        "cakephp/core": "^5.2",
+        "cakephp/core": "5.2.*@dev",
         "cakephp/chronos": "^3.1",
-        "cakephp/datasource": "^5.2",
+        "cakephp/datasource": "5.2.*@dev",
         "psr/log": "^3.0"
     },
     "require-dev": {
-        "cakephp/i18n": "^5.2",
+        "cakephp/i18n": "5.2.*@dev",
         "cakephp/log": "^5.2"
     },
     "autoload": {
@@ -43,6 +43,10 @@
         "cakephp/i18n": "If you are using locale-aware datetime formats.",
         "cakephp/log": "If you want to use query logging without providing a logger yourself."
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-5.next": "5.2.x-dev"
+        }
+    }
 }

--- a/src/Datasource/composer.json
+++ b/src/Datasource/composer.json
@@ -25,12 +25,12 @@
     },
     "require": {
         "php": ">=8.1",
-        "cakephp/core": "^5.2",
+        "cakephp/core": "5.2.*@dev",
         "psr/simple-cache": "^2.0 || ^3.0"
     },
     "require-dev": {
-        "cakephp/cache": "^5.2",
-        "cakephp/collection": "^5.2",
+        "cakephp/cache": "5.2.*@dev",
+        "cakephp/collection": "5.2.*@dev",
         "cakephp/utility": "^5.2"
     },
     "autoload": {
@@ -43,6 +43,10 @@
         "cakephp/collection": "If you decide to use ResultSetInterface.",
         "cakephp/cache": "If you decide to use Query caching."
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-5.next": "5.2.x-dev"
+        }
+    }
 }

--- a/src/Event/composer.json
+++ b/src/Event/composer.json
@@ -31,6 +31,10 @@
             "Cake\\Event\\": "."
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-5.next": "5.2.x-dev"
+        }
+    }
 }

--- a/src/Form/composer.json
+++ b/src/Form/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "cakephp/event": "^5.2",
+        "cakephp/event": "5.2.*@dev",
         "cakephp/validation": "^5.2"
     },
     "autoload": {
@@ -30,6 +30,10 @@
             "Cake\\Form\\": "."
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-5.next": "5.2.x-dev"
+        }
+    }
 }

--- a/src/Http/composer.json
+++ b/src/Http/composer.json
@@ -26,9 +26,9 @@
     },
     "require": {
         "php": ">=8.1",
-        "cakephp/core": "^5.2",
-        "cakephp/event": "^5.2",
-        "cakephp/utility": "^5.2",
+        "cakephp/core": "5.2.*@dev",
+        "cakephp/event": "5.2.*@dev",
+        "cakephp/utility": "5.2.*@dev",
         "composer/ca-bundle": "^1.5",
         "psr/http-client": "^1.0.2",
         "psr/http-factory": "^1.1",
@@ -39,10 +39,10 @@
         "laminas/laminas-httphandlerrunner": "^2.6"
     },
     "require-dev": {
-        "cakephp/cache": "^5.2",
-        "cakephp/console": "^5.2",
-        "cakephp/orm": "^5.2",
-        "cakephp/i18n": "^5.2",
+        "cakephp/cache": "5.2.*@dev",
+        "cakephp/console": "5.2.*@dev",
+        "cakephp/orm": "5.2.*@dev",
+        "cakephp/i18n": "5.2.*@dev",
         "paragonie/csp-builder": "^3.0"
     },
     "autoload": {
@@ -61,6 +61,10 @@
         "cakephp/orm": "To use database session storage",
         "paragonie/csp-builder": "To use CspMiddleware"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-5.next": "5.2.x-dev"
+        }
+    }
 }

--- a/src/I18n/composer.json
+++ b/src/I18n/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php": ">=8.1",
         "ext-intl": "*",
-        "cakephp/core": "^5.2",
+        "cakephp/core": "5.2.*@dev",
         "cakephp/chronos": "^3.1"
     },
     "autoload": {
@@ -44,6 +44,10 @@
     "suggest": {
         "cakephp/cache": "Require this if you want automatic caching of translators"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-5.next": "5.2.x-dev"
+        }
+    }
 }

--- a/src/Log/composer.json
+++ b/src/Log/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "cakephp/core": "^5.2",
+        "cakephp/core": "5.2.*@dev",
         "psr/log": "^3.0"
     },
     "autoload": {
@@ -35,6 +35,10 @@
     "provide": {
         "psr/log-implementation": "^3.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-5.next": "5.2.x-dev"
+        }
+    }
 }

--- a/src/ORM/composer.json
+++ b/src/ORM/composer.json
@@ -24,16 +24,16 @@
     },
     "require": {
         "php": ">=8.1",
-        "cakephp/collection": "^5.2",
-        "cakephp/core": "^5.2",
-        "cakephp/datasource": "^5.2",
-        "cakephp/database": "^5.2",
-        "cakephp/event": "^5.2",
-        "cakephp/utility": "^5.2",
+        "cakephp/collection": "5.2.*@dev",
+        "cakephp/core": "5.2.*@dev",
+        "cakephp/datasource": "5.2.*@dev",
+        "cakephp/database": "5.2.*@dev",
+        "cakephp/event": "5.2.*@dev",
+        "cakephp/utility": "5.2.*@dev",
         "cakephp/validation": "^5.2"
     },
     "require-dev": {
-        "cakephp/cache": "^5.2",
+        "cakephp/cache": "5.2.*@dev",
         "cakephp/i18n": "^5.2"
     },
     "autoload": {
@@ -48,6 +48,10 @@
         "cakephp/cache": "If you decide to use Query caching.",
         "cakephp/i18n": "If you are using Translate/TimestampBehavior or Chronos types."
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-5.next": "5.2.x-dev"
+        }
+    }
 }

--- a/src/Utility/composer.json
+++ b/src/Utility/composer.json
@@ -40,6 +40,10 @@
         "ext-intl": "To use Text::transliterate() or Text::slug()",
         "lib-ICU": "To use Text::transliterate() or Text::slug()"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-5.next": "5.2.x-dev"
+        }
+    }
 }

--- a/src/Validation/composer.json
+++ b/src/Validation/composer.json
@@ -23,8 +23,8 @@
     },
     "require": {
         "php": ">=8.1",
-        "cakephp/core": "^5.2",
-        "cakephp/utility": "^5.2",
+        "cakephp/core": "5.2.*@dev",
+        "cakephp/utility": "5.2.*@dev",
         "psr/http-message": "^1.1 || ^2.0"
     },
     "require-dev": {
@@ -38,6 +38,10 @@
     "suggest": {
         "cakephp/i18n": "If you want to use Validation::localizedTime()"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-5.next": "5.2.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
This should allow using/testing the 5.next branch of the split packages.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
