### PR TITLE
Don't remove index.php from the request path when URL rewriting is used.

### DIFF
--- a/src/Http/UriFactory.php
+++ b/src/Http/UriFactory.php
@@ -77,16 +77,26 @@ class UriFactory implements UriFactoryInterface
         if ($base !== '' && str_starts_with($path, $base)) {
             $path = substr($path, strlen($base));
         }
+
+        // App.baseUrl is meant to be set only when URL rewriting is not used.
+        if (!Configure::read('App.baseUrl')) {
+            if ($path === '' || $path === '//') {
+                $path = '/';
+            }
+
+            return $uri->withPath($path);
+        }
+
         if ($path === '/index.php' && $uri->getQuery()) {
             $path = $uri->getQuery();
         }
-        if (!$path || $path === '/' || $path === '//' || $path === '/index.php') {
+        if ($path === '' || $path === '//' || $path === '/index.php') {
             $path = '/';
         }
 
         // Check for $webroot/index.php at the start and end of the path.
         $search = '';
-        if ($path[0] === '/') {
+        if (str_starts_with($path, '/')) {
             $search .= '/';
         }
         $search .= (Configure::read('App.webroot') ?: 'webroot') . '/index.php';

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -236,17 +236,19 @@ class ServerRequestFactoryTest extends TestCase
      * Test base, webroot, URL and here parsing when there is URL rewriting but
      * CakePHP gets called with index.php in URL nonetheless.
      *
+     * The request instance generated should not have index.php stripped from its Uri.
+     *
      * Tests uri with
      *
      * - index.php/
-     * - index.php/
      * - index.php/apples/
+     * - index.php?%3C%3E?
      * - index.php/bananas/eat/tasty_banana
      */
     public function testBaseUrlWithModRewriteAndIndexPhp(): void
     {
         $request = ServerRequestFactory::fromGlobals([
-            'DOCUMENT_ROOT' => '/cakephp/webroot/index.php',
+            'DOCUMENT_ROOT' => '/cakephp/webroot',
             'PHP_SELF' => '/cakephp/webroot/index.php',
         ]);
 
@@ -255,44 +257,46 @@ class ServerRequestFactoryTest extends TestCase
         $this->assertSame('/', $request->getRequestTarget());
 
         $request = ServerRequestFactory::fromGlobals([
-            'REQUEST_URI' => '/cakephp/webroot/index.php/',
+            'REQUEST_URI' => '/cakephp/index.php/',
             'PHP_SELF' => '/cakephp/webroot/index.php/',
             'PATH_INFO' => '/',
         ]);
 
         $this->assertSame('/cakephp', $request->getAttribute('base'));
         $this->assertSame('/cakephp/', $request->getAttribute('webroot'));
-        $this->assertSame('/', $request->getRequestTarget());
+        $this->assertSame('/index.php/', $request->getRequestTarget());
 
         $request = ServerRequestFactory::fromGlobals([
-            'REQUEST_URI' => '/cakephp/webroot/index.php/apples',
+            'REQUEST_URI' => '/cakephp/index.php/apples',
             'PHP_SELF' => '/cakephp/webroot/index.php/apples',
             'PATH_INFO' => '/apples',
         ]);
 
         $this->assertSame('/cakephp', $request->getAttribute('base'));
         $this->assertSame('/cakephp/', $request->getAttribute('webroot'));
-        $this->assertSame('/apples', $request->getRequestTarget());
+        $this->assertSame('/index.php/apples', $request->getRequestTarget());
 
         $request = ServerRequestFactory::fromGlobals([
-            'REQUEST_URI' => '/cakephp/webroot/index.php/melons/share/',
-            'PHP_SELF' => '/cakephp/webroot/index.php/melons/share/',
-            'PATH_INFO' => '/melons/share/',
+            'QUERY_STRING' => '%3C%3E?',
+            'REQUEST_URI' => '/cakephp/index.php?%3C%3E?',
+            'PHP_SELF' => '/cakephp/webroot/index.php',
+            'SCRIPT_NAME' => '/filepath/cakephp/webroot/index.php',
         ]);
 
         $this->assertSame('/cakephp', $request->getAttribute('base'));
         $this->assertSame('/cakephp/', $request->getAttribute('webroot'));
-        $this->assertSame('/melons/share/', $request->getRequestTarget());
+        $this->assertSame('/index.php?%3C%3E?', $request->getRequestTarget());
+        $this->assertSame('%3C%3E?', $request->getUri()->getQuery());
 
         $request = ServerRequestFactory::fromGlobals([
-            'REQUEST_URI' => '/cakephp/webroot/index.php/bananas/eat/tasty_banana',
+            'REQUEST_URI' => '/cakephp/index.php/bananas/eat/tasty_banana',
             'PHP_SELF' => '/cakephp/webroot/index.php/bananas/eat/tasty_banana',
             'PATH_INFO' => '/bananas/eat/tasty_banana',
         ]);
 
         $this->assertSame('/cakephp', $request->getAttribute('base'));
         $this->assertSame('/cakephp/', $request->getAttribute('webroot'));
-        $this->assertSame('/bananas/eat/tasty_banana', $request->getRequestTarget());
+        $this->assertSame('/index.php/bananas/eat/tasty_banana', $request->getRequestTarget());
     }
 
     /**


### PR DESCRIPTION
URLs with "index.php" would be unexpected when URL rewriting is used and should not be handled in a special way. Often bots searching for vulnerabilities use URLs with index.php.

Before this fix accessing a URL like `index.php?<>?` resulted in an exception being thrown by Diactoros\Uri since our UriFactory tried to set `?<>?` as the uri path. This results in a blank page, instead of a normal error page, since the exception occurs too early in the request cycle.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
