### PR TITLE
Add EntityInterface::patch() for mass assigning fields.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -205,28 +205,10 @@ parameters:
 			path: src/Mailer/MailerAwareTrait.php
 
 		-
-			message: '#^Call to function method_exists\(\) with Cake\\Datasource\\EntityInterface and ''patch'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/ORM/Association/BelongsTo.php
-
-		-
 			message: '#^PHPDoc tag @var with type callable\(\)\: mixed is not subtype of native type Closure\(string\)\: string\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: src/ORM/Association/DependentDeleteHelper.php
-
-		-
-			message: '#^Call to function method_exists\(\) with Cake\\Datasource\\EntityInterface and ''patch'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/ORM/Association/HasMany.php
-
-		-
-			message: '#^Call to function method_exists\(\) with Cake\\Datasource\\EntityInterface and ''patch'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/ORM/Association/HasOne.php
 
 		-
 			message: '#^Trait Cake\\ORM\\Behavior\\Translate\\TranslateTrait is used zero times and is not analysed\.$#'
@@ -235,22 +217,10 @@ parameters:
 			path: src/ORM/Behavior/Translate/TranslateTrait.php
 
 		-
-			message: '#^Call to function method_exists\(\) with Cake\\Datasource\\EntityInterface and ''patch'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/ORM/Behavior/TreeBehavior.php
-
-		-
 			message: '#^Unsafe usage of new static\(\)\.$#'
 			identifier: new.static
 			count: 2
 			path: src/ORM/EagerLoader.php
-
-		-
-			message: '#^Call to function method_exists\(\) with Cake\\Datasource\\EntityInterface and ''patch'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 2
-			path: src/ORM/Marshaller.php
 
 		-
 			message: '#^Method Cake\\ORM\\Query\\SelectQuery\:\:find\(\) should return static\(Cake\\ORM\\Query\\SelectQuery\<TSubject of array\|Cake\\Datasource\\EntityInterface\>\) but returns Cake\\ORM\\Query\\SelectQuery\<TSubject of array\|Cake\\Datasource\\EntityInterface\>\.$#'
@@ -263,12 +233,6 @@ parameters:
 			identifier: return.phpDocType
 			count: 1
 			path: src/ORM/Query/SelectQuery.php
-
-		-
-			message: '#^Call to function method_exists\(\) with Cake\\Datasource\\EntityInterface and ''patch'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/ORM/Table.php
 
 		-
 			message: '#^PHPDoc tag @var with type class\-string\<Cake\\Datasource\\RulesChecker\> is not subtype of native type ''Cake\\\\Datasource\\\\RulesChecker''\|class\-string\<Cake\\ORM\\RulesChecker\>\.$#'

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -27,7 +27,6 @@ use Stringable;
  * @property mixed $id Alias for commonly used primary key.
  * @template-extends \ArrayAccess<string, mixed>
  * @method bool hasValue(string $field)
- * @method static patch(array $values, array $options = [])
  */
 interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
 {
@@ -206,17 +205,25 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     public function extractOriginalChanged(array $fields): array;
 
     /**
-     * Sets one or multiple fields to the specified value
+     * Sets a field to the specified value.
      *
-     * @param array<string, mixed>|string $field the name of field to set or a list of
-     * fields with their respective values
-     * @param mixed $value The value to set to the field or an array if the
-     * first argument is also an array, in which case will be treated as $options
+     * @param string $field The name of field to set.
+     * @param mixed $value The value to set to the field.
      * @param array<string, mixed> $options Options to be used for setting the field. Allowed option
      * keys are `setter` and `guard`
      * @return $this
      */
-    public function set(array|string $field, mixed $value = null, array $options = []): static;
+    public function set(string $field, mixed $value, array $options = []): static;
+
+    /**
+     * Patch the entity with provided values.
+     *
+     * @param array<string, mixed> $values Map of fields with their respective values.
+     * @param array<string, mixed> $options Options to be used for setting the field. Allowed option
+     * keys are `setter` and `guard`
+     * @return $this
+     */
+    public function patch(array $values, array $options = []): static;
 
     /**
      * Returns the value of a field by name

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -219,32 +219,18 @@ trait EntityTrait
      * print_r($entity->getOriginalFields()) // prints ['name', 'id', 'phone_number']
      * ```
      *
-     * @param array|string $field The name of field to set.
+     * @param string $field The name of field to set.
      * @param mixed $value The value to set to the field.
      * @param array<string, mixed> $options Options to be used for setting the field. Allowed option
      * keys are `setter`, `guard` and `asOriginal`
      * @return $this
      * @throws \InvalidArgumentException
      */
-    public function set(array|string $field, mixed $value = null, array $options = []): static
+    public function set(string $field, mixed $value, array $options = []): static
     {
-        if (is_string($field)) {
-            $options += ['guard' => false];
+        $options += ['guard' => false];
 
-            return $this->patch([$field => $value], $options);
-        }
-
-        deprecationWarning(
-            '5.2.0',
-            sprintf(
-                'Passing an array as the first argument to `%s::set()` is deprecated. '
-                . 'Use `%s::patch()` instead.',
-                static::class,
-                static::class
-            )
-        );
-
-        return $this->patch($field, (array)$value);
+        return $this->patch([$field => $value], $options);
     }
 
     /**
@@ -293,7 +279,7 @@ trait EntityTrait
      * @return $this
      * @throws \InvalidArgumentException
      */
-    public function patch(array $values, array $options = [])
+    public function patch(array $values, array $options = []): static
     {
         $options += ['setter' => true, 'guard' => true, 'asOriginal' => false];
 

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -153,12 +153,7 @@ class BelongsTo extends Association
             $foreignKeys,
             $targetEntity->extract((array)$this->getBindingKey()),
         );
-
-        if (method_exists($entity, 'patch')) {
-            $entity = $entity->patch($properties, ['guard' => false]);
-        } else {
-            $entity->set($properties, ['guard' => false]);
-        }
+        $entity->patch($properties, ['guard' => false]);
 
         return $entity;
     }

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -843,12 +843,8 @@ class BelongsToMany extends Association
             // or if we are updating an existing link.
             if ($changedKeys) {
                 $joint->setNew(true);
-                $joint->unset($junction->getPrimaryKey());
-                if (method_exists($joint, 'patch')) {
-                    $joint->patch(array_merge($sourceKeys, $targetKeys), ['guard' => false]);
-                } else {
-                    $joint->set(array_merge($sourceKeys, $targetKeys), ['guard' => false]);
-                }
+                $joint->unset($junction->getPrimaryKey())
+                    ->patch(array_merge($sourceKeys, $targetKeys), ['guard' => false]);
             }
             $saved = $junction->save($joint, $options);
 

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -228,11 +228,7 @@ class HasMany extends Association
             }
 
             if ($foreignKeyReference !== $entity->extract($foreignKey)) {
-                if (method_exists($entity, 'patch')) {
-                    $entity->patch($foreignKeyReference, ['guard' => false]);
-                } else {
-                    $entity->set($foreignKeyReference, ['guard' => false]);
-                }
+                $entity->patch($foreignKeyReference, ['guard' => false]);
             }
 
             if ($table->save($entity, $options)) {

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -131,11 +131,7 @@ class HasOne extends Association
             $foreignKeys,
             $entity->extract((array)$this->getBindingKey()),
         );
