### PR TITLE
Fixed description for `CollectionInterface::unique()`

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -101,7 +101,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
 
     /**
      * Loops through each value in the collection and returns a new collection
-     * with only unique values based on the value returned by ``callback``.
+     * with only unique values based on the value returned by the callback.
      *
      * The callback is passed the value as the first argument and the key as the
      * second argument.


### PR DESCRIPTION
A simple formatting error had ruined all the documentation output.

![Screenshot_20250218_202419](https://github.com/user-attachments/assets/0726375b-c883-4726-bb89-e7622588d9f1)
