### PR TITLE
`FlashComponent::__call()` supports named parameters

### DIFF
--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -173,6 +173,10 @@ class FlashComponent extends Component
 
         $options = ['element' => $element];
 
+        if (isset($args['options'])) {
+            $args[1] = $args['options'];
+        }
+
         if (!empty($args[1])) {
             if (!empty($args[1]['plugin'])) {
                 $options = ['element' => $args[1]['plugin'] . '.' . $element];
@@ -181,6 +185,6 @@ class FlashComponent extends Component
             $options += (array)$args[1];
         }
 
-        $this->set($args[0], $options);
+        $this->set($args[0] ?? $args['message'], $options);
     }
 }

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -313,6 +313,18 @@ class FlashComponentTest extends TestCase
         ];
         $result = $this->Session->read('Flash.flash');
         $this->assertEquals($expected, $result);
+
+        $this->Flash->success('It worked', options: ['plugin' => 'MyPlugin']);
+
+        $expected[] = [
+            'message' => 'It worked',
+            'key' => 'flash',
+            'element' => 'MyPlugin.flash/success',
+            'params' => [],
+        ];
+
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -274,6 +274,48 @@ class FlashComponentTest extends TestCase
     }
 
     /**
+     * Test magic call method, with named parameters.
+     */
+    public function testCallWithNamedParams(): void
+    {
+        $this->assertNull($this->Session->read('Flash.flash'));
+
+        $this->Flash->success(message: 'It worked');
+        $expected = [
+            [
+                'message' => 'It worked',
+                'key' => 'flash',
+                'element' => 'flash/success',
+                'params' => [],
+            ],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+
+        $this->Flash->error(message: 'It did not work', options: ['element' => 'error_thing']);
+
+        $expected[] = [
+            'message' => 'It did not work',
+            'key' => 'flash',
+            'element' => 'flash/error',
+            'params' => [],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result, 'Element is ignored in magic call.');
+
+        $this->Flash->success(message: 'It worked', options: ['plugin' => 'MyPlugin']);
+
+        $expected[] = [
+            'message' => 'It worked',
+            'key' => 'flash',
+            'element' => 'MyPlugin.flash/success',
+            'params' => [],
+        ];
+        $result = $this->Session->read('Flash.flash');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * Test a magic call with the "clear" flag to true
      */
     public function testCallWithClear(): void


### PR DESCRIPTION
Do you think it makes sense to make `FlashComponent::__call()` support named parameters?

Thanks.