### PR TITLE
Added support for strict fields check in fixtures

### DIFF
--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -208,7 +208,7 @@ class TestFixture implements FixtureInterface
                 if ($invalidFields !== []) {
                     throw new CakeException(
                         "Record #{$index} in fixture has additional fields that do not exist in the schema. " .
-                        "Remove the following fields: " . json_encode($invalidFields)
+                        'Remove the following fields: ' . json_encode($invalidFields)
                     );
                 }
             } else {

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -65,6 +65,12 @@ class TestFixture implements FixtureInterface
     protected TableSchemaInterface&SqlGeneratorInterface $_schema;
 
     /**
+     * Whether to be strict about invalid fields.
+     * Useful for catching typos.
+     */
+    protected bool $strictFields = false;
+
+    /**
      * Instantiate the fixture.
      *
      * @throws \Cake\Core\Exception\CakeException on invalid datasource usage.
@@ -195,11 +201,23 @@ class TestFixture implements FixtureInterface
         $values = [];
         $types = [];
         $columns = $this->_schema->columns();
-        foreach ($this->records as $record) {
-            $fields = array_merge($fields, array_intersect(array_keys($record), $columns));
+        foreach ($this->records as $index => $record) {
+            $recordFields = array_keys($record);
+            if ($this->strictFields) {
+                $invalidFields = array_values(array_filter($recordFields, fn ($f) => !in_array($f, $columns, true)));
+                if ($invalidFields !== []) {
+                    throw new CakeException(
+                        "Record #{$index} in fixture has invalid fields: " . json_encode($invalidFields)
+                    );
+                }
+            } else {
+                $recordFields = array_intersect($recordFields, $columns);
+            }
+
+            $fields = array_unique(array_merge($fields, $recordFields));
         }
-        /** @var array<string> $fields */
-        $fields = array_values(array_unique($fields));
+        /** @var list<string> $fields */
+        $fields = array_values($fields);
         foreach ($fields as $field) {
             $column = $this->_schema->getColumn($field);
             assert($column !== null);

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -207,7 +207,8 @@ class TestFixture implements FixtureInterface
                 $invalidFields = array_values(array_filter($recordFields, fn ($f) => !in_array($f, $columns, true)));
                 if ($invalidFields !== []) {
                     throw new CakeException(
-                        "Record #{$index} in fixture has additional fields that do not exist in the schema. Remove the following fields: " . json_encode($invalidFields)
+                        "Record #{$index} in fixture has additional fields that do not exist in the schema. " .
+                        "Remove the following fields: " . json_encode($invalidFields)
                     );
                 }
             } else {

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -207,7 +207,7 @@ class TestFixture implements FixtureInterface
                 $invalidFields = array_values(array_filter($recordFields, fn ($f) => !in_array($f, $columns, true)));
                 if ($invalidFields !== []) {
                     throw new CakeException(
-                        "Record #{$index} in fixture has invalid fields: " . json_encode($invalidFields)
+                        "Record #{$index} in fixture has additional fields that do not exist in the schema. Remove the following fields: " . json_encode($invalidFields)
                     );
                 }
             } else {

--- a/tests/TestCase/TestSuite/Fixture/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TestFixtureTest.php
@@ -50,7 +50,7 @@ class TestFixtureTest extends TestCase
         };
 
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('Record #0 in fixture has additional fields that do not exist in the schema.'.
+        $this->expectExceptionMessage('Record #0 in fixture has additional fields that do not exist in the schema.' .
             ' Remove the following fields: ["non_existent_field"]');
         $fixture->insert(ConnectionManager::get('test'));
     }

--- a/tests/TestCase/TestSuite/Fixture/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TestFixtureTest.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\TestSuite\Fixture;
+
+use Cake\Core\Exception\CakeException;
+use Cake\Database\Schema\TableSchema;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\Fixture\TestFixture;
+use Cake\TestSuite\TestCase;
+
+class TestFixtureTest extends TestCase
+{
+    public function testStrictFields(): void
+    {
+        $fixture = new class extends TestFixture {
+            public string $table = 'my_table';
+            protected bool $strictFields = true;
+
+            public function init(): void
+            {
+                parent::init();
+                $this->records = [
+                    [
+                        'non_existent_field' => 'value',
+                    ],
+                ];
+            }
+
+            protected function _schemaFromReflection(): void
+            {
+                $this->_schema = new TableSchema(
+                    'my_table',
+                    []
+                );
+            }
+        };
+
+        $this->expectException(CakeException::class);
+        $this->expectExceptionMessage('Record #0 in fixture has invalid fields: ["non_existent_field"]');
+        $fixture->insert(ConnectionManager::get('test'));
+    }
+}

--- a/tests/TestCase/TestSuite/Fixture/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TestFixtureTest.php
@@ -50,7 +50,8 @@ class TestFixtureTest extends TestCase
         };
 
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('Record #0 in fixture has invalid fields: ["non_existent_field"]');
+        $this->expectExceptionMessage('Record #0 in fixture has additional fields that do not exist in the schema.'.
+            ' Remove the following fields: ["non_existent_field"]');
         $fixture->insert(ConnectionManager::get('test'));
     }
 }


### PR DESCRIPTION
Add optional flag for test fixtures to stop ignoring invalid fields and raise an exception instead. This prevents typos while remaining fully backwards compatible.
