### PR TITLE
Don't make EntityInterface extend Stringable.

### DIFF
--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -18,7 +18,6 @@ namespace Cake\Datasource;
 
 use ArrayAccess;
 use JsonSerializable;
-use Stringable;
 
 /**
  * Describes the methods that any class representing a data storage should
@@ -28,7 +27,7 @@ use Stringable;
  * @template-extends \ArrayAccess<string, mixed>
  * @method bool hasValue(string $field)
  */
-interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
+interface EntityInterface extends ArrayAccess, JsonSerializable
 {
     /**
      * Sets hidden fields.

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -1387,16 +1387,6 @@ trait EntityTrait
     }
 
     /**
-     * Returns a string representation of this object in a human readable format.
-     *
-     * @return string
-     */
-    public function __toString(): string
-    {
-        return (string)json_encode($this, JSON_PRETTY_PRINT);
-    }
-
-    /**
      * Returns an array that can be used to describe the internal state of this
      * object.
      *

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -258,7 +258,6 @@ class HasMany extends Association
      * When using this method, all entities in `$targetEntities` will be appended to
      * the source entity's property corresponding to this association object.
      *
-     * This method does not check link uniqueness.
      * Changes are persisted in the database and also in the source entity.
      *
      * ### Example:
@@ -284,12 +283,32 @@ class HasMany extends Association
         $this->setSaveStrategy(self::SAVE_APPEND);
         $property = $this->getProperty();
 
-        $currentEntities = array_unique(
-            array_merge(
-                (array)$sourceEntity->get($property),
-                $targetEntities,
-            ),
-        );
+        $currentEntities = (array)$sourceEntity->get($property);
+
+        if ($currentEntities === []) {
+            $currentEntities = $targetEntities;
+        } else {
+            $pkFields = (array)$this->getTarget()->getPrimaryKey();
+            $targetEntities = (new Collection($targetEntities))
+                ->reject(
+                    function (EntityInterface $entity) use ($currentEntities, $pkFields) {
+                        if ($entity->isNew()) {
+                            return false;
+                        }
+
+                        foreach ($currentEntities as $cEntity) {
+                            if ($entity->extract($pkFields) === $cEntity->extract($pkFields)) {
+                                return true;
+                            }
+                        }
+
+                        return false;
+                    },
+                )
+                ->toList();
+
+            $currentEntities = array_merge($currentEntities, $targetEntities);
+        }
 
         $sourceEntity->set($property, $currentEntities);
 

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -18,7 +18,6 @@ namespace Cake\Test\TestCase\Core;
 
 use Cake\Core\Configure;
 use Cake\Http\Response;
-use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
@@ -449,7 +448,6 @@ class FunctionsTest extends TestCase
             '(other) int-array' => [[5], null],
             '(other) string-array' => [['5'], null],
             '(other) simple object' => [new stdClass(), null],
-            '(other) Stringable object' => [new Entity(), '[]'],
         ];
     }
 

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1445,15 +1445,6 @@ class EntityTest extends TestCase
     }
 
     /**
-     * Tests the entity's __toString method
-     */
-    public function testToString(): void
-    {
-        $entity = new Entity(['foo' => 1, 'bar' => 2]);
-        $this->assertEquals(json_encode($entity, JSON_PRETTY_PRINT), (string)$entity);
-    }
-
-    /**
      * Tests __debugInfo
      */
     public function testDebugInfo(): void


### PR DESCRIPTION
Strigifying an entity doesn't really make sense, it's already JSON serializable.

Update HasMany::link() to check the primary key fields only instead of implicit string conversion to check for entity list uniqueness.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
