### PR TITLE
Simplify `inputContainer` template of `FormHelper`.

### DIFF
--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -513,7 +513,7 @@ class FormHelperTest extends TestCase
         ]);
         $result = $this->Form->control('title');
         $expected = [
-            'div' => ['class' => 'input text is-required'],
+            'div' => ['class' => 'input is-required'],
             'label' => ['for' => 'title'],
             'Title',
             '/label',
@@ -541,7 +541,7 @@ class FormHelperTest extends TestCase
                 'input' => '<input custom="{{forinput}}" type="{{type}}" name="{{name}}"{{attrs}}/>',
                 'label' => '<label{{attrs}}>{{text}} {{forlabel}}</label>',
                 'formGroup' => '{{label}}{{forgroup}}{{input}}',
-                'inputContainer' => '<div class="input {{type}}{{required}}">{{content}}{{forcontainer}}</div>',
+                'inputContainer' => '<div class="input">{{content}}{{forcontainer}}</div>',
             ],
             'templateVars' => [
                 'forinput' => 'in-input',
@@ -1149,7 +1149,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->create($this->article);
         $result = $this->Form->control('foo');
-        $this->assertStringContainsString('class="input number"', $result);
+        $this->assertStringContainsString('class="input"', $result);
         $this->assertStringContainsString('type="number"', $result);
     }
 
@@ -1169,7 +1169,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->create($this->article);
         $result = $this->Form->control('foo');
-        $this->assertStringContainsString('class="input number"', $result);
+        $this->assertStringContainsString('class="input"', $result);
         $this->assertStringContainsString('type="number"', $result);
     }
 
