### PR TITLE
Fix a regression in PostgresSchemaDialect

### DIFF
--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -255,15 +255,16 @@ class PostgresSchemaDialect extends SchemaDialect
      * schema will be used.
      *
      * @param string $tableName The table name to split
+     * @param array $config Additional configuration data
      * @return array A tuple of [schema, tablename]
      */
-    private function splitTablename(string $tableName): array
+    private function splitTablename(string $tableName, array $config = []): array
     {
-        $config = $this->_driver->config();
-        $schema = $config['schema'] ?? 'public';
         if (str_contains($tableName, '.')) {
             return explode('.', $tableName);
         }
+        $driverConfig = $this->_driver->config();
+        $schema = $config['schema'] ?? $driverConfig['schema'] ?? 'public';
 
         return [$schema, $tableName];
     }
@@ -383,7 +384,7 @@ class PostgresSchemaDialect extends SchemaDialect
     public function describeIndexSql(string $tableName, array $config): array
     {
         $sql = $this->describeIndexQuery();
-        [$schema, $name] = $this->splitTablename($tableName);
+        [$schema, $name] = $this->splitTablename($tableName, $config);
 
         return [$sql, [$schema, $name]];
     }
@@ -480,7 +481,7 @@ class PostgresSchemaDialect extends SchemaDialect
     public function describeForeignKeySql(string $tableName, array $config): array
     {
         $sql = $this->describeForeignKeyQuery();
-        [$schema, $name] = $this->splitTablename($tableName);
+        [$schema, $name] = $this->splitTablename($tableName, $config);
 
         return [$sql, [$schema, $name]];
     }

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -337,6 +337,7 @@ SQL;
         $result = $schema->describe('public.schema_articles');
         $this->assertEquals(['id'], $result->getPrimaryKey());
         $this->assertSame('schema_articles', $result->name());
+        $this->assertCount(1, $result->indexes());
     }
 
     /**
@@ -1517,6 +1518,30 @@ SQL;
         $result = $table->truncateSql($connection);
         $this->assertCount(1, $result);
         $this->assertSame('TRUNCATE "schema_articles" RESTART IDENTITY CASCADE', $result[0]);
+    }
+
+    public function testDescribeIndexSql(): void
+    {
+        $driver = $this->getMockBuilder(Postgres::class)->getMock();
+        $dialect = new PostgresSchemaDialect($driver);
+
+        $result = $dialect->describeIndexSql('schema_name.table_name', []);
+        $this->assertEquals(['schema_name', 'table_name'], $result[1]);
+
+        $result = $dialect->describeIndexSql('table_name', ['schema' => 'schema_name']);
+        $this->assertEquals(['schema_name', 'table_name'], $result[1]);
+    }
+
+    public function testDescribeForeignKeySql(): void
+    {
+        $driver = $this->getMockBuilder(Postgres::class)->getMock();
+        $dialect = new PostgresSchemaDialect($driver);
+
+        $result = $dialect->describeForeignKeySql('schema_name.table_name', []);
+        $this->assertEquals(['schema_name', 'table_name'], $result[1]);
+
+        $result = $dialect->describeForeignKeySql('table_name', ['schema' => 'schema_name']);
+        $this->assertEquals(['schema_name', 'table_name'], $result[1]);
     }
 
     /**


### PR DESCRIPTION
When doing cleanup on the schema reflection methods, I introduced a regression that was caught by migrations tests.