### PR TITLE
Deprecate returning values from event listeners.

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -149,6 +149,8 @@ class Event implements EventInterface
     /**
      * Listeners can attach a result value to the event.
      *
+     * Setting the result to `false` will also stop event propagation.
+     *
      * @param mixed $value The value to set.
      * @return $this
      */

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -18,6 +18,7 @@ namespace Cake\Event;
 
 use Cake\Core\Exception\CakeException;
 use InvalidArgumentException;
+use function Cake\Core\deprecationWarning;
 
 /**
  * The event manager is responsible for keeping track of event listeners, passing the correct
@@ -309,13 +310,8 @@ class EventManager implements EventManagerInterface
             if ($event->isStopped()) {
                 break;
             }
-            $result = $this->_callListener($listener['callable'], $event);
-            if ($result === false) {
-                $event->stopPropagation();
-            }
-            if ($result !== null) {
-                $event->setResult($result);
-            }
+
+            $this->_callListener($listener['callable'], $event);
         }
 
         return $event;
@@ -327,11 +323,24 @@ class EventManager implements EventManagerInterface
      * @template TSubject of object
      * @param callable $listener The listener to trigger.
      * @param \Cake\Event\EventInterface<TSubject> $event Event instance.
-     * @return mixed The result of the $listener function.
+     * @return void
      */
-    protected function _callListener(callable $listener, EventInterface $event): mixed
+    protected function _callListener(callable $listener, EventInterface $event): void
     {
-        return $listener($event, ...array_values($event->getData()));
+        $result = $listener($event, ...array_values($event->getData()));
+
+        if ($result !== null) {
+            deprecationWarning(
+                '5.2.0',
+                'Returning a value from event listeners is deprecated. ' .
+                'Use `$event->setResult()` instead.'
+            );
+            $event->setResult($result);
+        }
+
+        if ($event->getResult() === false) {
+            $event->stopPropagation();
+        }
     }
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2029,7 +2029,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 assert(
                     $result instanceof EntityInterface,
                     sprintf(
-                        'The beforeSave callback must return `false` or `EntityInterface` instance. Got `%s` instead.',
+                        'The result for the `Model.beforeSave` event must be `false` or `EntityInterface` instance.'
+                        . ' Got `%s` instead.',
                         get_debug_type($result),
                     ),
                 );

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -448,7 +448,7 @@ class ControllerTest extends TestCase
         $Controller = new Controller(new ServerRequest());
 
         $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $event) {
-            return false;
+            $event->stopPropagation();
         });
 
         $result = $Controller->render('index');
@@ -542,7 +542,7 @@ class ControllerTest extends TestCase
 
         $newResponse = new Response();
         $Controller->getEventManager()->on('Controller.beforeRedirect', function (EventInterface $event, $url, Response $response) use ($newResponse) {
-            return $newResponse;
+            $event->setResult($newResponse);
         });
 
         $result = $Controller->redirect('http://cakephp.org');

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -292,7 +292,7 @@ class ErrorTrapTest extends TestCase
         $trap = new ErrorTrap(['errorRenderer' => TextErrorRenderer::class]);
         $trap->register();
         $trap->getEventManager()->on('Error.beforeRender', function ($event, PhpError $error) {
-            return "This ain't so bad";
+            $event->setResult("This ain't so bad");
         });
 
         ob_start();

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -350,7 +350,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         EventManager::instance()->on(
             'Exception.beforeRender',
             function (EventInterface $event, Throwable $e, ServerRequestInterface $req) {
-                return 'Response string from event';
+                $event->setResult('Response string from event');
             },
         );
 

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -284,11 +284,11 @@ class EventManagerTest extends TestCase
         $listener = new class implements EventListenerInterface {
             public array $callList = [];
 
-            public function listenerFunction(EventInterface $event): string
+            public function listenerFunction(EventInterface $event): void
             {
                 $this->callList[] = 'listenerFunction';
 
-                return 'something special';
+                $event->setResult('something special');
             }
 
             public function implementedEvents(): array
@@ -330,11 +330,11 @@ class EventManagerTest extends TestCase
         $listener = new class implements EventListenerInterface {
             public array $callList = [];
 
-            public function listenerFunction(EventInterface $event): bool
+            public function listenerFunction(EventInterface $event): void
             {
                 $this->callList[] = 'listenerFunction';
 
-                return false;
+                $event->setResult(false);
             }
 
             public function implementedEvents(): array

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1919,7 +1919,7 @@ class MarshallerTest extends TestCase
             ->on('Model.beforeFind', function (EventInterface $event, $query) use (&$called) {
                 $called = true;
 
-                return $query->where(['Tags.id >=' => 1]);
+                $query->where(['Tags.id >=' => 1]);
             });
 
         $entity = new Entity([
@@ -2589,7 +2589,7 @@ class MarshallerTest extends TestCase
             ['id' => 2, 'comment' => 'Changed 2', 'user_id' => 2],
         ];
         $this->comments->getEventManager()->on('Model.beforeFind', function (EventInterface $event, $query) {
-            return $query->contain(['Articles']);
+            $query->contain(['Articles']);
         });
         $marshall = new Marshaller($this->comments);
         $result = $marshall->mergeMany($entities, $data);

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -673,7 +673,7 @@ class RulesCheckerIntegrationTest extends TestCase
                 $this->assertSame('create', $operation);
                 $event->stopPropagation();
 
-                return true;
+                $event->setResult(true);
             },
         );
 
@@ -712,7 +712,7 @@ class RulesCheckerIntegrationTest extends TestCase
                 $this->assertFalse($result);
                 $event->stopPropagation();
 
-                return true;
+                $event->setResult(true);
             },
         );
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2298,8 +2298,7 @@ class TableTest extends TestCase
         ]);
         $listener = function (EventInterface $event, $entity) {
             $event->stopPropagation();
-
-            return $entity;
+            $event->setResult($entity);
         };
         $table->getEventManager()->on('Model.beforeSave', $listener);
         $this->assertSame($data, $table->save($data));
@@ -2330,7 +2329,7 @@ class TableTest extends TestCase
     public function testBeforeSaveException(): void
     {
         $this->expectException(AssertionError::class);
-        $this->expectExceptionMessage('The beforeSave callback must return `false` or `EntityInterface` instance. Got `int` instead.');
+        $this->expectExceptionMessage('The result for the `Model.beforeSave` event must be `false` or `EntityInterface` instance. Got `int` instead.');
 
         $table = $this->getTableLocator()->get('users');
         $data = new Entity([
@@ -2340,8 +2339,7 @@ class TableTest extends TestCase
         ]);
         $listener = function (EventInterface $event, $entity) {
             $event->stopPropagation();
-
-            return 1;
+            $event->setResult(1);
         };
         $table->getEventManager()->on('Model.beforeSave', $listener);
         $table->save($data);

--- a/tests/test_app/TestApp/Auth/TestAuthenticate.php
+++ b/tests/test_app/TestApp/Auth/TestAuthenticate.php
@@ -60,7 +60,7 @@ class TestAuthenticate extends BaseAuthenticate
         $this->authenticationProvider = $event->getData('1');
 
         if ($this->modifiedUser) {
-            return $user + ['extra' => 'foo'];
+            $event->setResult($user + ['extra' => 'foo']);
         }
     }
 


### PR DESCRIPTION
This allows callback methods to have a consistent return type `void`.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
