### PR TITLE
Only enforce requireFieldPresence on property access. 

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -400,7 +400,13 @@ trait EntityTrait
     }
 
     /**
-     * Get with option for requireFieldPresence
+     * Get field with option for requireFieldPresence
+     *
+     * @param string $field the name of the field to retrieve
+     * @param bool $requireFieldPresence Whether to throw an exception if the field is not present
+     * @return mixed
+     * @throws \InvalidArgumentException if an empty field name is passed
+     * @throws \Cake\Datasource\Exception\MissingPropertyException If property does not exist and $requireFieldPresence
      */
     protected function &getEx(string $field, bool $requireFieldPresence): mixed
     {

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -151,7 +151,7 @@ trait EntityTrait
      */
     public function &__get(string $field): mixed
     {
-        return $this->get($field);
+        return $this->getEx($field, $this->requireFieldPresence);
     }
 
     /**
@@ -383,6 +383,27 @@ trait EntityTrait
      */
     public function &get(string $field): mixed
     {
+        return $this->getEx($field, false);
+    }
+
+    /**
+     * Returns the value of a field by name
+     *
+     * @param string $field the name of the field to retrieve
+     * @return mixed
+     * @throws \InvalidArgumentException if an empty field name is passed
+     * @throws \Cake\Datasource\Exception\MissingPropertyException If property does not exist
+     */
+    public function &getOrFail(string $field): mixed
+    {
+        return $this->getEx($field, true);
+    }
+
+    /**
+     * Get with option for requireFieldPresence
+     */
+    protected function &getEx(string $field, bool $requireFieldPresence): mixed
+    {
         if ($field === '') {
             throw new InvalidArgumentException('Cannot get an empty field');
         }
@@ -402,7 +423,7 @@ trait EntityTrait
             return $result;
         }
 
-        if (!$fieldIsPresent && $this->requireFieldPresence) {
+        if (!$fieldIsPresent && $requireFieldPresence) {
             throw new MissingPropertyException([
                 'property' => $field,
                 'entity' => $this::class,

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -151,7 +151,7 @@ trait EntityTrait
      */
     public function &__get(string $field): mixed
     {
-        return $this->getEx($field, $this->requireFieldPresence);
+        return $this->getRequiredOrFail($field, $this->requireFieldPresence);
     }
 
     /**
@@ -383,7 +383,7 @@ trait EntityTrait
      */
     public function &get(string $field): mixed
     {
-        return $this->getEx($field, false);
+        return $this->getRequiredOrFail($field, false);
     }
 
     /**
@@ -399,9 +399,9 @@ trait EntityTrait
      * @throws \InvalidArgumentException if an empty field name is passed
      * @throws \Cake\Datasource\Exception\MissingPropertyException If property does not exist
      */
-    public function &getExistingOrFail(string $field): mixed
+    public function &getOrFail(string $field): mixed
     {
-        return $this->getEx($field, true);
+        return $this->getRequiredOrFail($field, true);
     }
 
     /**
@@ -413,7 +413,7 @@ trait EntityTrait
      * @throws \InvalidArgumentException if an empty field name is passed
      * @throws \Cake\Datasource\Exception\MissingPropertyException If property does not exist and $requireFieldPresence
      */
-    protected function &getEx(string $field, bool $requireFieldPresence): mixed
+    protected function &getRequiredOrFail(string $field, bool $requireFieldPresence): mixed
     {
         if ($field === '') {
             throw new InvalidArgumentException('Cannot get an empty field');

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -387,7 +387,12 @@ trait EntityTrait
     }
 
     /**
-     * Returns the value of a field by name
+     * Returns the value of an existing field by name.
+     *
+     * Unlike get() this function will throw a MissingPropertyException
+     * if the field does not exist in the entity.
+     *
+     * Note: The returned value might be null if the field is set to null.
      *
      * @param string $field the name of the field to retrieve
      * @return mixed

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -387,25 +387,9 @@ trait EntityTrait
     }
 
     /**
-     * Returns the value of an existing field by name.
-     *
-     * Unlike get() this function will throw a MissingPropertyException
-     * if the field does not exist in the entity.
+     * Get field with option for requireFieldPresence.
      *
      * Note: The returned value might be null if the field is set to null.
-     *
-     * @param string $field the name of the field to retrieve
-     * @return mixed
-     * @throws \InvalidArgumentException if an empty field name is passed
-     * @throws \Cake\Datasource\Exception\MissingPropertyException If property does not exist
-     */
-    public function &getOrFail(string $field): mixed
-    {
-        return $this->getRequiredOrFail($field, true);
-    }
-
-    /**
-     * Get field with option for requireFieldPresence
      *
      * @param string $field the name of the field to retrieve
      * @param bool $requireFieldPresence Whether to throw an exception if the field is not present
@@ -413,7 +397,7 @@ trait EntityTrait
      * @throws \InvalidArgumentException if an empty field name is passed
      * @throws \Cake\Datasource\Exception\MissingPropertyException If property does not exist and $requireFieldPresence
      */
-    protected function &getRequiredOrFail(string $field, bool $requireFieldPresence): mixed
+    public function &getRequiredOrFail(string $field, bool $requireFieldPresence = true): mixed
     {
         if ($field === '') {
             throw new InvalidArgumentException('Cannot get an empty field');

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -394,7 +394,7 @@ trait EntityTrait
      * @throws \InvalidArgumentException if an empty field name is passed
      * @throws \Cake\Datasource\Exception\MissingPropertyException If property does not exist
      */
-    public function &getOrFail(string $field): mixed
+    public function &getExistingOrFail(string $field): mixed
     {
         return $this->getEx($field, true);
     }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -314,6 +314,24 @@ class EntityTest extends TestCase
         $entity->{'not_present'};
     }
 
+    public function testGetOrFailException(): void
+    {
+        $this->expectException(MissingPropertyException::class);
+        $this->expectExceptionMessage('Property `not_present` does not exist for the entity `Cake\ORM\Entity`');
+
+        $entity = new Entity();
+        $entity->getOrFail('not_present');
+    }
+
+    // Ensure that requireFieldPresence does not affect get
+    public function testGetNoException(): void
+    {
+        $entity = new Entity();
+        $entity->requireFieldPresence();
+        $entity->get('not_present');
+        $this->addToAssertionCount(1);
+    }
+
     public function testRequirePresenceNoException(): void
     {
         $entity = new Entity(['is_present' => null]);

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -320,7 +320,7 @@ class EntityTest extends TestCase
         $this->expectExceptionMessage('Property `not_present` does not exist for the entity `Cake\ORM\Entity`');
 
         $entity = new Entity();
-        $entity->getExistingOrFail('not_present');
+        $entity->getOrFail('not_present');
     }
 
     /**

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -320,7 +320,7 @@ class EntityTest extends TestCase
         $this->expectExceptionMessage('Property `not_present` does not exist for the entity `Cake\ORM\Entity`');
 
         $entity = new Entity();
-        $entity->getOrFail('not_present');
+        $entity->getRequiredOrFail('not_present');
     }
 
     /**

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -311,7 +311,7 @@ class EntityTest extends TestCase
 
         $entity = new Entity();
         $entity->requireFieldPresence();
-        $entity->get('not_present');
+        $entity->{'not_present'};
     }
 
     public function testRequirePresenceNoException(): void

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -323,7 +323,9 @@ class EntityTest extends TestCase
         $entity->getOrFail('not_present');
     }
 
-    // Ensure that requireFieldPresence does not affect get
+    /**
+     * Test to ensure that requireFieldPresence does not affect get
+     */
     public function testGetNoException(): void
     {
         $entity = new Entity();

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -320,7 +320,7 @@ class EntityTest extends TestCase
         $this->expectExceptionMessage('Property `not_present` does not exist for the entity `Cake\ORM\Entity`');
 
         $entity = new Entity();
-        $entity->getOrFail('not_present');
+        $entity->getExistingOrFail('not_present');
     }
 
     /**
@@ -330,8 +330,7 @@ class EntityTest extends TestCase
     {
         $entity = new Entity();
         $entity->requireFieldPresence();
-        $entity->get('not_present');
-        $this->addToAssertionCount(1);
+        $this->assertNull($entity->get('not_present'));
     }
 
     public function testRequirePresenceNoException(): void


### PR DESCRIPTION
- Make requireFieldPresence only affect property access.
- Introduce getExistingOrFail() if we want strict checks unconditionally.

Issue: https://github.com/cakephp/cakephp/issues/18211