### PR TITLE
Optimize/cleanup marshaller code.

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -594,32 +594,9 @@ class Marshaller
                 }
                 continue;
             }
-            $original = $this->fieldValue($entity, $key);
 
             if (isset($propertyMap[$key])) {
                 $value = $propertyMap[$key]($value, $entity);
-
-                // Don't dirty scalar values and objects that didn't
-                // change. Arrays will always be marked as dirty because
-                // the original/updated list could contain references to the
-                // same objects, even though those objects may have changed internally.
-                if (
-                    (
-                        is_scalar($value)
-                        && $original === $value
-                    )
-                    || (
-                        $value === null
-                        && $original === $value
-                    )
-                    || (
-                        is_object($value)
-                        && !($value instanceof EntityInterface)
-                        && $original == $value
-                    )
-                ) {
-                    continue;
-                }
             }
             $properties[$key] = $value;
         }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -791,9 +791,10 @@ class EntityTest extends TestCase
         $this->assertFalse($entity->isDirty('title'));
 
         $entity->set('title', 'Foo');
-        $this->assertTrue($entity->isDirty('title'));
+        // Not dirty as the value set is the same as the existing value
+        $this->assertFalse($entity->isDirty('title'));
 
-        $entity->set('title', 'Foo');
+        $entity->set('title', 'Bar');
         $this->assertTrue($entity->isDirty('title'));
 
         $entity->set('something', 'else');


### PR DESCRIPTION
Now `Entity::set()` itself compares the new and existing value to avoid setting a field as dirty.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
