### PR TITLE
Use requestSubmit() instead of submit() in postLink

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1955,7 +1955,7 @@ class FormHelper extends Helper
         }
 
         $url = '#';
-        $onClick = 'document.' . $formName . '.submit();';
+        $onClick = 'document.' . $formName . '.requestSubmit();';
         if ($confirmMessage) {
             $onClick = $this->_confirm($onClick, '');
             $onClick .= 'event.returnValue = false; return false;';

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -6951,7 +6951,7 @@ class FormHelperTest extends TestCase
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/form',
-            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.submit\(\); event\.returnValue = false; return false;/'],
+            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.requestSubmit\(\); event\.returnValue = false; return false;/'],
             'Delete',
             '/a',
         ];
@@ -6966,7 +6966,7 @@ class FormHelperTest extends TestCase
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'DELETE'],
             '/form',
-            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.submit\(\); event\.returnValue = false; return false;/'],
+            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.requestSubmit\(\); event\.returnValue = false; return false;/'],
             'Delete',
             '/a',
         ];
@@ -6985,7 +6985,7 @@ class FormHelperTest extends TestCase
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/form',
-            'a' => ['class' => 'btn btn-danger', 'href' => '#', 'onclick' => 'preg:/document\.post_\w+\.submit\(\); event\.returnValue = false; return false;/'],
+            'a' => ['class' => 'btn btn-danger', 'href' => '#', 'onclick' => 'preg:/document\.post_\w+\.requestSubmit\(\); event\.returnValue = false; return false;/'],
             'Delete',
             '/a',
         ];
@@ -7010,7 +7010,7 @@ class FormHelperTest extends TestCase
             'a' => [
                 'href' => '#',
                 'data-confirm-message' => 'Confirm?',
-                'onclick' => 'preg:/if \(confirm\(this.dataset.confirmMessage\)\) \{ document\.post_\w+\.submit\(\); \} event\.returnValue = false; return false;/',
+                'onclick' => 'preg:/if \(confirm\(this.dataset.confirmMessage\)\) \{ document\.post_\w+\.requestSubmit\(\); \} event\.returnValue = false; return false;/',
             ],
             'Delete',
             '/a',
@@ -7032,7 +7032,7 @@ class FormHelperTest extends TestCase
             'a' => [
                 'href' => '#',
                 'data-confirm-message' => "&#039;Confirm&#039;\nthis &quot;deletion&quot;?",
-                'onclick' => "preg:/if \(confirm\(this.dataset.confirmMessage\)\) \{ document\.post_\w+\.submit\(\); \} event\.returnValue = false; return false;/",
+                'onclick' => "preg:/if \(confirm\(this.dataset.confirmMessage\)\) \{ document\.post_\w+\.requestSubmit\(\); \} event\.returnValue = false; return false;/",
             ],
             'Delete',
             '/a',
@@ -7087,7 +7087,7 @@ class FormHelperTest extends TestCase
             'script' => [
                 'nonce' => 'i-am-nonce',
             ],
-            'preg:/document\.getElementById\("link\-post\-\w+"\)\.addEventListener\("click", function\(event\) { if \(confirm\(this\.dataset\.confirmMessage\)\) \{ document\.post_\w+\.submit\(\); \} event\.returnValue = false; return false; }\);/',
+            'preg:/document\.getElementById\("link\-post\-\w+"\)\.addEventListener\("click", function\(event\) { if \(confirm\(this\.dataset\.confirmMessage\)\) \{ document\.post_\w+\.requestSubmit\(\); \} event\.returnValue = false; return false; }\);/',
             '/script',
         ];
         $this->assertHtml($expected, $result);
@@ -7115,7 +7115,7 @@ class FormHelperTest extends TestCase
             'script' => [
                 'nonce' => 'i-am-nonce',
             ],
-            'preg:/document\.getElementById\("link\-post\-\w+"\)\.addEventListener\("click", function\(event\) { if \(confirm\(this\.dataset\.confirmMessage\)\) \{ document\.post_\w+\.submit\(\); \} event\.returnValue = false; return false; }\);/',
+            'preg:/document\.getElementById\("link\-post\-\w+"\)\.addEventListener\("click", function\(event\) { if \(confirm\(this\.dataset\.confirmMessage\)\) \{ document\.post_\w+\.requestSubmit\(\); \} event\.returnValue = false; return false; }\);/',
             '/script',
         ];
         $this->assertHtml($expected, $result);
@@ -7142,7 +7142,7 @@ class FormHelperTest extends TestCase
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/form',
-            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.submit\(\); event\.returnValue = false; return false;/'],
+            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.requestSubmit\(\); event\.returnValue = false; return false;/'],
             'Delete',
             '/a',
         ];
@@ -7210,7 +7210,7 @@ class FormHelperTest extends TestCase
             ]],
             '/div',
             '/form',
-            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.submit\(\); event\.returnValue = false; return false;/'],
+            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.requestSubmit\(\); event\.returnValue = false; return false;/'],
             'Delete',
             '/a',
         ];
@@ -7273,7 +7273,7 @@ class FormHelperTest extends TestCase
             ['input' => ['type' => 'hidden', 'name' => '_Token[unlocked]', 'value' => '']],
             '/div',
             '/form',
-            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.submit\(\); event\.returnValue = false; return false;/'],
+            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.requestSubmit\(\); event\.returnValue = false; return false;/'],
             'Delete',
             '/a',
         ];
@@ -7336,7 +7336,7 @@ class FormHelperTest extends TestCase
             ]],
             '/div',
             '/form',
-            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.submit\(\); event\.returnValue = false; return false;/'],
+            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.requestSubmit\(\); event\.returnValue = false; return false;/'],
             'Delete',
             '/a',
         ];
@@ -7352,7 +7352,7 @@ class FormHelperTest extends TestCase
     {
         $result = $this->Form->postLink('Delete', '/posts/delete/1', ['block' => true]);
         $expected = [
-            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.submit\(\); event\.returnValue = false; return false;/'],
+            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.requestSubmit\(\); event\.returnValue = false; return false;/'],
             'Delete',
             '/a',
         ];
@@ -7375,7 +7375,7 @@ class FormHelperTest extends TestCase
             ['block' => true, 'method' => 'DELETE'],
         );
         $expected = [
-            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.submit\(\); event\.returnValue = false; return false;/'],
+            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.requestSubmit\(\); event\.returnValue = false; return false;/'],
             'Delete',
             '/a',
         ];
@@ -7402,7 +7402,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->postLink('Delete', '/posts/delete/1', ['block' => 'foobar']);
         $expected = [
-            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.submit\(\); event\.returnValue = false; return false;/'],
+            'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.requestSubmit\(\); event\.returnValue = false; return false;/'],
             'Delete',
             '/a',
         ];


### PR DESCRIPTION
This change replaces submit() with requestSubmit() for form submissions in the postLink method.

- Triggers submit events: Ensures form submission events (e.g., validation, interceptors) are properly dispatched, aligning with modern web standards.
- Respects HTML5 validation: Native browser validation (e.g., required, pattern) now works as expected.
- Backward-compatible: No breaking changes; existing behavior is preserved unless custom submit listeners or validation are used.
- Enables easier event handling (e.g., capturing submissions via addEventListener('submit', ...)).

https://html.spec.whatwg.org/multipage/forms.html#dom-form-requestsubmit-dev
https://caniuse.com/mdn-api_htmlformelement_requestsubmit