### PR TITLE
Remove methods related to "original" values from `EntityInterface`.

### DIFF
--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -63,23 +63,6 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     public function getVirtual(): array;
 
     /**
-     * Returns whether a field is an original one.
-     * Original fields are those that an entity was instantiated with.
-     *
-     * @param string $name Name
-     * @return bool
-     */
-    public function isOriginalField(string $name): bool;
-
-    /**
-     * Returns an array of original fields.
-     * Original fields are those that an entity was initialized with.
-     *
-     * @return array<string>
-     */
-    public function getOriginalFields(): array;
-
-    /**
      * Sets the dirty status of a single field.
      *
      * @param string $field the field to set or check status for
@@ -187,24 +170,6 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     public function getSource(): string;
 
     /**
-     * Returns an array with the requested original fields
-     * stored in this entity, indexed by field name.
-     *
-     * @param array<string> $fields List of fields to be returned
-     * @return array<string, mixed>
-     */
-    public function extractOriginal(array $fields): array;
-
-    /**
-     * Returns an array with only the original fields
-     * stored in this entity, indexed by field name.
-     *
-     * @param array<string> $fields List of fields to be returned
-     * @return array<string, mixed>
-     */
-    public function extractOriginalChanged(array $fields): array;
-
-    /**
      * Sets one or multiple fields to the specified value
      *
      * @param array<string, mixed>|string $field the name of field to set or a list of
@@ -233,30 +198,6 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
      * @param bool $value `true` to enable, `false` to disable.
      */
     public function requireFieldPresence(bool $value = true): void;
-
-    /**
-     * Returns whether a field has an original value
-     *
-     * @param string $field
-     * @return bool
-     */
-    public function hasOriginal(string $field): bool;
-
-    /**
-     * Returns the original value of a field.
-     *
-     * @param string $field The name of the field.
-     * @param bool $allowFallback whether to allow falling back to the current field value if no original exists
-     * @return mixed
-     */
-    public function getOriginal(string $field, bool $allowFallback = true): mixed;
-
-    /**
-     * Gets all original values of the entity.
-     *
-     * @return array
-     */
-    public function getOriginalValues(): array;
 
     /**
      * Returns whether this entity contains a field named $field.

--- a/src/Datasource/OriginalValueInterface.php
+++ b/src/Datasource/OriginalValueInterface.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Datasource;
+
+/**
+ * Describes the methods related to storing and retrieving original values
+ * of fields in an entity, before it was modified.
+ */
+interface OriginalValueInterface
+{
+    /**
+     * Returns whether a field is an original one.
+     * Original fields are those that an entity was instantiated with.
+     *
+     * @param string $name Name
+     * @return bool
+     */
+    public function isOriginalField(string $name): bool;
+
+    /**
+     * Returns an array of original fields.
+     * Original fields are those that an entity was initialized with.
+     *
+     * @return array<string>
+     */
+    public function getOriginalFields(): array;
+
+    /**
+     * Returns an array with the requested original fields
+     * stored in this entity, indexed by field name.
+     *
+     * @param array<string> $fields List of fields to be returned
+     * @return array<string, mixed>
+     */
+    public function extractOriginal(array $fields): array;
+
+    /**
+     * Returns an array with only the original fields
+     * stored in this entity, indexed by field name.
+     *
+     * @param array<string> $fields List of fields to be returned
+     * @return array<string, mixed>
+     */
+    public function extractOriginalChanged(array $fields): array;
+
+    /**
+     * Returns whether a field has an original value
+     *
+     * @param string $field
+     * @return bool
+     */
+    public function hasOriginal(string $field): bool;
+
+    /**
+     * Returns the original value of a field.
+     *
+     * @param string $field The name of the field.
+     * @param bool $allowFallback whether to allow falling back to the current field value if no original exists
+     * @return mixed
+     */
+    public function getOriginal(string $field, bool $allowFallback = true): mixed;
+
+    /**
+     * Gets all original values of the entity.
+     *
+     * @return array
+     */
+    public function getOriginalValues(): array;
+}

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -19,12 +19,13 @@ namespace Cake\ORM;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\EntityTrait;
 use Cake\Datasource\InvalidPropertyInterface;
+use Cake\Datasource\OriginalValueInterface;
 
 /**
  * An entity represents a single result row from a repository. It exposes the
  * methods for retrieving and storing properties associated in this row.
  */
-class Entity implements EntityInterface, InvalidPropertyInterface
+class Entity implements EntityInterface, InvalidPropertyInterface, OriginalValueInterface
 {
     use EntityTrait;
 


### PR DESCRIPTION
These methods have limited usage and "original" value tracking can be considered an optional feature of the entity. The removed methods have been moved into the new `OriginalValueInterface`.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
