### PR TITLE
Start moving new schema reflection down 

### DIFF
--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -196,6 +196,7 @@ abstract class SchemaDialect
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array An array of (sql, params) to execute.
+     * @deprecated 5.2.0 Use `listTables()` instead.
      */
     abstract public function listTablesSql(array $config): array;
 
@@ -205,6 +206,7 @@ abstract class SchemaDialect
      * @param string $tableName The table name to get information on.
      * @param array<string, mixed> $config The connection configuration.
      * @return array An array of (sql, params) to execute.
+     * @deprecated 5.2.0 Use `describeColumns()` instead.
      */
     abstract public function describeColumnSql(string $tableName, array $config): array;
 
@@ -214,6 +216,7 @@ abstract class SchemaDialect
      * @param string $tableName The table name to get information on.
      * @param array<string, mixed> $config The connection configuration.
      * @return array An array of (sql, params) to execute.
+     * @deprecated 5.2.0 Use `describeIndexes()` instead.
      */
     abstract public function describeIndexSql(string $tableName, array $config): array;
 
@@ -223,6 +226,7 @@ abstract class SchemaDialect
      * @param string $tableName The table name to get information on.
      * @param array<string, mixed> $config The connection configuration.
      * @return array An array of (sql, params) to execute.
+     * @deprecated 5.2.0 Use `describeForeignKeys()` instead.
      */
     abstract public function describeForeignKeySql(string $tableName, array $config): array;
 
@@ -232,6 +236,7 @@ abstract class SchemaDialect
      * @param string $tableName Table name.
      * @param array<string, mixed> $config The connection configuration.
      * @return array SQL statements to get options for a table.