@@ -1190,7 +1190,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($this->article);
         $result = $this->Form->control('foo');
         $expected = [
-            'div' => ['class' => 'input number'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'foo'],
             'Foo',
             '/label',
@@ -1206,7 +1206,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('foo', ['step' => 0.5]);
         $expected = [
-            'div' => ['class' => 'input number'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'foo'],
             'Foo',
             '/label',
@@ -1232,7 +1232,7 @@ class FormHelperTest extends TestCase
         $this->Form->create([], ['context' => ['table' => 'Contacts']]);
         $result = $this->Form->control('age');
         $expected = [
-            'div' => ['class' => 'input number'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'age'],
             'Age',
             '/label',
@@ -1263,7 +1263,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('foo');
         $expected = [
-            'div' => ['class' => 'input file'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'foo'],
             'Foo',
             '/label',
@@ -1464,7 +1464,7 @@ class FormHelperTest extends TestCase
     /**
      * testFormSecurityMultipleControlFields method
      *
-     * Test secure form creation with multiple row creation. Checks hidden, text, checkbox field types
+     * Test secure form creation with multiple row creation. Checks hidden,, checkbox field types
      */
     public function testFormSecurityMultipleControlFields(): void
     {
@@ -1953,7 +1953,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('published', ['type' => 'text']);
         $expected = [
-            'div' => ['class' => 'input text'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'published'],
             'Published',
             '/label',
@@ -1968,7 +1968,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('other', ['type' => 'text']);
         $expected = [
-            'div' => ['class' => 'input text'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'other'],
             'Other',
             '/label',
@@ -2001,7 +2001,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('something', ['type' => 'checkbox']);
         $expected = [
-            'div' => ['class' => 'input checkbox'],
+            'div' => ['class' => 'input'],
             ['input' => [
                 'type' => 'hidden',
                 'name' => 'something',
@@ -2116,9 +2116,9 @@ class FormHelperTest extends TestCase
 
         $this->Form->control('text_val', [
                 'type' => 'hidden',
-                'value' => 'some text',
+                'value' => 'some',
         ]);
-        $expected = ['text_val' => 'some text'];
+        $expected = ['text_val' => 'some'];
         $result = $this->Form->getFormProtector()->__debugInfo()['fields'];
         $this->assertEquals($expected, $result);
 
@@ -2400,7 +2400,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('Article.title');
         $expected = [
-            'div' => ['class' => 'input text error'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'article-title'],
             'Title',
             '/label',
@@ -2421,7 +2421,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('Article.title', ['templates' => ['errorClass' => 'danger']]);
         $expected = [
-            'div' => ['class' => 'input text error'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'article-title'],
             'Title',
             '/label',
@@ -2445,7 +2445,7 @@ class FormHelperTest extends TestCase
             'options' => ['1' => 'One', '2' => 'Two'],
         ]);
         $expected = [
-            'div' => ['class' => 'input select error'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'article-user-id'],
             'User',
             '/label',
@@ -2472,12 +2472,12 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('Article.title', [
             'templates' => [
-                'inputContainerError' => '<div class="input {{type}}{{required}} error">{{content}}</div>',
+                'inputContainerError' => '<div class="{{containerClass}} has-error">{{content}}</div>',
             ],
         ]);
 
         $expected = [
-            'div' => ['class' => 'input text error'],
+            'div' => ['class' => 'input has-error'],
             'label' => ['for' => 'article-title'],
             'Title',
             '/label',
@@ -2495,7 +2495,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('Article.content');
         $expected = [
-            'div' => ['class' => 'input text error'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'article-content'],
             'Content',
             '/label',
@@ -2516,7 +2516,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('Article.content', ['error' => ['escape' => true]]);
         $expected = [
-            'div' => ['class' => 'input text error'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'article-content'],
             'Content',
             '/label',
@@ -2537,7 +2537,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('Article.content', ['error' => ['escape' => false]]);
         $expected = [
-            'div' => ['class' => 'input text error'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'article-content'],
             'Content',
             '/label',
@@ -2571,7 +2571,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('Article.title');
         $expected = [
-            'div' => ['class' => 'input text error'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'article-title'],
             'Title',
             '/label',
@@ -2605,7 +2605,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('Article.title', ['error' => '']);
         $expected = [
-            'div' => ['class' => 'input text error'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'article-title'],
             'Title',
             '/label',
@@ -2641,7 +2641,7 @@ class FormHelperTest extends TestCase
             'error' => 'Custom error!',
         ]);
         $expected = [
-            'div' => ['class' => 'input text required error'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'title'],
             'Title',
             '/label',
@@ -2668,7 +2668,7 @@ class FormHelperTest extends TestCase
             'error' => ['error message' => 'Custom error!'],
         ]);
         $expected = [
-            'div' => ['class' => 'input text required error'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'title'],
             'Title',
             '/label',
@@ -2745,7 +2745,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('0.email');
         $expected = [
-            'div' => ['class' => 'input email error'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => '0-email'],
             'Email',
             '/label',
@@ -2768,7 +2768,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('1.name');
         $expected = [
-            'div' => ['class' => 'input text error'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => '1-name'],
             'Name',
             '/label',
@@ -2853,7 +2853,7 @@ class FormHelperTest extends TestCase
             ],
         ]);
         $expected = [
-            'div' => ['class' => 'ic email'],
+            'div' => ['class' => 'ic'],
             'label' => ['for' => 'custom'],
             'Email',
             '/label',
@@ -2904,7 +2904,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('Contact.email', ['type' => 'text']);
         $expected = [
-            'div' => ['class' => 'input text'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'contact-email'],
             'Email',
             '/label',
@@ -2918,7 +2918,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('Contact.5.email', ['type' => 'text']);
         $expected = [
-            'div' => ['class' => 'input text'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'contact-5-email'],
             'Email',
             '/label',
@@ -2932,7 +2932,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('Contact.password');
         $expected = [
-            'div' => ['class' => 'input password'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'contact-password'],
             'Password',
             '/label',
@@ -2948,7 +2948,7 @@ class FormHelperTest extends TestCase
             'type' => 'file', 'class' => 'textbox',
         ]);
         $expected = [
-            'div' => ['class' => 'input file'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'contact-email'],
             'Email',
             '/label',
@@ -2964,7 +2964,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($entity, ['context' => ['table' => 'Contacts']]);
         $result = $this->Form->control('phone');
         $expected = [
-            'div' => ['class' => 'input tel'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'phone'],
             'Phone',
             '/label',
@@ -2983,7 +2983,7 @@ class FormHelperTest extends TestCase
         $this->Form->create();
         $result = $this->Form->control('Model.0.OtherModel.field', ['id' => 'myId']);
         $expected = [
-            'div' => ['class' => 'input text'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'myId'],
             'Field',
             '/label',
@@ -3002,7 +3002,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($entity, ['context' => ['table' => 'Contacts']]);
         $result = $this->Form->control('field');
         $expected = [
-            'div' => ['class' => 'input text error'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'field'],
             'Field',
             '/label',
@@ -3053,7 +3053,7 @@ class FormHelperTest extends TestCase
             ],
         ]);
         $expected = [
-            'div' => ['class' => 'input text error'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'field'],
             'Field',
             '/label',
@@ -3083,7 +3083,7 @@ class FormHelperTest extends TestCase
             ],
         ]);
         $expected = [
-            'div' => ['class' => 'input-container text error'],
+            'div' => ['class' => 'input-container'],
             'label' => ['for' => 'field'],
             'Field',
             '/label',
@@ -3160,7 +3160,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('field');
         $expected = [
-            'div' => ['class' => 'input text'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'prefix-field'],
             'Field',
             '/label',
@@ -3171,7 +3171,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('field', ['id' => 'custom-id']);
         $expected = [
-            'div' => ['class' => 'input text'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'custom-id'],
             'Field',
             '/label',
@@ -3234,7 +3234,7 @@ class FormHelperTest extends TestCase
         $this->Form->end();
         $result = $this->Form->control('field');
         $expected = [
-            'div' => ['class' => 'input text'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'field'],
             'Field',
             '/label',
@@ -3257,7 +3257,7 @@ class FormHelperTest extends TestCase
         $this->Form->create([], ['context' => ['table' => 'Contacts']]);
         $result = $this->Form->control('0');
         $expected = [
-            'div' => ['class' => 'input text'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => '0'], '/label',
             'input' => ['type' => 'text', 'name' => '0', 'id' => '0'],
             '/div',
@@ -3280,7 +3280,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('Articles.active');
         $expected = [
-            'div' => ['class' => 'input checkbox'],
+            'div' => ['class' => 'input'],
             'input' => ['type' => 'hidden', 'name' => 'Articles[active]', 'value' => '0'],
             'label' => ['for' => 'articles-active'],
             ['input' => ['type' => 'checkbox', 'name' => 'Articles[active]', 'value' => '1', 'id' => 'articles-active']],
@@ -3292,7 +3292,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('Articles.active', ['label' => false, 'checked' => true]);
         $expected = [
-            'div' => ['class' => 'input checkbox'],
+            'div' => ['class' => 'input'],
             'input' => ['type' => 'hidden', 'name' => 'Articles[active]', 'value' => '0'],
             ['input' => ['type' => 'checkbox', 'name' => 'Articles[active]', 'value' => '1', 'id' => 'articles-active', 'checked' => 'checked']],
             '/div',
@@ -3301,7 +3301,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('Articles.active', ['label' => false, 'checked' => 1]);
         $expected = [
-            'div' => ['class' => 'input checkbox'],
+            'div' => ['class' => 'input'],
             'input' => ['type' => 'hidden', 'name' => 'Articles[active]', 'value' => '0'],
             ['input' => ['type' => 'checkbox', 'name' => 'Articles[active]', 'value' => '1', 'id' => 'articles-active', 'checked' => 'checked']],
             '/div',
@@ -3310,7 +3310,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('Articles.active', ['label' => false, 'checked' => '1']);
         $expected = [
-            'div' => ['class' => 'input checkbox'],
+            'div' => ['class' => 'input'],
             'input' => ['type' => 'hidden', 'name' => 'Articles[active]', 'value' => '0'],
             ['input' => ['type' => 'checkbox', 'name' => 'Articles[active]', 'value' => '1', 'id' => 'articles-active', 'checked' => 'checked']],
             '/div',
@@ -3323,7 +3323,7 @@ class FormHelperTest extends TestCase
             'data-foo' => 'disabled',
         ]);
         $expected = [
-            'div' => ['class' => 'input checkbox'],
+            'div' => ['class' => 'input'],
             'input' => ['type' => 'hidden', 'name' => 'Articles[disabled]', 'value' => '0'],
             'label' => ['for' => 'articles-disabled'],
             ['input' => [
@@ -3345,7 +3345,7 @@ class FormHelperTest extends TestCase
             'escape' => false,
         ]);
         $expected = [
-            'div' => ['class' => 'input checkbox'],
+            'div' => ['class' => 'input'],
             'input' => ['type' => 'hidden', 'name' => 'Articles[confirm]', 'value' => '0'],
             'label' => ['for' => 'articles-confirm'],
             ['input' => [
@@ -3398,7 +3398,7 @@ class FormHelperTest extends TestCase
             'value' => new DateTime('2019-09-27 02:52:43'),
         ]);
         $expected = [
-            'div' => ['class' => 'input datetime'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'prueba'],
             'Prueba',
             '/label',
@@ -3427,7 +3427,7 @@ class FormHelperTest extends TestCase
             'type' => 'datetime',
         ]);
         $expected = [
-            'div' => ['class' => 'input datetime'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'prefix-prueba'],
             'Prueba',
             '/label',
@@ -3456,7 +3456,7 @@ class FormHelperTest extends TestCase
             'step' => '0.5',
         ]);
         $expected = [
-            'div' => ['class' => 'input datetime'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'prueba'],
             'Prueba',
             '/label',
@@ -3487,7 +3487,7 @@ class FormHelperTest extends TestCase
         ]);
 
         $expected = [
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
             ['label' => ['for' => 'contact-multiple']],
             'Multiple',
             '/label',
@@ -3519,7 +3519,7 @@ class FormHelperTest extends TestCase
         $disabled = [50];
 
         $expected = [
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
             ['label' => ['for' => 'contact-multiple']],
             'Multiple',
             '/label',
@@ -3569,7 +3569,7 @@ class FormHelperTest extends TestCase
             'options' => ['è' => 'Firést', 'é' => 'Secoènd'], 'empty' => true],
         );
         $expected = [
-            'div' => ['class' => 'input select'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'email'],
             'Email',
             '/label',
@@ -3593,7 +3593,7 @@ class FormHelperTest extends TestCase
             'options' => ['First', 'Second'], 'empty' => true],
         );
         $expected = [
-            'div' => ['class' => 'input select'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'email'],
             'Email',
             '/label',
@@ -3625,7 +3625,7 @@ class FormHelperTest extends TestCase
         $this->Form->create();
         $result = $this->Form->control('Model.user_id', ['empty' => true]);
         $expected = [
-            'div' => ['class' => 'input select'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'model-user-id'],
             'User',
             '/label',
@@ -3649,7 +3649,7 @@ class FormHelperTest extends TestCase
         );
         $result = $this->Form->control('Thing.user_id', ['empty' => 'Some Empty']);
         $expected = [
-            'div' => ['class' => 'input select'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'thing-user-id'],
             'User',
             '/label',
@@ -3675,7 +3675,7 @@ class FormHelperTest extends TestCase
         $this->Form->create();
         $result = $this->Form->control('Thing.user_id', ['empty' => 'Some Empty']);
         $expected = [
-            'div' => ['class' => 'input select'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'thing-user-id'],
             'User',
             '/label',
@@ -3701,7 +3701,7 @@ class FormHelperTest extends TestCase
             'options' => ['Value 1' => 'Label 1', 'Value 2' => 'Label 2'],
         ]);
         $expected = [
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
                 ['label' => ['for' => 'publisher-id']],
                 'Publisher',
                 '/label',
@@ -3730,7 +3730,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($articlesTable->newEmptyEntity());
         $result = $this->Form->control('published');
         $expected = [
-            'div' => ['class' => 'input select'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'published'],
             'Published',
             '/label',
@@ -3753,7 +3753,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->create($articlesTable->newEmptyEntity());
         $expected = [
-            'div' => ['class' => 'input select'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'published'],
             'Published',
             '/label',
@@ -3780,7 +3780,7 @@ class FormHelperTest extends TestCase
         // Select empty by default
         $result = $this->Form->control('priority', ['empty' => ['' => ' - please select - '], 'default' => '']);
         $expected = [
-            'div' => ['class' => 'input select'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'priority'],
             'Priority',
             '/label',
@@ -3843,7 +3843,7 @@ class FormHelperTest extends TestCase
         $this->View->set('users', ['value' => 'good', 'other' => 'bad']);
         $result = $this->Form->control('Model.user_id', ['type' => 'text']);
         $expected = [
-            'div' => ['class' => 'input text'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'model-user-id'], 'User', '/label',
             'input' => ['name' => 'Model[user_id]', 'type' => 'text', 'id' => 'model-user-id'],
             '/div',
@@ -3854,7 +3854,7 @@ class FormHelperTest extends TestCase
         $this->View->set('types', ['value' => 'good', 'other' => 'bad']);
         $result = $this->Form->control('Model.type');
         $expected = [
-            'div' => ['class' => 'input select'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'model-type'], 'Type', '/label',
             'select' => ['name' => 'Model[type]', 'id' => 'model-type'],
             ['option' => ['value' => 'value']], 'good', '/option',
@@ -3875,7 +3875,7 @@ class FormHelperTest extends TestCase
         $this->View->set('users', ['value' => 'good', 'other' => 'bad']);
         $result = $this->Form->control('Model.user', ['type' => 'checkbox']);
         $expected = [
-            'div' => ['class' => 'input checkbox'],
+            'div' => ['class' => 'input'],
             ['input' => [
                 'type' => 'hidden',
                 'name' => 'Model[user]',
@@ -3901,7 +3901,7 @@ class FormHelperTest extends TestCase
         ];
         $result = $this->Form->control('tags._ids', ['options' => $options, 'multiple' => 'checkbox']);
         $expected = [
-            'div' => ['class' => 'input select'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'tags-ids'],
             'Tags',
             '/label',
@@ -3947,7 +3947,7 @@ class FormHelperTest extends TestCase
         $this->View->set('balances', [0 => 'nothing', 1 => 'some', 100 => 'a lot']);
         $result = $this->Form->control('balance');
         $expected = [
-            'div' => ['class' => 'input select'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'balance'],
             'Balance',
             '/label',
@@ -3988,7 +3988,7 @@ class FormHelperTest extends TestCase
     {
         $this->View->set('users', ['value' => 'good', 'other' => 'bad']);
         $result = $this->Form->control('Model.user_id', ['type' => 'radio']);
-        $this->assertStringContainsString('input type="radio"', $result);
+        $this->assertStringContainsString('input', $result);
     }
 
     /**
@@ -4095,13 +4095,13 @@ class FormHelperTest extends TestCase
             '<fieldset',
             '<legend', 'New Article', '/legend',
             'input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id'],
-            ['div' => ['class' => 'input select required']],
+            ['div' => ['class' => 'input']],
             '*/div',
-            ['div' => ['class' => 'input text required']],
+            ['div' => ['class' => 'input']],
             '*/div',
-            ['div' => ['class' => 'input text']],
+            ['div' => ['class' => 'input']],
             '*/div',
-            ['div' => ['class' => 'input text']],
+            ['div' => ['class' => 'input']],
             '*/div',
             '/fieldset',
         ];
@@ -4114,13 +4114,13 @@ class FormHelperTest extends TestCase
             '<fieldset',
             '<legend', 'New Article', '/legend',
             'input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id'],
-            ['div' => ['class' => 'input select required']],
+            ['div' => ['class' => 'input']],
             '*/div',
-            ['div' => ['class' => 'input text required']],
+            ['div' => ['class' => 'input']],
             '*/div',
-            ['div' => ['class' => 'input text']],
+            ['div' => ['class' => 'input']],
             '*/div',
-            ['div' => ['class' => 'input boolean']],
+            ['div' => ['class' => 'input']],
             '*/div',
             '/fieldset',
         ];
@@ -4134,13 +4134,13 @@ class FormHelperTest extends TestCase
             'Hello',
             '/legend',
             'input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id'],
-            ['div' => ['class' => 'input select required']],
+            ['div' => ['class' => 'input']],
             '*/div',
-            ['div' => ['class' => 'input text required']],
+            ['div' => ['class' => 'input']],
             '*/div',
-            ['div' => ['class' => 'input text']],
+            ['div' => ['class' => 'input']],
             '*/div',
-            ['div' => ['class' => 'input text']],
+            ['div' => ['class' => 'input']],
             '*/div',
             '/fieldset',
         ];
@@ -4149,7 +4149,7 @@ class FormHelperTest extends TestCase
         $this->Form->create();
         $expected = [
             'fieldset' => [],
-            ['div' => ['class' => 'input text']],
+            ['div' => ['class' => 'input']],
             'label' => ['for' => 'foo'],
             'Foo',
             '/label',
@@ -4176,13 +4176,13 @@ class FormHelperTest extends TestCase
         $expected = [
             '<fieldset',
             '<legend', 'New Article', '/legend',
-            ['div' => ['class' => 'input select required']],
+            ['div' => ['class' => 'input']],
             '*/div',
-            ['div' => ['class' => 'input text required']],
+            ['div' => ['class' => 'input']],
             '*/div',
-            ['div' => ['class' => 'input text']],
+            ['div' => ['class' => 'input']],
             '*/div',
-            ['div' => ['class' => 'input text']],
+            ['div' => ['class' => 'input']],
             '*/div',
             '/fieldset',
         ];
@@ -4196,13 +4196,13 @@ class FormHelperTest extends TestCase
             '<fieldset',
             '<legend', 'New Article', '/legend',
             'input' => ['type' => 'hidden', 'name' => 'id', 'id' => 'id'],
-            ['div' => ['class' => 'input select required']],
+            ['div' => ['class' => 'input']],
             '*/div',
-            ['div' => ['class' => 'input text required']],
+            ['div' => ['class' => 'input']],
             '*/div',
-            ['div' => ['class' => 'input text']],
+            ['div' => ['class' => 'input']],
             '*/div',
-            ['div' => ['class' => 'input text']],
+            ['div' => ['class' => 'input']],
             '*/div',
             '/fieldset',
         ];
@@ -4326,7 +4326,7 @@ class FormHelperTest extends TestCase
     /**
      * testTextbox method
      *
-     * Test textbox element generation.
+     * Testbox element generation.
      */
     public function testTextbox(): void
     {
@@ -4346,7 +4346,7 @@ class FormHelperTest extends TestCase
     /**
      * testTextBoxDataAndError method
      *
-     * Test that text() hooks up with request data and error fields.
+     * Test that() hooks up with request data and error fields.
      */
     public function testTextBoxDataAndError(): void
     {
@@ -4789,7 +4789,7 @@ class FormHelperTest extends TestCase
             'options' => ['A', 'B'],
         ]);
         $expected = [
-            ['div' => ['class' => 'input radio']],
+            ['div' => ['class' => 'input']],
                 '<label',
                 'Test',
                 '/label',
@@ -4812,7 +4812,7 @@ class FormHelperTest extends TestCase
             'value' => '0',
         ]);
         $expected = [
-            ['div' => ['class' => 'input radio']],
+            ['div' => ['class' => 'input']],
                 '<label',
                 'Test',
                 '/label',
@@ -4835,7 +4835,7 @@ class FormHelperTest extends TestCase
             'label' => false,
         ]);
         $expected = [
-            ['div' => ['class' => 'input radio']],
+            ['div' => ['class' => 'input']],
                 ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '', 'id' => 'test']],
                 ['label' => ['for' => 'test-0']],
                     ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
@@ -4858,7 +4858,7 @@ class FormHelperTest extends TestCase
             'label' => false,
         ]);
         $expected = [
-            ['div' => ['class' => 'input radio']],
+            ['div' => ['class' => 'input']],
                 ['input' => ['type' => 'hidden', 'name' => 'accept', 'value' => '', 'id' => 'accept']],
                 ['label' => ['for' => 'accept-1']],
                 ['input' => [
@@ -4890,7 +4890,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($articlesTable->newEmptyEntity());
         $result = $this->Form->control('published', ['type' => 'radio', 'label' => false,]);
         $expected = [
-            ['div' => ['class' => 'input radio']],
+            ['div' => ['class' => 'input']],
                 'input' => ['type' => 'hidden', 'name' => 'published', 'value' => '', 'id' => 'published'],
                 ['label' => ['for' => 'published-y']],
                 ['input' => ['type' => 'radio', 'name' => 'published', 'value' => 'Y', 'id' => 'published-y']],
@@ -5312,7 +5312,7 @@ class FormHelperTest extends TestCase
             'hiddenField' => '1',
         ]);
         $expected = [
-            'div' => ['class' => 'input checkbox'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'user-get-spam'],
             ['input' => [
                 'type' => 'hidden', 'name' => 'User[get_spam]',
@@ -5334,7 +5334,7 @@ class FormHelperTest extends TestCase
             'hiddenField' => '',
         ]);
         $expected = [
-            'div' => ['class' => 'input checkbox'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'user-get-spam'],
             ['input' => [
                 'type' => 'hidden', 'name' => 'User[get_spam]',
@@ -5371,7 +5371,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($article);
         $result = $this->Form->control('tags._ids', ['options' => $options]);
         $expected = [
-            'div' => ['class' => 'input select'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'tags-ids'],
             'Tags',
             '/label',
@@ -5408,7 +5408,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($article);
         $result = $this->Form->control('tags._ids', ['options' => $options]);
         $expected = [
-            'div' => ['class' => 'input select'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'tags-ids'],
             'Tags',
             '/label',
@@ -5439,7 +5439,7 @@ class FormHelperTest extends TestCase
         $this->Form->create();
         $result = $this->Form->control('spacecraft._ids');
         $expected = [
-            'div' => ['class' => 'input select'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'spacecraft-ids'],
             'Spacecraft',
             '/label',
@@ -5481,7 +5481,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('spacecraft._ids');
 
         $expected = [
-            ['div' => ['class' => 'input select error']],
+            ['div' => ['class' => 'input']],
             'label' => ['for' => 'spacecraft-ids'],
             'Spacecraft',
             '/label',
@@ -5675,7 +5675,7 @@ class FormHelperTest extends TestCase
     /**
      * testSelectMultipleCheckboxSecurity method
      *
-     * Checks the security hash array generated for multiple-input checkbox elements.
+     * Checks the security hash array generated for multiple-input elements.
      */
     public function testSelectMultipleCheckboxSecurity(): void
     {
@@ -5755,7 +5755,7 @@ class FormHelperTest extends TestCase
             'multiple' => 'checkbox',
         ]);
         $expected = [
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
             ['label' => ['for' => 'model-multi-field']],
             'Multi Field',
             '/label',
@@ -5787,7 +5787,7 @@ class FormHelperTest extends TestCase
             'multiple' => 'checkbox',
         ]);
         $expected = [
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
             ['label' => ['for' => 'model-multi-field']],
             'Multi Field',
             '/label',
@@ -5919,7 +5919,7 @@ class FormHelperTest extends TestCase
             'options' => ['1', '2'],
         ]);
         $expected = [
-            ['div' => ['class' => 'input multicheckbox']],
+            ['div' => ['class' => 'input']],
             '<label',
             'Category',
             '/label',
@@ -6491,7 +6491,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($this->article);
         $result = $this->Form->control('title', ['label' => 'Title', 'placeholder' => 'Add title']);
         $expected = [
-            'div' => ['class' => 'input text required'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'title'],
             'Title',
             '/label',
@@ -6520,7 +6520,7 @@ class FormHelperTest extends TestCase
         $this->Form->create($this->article);
         $result = $this->Form->control('title', ['label' => false]);
         $expected = [
-            'div' => ['class' => 'input text required'],
+            'div' => ['class' => 'input'],
             'input' => [
                 'type' => 'text',
                 'required' => 'required',
@@ -6546,7 +6546,7 @@ class FormHelperTest extends TestCase
     /**
      * testTextArea method
      *
-     * Test generation of a textarea input.
+     * Test generation of aarea input.
      */
     public function testTextArea(): void
     {
@@ -6601,7 +6601,7 @@ class FormHelperTest extends TestCase
     /**
      * testTextAreaWithStupidCharacters method
      *
-     * Test text area with non-ascii characters.
+     * Test area with non-ascii characters.
      */
     public function testTextAreaWithStupidCharacters(): void
     {
@@ -6621,7 +6621,7 @@ class FormHelperTest extends TestCase
     /**
      * testTextAreaMaxLength method
      *
-     * Test textareas maxlength read from schema.
+     * Testareas maxlength read from schema.
      */
     public function testTextAreaMaxLength(): void
     {
@@ -6632,7 +6632,7 @@ class FormHelperTest extends TestCase
         ]);
         $result = $this->Form->control('other', ['type' => 'textarea']);
         $expected = [
-            'div' => ['class' => 'input textarea'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'other'],
             'Other',
             '/label',
@@ -6644,7 +6644,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('stuff', ['type' => 'textarea']);
         $expected = [
-            'div' => ['class' => 'input textarea'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'stuff'],
             'Stuff',
             '/label',
@@ -7699,7 +7699,7 @@ class FormHelperTest extends TestCase
             'val' => new DateTime('2019-09-27 02:52:43.123'),
         ]);
         $expected = [
-            'div' => ['class' => 'input datetime'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'created'],
             'Created',
             '/label',
@@ -7878,7 +7878,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('0.comments.1.comment');
         // phpcs:disable
         $expected = [
-            'div' => ['class' => 'input textarea'],
+            'div' => ['class' => 'input'],
                 'label' => ['for' => '0-comments-1-comment'],
                     'Comment',
                 '/label',
@@ -7896,7 +7896,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('0.comments.0.comment');
         // phpcs:disable
         $expected = [
-            'div' => ['class' => 'input textarea'],
+            'div' => ['class' => 'input'],
                 'label' => ['for' => '0-comments-0-comment'],
                     'Comment',
                 '/label',
@@ -7916,7 +7916,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('0.comments.0.comment');
         // phpcs:disable
         $expected = [
-            'div' => ['class' => 'input textarea error'],
+            'div' => ['class' => 'input'],
                 'label' => ['for' => '0-comments-0-comment'],
                     'Comment',
                 '/label',
@@ -7944,7 +7944,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('0.comments.1.comment');
         // phpcs:disable
         $expected = [
-            'div' => ['class' => 'input textarea required'],
+            'div' => ['class' => 'input'],
                 'label' => ['for' => '0-comments-1-comment'],
                     'Comment',
                 '/label',
@@ -8225,7 +8225,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('title');
         $expected = [
-            'div' => ['class' => 'input text required'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'title'],
             'Title',
             '/label',
@@ -8247,7 +8247,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('body');
         $expected = [
-            'div' => ['class' => 'input text'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'body'],
             'Body',
             '/label',
@@ -8277,7 +8277,7 @@ class FormHelperTest extends TestCase
         ]);
         $result = $this->Form->control('foo', ['type' => 'checkbox']);
         $expected = [
-            'div' => ['class' => 'input checkbox'],
+            'div' => ['class' => 'input'],
             ['input' => ['type' => 'hidden', 'name' => 'foo', 'value' => '0']],
             ['input' => ['type' => 'checkbox', 'name' => 'foo', 'id' => 'foo', 'value' => '1']],
             'label' => ['for' => 'foo'],
@@ -8289,7 +8289,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('foo', ['type' => 'checkbox', 'label' => false]);
         $expected = [
-            'div' => ['class' => 'input checkbox'],
+            'div' => ['class' => 'input'],
             ['input' => ['type' => 'hidden', 'name' => 'foo', 'value' => '0']],
             ['input' => ['type' => 'checkbox', 'name' => 'foo', 'id' => 'foo', 'value' => '1']],
             '/div',
@@ -8301,7 +8301,7 @@ class FormHelperTest extends TestCase
             'options' => ['Y' => 'Yes', 'N' => 'No'],
         ]);
         $expected = [
-            'div' => ['class' => 'input radio'],
+            'div' => ['class' => 'input'],
             ['input' => ['type' => 'hidden', 'name' => 'confirm', 'value' => '', 'id' => 'confirm']],
             ['input' => ['type' => 'radio', 'name' => 'confirm', 'id' => 'confirm-y', 'value' => 'Y']],
             ['label' => ['for' => 'confirm-y']],
@@ -8804,7 +8804,7 @@ class FormHelperTest extends TestCase
     {
         $result = $this->Form->control('foo', ['nestedInput' => true]);
         $expected = [
-            'div' => ['class' => 'input text'],
+            'div' => ['class' => 'input'],
             'label' => ['for' => 'foo'],
             ['input' => [
                 'type' => 'text',
@@ -8831,7 +8831,7 @@ class FormHelperTest extends TestCase
             'labelOptions' => false,
         ]);
         $expected = [
-            ['div' => ['class' => 'input radio']],
+            ['div' => ['class' => 'input']],
             '<label',
             'Test',
             '/label',
@@ -8853,7 +8853,7 @@ class FormHelperTest extends TestCase
             'labelOptions' => false,
         ]);
         $expected = [
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
             ['label' => ['for' => 'checkbox1']],
             'My checkboxes',
             '/label',
@@ -8885,7 +8885,7 @@ class FormHelperTest extends TestCase
             'labelOptions' => ['class' => 'custom-class'],
         ]);
         $expected = [
-            ['div' => ['class' => 'input radio']],
+            ['div' => ['class' => 'input']],
             '<label',
             'Test',
             '/label',
@@ -8909,7 +8909,7 @@ class FormHelperTest extends TestCase
             'labelOptions' => ['class' => 'custom-class'],
         ]);
         $expected = [
-            ['div' => ['class' => 'input radio']],
+            ['div' => ['class' => 'input']],
             '<label',
             'Test',
             '/label',
@@ -8933,7 +8933,7 @@ class FormHelperTest extends TestCase
             'labelOptions' => ['class' => ['custom-class', 'custom-class-array']],
         ]);
         $expected = [
-            ['div' => ['class' => 'input radio']],
+            ['div' => ['class' => 'input']],
             '<label',
             'Test',
             '/label',
@@ -8999,7 +8999,7 @@ class FormHelperTest extends TestCase
             'value' => ['1'],
         ]);
         $expected = [
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
             ['label' => ['for' => 'checkbox1']],
             'My checkboxes',
             '/label',
@@ -9049,7 +9049,7 @@ class FormHelperTest extends TestCase
             'value' => ['1'],
         ]);
         $expected = [
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
             ['label' => ['for' => 'checkbox1']],
             'My checkboxes',
             '/label',

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2714,7 +2714,7 @@ class PaginatorHelperTest extends TestCase
         $out = $this->Paginator->limitControl([1 => 1]);
         $expected = [
             ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
             ['label' => ['for' => 'limit']],
             'View',
             '/label',
@@ -2731,7 +2731,7 @@ class PaginatorHelperTest extends TestCase
         $out = $this->Paginator->limitControl([1 => 1, 5 => 5], null, ['class' => 'form-control']);
         $expected = [
             ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
             ['label' => ['for' => 'limit']],
             'View',
             '/label',
@@ -2751,7 +2751,7 @@ class PaginatorHelperTest extends TestCase
         $out = $this->Paginator->limitControl([], null, ['class' => 'form-control']);
         $expected = [
             ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
             ['label' => ['for' => 'limit']],
             'View',
             '/label',
@@ -2774,7 +2774,7 @@ class PaginatorHelperTest extends TestCase
         $out = $this->Paginator->limitControl();
         $expected = [
             ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
             ['label' => ['for' => 'limit']],
             'View',
             '/label',
@@ -2818,7 +2818,7 @@ class PaginatorHelperTest extends TestCase
         $out = $this->Paginator->limitControl([1 => 1]);
         $expected = [
             ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/batches?owner=billy&amp;expected=1&amp;page=1']],
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
             ['label' => ['for' => 'limit']],
             'View',
             '/label',
@@ -2841,7 +2841,7 @@ class PaginatorHelperTest extends TestCase
         $out = $this->Paginator->limitControl([], 50);
         $expected = [
             ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
             ['label' => ['for' => 'limit']],
             'View',
             '/label',
@@ -2865,7 +2865,7 @@ class PaginatorHelperTest extends TestCase
         $out = $this->Paginator->limitControl([], 50);
         $expected = [
             ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
             ['label' => ['for' => 'limit']],
             'View',
             '/label',
@@ -2917,7 +2917,7 @@ class PaginatorHelperTest extends TestCase
         $out = $this->Paginator->limitControl([25 => 25, 50 => 50]);
         $expected = [
             ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/?article%5Bpage%5D=1']],
-            ['div' => ['class' => 'input select']],
+            ['div' => ['class' => 'input']],
             ['label' => ['for' => 'article-limit']],
             'View',
             '/label',


### PR DESCRIPTION
- The template no longer adds classes based on input type, nor the "required" class.
- The `requiredClass` template can be specified to add a class to the container if its input is required.
- `inputContainerError` is now optional. By default `inputContainer` is used even when a field has error(s).

Closes #18159

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
