### PR TITLE
Schemadialect cleanup

### DIFF
--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -213,7 +213,7 @@ class MysqlSchemaDialect extends SchemaDialect
      */
     public function describeOptions(string $tableName): array
     {
-        $name = $this->splitTablename($tableName)[1];
+        [, $name] = $this->splitTablename($tableName);
         $sql = 'SHOW TABLE STATUS WHERE Name = ?';
         $statement = $this->_driver->execute($sql, [$name]);
         $row = $statement->fetch('assoc');

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -18,6 +18,7 @@ namespace Cake\Database\Schema;
 
 use Cake\Database\DriverFeatureEnum;
 use Cake\Database\Exception\DatabaseException;
+use PDOException;
 
 /**
  * Schema generation/reflection features for MySQL
@@ -85,13 +86,18 @@ class MysqlSchemaDialect extends SchemaDialect
         }
         $sql = $this->describeColumnQuery($tableName);
         $columns = [];
-        $statement = $this->_driver->execute($sql);
+        try {
+            $statement = $this->_driver->execute($sql);
+        } catch (PDOException $e) {
+            throw new DatabaseException("Could not describe columns on `{$tableName}`", null, $e);
+        }
         foreach ($statement->fetchAll('assoc') as $row) {
             $field = $this->_convertColumn($row['Type']);
             $field += [
                 'name' => $row['Field'],
                 'null' => $row['Null'] === 'YES',
                 'default' => $row['Default'],
+                'collate' => $row['Collation'],
                 'comment' => $row['Comment'],
                 'length' => null,
             ];
@@ -160,8 +166,10 @@ class MysqlSchemaDialect extends SchemaDialect
                     'length' => [],
                 ];
             }
-
-            $indexes[$name]['columns'][] = $row['Column_name'];
+            // conditional indexes can have null columns
+            if ($row['Column_name'] !== null) {
+                $indexes[$name]['columns'][] = $row['Column_name'];
+            }
             if (!empty($row['Sub_part'])) {
                 $indexes[$name]['length'][$row['Column_name']] = $row['Sub_part'];
             }

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -213,7 +213,7 @@ class MysqlSchemaDialect extends SchemaDialect
      */
     public function describeOptions(string $tableName): array
     {
-        [$_, $name] = $this->splitTablename($tableName);
+        $name = $this->splitTablename($tableName)[1];
         $sql = 'SHOW TABLE STATUS WHERE Name = ?';
         $statement = $this->_driver->execute($sql, [$name]);
         $row = $statement->fetch('assoc');

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -76,14 +76,29 @@ class MysqlSchemaDialect extends SchemaDialect
     }
 
     /**
+     * Split a tablename into a tuple of database, table
+     * If the table does not have a database name included, the connection
+     * database will be used.
+     *
+     * @param string $tableName The table name to split
+     * @return array A tuple of [database, tablename]
+     */
+    private function splitTablename(string $tableName): array
+    {
+        $config = $this->_driver->config();
+        $db = $config['database'];
+        if (str_contains($tableName, '.')) {
+            return explode('.', $tableName);
+        }
+
+        return [$db, $tableName];
+    }
+
+    /**
      * @inheritDoc
      */
     public function describeColumns(string $tableName): array
     {
-        $config = $this->_driver->config();
-        if (str_contains($tableName, '.')) {
-            [$config['database'], $tableName] = explode('.', $tableName);
-        }
         $sql = $this->describeColumnQuery($tableName);
         $columns = [];
         try {
@@ -136,10 +151,6 @@ class MysqlSchemaDialect extends SchemaDialect
      */
     public function describeIndexes(string $tableName): array
     {
-        $config = $this->_driver->config();
-        if (str_contains($tableName, '.')) {
-            [$config['database'], $tableName] = explode('.', $tableName);
-        }
         $sql = $this->describeIndexQuery($tableName);
         $statement = $this->_driver->execute($sql);
         $indexes = [];
@@ -202,12 +213,9 @@ class MysqlSchemaDialect extends SchemaDialect
      */
     public function describeOptions(string $tableName): array
     {
-        $config = $this->_driver->config();
-        if (str_contains($tableName, '.')) {
-            [$config['database'], $tableName] = explode('.', $tableName);
-        }
+        [$_, $name] = $this->splitTablename($tableName);
         $sql = 'SHOW TABLE STATUS WHERE Name = ?';
-        $statement = $this->_driver->execute($sql, [$tableName]);
+        $statement = $this->_driver->execute($sql, [$name]);
         $row = $statement->fetch('assoc');
 
         return [
@@ -457,11 +465,7 @@ class MysqlSchemaDialect extends SchemaDialect
      */
     public function describeForeignKeys(string $tableName): array
     {
-        $config = $this->_driver->config();
-        if (str_contains($tableName, '.')) {
-            [$config['database'], $tableName] = explode('.', $tableName);
-        }
-
+        [$database, $name] = $this->splitTablename($tableName);
         $sql = 'SELECT * FROM information_schema.key_column_usage AS kcu
             INNER JOIN information_schema.referential_constraints AS rc
             ON (
@@ -470,8 +474,7 @@ class MysqlSchemaDialect extends SchemaDialect
             )
             WHERE kcu.TABLE_SCHEMA = ? AND kcu.TABLE_NAME = ? AND rc.TABLE_NAME = ?
             ORDER BY kcu.ORDINAL_POSITION ASC';
-        $params = [$config['database'], $tableName, $tableName];
-        $statement = $this->_driver->execute($sql, $params);
+        $statement = $this->_driver->execute($sql, [$database, $name, $name]);
         $keys = [];
         foreach ($statement->fetchAll('assoc') as $row) {
             $name = $row['CONSTRAINT_NAME'];

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -250,15 +250,34 @@ class PostgresSchemaDialect extends SchemaDialect
     }
 
     /**
+     * Split a tablename into a tuple of schema, table
+     * If the table does not have a schema name included, the connection
+     * schema will be used.
+     *
+     * @param string $tableName The table name to split
+     * @return array A tuple of [schema, tablename]
+     */
+    protected function splitTablename(string $tableName): array
+    {
+        $config = $this->_driver->config();
+        $schema = $config['schema'] ?? 'public';
+        if (str_contains($tableName, '.')) {
+            return explode('.', $tableName);
+        }
+
+        return [$schema, $tableName];
+    }
+
+    /**
      * @inheritDoc
      */
     public function describeColumns(string $tableName): array
     {
         $config = $this->_driver->config();
-        $schema = $config['schema'] ?? 'public';
+        [$schema, $name] = $this->splitTablename($tableName);
 
         $sql = $this->describeColumnQuery();
-        $statement = $this->_driver->execute($sql, [$tableName, $schema, $config['database']]);
+        $statement = $this->_driver->execute($sql, [$name, $schema, $config['database']]);
         $columns = [];
         foreach ($statement->fetchAll('assoc') as $row) {
             $field = $this->_convertColumn($row['type']);
@@ -364,9 +383,9 @@ class PostgresSchemaDialect extends SchemaDialect
     public function describeIndexSql(string $tableName, array $config): array
     {
         $sql = $this->describeIndexQuery();
-        $schema = $config['schema'] ?? 'public';
+        [$schema, $name] = $this->splitTablename($tableName);
 
-        return [$sql, [$schema, $tableName]];
+        return [$sql, [$schema, $name]];
     }
 
     /**
@@ -404,11 +423,11 @@ class PostgresSchemaDialect extends SchemaDialect
      */
     public function describeIndexes(string $tableName): array
     {
+        [$schema, $name] = $this->splitTablename($tableName);
         $sql = $this->describeIndexQuery();
-        $config = $this->_driver->config();
-        $schema = $config['schema'] ?? 'public';
+
         $indexes = [];
-        $statement = $this->_driver->execute($sql, [$schema, $tableName]);
+        $statement = $this->_driver->execute($sql, [$schema, $name]);
         foreach ($statement->fetchAll('assoc') as $row) {
             $type = TableSchema::INDEX_INDEX;
             $name = $row['relname'];
@@ -461,9 +480,9 @@ class PostgresSchemaDialect extends SchemaDialect
     public function describeForeignKeySql(string $tableName, array $config): array
     {
         $sql = $this->describeForeignKeyQuery();
-        $schema = $config['schema'] ?? 'public';
+        [$schema, $name] = $this->splitTablename($tableName);
 
-        return [$sql, [$schema, $tableName]];
+        return [$sql, [$schema, $name]];
     }
 
     /**
@@ -486,11 +505,10 @@ class PostgresSchemaDialect extends SchemaDialect
      */
     public function describeForeignKeys(string $tableName): array
     {
-        $config = $this->_driver->config();
-        $schema = $config['schema'] ?? 'public';
+        [$schema, $name] = $this->splitTablename($tableName);
         $sql = $this->describeForeignKeyQuery();
         $keys = [];
-        $statement = $this->_driver->execute($sql, [$schema, $tableName]);
+        $statement = $this->_driver->execute($sql, [$schema, $name]);
         foreach ($statement->fetchAll('assoc') as $row) {
             $name = $row['name'];
             if (!isset($keys[$name])) {

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -257,7 +257,7 @@ class PostgresSchemaDialect extends SchemaDialect
      * @param string $tableName The table name to split
      * @return array A tuple of [schema, tablename]
      */
-    protected function splitTablename(string $tableName): array
+    private function splitTablename(string $tableName): array
     {
         $config = $this->_driver->config();
         $schema = $config['schema'] ?? 'public';

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -23,8 +23,6 @@ use Cake\Database\Type\ColumnSchemaAwareInterface;
 use Cake\Database\TypeFactory;
 use InvalidArgumentException;
 use PDOException;
-use RuntimeException;
-
 use function Cake\Core\deprecationWarning;
 
 /**

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -400,10 +400,9 @@ abstract class SchemaDialect
      */
     public function describe(string $name): TableSchemaInterface
     {
-        $config = $this->_driver->config();
         $tableName = $name;
         if (str_contains($name, '.')) {
-            [$config['schema'], $tableName] = explode('.', $name);
+            [$_, $tableName] = explode('.', $name);
         }
         $table = $this->_driver->newTableSchema($tableName);
         foreach ($this->describeColumns($name) as $column) {

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -401,45 +401,33 @@ abstract class SchemaDialect
     public function describe(string $name): TableSchemaInterface
     {
         $config = $this->_driver->config();
+        $tableName = $name;
         if (str_contains($name, '.')) {
-            [$config['schema'], $name] = explode('.', $name);
+            [$config['schema'], $tableName] = explode('.', $name);
         }
         // This is kind of a lie, but the convert methods
         // would have a breaking change to change their parameter type.
         /** @var \Cake\Database\Schema\TableSchema $table */
-        $table = $this->_driver->newTableSchema($name);
-
-        [$sql, $params] = $this->describeColumnSql($name, $config);
-        try {
-            $statement = $this->_driver->execute($sql, $params);
-        } catch (PDOException $e) {
-            throw new DatabaseException($e->getMessage(), 500, $e);
+        $table = $this->_driver->newTableSchema($tableName);
+        foreach ($this->describeColumns($name) as $column) {
+            $table->addColumn($column['name'], $column);
         }
-        foreach ($statement->fetchAll('assoc') as $row) {
-            $this->convertColumnDescription($table, $row);
+        foreach ($this->describeIndexes($name) as $index) {
+            if (in_array($index['type'], [TableSchema::CONSTRAINT_UNIQUE, TableSchema::CONSTRAINT_PRIMARY])) {
+                $table->addConstraint($index['name'], $index);
+            } else {
+                $table->addIndex($index['name'], $index);
+            }
+        }
+        foreach ($this->describeForeignKeys($name) as $key) {
+            $table->addConstraint($key['name'], $key);
+        }
+        $options = $this->describeOptions($name);
+        if ($options) {
+            $table->setOptions($options);
         }
         if ($table->columns() === []) {
             throw new DatabaseException(sprintf('Cannot describe %s. It has 0 columns.', $name));
-        }
-
-        [$sql, $params] = $this->describeForeignKeySql($name, $config);
-        $statement = $this->_driver->execute($sql, $params);
-        foreach ($statement->fetchAll('assoc') as $row) {
-            $this->convertForeignKeyDescription($table, $row);
-        }
-
-        [$sql, $params] = $this->describeIndexSql($name, $config);
-        $statement = $this->_driver->execute($sql, $params);
-        foreach ($statement->fetchAll('assoc') as $row) {
-            $this->convertIndexDescription($table, $row);
-        }
-
-        [$sql, $params] = $this->describeOptionsSql($name, $config);
-        if ($sql) {
-            $statement = $this->_driver->execute($sql, $params);
-            foreach ($statement->fetchAll('assoc') as $row) {
-                $this->convertOptionsDescription($table, $row);
-            }
         }
 
         return $table;

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -503,7 +503,10 @@ abstract class SchemaDialect
      */
     public function describeOptions(string $tableName): array
     {
-        throw new RuntimeException(static::class . ' does not implement describeOptions(). This method will become abstract in the future.');
+        throw new RuntimeException(
+            static::class . ' does not implement describeOptions(). ' .
+            'This method will become abstract in the future.'
+        );
     }
 
     /**
@@ -517,7 +520,7 @@ abstract class SchemaDialect
     {
         try {
             $columns = $this->describeColumns($tableName);
-        } catch (QueryException) {
+        } catch (PDOException | DatabaseException) {
             return false;
         }
         foreach ($columns as $column) {

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -23,6 +23,7 @@ use Cake\Database\Type\ColumnSchemaAwareInterface;
 use Cake\Database\TypeFactory;
 use InvalidArgumentException;
 use PDOException;
+use RuntimeException;
 
 /**
  * Base class for schema implementations.
@@ -463,26 +464,7 @@ abstract class SchemaDialect
      */
     public function describeColumns(string $tableName): array
     {
-        $config = $this->_driver->config();
-        if (str_contains($tableName, '.')) {
-            [$config['schema'], $tableName] = explode('.', $tableName);
-        }
-        /** @var \Cake\Database\Schema\TableSchema $table */
-        $table = $this->_driver->newTableSchema($tableName);
-
-        [$sql, $params] = $this->describeColumnSql($tableName, $config);
-        $statement = $this->_driver->execute($sql, $params);
-        foreach ($statement->fetchAll('assoc') as $row) {
-            $this->convertColumnDescription($table, $row);
-        }
-        $columns = [];
-        foreach ($table->columns() as $columnName) {
-            $column = $table->getColumn($columnName);
-            $column['name'] = $columnName;
-            $columns[] = $column;
-        }
-
-        return $columns;
+        throw new RuntimeException(static::class . ' does not implement describeColumns(). This method will become abstract in the future.');
     }
 
     /**
@@ -502,30 +484,7 @@ abstract class SchemaDialect
      */
     public function describeForeignKeys(string $tableName): array
     {
-        $config = $this->_driver->config();
-        if (str_contains($tableName, '.')) {
-            [$config['schema'], $tableName] = explode('.', $tableName);
-        }
-        /** @var \Cake\Database\Schema\TableSchema $table */
-        $table = $this->_driver->newTableSchema($tableName);
-        // Add the columns because TableSchema needs them.
-        foreach ($this->describeColumns($tableName) as $column) {
-            $table->addColumn($column['name'], $column);
-        }
-
-        [$sql, $params] = $this->describeForeignKeySql($tableName, $config);
-        $statement = $this->_driver->execute($sql, $params);
-        foreach ($statement->fetchAll('assoc') as $row) {
-            $this->convertForeignKeyDescription($table, $row);
-        }
-        $keys = [];
-        foreach ($table->constraints() as $name) {
-            $key = $table->getConstraint($name);
-            $key['name'] = $name;
-            $keys[] = $key;
-        }
-
-        return $keys;
+        throw new RuntimeException(static::class . ' does not implement describeForeignKeys(). This method will become abstract in the future.');
     }
 
     /**
@@ -543,30 +502,7 @@ abstract class SchemaDialect
      */
     public function describeIndexes(string $tableName): array
     {
-        $config = $this->_driver->config();
-        if (str_contains($tableName, '.')) {
-            [$config['schema'], $tableName] = explode('.', $tableName);
-        }
-        /** @var \Cake\Database\Schema\TableSchema $table */
-        $table = $this->_driver->newTableSchema($tableName);
-        // Add the columns because TableSchema needs them.
-        foreach ($this->describeColumns($tableName) as $column) {
-            $table->addColumn($column['name'], $column);
-        }
-
-        [$sql, $params] = $this->describeIndexSql($tableName, $config);
-        $statement = $this->_driver->execute($sql, $params);
-        foreach ($statement->fetchAll('assoc') as $row) {
-            $this->convertIndexDescription($table, $row);
-        }
-        $indexes = [];
-        foreach ($table->indexes() as $name) {
-            $index = $table->getIndex($name);
-            $index['name'] = $name;
-            $indexes[] = $index;
-        }
-
-        return $indexes;
+        throw new RuntimeException(static::class . ' does not implement describeIndexes(). This method will become abstract in the future.');
     }
 
     /**
@@ -579,22 +515,7 @@ abstract class SchemaDialect
      */
     public function describeOptions(string $tableName): array
     {
-        $config = $this->_driver->config();
-        if (str_contains($tableName, '.')) {
-            [$config['schema'], $tableName] = explode('.', $tableName);
-        }
-        /** @var \Cake\Database\Schema\TableSchema $table */
-        $table = $this->_driver->newTableSchema($tableName);
-
-        [$sql, $params] = $this->describeOptionsSql($tableName, $config);
-        if ($sql) {
-            $statement = $this->_driver->execute($sql, $params);
-            foreach ($statement->fetchAll('assoc') as $row) {
-                $this->convertOptionsDescription($table, $row);
-            }
-        }
-
-        return $table->getOptions();
+        throw new RuntimeException(static::class . ' does not implement describeOptions(). This method will become abstract in the future.');
     }
 
     /**

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -405,9 +405,6 @@ abstract class SchemaDialect
         if (str_contains($name, '.')) {
             [$config['schema'], $tableName] = explode('.', $name);
         }
-        // This is kind of a lie, but the convert methods
-        // would have a breaking change to change their parameter type.
-        /** @var \Cake\Database\Schema\TableSchema $table */
         $table = $this->_driver->newTableSchema($tableName);
         foreach ($this->describeColumns($name) as $column) {
             $table->addColumn($column['name'], $column);

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -25,6 +25,8 @@ use InvalidArgumentException;
 use PDOException;
 use RuntimeException;
 
+use function Cake\Core\deprecationWarning;
+
 /**
  * Base class for schema implementations.
  *
@@ -448,6 +450,10 @@ abstract class SchemaDialect
      */
     public function describeColumns(string $tableName): array
     {
+        deprecationWarning(
+            '5.2.0',
+            'SchemaDialect subclasses need to implement `describeColumns` before 6.0.0',
+        );
         $config = $this->_driver->config();
         if (str_contains($tableName, '.')) {
             [$config['schema'], $tableName] = explode('.', $tableName);
@@ -487,6 +493,10 @@ abstract class SchemaDialect
      */
     public function describeForeignKeys(string $tableName): array
     {
+        deprecationWarning(
+            '5.2.0',
+            'SchemaDialect subclasses need to implement `describeForeignKeys` before 6.0.0',
+        );
         $config = $this->_driver->config();
         if (str_contains($tableName, '.')) {
             [$config['schema'], $tableName] = explode('.', $tableName);
@@ -528,6 +538,10 @@ abstract class SchemaDialect
      */
     public function describeIndexes(string $tableName): array
     {
+        deprecationWarning(
+            '5.2.0',
+            'SchemaDialect subclasses need to implement `describeIndexes` before 6.0.0',
+        );
         $config = $this->_driver->config();
         if (str_contains($tableName, '.')) {
             [$config['schema'], $tableName] = explode('.', $tableName);
@@ -564,6 +578,10 @@ abstract class SchemaDialect
      */
     public function describeOptions(string $tableName): array
     {
+        deprecationWarning(
+            '5.2.0',
+            'SchemaDialect subclasses need to implement `describeOptions` before 6.0.0',
+        );
         $config = $this->_driver->config();
         if (str_contains($tableName, '.')) {
             [$config['schema'], $tableName] = explode('.', $tableName);

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -402,7 +402,7 @@ abstract class SchemaDialect
     {
         $tableName = $name;
         if (str_contains($name, '.')) {
-            [$_, $tableName] = explode('.', $name);
+            $tableName = explode('.', $name)[1];
         }
         $table = $this->_driver->newTableSchema($tableName);
         foreach ($this->describeColumns($name) as $column) {
@@ -448,7 +448,10 @@ abstract class SchemaDialect
      */
     public function describeColumns(string $tableName): array
     {
-        throw new RuntimeException(static::class . ' does not implement describeColumns(). This method will become abstract in the future.');
+        throw new RuntimeException(
+            static::class . ' does not implement describeColumns(). ' .
+                'This method will become abstract in the future.'
+        );
     }
 
     /**
@@ -468,7 +471,10 @@ abstract class SchemaDialect
      */
     public function describeForeignKeys(string $tableName): array
     {
-        throw new RuntimeException(static::class . ' does not implement describeForeignKeys(). This method will become abstract in the future.');
+        throw new RuntimeException(
+            static::class . ' does not implement describeForeignKeys(). ' .
+                'This method will become abstract in the future.'
+        );
     }
 
     /**
@@ -486,7 +492,10 @@ abstract class SchemaDialect
      */
     public function describeIndexes(string $tableName): array
     {
-        throw new RuntimeException(static::class . ' does not implement describeIndexes(). This method will become abstract in the future.');
+        throw new RuntimeException(
+            static::class . ' does not implement describeIndexes(). ' .
+                'This method will become abstract in the future.'
+        );
     }
 
     /**

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -448,10 +448,26 @@ abstract class SchemaDialect
      */
     public function describeColumns(string $tableName): array
     {
-        throw new RuntimeException(
-            static::class . ' does not implement describeColumns(). ' .
-                'This method will become abstract in the future.'
-        );
+        $config = $this->_driver->config();
+        if (str_contains($tableName, '.')) {
+            [$config['schema'], $tableName] = explode('.', $tableName);
+        }
+        /** @var \Cake\Database\Schema\TableSchema $table */
+        $table = $this->_driver->newTableSchema($tableName);
+
+        [$sql, $params] = $this->describeColumnSql($tableName, $config);
+        $statement = $this->_driver->execute($sql, $params);
+        foreach ($statement->fetchAll('assoc') as $row) {
+            $this->convertColumnDescription($table, $row);
+        }
+        $columns = [];
+        foreach ($table->columns() as $columnName) {
+            $column = $table->getColumn($columnName);
+            $column['name'] = $columnName;
+            $columns[] = $column;
+        }
+
+        return $columns;
     }
 
     /**
@@ -471,10 +487,30 @@ abstract class SchemaDialect
      */
     public function describeForeignKeys(string $tableName): array
     {
-        throw new RuntimeException(
-            static::class . ' does not implement describeForeignKeys(). ' .
-                'This method will become abstract in the future.'
-        );
+        $config = $this->_driver->config();
+        if (str_contains($tableName, '.')) {
+            [$config['schema'], $tableName] = explode('.', $tableName);
+        }
+        /** @var \Cake\Database\Schema\TableSchema $table */
+        $table = $this->_driver->newTableSchema($tableName);
+        // Add the columns because TableSchema needs them.
+        foreach ($this->describeColumns($tableName) as $column) {
+            $table->addColumn($column['name'], $column);
+        }
+
+        [$sql, $params] = $this->describeForeignKeySql($tableName, $config);
+        $statement = $this->_driver->execute($sql, $params);
+        foreach ($statement->fetchAll('assoc') as $row) {
+            $this->convertForeignKeyDescription($table, $row);
+        }
+        $keys = [];
+        foreach ($table->constraints() as $name) {
+            $key = $table->getConstraint($name);
+            $key['name'] = $name;
+            $keys[] = $key;
+        }
+
+        return $keys;
     }
 
     /**
@@ -492,10 +528,30 @@ abstract class SchemaDialect
      */
     public function describeIndexes(string $tableName): array
     {
-        throw new RuntimeException(
-            static::class . ' does not implement describeIndexes(). ' .
-                'This method will become abstract in the future.'
-        );
+        $config = $this->_driver->config();
+        if (str_contains($tableName, '.')) {
+            [$config['schema'], $tableName] = explode('.', $tableName);
+        }
+        /** @var \Cake\Database\Schema\TableSchema $table */
+        $table = $this->_driver->newTableSchema($tableName);
+        // Add the columns because TableSchema needs them.
+        foreach ($this->describeColumns($tableName) as $column) {
+            $table->addColumn($column['name'], $column);
+        }
+
+        [$sql, $params] = $this->describeIndexSql($tableName, $config);
+        $statement = $this->_driver->execute($sql, $params);
+        foreach ($statement->fetchAll('assoc') as $row) {
+            $this->convertIndexDescription($table, $row);
+        }
+        $indexes = [];
+        foreach ($table->indexes() as $name) {
+            $index = $table->getIndex($name);
+            $index['name'] = $name;
+            $indexes[] = $index;
+        }
+
+        return $indexes;
     }
 
     /**
@@ -508,10 +564,22 @@ abstract class SchemaDialect
      */
     public function describeOptions(string $tableName): array
     {
-        throw new RuntimeException(
-            static::class . ' does not implement describeOptions(). ' .
-            'This method will become abstract in the future.'
-        );
+        $config = $this->_driver->config();
+        if (str_contains($tableName, '.')) {
+            [$config['schema'], $tableName] = explode('.', $tableName);
+        }
+        /** @var \Cake\Database\Schema\TableSchema $table */
+        $table = $this->_driver->newTableSchema($tableName);
+
+        [$sql, $params] = $this->describeOptionsSql($tableName, $config);
+        if ($sql) {
+            $statement = $this->_driver->execute($sql, $params);
+            foreach ($statement->fetchAll('assoc') as $row) {
+                $this->convertOptionsDescription($table, $row);
+            }
+        }
+
+        return $table->getOptions();
     }
 
     /**

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -272,20 +272,27 @@ class SqliteSchemaDialect extends SchemaDialect
         $sql = $this->describeColumnQuery($tableName);
         $columns = [];
         $statement = $this->_driver->execute($sql);
-        foreach ($statement->fetchAll('assoc') as $row) {
+        $primary = [];
+        foreach ($statement->fetchAll('assoc') as $i => $row) {
+            $name = $row['name'];
             $field = $this->_convertColumn($row['type']);
             $field += [
-                'name' => $row['name'],
+                'name' => $name,
                 'null' => !$row['notnull'],
                 'default' => $this->_defaultValue($row['dflt_value']),
                 'comment' => null,
                 'length' => null,
             ];
             if ($row['pk']) {
-                $field['null'] = false;
-                $field['autoIncrement'] = true;
+                $primary[] = $i;
             }
             $columns[] = $field;
+        }
+        // If sqlite has a single primary column, it can be marked as autoIncrement
+        if (count($primary) == 1) {
+            $offset = $primary[0];
+            $columns[$offset]['autoIncrement'] = true;
+            $columns[$offset]['null'] = false;
         }
 
         return $columns;
@@ -491,6 +498,9 @@ class SqliteSchemaDialect extends SchemaDialect
         $indexes = [];
 
         foreach ($statement->fetchAll('assoc') as $row) {
+            if ($row['origin'] == 'pk') {
+                continue;
+            }
             $indexName = $row['name'];
             $indexSql = sprintf(
                 'PRAGMA index_info(%s)',
@@ -519,6 +529,24 @@ class SqliteSchemaDialect extends SchemaDialect
                 'columns' => $columns,
                 'length' => [],
             ];
+        }
+        // Primary keys aren't available from the index_info pragma
+        // instead we have to read the columns again.
+        $sql = $this->describeColumnQuery($tableName);
+        $statement = $this->_driver->execute($sql);
+        foreach ($statement->fetchAll('assoc') as $row) {
+            if (!$row['pk']) {
+                continue;
+            }
+            if (!isset($indexes['primary'])) {
+                $indexes['primary'] = [
+                    'name' => 'primary',
+                    'type' => TableSchema::CONSTRAINT_PRIMARY,
+                    'columns' => [],
+                    'length' => [],
+                ];
+            }
+            $indexes['primary']['columns'][] = $row['name'];
         }
 
         return array_values($indexes);

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -490,6 +490,20 @@ SQL;
     }
 
     /**
+     * Test describing a table with MySQL
+     */
+    public function testDescribeTableDatabasePrefix(): void
+    {
+        $connection = ConnectionManager::get('test');
+        $this->_createTables($connection);
+
+        $config = $connection->getDriver()->config();
+        $dialect = $connection->getDriver()->schemaDialect();
+        $result = $dialect->describe($config['database'] . '.schema_articles');
+        $this->assertInstanceOf(TableSchema::class, $result);
+    }
+
+    /**
      * Test that schema reflection works for geosptial columns.
      *
      * We currently cannot reflect the postgis types from postgres.

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -594,6 +594,7 @@ SQL;
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
 
+        $database = $connection->getDriver()->config()['database'];
         $dialect = $connection->getDriver()->schemaDialect();
         $result = $dialect->describe('schema_articles');
         $this->assertInstanceOf(TableSchema::class, $result);
@@ -648,6 +649,9 @@ SQL;
 
         // Compare with describeIndexes() which includes indexes + uniques
         $indexes = $dialect->describeIndexes('schema_articles');
+        $prefixed = $dialect->describeIndexes("{$database}.schema_articles");
+        $this->assertEquals($indexes, $prefixed, 'prefixed tables should work');
+
         foreach ($indexes as $index) {
             $this->assertArrayHasKey($index['name'], $expected);
             $expectedItem = $expected[$index['name']];
@@ -660,6 +664,9 @@ SQL;
 
         // Compare describeForeignKeys()
         $keys = $dialect->describeForeignKeys('schema_articles');
+        $prefixed = $dialect->describeForeignKeys("{$database}.schema_articles");
+        $this->assertEquals($keys, $prefixed, 'prefixed tables should work');
+
         $isMariaDb = ConnectionManager::get('test')->getDriver()->isMariaDb();
         foreach ($keys as $foreignKey) {
             $name = $foreignKey['name'];

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -53,9 +53,6 @@ class SchemaDialectTest extends TestCase
 
     /**
      * Test that describing nonexistent tables fails.
-     *
-     * Tests for positive describe() calls are in each platformSchema
-     * test case.
      */
     public function testDescribeIncorrectTable(): void
     {

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -235,13 +235,11 @@ class SchemaDialectTest extends TestCase
         /** @var \Cake\Database\Driver $driver */
         $driver = ConnectionManager::get('test')->getDriver();
         $this->skipIf(!($driver instanceof Sqlite), 'requires sqlite connection');
-        // $this->deprecated(function () use ($driver): void {
-            $dialect = new CompatDialect($driver);
-            $table = $dialect->describe('orders');
+        $dialect = new CompatDialect($driver);
+        $table = $dialect->describe('orders');
 
-            $this->assertNotEmpty($table->columns());
-            $this->assertNotEmpty($table->indexes());
-            $this->assertNotEmpty($table->constraints());
-        // });
+        $this->assertNotEmpty($table->columns());
+        $this->assertNotEmpty($table->indexes());
+        $this->assertNotEmpty($table->constraints());
     }
 }

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -235,11 +235,13 @@ class SchemaDialectTest extends TestCase
         /** @var \Cake\Database\Driver $driver */
         $driver = ConnectionManager::get('test')->getDriver();
         $this->skipIf(!($driver instanceof Sqlite), 'requires sqlite connection');
-        $dialect = new CompatDialect($driver);
-        $table = $dialect->describe('orders');
+        $this->deprecated(function () use ($driver): void {
+            $dialect = new CompatDialect($driver);
+            $table = $dialect->describe('orders');
 
-        $this->assertNotEmpty($table->columns());
-        $this->assertNotEmpty($table->indexes());
-        $this->assertNotEmpty($table->constraints());
+            $this->assertNotEmpty($table->columns());
+            $this->assertNotEmpty($table->indexes());
+            $this->assertNotEmpty($table->constraints());
+        });
     }
 }

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -235,13 +235,13 @@ class SchemaDialectTest extends TestCase
         /** @var \Cake\Database\Driver $driver */
         $driver = ConnectionManager::get('test')->getDriver();
         $this->skipIf(!($driver instanceof Sqlite), 'requires sqlite connection');
-        $this->deprecated(function () use ($driver): void {
+        // $this->deprecated(function () use ($driver): void {
             $dialect = new CompatDialect($driver);
             $table = $dialect->describe('orders');
 
             $this->assertNotEmpty($table->columns());
             $this->assertNotEmpty($table->indexes());
             $this->assertNotEmpty($table->constraints());
-        });
+        // });
     }
 }

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -21,6 +21,7 @@ use Cake\Database\Driver\Sqlite;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
+use TestApp\Database\Schema\CompatDialect;
 
 /**
  * Test case for SchemaDialect methods
@@ -223,5 +224,22 @@ class SchemaDialectTest extends TestCase
 
         $this->assertTrue($this->dialect->hasForeignKey('orders', ['product_category', 'product_id'], 'product_category_fk'));
         $this->assertTrue($this->dialect->hasForeignKey('orders', [], 'product_category_fk'));
+    }
+
+    /**
+     * Test that SchemaDialect implementations without describeColumns etc
+     * implemented still work with describe().
+     */
+    public function testBackwardsCompatibility(): void
+    {
+        /** @var \Cake\Database\Driver $driver */
+        $driver = ConnectionManager::get('test')->getDriver();
+        $this->skipIf(!($driver instanceof Sqlite), 'requires sqlite connection');
+        $dialect = new CompatDialect($driver);
+        $table = $dialect->describe('orders');
+
+        $this->assertNotEmpty($table->columns());
+        $this->assertNotEmpty($table->indexes());
+        $this->assertNotEmpty($table->constraints());
     }
 }

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -506,8 +506,8 @@ SQL;
                 'length' => null,
                 'null' => true,
                 'default' => null,
-                'precision' => null,
                 'comment' => null,
+                'precision' => null,
                 'collate' => null,
             ],
         ];
@@ -548,7 +548,7 @@ SQL;
 
         // Includes unique keys.
         $indexes = $dialect->describeIndexes('schema_articles');
-        $this->assertCount(3, $indexes);
+        $this->assertCount(4, $indexes);
 
         $foreignKeys = $dialect->describeForeignKeys('schema_articles');
         $this->assertCount(1, $foreignKeys);
@@ -688,7 +688,7 @@ SQL;
         // Because all our 'constraints' are unique indexes
         // they are treated as indexes by the basic reflection API
         $indexes = $dialect->describeIndexes('schema_unique_constraint_variations');
-        $this->assertCount(6, $indexes);
+        $this->assertCount(7, $indexes);
         foreach ($indexes as $index) {
             $expectedIndex = $expected[$index['name']];
             unset($index['name']);

--- a/tests/test_app/TestApp/Database/Schema/CompatDialect.php
+++ b/tests/test_app/TestApp/Database/Schema/CompatDialect.php
@@ -1,0 +1,574 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Database\Schema;
+
+use Cake\Core\Configure;
+use Cake\Database\Exception\DatabaseException;
+use Cake\Database\Schema\SchemaDialect;
+use Cake\Database\Schema\TableSchema;
+use Cake\Database\Schema\TableSchemaInterface;
+use PDO;
+
+/**
+ * Schema dialect stub to test backwards compat for dialects
+ * that lack the new describe API.
+ */
+class CompatDialect extends SchemaDialect
+{
+    /**
+     * Convert a column definition to the abstract types.
+     *
+     * The returned type will be a type that
+     * Cake\Database\TypeFactory can handle.
+     *
+     * @param string $column The column type + length
+     * @throws \Cake\Database\Exception\DatabaseException when unable to parse column type
+     * @return array<string, mixed> Array of column information.
+     */
+    protected function _convertColumn(string $column): array
+    {
+        if ($column === '') {
+            return ['type' => TableSchemaInterface::TYPE_TEXT, 'length' => null];
+        }
+
+        preg_match('/(unsigned)?\s*([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
+        if (!$matches) {
+            throw new DatabaseException(sprintf('Unable to parse column type from `%s`', $column));
+        }
+
+        $unsigned = false;
+        if (strtolower($matches[1]) === 'unsigned') {
+            $unsigned = true;
+        }
+
+        $col = strtolower($matches[2]);
+        $length = null;
+        $precision = null;
+        $scale = null;
+        if (isset($matches[3])) {
+            $length = $matches[3];
+            if (str_contains($length, ',')) {
+                [$length, $precision] = explode(',', $length);
+            }
+            $length = (int)$length;
+            $precision = (int)$precision;
+        }
+
+        $type = $this->_applyTypeSpecificColumnConversion(
+            $col,
+            compact('length', 'precision', 'scale'),
+        );
+        if ($type !== null) {
+            return $type;
+        }
+
+        if ($col === 'bigint') {
+            return ['type' => TableSchemaInterface::TYPE_BIGINTEGER, 'length' => $length, 'unsigned' => $unsigned];
+        }
+        if ($col === 'smallint') {
+            return ['type' => TableSchemaInterface::TYPE_SMALLINTEGER, 'length' => $length, 'unsigned' => $unsigned];
+        }
+        if ($col === 'tinyint') {
+            return ['type' => TableSchemaInterface::TYPE_TINYINTEGER, 'length' => $length, 'unsigned' => $unsigned];
+        }
+        if (str_contains($col, 'int') && $col !== 'point') {
+            return ['type' => TableSchemaInterface::TYPE_INTEGER, 'length' => $length, 'unsigned' => $unsigned];
+        }
+        if (str_contains($col, 'decimal')) {
+            return [
+                'type' => TableSchemaInterface::TYPE_DECIMAL,
+                'length' => $length,
+                'precision' => $precision,
+                'unsigned' => $unsigned,
+            ];
+        }
+        if (in_array($col, ['float', 'real', 'double'])) {
+            return [
+                'type' => TableSchemaInterface::TYPE_FLOAT,
+                'length' => $length,
+                'precision' => $precision,
+                'unsigned' => $unsigned,
+            ];
+        }
+
+        if (str_contains($col, 'boolean')) {
+            return ['type' => TableSchemaInterface::TYPE_BOOLEAN, 'length' => null];
+        }
+
+        if (($col === 'binary' && $length === 16) || strtolower($column) === 'uuid_blob') {
+            return ['type' => TableSchemaInterface::TYPE_BINARY_UUID, 'length' => null];
+        }
+        if (($col === 'char' && $length === 36) || $col === 'uuid') {
+            return ['type' => TableSchemaInterface::TYPE_UUID, 'length' => null];
+        }
+        if ($col === 'char') {
+            return ['type' => TableSchemaInterface::TYPE_CHAR, 'length' => $length];
+        }
+        if (str_contains($col, 'char')) {
+            return ['type' => TableSchemaInterface::TYPE_STRING, 'length' => $length];
+        }
+
+        if (in_array($col, ['blob', 'clob', 'binary', 'varbinary'])) {
+            return ['type' => TableSchemaInterface::TYPE_BINARY, 'length' => $length];
+        }
+
+        $datetimeTypes = [
+            'date',
+            'time',
+            'timestamp',
+            'timestampfractional',
+            'timestamptimezone',
+            'datetime',
+            'datetimefractional',
+        ];
+        if (in_array($col, $datetimeTypes)) {
+            return ['type' => $col, 'length' => null];
+        }
+
+        if (Configure::read('ORM.mapJsonTypeForSqlite') === true) {
+            if (str_contains($col, TableSchemaInterface::TYPE_JSON) && !str_contains($col, 'jsonb')) {
+                return ['type' => TableSchemaInterface::TYPE_JSON, 'length' => null];
+            }
+        }
+
+        if (in_array($col, TableSchemaInterface::GEOSPATIAL_TYPES)) {
+            // TODO how can srid be preserved? It doesn't come back
+            // in the output of show full columns from ...
+            return [
+                'type' => $col,
+                'length' => null,
+            ];
+        }
+
+        return ['type' => TableSchemaInterface::TYPE_TEXT, 'length' => null];
+    }
+
+    /**
+     * Generate the SQL to list the tables and views.
+     *
+     * @param array<string, mixed> $config The connection configuration to use for
+     *    getting tables from.
+     * @return array An array of (sql, params) to execute.
+     */
+    public function listTablesSql(array $config): array
+    {
+        return [
+            'SELECT name FROM sqlite_master ' .
+            'WHERE (type="table" OR type="view") ' .
+            'AND name != "sqlite_sequence" ORDER BY name',
+            [],
+        ];
+    }
+
+    /**
+     * Generate the SQL to list the tables, excluding all views.
+     *
+     * @param array<string, mixed> $config The connection configuration to use for
+     *    getting tables from.
+     * @return array<mixed> An array of (sql, params) to execute.
+     */
+    public function listTablesWithoutViewsSql(array $config): array
+    {
+        return [
+            'SELECT name FROM sqlite_master WHERE type="table" ' .
+            'AND name != "sqlite_sequence" ORDER BY name',
+            [],
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function describeColumnSql(string $tableName, array $config): array
+    {
+        $sql = $this->describeColumnQuery($tableName);
+
+        return [$sql, []];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function convertColumnDescription(TableSchema $schema, array $row): void
+    {
+        $field = $this->_convertColumn($row['type']);
+        $field += [
+            'null' => !$row['notnull'],
+            'default' => $this->_defaultValue($row['dflt_value']),
+        ];
+        $primary = $schema->getConstraint('primary');
+
+        if ($row['pk'] && empty($primary)) {
+            $field['null'] = false;
+            $field['autoIncrement'] = true;
+        }
+
+        // SQLite does not support autoincrement on composite keys.
+        if ($row['pk'] && !empty($primary)) {
+            $existingColumn = $primary['columns'][0];
+            /** @psalm-suppress PossiblyNullOperand */
+            $schema->addColumn($existingColumn, ['autoIncrement' => null] + $schema->getColumn($existingColumn));
+        }
+
+        $schema->addColumn($row['name'], $field);
+        if ($row['pk']) {
+            $constraint = (array)$schema->getConstraint('primary') + [
+                'type' => TableSchema::CONSTRAINT_PRIMARY,
+                'columns' => [],
+            ];
+            $constraint['columns'] = array_merge($constraint['columns'], [$row['name']]);
+            $schema->addConstraint('primary', $constraint);
+        }
+    }
+
+    /**
+     * Helper method for creating SQL to describe columns in a table.
+     *
+     * @param string $tableName The table to describe.
+     * @return string SQL to reflect columns
+     */
+    private function describeColumnQuery(string $tableName): string
+    {
+        $pragma = 'table_xinfo';
+        if (version_compare($this->_driver->version(), '3.26.0', '<')) {
+            $pragma = 'table_info';
+        }
+
+        return sprintf(
+            'PRAGMA %s(%s)',
+            $pragma,
+            $this->_driver->quoteIdentifier($tableName),
+        );
+    }
+
+    /**
+     * Manipulate the default value.
+     *
+     * Sqlite includes quotes and bared NULLs in default values.
+     * We need to remove those.
+     *
+     * @param string|int|null $default The default value.
+     * @return string|int|null
+     */
+    protected function _defaultValue(string|int|null $default): string|int|null
+    {
+        if ($default === 'NULL' || $default === null) {
+            return null;
+        }
+
+        // Remove quotes
+        if (is_string($default) && preg_match("/^'(.*)'$/", $default, $matches)) {
+            return str_replace("''", "'", $matches[1]);
+        }
+
+        return $default;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function describeIndexSql(string $tableName, array $config): array
+    {
+        $sql = $this->describeIndexQuery($tableName);
+
+        return [$sql, []];
+    }
+
+    /**
+     * Generates a regular expression to match identifiers that may or
+     * may not be quoted with any of the supported quotes.
+     *
+     * @param string $identifier The identifier to match.
+     * @return string
+     */
+    protected function possiblyQuotedIdentifierRegex(string $identifier): string
+    {
+        $identifiers = [];
+        $identifier = preg_quote($identifier, '/');
+
+        $hasTick = str_contains($identifier, '`');
+        $hasDoubleQuote = str_contains($identifier, '"');
+        $hasSingleQuote = str_contains($identifier, "'");
+
+        $identifiers[] = '\[' . $identifier . '\]';
+        $identifiers[] = '`' . ($hasTick ? str_replace('`', '``', $identifier) : $identifier) . '`';
+        $identifiers[] = '"' . ($hasDoubleQuote ? str_replace('"', '""', $identifier) : $identifier) . '"';
+        $identifiers[] = "'" . ($hasSingleQuote ? str_replace("'", "''", $identifier) : $identifier) . "'";
+
+        if (!$hasTick && !$hasDoubleQuote && !$hasSingleQuote) {
+            $identifiers[] = $identifier;
+        }
+
+        return implode('|', $identifiers);
+    }
+
+    /**
+     * Removes possible escape characters and surrounding quotes from
+     * identifiers.
+     *
+     * @param string $value The identifier to normalize.
+     * @return string
+     */
+    protected function normalizePossiblyQuotedIdentifier(string $value): string
+    {
+        $value = trim($value);
+
+        if (str_starts_with($value, '[') && str_ends_with($value, ']')) {
+            return mb_substr($value, 1, -1);
+        }
+
+        foreach (['`', "'", '"'] as $quote) {
+            if (str_starts_with($value, $quote) && str_ends_with($value, $quote)) {
+                $value = str_replace($quote . $quote, $quote, $value);
+
+                return mb_substr($value, 1, -1);
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function convertIndexDescription(TableSchema $schema, array $row): void
+    {
+        // Skip auto-indexes created for non-ROWID primary keys.
+        if ($row['origin'] === 'pk') {
+            return;
+        }
+
+        $sql = sprintf(
+            'PRAGMA index_info(%s)',
+            $this->_driver->quoteIdentifier($row['name']),
+        );
+        $statement = $this->_driver->execute($sql);
+        $columns = [];
+        foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $column) {
+            $columns[] = $column['name'];
+        }
+        if ($row['unique']) {
+            if ($row['origin'] === 'u') {
+                $name = $this->extractIndexName($schema->name(), $columns);
+                if ($name !== null) {
+                    $row['name'] = $name;
+                }
+            }
+
+            $schema->addConstraint($row['name'], [
+                'type' => TableSchema::CONSTRAINT_UNIQUE,
+                'columns' => $columns,
+            ]);
+        } else {
+            $schema->addIndex($row['name'], [
+                'type' => TableSchema::INDEX_INDEX,
+                'columns' => $columns,
+            ]);
+        }
+    }
+
+    /**
+     * Helper method for creating SQL to reflect indexes in a table.
+     *
+     * @param string $tableName The table to get indexes from.
+     * @return string SQL to reflect indexes
+     */
+    private function describeIndexQuery(string $tableName): string
+    {
+        return sprintf(
+            'PRAGMA index_list(%s)',
+            $this->_driver->quoteIdentifier($tableName),
+        );
+    }
+
+    /**
+     * Try to extract the original unique index name from table sql.
+     *
+     * @param string $tableName The table name.
+     * @param array $columns The columns in the index.
+     * @return string|null The name of the unique index if it could be inferred.
+     */
+    private function extractIndexName(string $tableName, array $columns): ?string
+    {
+        $sql = 'SELECT sql FROM sqlite_master WHERE type = "table" AND tbl_name = ?';
+        $statement = $this->_driver->execute($sql, [$tableName]);
+        $statement->execute();
+
+        $tableRow = $statement->fetchAssoc();
+        $tableSql = $tableRow['sql'] ??= null;
+        if (!$tableSql) {
+            return null;
+        }
+
+        $columnsPattern = implode(
+            '\s*,\s*',
+            array_map(
+                fn ($column) => '(?:' . $this->possiblyQuotedIdentifierRegex($column) . ')',
+                $columns,
+            ),
+        );
+
+        $regex = "/CONSTRAINT\s*(['\"`\[ ].+?['\"`\] ])\s*UNIQUE\s*\(\s*(?:{$columnsPattern})\s*\)/i";
+        if (preg_match($regex, $tableSql, $matches)) {
+            return $this->normalizePossiblyQuotedIdentifier($matches[1]);
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function describeForeignKeySql(string $tableName, array $config): array
+    {
+        $sql = sprintf(
+            'SELECT id FROM pragma_foreign_key_list(%s) GROUP BY id',
+            $this->_driver->quoteIdentifier($tableName),
+        );
+
+        return [$sql, []];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function convertForeignKeyDescription(TableSchema $schema, array $row): void
+    {
+        $sql = sprintf(
+            'SELECT * FROM pragma_foreign_key_list(%s) WHERE id = %d ORDER BY seq',
+            $this->_driver->quoteIdentifier($schema->name()),
+            $row['id'],
+        );
+        $statement = $this->_driver->prepare($sql);
+        $statement->execute();
+
+        $data = [
+            'type' => TableSchema::CONSTRAINT_FOREIGN,
+            'columns' => [],
+            'references' => [],
+        ];
+
+        $foreignKey = null;
+        foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $foreignKey) {
+            $data['columns'][] = $foreignKey['from'];
+            $data['references'][] = $foreignKey['to'];
+        }
+
+        if (count($data['references']) === 1) {
+            $data['references'] = [$foreignKey['table'], $data['references'][0]];
+        } else {
+            $data['references'] = [$foreignKey['table'], $data['references']];
+        }
+        $data['update'] = $this->_convertOnClause($foreignKey['on_update'] ?? '');
+        $data['delete'] = $this->_convertOnClause($foreignKey['on_delete'] ?? '');
+
+        $name = implode('_', $data['columns']) . '_' . $row['id'] . '_fk';
+
+        $schema->addConstraint($name, $data);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param \Cake\Database\Schema\TableSchema $schema The table instance the column is in.
+     * @param string $name The name of the column.
+     * @return string SQL fragment.
+     * @throws \Cake\Database\Exception\DatabaseException when the column type is unknown
+     */
+    public function columnSql(TableSchema $schema, string $name): string
+    {
+        return 'not implemented';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Note integer primary keys will return ''. This is intentional as Sqlite requires
+     * that integer primary keys be defined in the column definition.
+     *
+     * @param \Cake\Database\Schema\TableSchema $schema The table instance the column is in.
+     * @param string $name The name of the column.
+     * @return string SQL fragment.
+     */
+    public function constraintSql(TableSchema $schema, string $name): string
+    {
+        return 'not implemented';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * SQLite can not properly handle adding a constraint to an existing table.
+     * This method is no-op
+     *
+     * @param \Cake\Database\Schema\TableSchema $schema The table instance the foreign key constraints are.
+     * @return array SQL fragment.
+     */
+    public function addConstraintSql(TableSchema $schema): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * SQLite can not properly handle dropping a constraint to an existing table.
+     * This method is no-op
+     *
+     * @param \Cake\Database\Schema\TableSchema $schema The table instance the foreign key constraints are.
+     * @return array SQL fragment.
+     */
+    public function dropConstraintSql(TableSchema $schema): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function indexSql(TableSchema $schema, string $name): string
+    {
+        return 'not implemented';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createTableSql(TableSchema $schema, array $columns, array $constraints, array $indexes): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function truncateTableSql(TableSchema $schema): array
+    {
+        return [];
+    }
+
+    /**
+     * Returns whether there is any table in this connection to SQLite containing
+     * sequences
+     *
+     * @return bool
+     */
+    public function hasSequences(): bool
+    {
+        return true;
+    }
+}

--- a/tests/test_app/TestApp/Database/Schema/CompatDialect.php
+++ b/tests/test_app/TestApp/Database/Schema/CompatDialect.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         3.0.0
+ * @since         5.2.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestApp\Database\Schema;


### PR DESCRIPTION
- Use the new describexyz methods to compose `describe()` logic. This is a necessary step to deprecate the sql + convert methods.
- Fix a few inconsistencies and gaps in the new methods.
- Improve error messages for describing tables that don't exist in mysql.

Part of #18123
