### PR TITLE
Don't overwrite content body when request data is empty

### DIFF
--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -55,7 +55,6 @@ class Request extends Message implements RequestInterface
             'User-Agent' => ini_get('user_agent') ?: 'CakePHP',
         ];
         $this->addHeaders($headers);
-
         if ($data === null) {
             $this->stream = new Stream('php://memory', 'rw');
         } else {
@@ -101,9 +100,11 @@ class Request extends Message implements RequestInterface
             } else {
                 $formData = new FormData();
                 $formData->addMany($content);
-                /** @phpstan-var array<non-empty-string, non-empty-string> $headers */
-                $headers = ['Content-Type' => $formData->contentType()];
-                $this->addHeaders($headers);
+                if ($formData->count()) {
+                    /** @phpstan-var array<non-empty-string, non-empty-string> $headers */
+                    $headers = ['Content-Type' => $formData->contentType()];
+                    $this->addHeaders($headers);
+                }
                 $content = (string)$formData;
             }
         }

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -55,7 +55,7 @@ class Request extends Message implements RequestInterface
             'User-Agent' => ini_get('user_agent') ?: 'CakePHP',
         ];
         $this->addHeaders($headers);
-        if ($data === null) {
+        if ($data === null || $data === '' || $data === []) {
             $this->stream = new Stream('php://memory', 'rw');
         } else {
             $this->setContent($data);
@@ -100,11 +100,10 @@ class Request extends Message implements RequestInterface
             } else {
                 $formData = new FormData();
                 $formData->addMany($content);
-                if ($formData->count()) {
-                    /** @phpstan-var array<non-empty-string, non-empty-string> $headers */
-                    $headers = ['Content-Type' => $formData->contentType()];
-                    $this->addHeaders($headers);
-                }
+
+                /** @phpstan-var array<non-empty-string, non-empty-string> $headers */
+                $headers = ['Content-Type' => $formData->contentType()];
+                $this->addHeaders($headers);
                 $content = (string)$formData;
             }
         }

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -542,6 +542,40 @@ class ClientTest extends TestCase
         $http->post('/projects/add', $data, ['type' => $type]);
     }
 
+    public function testPostWithContentType(): void
+    {
+        $response = new Response();
+        $headers = [
+            'Content-Type' => 'application/octet-stream',
+        ];
+
+        $mock = $this->getMockBuilder(Stream::class)
+            ->onlyMethods(['send'])
+            ->getMock();
+        $mock->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function ($request) use ($headers) {
+                $this->assertSame(Request::METHOD_POST, $request->getMethod());
+                $this->assertEquals($headers['Content-Type'], $request->getHeaderLine('Content-Type'));
+
+                return true;
+            }))
+            ->willReturn([$response]);
+
+        $http = new Client([
+            'adapter' => $mock,
+        ]);
+        $http->post(
+            'https://example.org/2/files/upload',
+            [],
+            [
+                'headers' => [
+                    'Content-Type' => 'application/octet-stream',
+                ],
+            ]
+        );
+    }
+
     /**
      * Test that string payloads with no content type have a default content-type set.
      */

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -557,6 +557,7 @@ class ClientTest extends TestCase
             ->with($this->callback(function ($request) use ($headers) {
                 $this->assertSame(Request::METHOD_POST, $request->getMethod());
                 $this->assertEquals($headers['Content-Type'], $request->getHeaderLine('Content-Type'));
+                $this->assertEquals('', (string)$request->getBody());
 
                 return true;
             }))
@@ -568,6 +569,41 @@ class ClientTest extends TestCase
         $http->post(
             'https://example.org/2/files/upload',
             [],
+            [
+                'headers' => [
+                    'Content-Type' => 'application/octet-stream',
+                ],
+            ]
+        );
+    }
+
+    public function testPostWithZero(): void
+    {
+        $response = new Response();
+        $headers = [
+            'Content-Type' => 'application/octet-stream',
+        ];
+
+        $mock = $this->getMockBuilder(Stream::class)
+            ->onlyMethods(['send'])
+            ->getMock();
+        $mock->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function ($request) use ($headers) {
+                $this->assertSame(Request::METHOD_POST, $request->getMethod());
+                $this->assertEquals($headers['Content-Type'], $request->getHeaderLine('Content-Type'));
+                $this->assertEquals('0', (string)$request->getBody());
+
+                return true;
+            }))
+            ->willReturn([$response]);
+
+        $http = new Client([
+            'adapter' => $mock,
+        ]);
+        $http->post(
+            'https://example.org/2/files/upload',
+            '0',
             [
                 'headers' => [
                     'Content-Type' => 'application/octet-stream',


### PR DESCRIPTION
We should only overwrite the request content-type if the request body has form encoded data.

Fixes #18181