-        if (method_exists($targetEntity, 'patch')) {
-            $targetEntity = $targetEntity->patch($properties, ['guard' => false]);
-        } else {
-            $targetEntity->set($properties, ['guard' => false]);
-        }
+        $targetEntity->patch($properties, ['guard' => false]);
 
         if (!$this->getTarget()->save($targetEntity, $options)) {
             $targetEntity->unset(array_keys($properties));

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -507,11 +507,7 @@ class EavStrategy implements TranslateStrategyInterface
             } else {
                 $translation['model'] = $this->_config['referenceName'];
                 unset($translation['foreign_key IS']);
-                if (method_exists($contents[$i], 'patch')) {
-                    $contents[$i]->patch($translation, ['setter' => false, 'guard' => false]);
-                } else {
-                    $contents[$i]->set($translation, ['setter' => false, 'guard' => false]);
-                }
+                $contents[$i]->patch($translation, ['setter' => false, 'guard' => false]);
                 $contents[$i]->setNew(true);
             }
         }

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -420,11 +420,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
         }
 
         if ($translation) {
-            if (method_exists($translation, 'patch')) {
-                $translation->patch($values);
-            } else {
-                $translation->set($values);
-            }
+            $translation->patch($values);
         } else {
             $translation = new ($this->translationTable->getEntityClass())(
                 $where + $values,
@@ -620,11 +616,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                 if ($key !== null) {
                     $update['id'] = $key;
                 }
-                if (method_exists($translation, 'patch')) {
-                    $translation->patch($update, ['guard' => false]);
-                } else {
-                    $translation->set($update, ['guard' => false]);
-                }
+                $translation->patch($update, ['guard' => false]);
             }
         }
 

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -949,11 +949,7 @@ class TreeBehavior extends Behavior
         }
 
         $fresh = $this->_table->get($entity->get($this->_getPrimaryKey()));
-        if (method_exists($entity, 'patch')) {
-            $entity->patch($fresh->extract($fields), ['guard' => false]);
-        } else {
-            $entity->set($fresh->extract($fields), ['guard' => false]);
-        }
+        $entity->patch($fresh->extract($fields), ['guard' => false]);
 
         foreach ($fields as $field) {
             $entity->setDirty($field, false);

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -243,11 +243,7 @@ class Marshaller
                 }
             }
         } else {
-            if (method_exists($entity, 'patch')) {
-                $entity->patch($properties, ['asOriginal' => true]);
-            } else {
-                $entity->set($properties, ['asOriginal' => true]);
-            }
+            $entity->patch($properties, ['asOriginal' => true]);
         }
 
         // Don't flag clean association entities as
@@ -607,11 +603,7 @@ class Marshaller
 
         $entity->setErrors($errors);
         if (!isset($options['fields'])) {
-            if (method_exists($entity, 'patch')) {
-                $entity->patch($properties);
-            } else {
-                $entity->set($properties);
-            }
+            $entity->patch($properties);
 
             foreach ($properties as $field => $value) {
                 if ($value instanceof EntityInterface) {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2152,13 +2152,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $success = false;
         if ($statement->rowCount() !== 0) {
             $success = $entity;
-
-            if (method_exists($entity, 'patch')) {
-                $entity = $entity->patch($filteredKeys, ['guard' => false]);
-            } else {
-                $entity->set($filteredKeys, ['guard' => false]);
-            }
-
+            $entity->patch($filteredKeys, ['guard' => false]);
             $schema = $this->getSchema();
             $driver = $this->getConnection()->getDriver();
             foreach ($primary as $key => $v) {

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -54,15 +54,6 @@ class EntityTest extends TestCase
         $this->assertSame('bar', $entity->getOriginal('foo'));
     }
 
-    #[WithoutErrorHandler]
-    public function testEntitySetDeprecated(): void
-    {
-        $this->deprecated(function () {
-            $entity = new Entity();
-            $entity->set(['foo' => 'bar']);
-        });
-    }
-
     /**
      * Tests setting multiple properties without custom setters
      */


### PR DESCRIPTION
EntityInterface::set() can now be used to only set one field.

Refs #18176

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
