### PR TITLE
Improve foreign key reflection in sqlite

### DIFF
--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -216,7 +216,6 @@ class SchemaDialectTest extends TestCase
         // TODO this could be resolved if we use the key reflection logic from phinx/migrations
         // that logic parses the SQL of the key to extract and preserve the name.
         $driver = ConnectionManager::get('test')->getDriver();
-        $this->skipIf($driver instanceof Sqlite, 'sqlite does not preserve foreign key names');
         $this->skipIf($driver instanceof Mysql, 'mysql tests fail when this runs');
 
         // Name is wrong

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -297,7 +297,7 @@ field1 VARCHAR(10) DEFAULT NULL,
 field2 VARCHAR(10) DEFAULT 'NULL',
 location POINT_TEXT,
 CONSTRAINT "title_idx" UNIQUE ("title", "body")
-CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON UPDATE CASCADE ON DELETE RESTRICT
+CONSTRAINT "author_fk" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON UPDATE CASCADE ON DELETE RESTRICT
 );
 SQL;
         $connection->execute($table);
@@ -565,7 +565,7 @@ SQL;
                 'columns' => ['title', 'body'],
                 'length' => [],
             ],
-            'author_id_0_fk' => [
+            'author_fk' => [
                 'type' => 'foreign',
                 'columns' => ['author_id'],
                 'references' => ['schema_authors', 'id'],
@@ -584,13 +584,13 @@ SQL;
         $this->assertCount(4, $result->constraints());
         $this->assertEquals($expected['primary'], $result->getConstraint('primary'));
         $this->assertEquals(
-            $expected['author_id_0_fk'],
-            $result->getConstraint('author_id_0_fk'),
+            $expected['author_fk'],
+            $result->getConstraint('author_fk'),
         );
 
         $authorIdFk = $foreignKeys[0];
-        $expectedAuthorIdFk = $expected['author_id_0_fk'];
-        $this->assertEquals('author_id_0_fk', $authorIdFk['name']);
+        $expectedAuthorIdFk = $expected['author_fk'];
+        $this->assertEquals('author_fk', $authorIdFk['name']);
 
         unset($authorIdFk['name']);
         $this->assertEquals($expectedAuthorIdFk, $authorIdFk);
@@ -691,6 +691,7 @@ SQL;
         $this->assertCount(7, $indexes);
         foreach ($indexes as $index) {
             $expectedIndex = $expected[$index['name']];
+            $this->assertNotEmpty($expectedIndex, 'Could not find expected for ' . $index['name']);
             unset($index['name']);
             $this->assertEquals($expectedIndex, $index);
         }
@@ -720,7 +721,7 @@ SQL;
                 ],
                 'length' => [],
             ],
-            'author_id_author_name_0_fk' => [
+            'multi_col_author_fk' => [
                 'type' => 'foreign',
                 'columns' => [
                     'author_id',
@@ -734,7 +735,7 @@ SQL;
                 'delete' => 'noAction',
                 'length' => [],
             ],
-            'author_id_1_fk' => [
+            'author_fk' => [
                 'type' => 'foreign',
                 'columns' => [
                     'author_id',

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database\Schema;
 
 use Cake\Database\Driver\Postgres;
-use Cake\Database\Driver\Sqlite;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\TypeFactory;

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -515,10 +515,6 @@ class TableSchemaTest extends TestCase
         $table = $this->getTableLocator()->get('ArticlesTags');
 
         $name = 'tag_id_fk';
-        if ($table->getConnection()->getDriver() instanceof Sqlite) {
-            $name = 'tag_id_0_fk';
-        }
-
         $compositeConstraint = $table->getSchema()->getConstraint($name);
         $expected = [
             'type' => 'foreign',
@@ -548,10 +544,6 @@ class TableSchemaTest extends TestCase
         );
 
         $name = 'product_category_fk';
-        if ($table->getConnection()->getDriver() instanceof Sqlite) {
-            $name = 'product_category_product_id_0_fk';
-        }
-
         $compositeConstraint = $table->getSchema()->getConstraint($name);
         $expected = [
             'type' => 'foreign',


### PR DESCRIPTION
Properly preserve foreign key names when reflecting schema from sqlite. This also simplifies the logic used for extracting unique index names. This allows a few workarounds to be removed from our tests and makes sqlite behave more consistently with other drivers. This is also necessary to streamline `migrations`.

This is a behavior change that will need to be documented in the migration guide.