### PR TITLE
Add Driver::quote()

### DIFF
--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -750,6 +750,25 @@ abstract class Driver
     }
 
     /**
+     * Quotes a database value.
+     *
+     * This makes values safe for concatenation in SQL queries.
+     *
+     * Using this method **is not** recommended. You should use `execute()`
+     * instead, as it uses prepared statements which are safer than
+     * string concatenation.
+     *
+     * This method should only be used for queries that do not support placeholders.
+     *
+     * @param string $identifier The identifier to quote.
+     * @return string
+     */
+    public function quote(string $value): string
+    {
+        return $this->getPdo()->quote($value);
+    }
+
+    /**
      * Get identifier quoter instance.
      *
      * @return \Cake\Database\IdentifierQuoter

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -760,7 +760,7 @@ abstract class Driver
      *
      * This method should only be used for queries that do not support placeholders.
      *
-     * @param string $identifier The identifier to quote.
+     * @param string $value The value to quote.
      * @return string
      */
     public function quote(string $value): string

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -347,4 +347,33 @@ class MysqlTest extends TestCase
         $expected = '`Model`.`näme Datum` AS `y`';
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * Tests value quoting
+     */
+    public function testQuote(): void
+    {
+        $driver = ConnectionManager::get('test')->getDriver();
+        $this->skipIf(!$driver instanceof Mysql);
+
+        $result = $driver->quote('name');
+        $expected = "'name'";
+        $this->assertEquals($expected, $result);
+
+        $result = $driver->quote('Model.*');
+        $expected = "'Model.*'";
+        $this->assertEquals($expected, $result);
+
+        $result = $driver->quote("O'hare");
+        $expected = "'O\\'hare'";
+        $this->assertEquals($expected, $result);
+
+        $result = $driver->quote("O''hare");
+        $expected = "'O\\'\\'hare'";
+        $this->assertEquals($expected, $result);
+
+        $result = $driver->quote("O\slash");
+        $expected = "'O\\\\slash'";
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -237,4 +237,33 @@ class PostgresTest extends TestCase
 
         $this->assertFalse($driver->supports(DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));
     }
+
+    /**
+     * Tests value quoting
+     */
+    public function testQuote(): void
+    {
+        $driver = ConnectionManager::get('test')->getDriver();
+        $this->skipIf(!$driver instanceof Postgres);
+
+        $result = $driver->quote('name');
+        $expected = "'name'";
+        $this->assertEquals($expected, $result);
+
+        $result = $driver->quote('Model.*');
+        $expected = "'Model.*'";
+        $this->assertEquals($expected, $result);
+
+        $result = $driver->quote("O'hare");
+        $expected = "'O''hare'";
+        $this->assertEquals($expected, $result);
+
+        $result = $driver->quote("O''hare");
+        $expected = "'O''''hare'";
+        $this->assertEquals($expected, $result);
+
+        $result = $driver->quote("O\slash");
+        $expected = "'O\slash'";
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -350,4 +350,32 @@ class SqliteTest extends TestCase
         $expected = '"Model"."näme Datum" AS "y"';
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * Tests value quoting
+     */
+    public function testQuote(): void
+    {
+        $driver = new Sqlite();
+
+        $result = $driver->quote('name');
+        $expected = "'name'";
+        $this->assertEquals($expected, $result);
+
+        $result = $driver->quote('Model.*');
+        $expected = "'Model.*'";
+        $this->assertEquals($expected, $result);
+
+        $result = $driver->quote("O'hare");
+        $expected = "'O''hare'";
+        $this->assertEquals($expected, $result);
+
+        $result = $driver->quote("O''hare");
+        $expected = "'O''''hare'";
+        $this->assertEquals($expected, $result);
+
+        $result = $driver->quote("O\slash");
+        $expected = "'O\slash'";
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -356,6 +356,7 @@ class SqliteTest extends TestCase
      */
     public function testQuote(): void
     {
+        $this->skipIf(!extension_loaded('pdo_sqlite'), 'Skipping as SQLite extension is missing');
         $driver = new Sqlite();
 
         $result = $driver->quote('name');


### PR DESCRIPTION
We need this method in migrations to properly escape values when building DDL statements. DDL statements often cannot be prepared and must use string concatenation.

https://github.com/cakephp/migrations/blob/1861eec639076cc9677daf8c465b8c2bcb5cf925/src/Db/Adapter/PdoAdapter.php#L434-L442

Is the current workaround in migrations for this. `quoteString` shows up a few times within the migrations codebase. `quoteValue` also has a few hits https://github.com/search?q=repo%3Acakephp/migrations%20quoteValue&type=code