+     * @deprecated 5.2.0 Use `describeOptions()` instead.
      */
     public function describeOptionsSql(string $tableName, array $config): array
     {
@@ -244,6 +249,7 @@ abstract class SchemaDialect
      * @param \Cake\Database\Schema\TableSchema $schema The table object to append fields to.
      * @param array $row The row data from `describeColumnSql`.
      * @return void
+     * @deprecated 5.2.0 Use `describeColumns()` instead.
      */
     abstract public function convertColumnDescription(TableSchema $schema, array $row): void;
 
@@ -254,6 +260,7 @@ abstract class SchemaDialect
      *    an index or constraint to.
      * @param array $row The row data from `describeIndexSql`.
      * @return void
+     * @deprecated 5.2.0 Use `describeIndexes()` instead.
      */
     abstract public function convertIndexDescription(TableSchema $schema, array $row): void;
 
@@ -264,6 +271,7 @@ abstract class SchemaDialect
      *    a constraint to.
      * @param array $row The row data from `describeForeignKeySql`.
      * @return void
+     * @deprecated 5.2.0 Use `describeForeignKeys()` instead.
      */
     abstract public function convertForeignKeyDescription(TableSchema $schema, array $row): void;
 
@@ -273,6 +281,7 @@ abstract class SchemaDialect
      * @param \Cake\Database\Schema\TableSchema $schema Table instance.
      * @param array $row The row of data.
      * @return void
+     * @deprecated 5.2.0 Use `describeOptions()` instead.
      */
     public function convertOptionsDescription(TableSchema $schema, array $row): void
     {
@@ -523,7 +532,7 @@ abstract class SchemaDialect
      * Each item in the array will contain the following:
      *
      * - name : the name of the index.
-     * - type : the type of the index. One of `unique`, `index`
+     * - type : the type of the index. One of `unique`, `index`, `primary`.
      * - columns : the columns in the index.
      * - length : the length of the index if applicable.
      *

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -261,7 +261,7 @@ class SqliteSchemaDialect extends SchemaDialect
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function describeColumns(string $tableName): array
     {

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -27,8 +27,6 @@ use Cake\TestSuite\TestCase;
 use PDO;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-use function Cake\Collection\collection;
-
 /**
  * Test case for Sqlite Schema Dialect.
  */

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -27,6 +27,8 @@ use Cake\TestSuite\TestCase;
 use PDO;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+use function Cake\Collection\collection;
+
 /**
  * Test case for Sqlite Schema Dialect.
  */
@@ -543,8 +545,16 @@ SQL;
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
 
-        $schema = new SchemaCollection($connection);
-        $result = $schema->describe('schema_articles');
+        $dialect = $connection->getDriver()->schemaDialect();
+        $result = $dialect->describe('schema_articles');
+
+        // Includes unique keys.
+        $indexes = $dialect->describeIndexes('schema_articles');
+        $this->assertCount(3, $indexes);
+
+        $foreignKeys = $dialect->describeForeignKeys('schema_articles');
+        $this->assertCount(1, $foreignKeys);
+
         $this->assertInstanceOf(TableSchema::class, $result);
         $expected = [
             'primary' => [
@@ -576,14 +586,26 @@ SQL;
         $this->assertCount(4, $result->constraints());
         $this->assertEquals($expected['primary'], $result->getConstraint('primary'));
         $this->assertEquals(
-            $expected['title_idx'],
-            $result->getConstraint('title_idx'),
-        );
-        $this->assertEquals(
             $expected['author_id_0_fk'],
             $result->getConstraint('author_id_0_fk'),
         );
+
+        $authorIdFk = $foreignKeys[0];
+        $expectedAuthorIdFk = $expected['author_id_0_fk'];
+        $this->assertEquals('author_id_0_fk', $authorIdFk['name']);
+
+        unset($authorIdFk['name']);
+        $this->assertEquals($expectedAuthorIdFk, $authorIdFk);
+
+        $this->assertEquals(
+            $expected['title_idx'],
+            $result->getConstraint('title_idx'),
+        );
+
         $this->assertEquals($expected['unique_id_idx'], $result->getConstraint('unique_id_idx'));
+        // Compare with describeIndexes result
+        $uniqueIdIdx = $indexes[0];
+        $this->assertEquals($expected['unique_id_idx'] + ['name' => 'unique_id_idx'], $uniqueIdIdx);
 
         $this->assertCount(1, $result->indexes());
         $expected = [
@@ -592,6 +614,11 @@ SQL;
             'length' => [],
         ];
         $this->assertEquals($expected, $result->getIndex('created_idx'));
+
+        // Compare with describeIndexes result
+        $createdIdx = $indexes[1];
+        $expected['name'] = 'created_idx';
+        $this->assertEquals($expected, $createdIdx);
 
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('schema_no_rowid_pk');
@@ -658,11 +685,19 @@ SQL;
                 'length' => [],
             ],
         ];
-        foreach ($expected as $name => $constraint) {
-            $this->assertSame($constraint, $result->getConstraint($name));
-        }
         $this->assertCount(7, $result->constraints());
 
+        // Because all our 'constraints' are unique indexes
+        // they are treated as indexes by the basic reflection API
+        $indexes = $dialect->describeIndexes('schema_unique_constraint_variations');
+        $this->assertCount(6, $indexes);
+        foreach ($indexes as $index) {
+            $expectedIndex = $expected[$index['name']];
+            unset($index['name']);
+            $this->assertEquals($expectedIndex, $index);
+        }
+
+        // No indexes in the TableSchema API
         $this->assertEmpty($result->indexes());
     }
 
@@ -674,8 +709,9 @@ SQL;
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
 
-        $schema = new SchemaCollection($connection);
-        $result = $schema->describe('schema_foreign_key_variations');
+        /** @var \Cake\Database\Schema\SqliteSchemaDialect  $dialect */
+        $dialect = $connection->getDriver()->schemaDialect();
+        $result = $dialect->describe('schema_foreign_key_variations');
         $this->assertInstanceOf(TableSchema::class, $result);
 
         $expected = [
@@ -718,6 +754,120 @@ SQL;
             $this->assertSame($constraint, $result->getConstraint($name));
         }
         $this->assertCount(3, $result->constraints());
+
+        $foreignKeys = $dialect->describeForeignKeys('schema_foreign_key_variations');
+        $this->assertCount(2, $foreignKeys);
+        foreach ($foreignKeys as $foreignKey) {
+            $expectedForeignKey = $expected[$foreignKey['name']];
+            unset($foreignKey['name']);
+            $this->assertEquals($expectedForeignKey, $foreignKey);
+        }
+    }
+
+    public function testDescribeColumns(): void
+    {
+        $connection = ConnectionManager::get('test');
+        $this->_createTables($connection);
+        /** @var \Cake\Database\Schema\SqliteSchemaDialect  $dialect */
+        $dialect = $connection->getDriver()->schemaDialect();
+
+        $result = $dialect->describeColumns('schema_articles');
+        $expected = [
+            [
+                'name' => 'id',
+                'type' => 'integer',
+                'null' => false,
+                'default' => null,
+                'length' => null,
+                'comment' => null,
+                'unsigned' => false,
+                'autoIncrement' => true,
+            ],
+            [
+                'name' => 'title',
+                'type' => 'string',
+                'null' => true,
+                'default' => "Let 'em eat cake",
+                'length' => 20,
+                'comment' => null,
+            ],
+            [
+                'name' => 'body',
+                'type' => 'text',
+                'null' => true,
+                'default' => null,
+                'length' => null,
+                'comment' => null,
+            ],
+            [
+                'name' => 'author_id',
+                'type' => 'integer',
+                'null' => false,
+                'default' => null,
+                'length' => 11,
+                'unsigned' => false,
+                'comment' => null,
+            ],
+            [
+                'name' => 'unique_id',
+                'type' => 'integer',
+                'null' => false,
+                'default' => null,
+                'length' => 11,
+                'unsigned' => false,
+                'comment' => null,
+            ],
+            [
+                'name' => 'published',
+                'type' => 'boolean',
+                'null' => true,
+                'default' => 0,
+                'length' => null,
+                'comment' => null,
+            ],
+            [
+                'name' => 'created',
+                'type' => 'datetime',
+                'null' => true,
+                'default' => null,
+                'length' => null,
+                'comment' => null,
+            ],
+            [
+                'name' => 'field1',
+                'type' => 'string',
+                'null' => true,
+                'default' => null,
+                'length' => 10,
+                'comment' => null,
+            ],
+            [
+                'name' => 'field2',
+                'type' => 'string',
+                'null' => true,
+                'default' => 'NULL',
+                'length' => 10,
+                'comment' => null,
+            ],
+            [
+                'name' => 'location',
+                'type' => 'point',
+                'null' => true,
+                'default' => null,
+                'length' => null,
+                'comment' => null,
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+
+        // Test overlap with TableSchema
+        $schema = $dialect->describe('schema_articles');
+        foreach ($expected as $field) {
+            $schemaField = $schema->getColumn($field['name']);
+            $schemaAttrs = array_intersect_key($schemaField, $field);
+            $expectedAttrs = array_intersect_key($field, $schemaAttrs);
+            $this->assertEquals($expectedAttrs, $schemaAttrs);
+        }
     }
 
     /**


### PR DESCRIPTION
I find the interplay between the `describeXyzSql` and `convertXyzDescription` methods a poor public interface. Instead I'd like to push down the new array reflection APIs to each driver and colocate the query and processing logic into fewer methods. We can deprecated the existing methods, and end up with a simpler API that shares array keys with `TableSchema`.

This converts the Sqlite driver to this approach and I'll do other drivers one by one. Once all the drivers are complete, the methods in `SchemaDialect` could be removed and added as annotations. Ideally these methods would be added as abstract methods but that isn't backwards compatible.