### PR TITLE
Change Testcase's Property.

### DIFF
--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -40,7 +40,7 @@ class CacheTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Cache::enable();
@@ -49,7 +49,7 @@ class CacheTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Cache::drop('tests');

--- a/tests/TestCase/Cache/Engine/ApcuEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ApcuEngineTest.php
@@ -57,7 +57,7 @@ class ApcuEngineTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->skipIf(!function_exists('apcu_store'), 'APCu is not installed or configured properly.');
@@ -74,7 +74,7 @@ class ApcuEngineTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Cache::drop('apcu');

--- a/tests/TestCase/Cache/Engine/ArrayEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ArrayEngineTest.php
@@ -27,7 +27,7 @@ class ArrayEngineTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -39,7 +39,7 @@ class ArrayEngineTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Cache::drop('array');

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -30,7 +30,7 @@ class FileEngineTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Cache::enable();
@@ -41,7 +41,7 @@ class FileEngineTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Cache::drop('file_test');
         Cache::drop('file_groups');

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -37,7 +37,7 @@ class MemcachedEngineTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->skipIf(!class_exists('Memcached'), 'Memcached is not installed or configured properly.');
@@ -73,7 +73,7 @@ class MemcachedEngineTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Cache::drop('memcached');

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -36,7 +36,7 @@ class RedisEngineTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->skipIf(!class_exists('Redis'), 'Redis extension is not installed or configured properly.');
@@ -56,7 +56,7 @@ class RedisEngineTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Cache::drop('redis');

--- a/tests/TestCase/Command/CacheCommandsTest.php
+++ b/tests/TestCase/Command/CacheCommandsTest.php
@@ -31,7 +31,7 @@ class CacheCommandsTest extends TestCase
     /**
      * setup method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Cache::setConfig('test', ['engine' => 'File', 'path' => CACHE, 'groups' => ['test_group']]);

--- a/tests/TestCase/Command/CompletionCommandTest.php
+++ b/tests/TestCase/Command/CompletionCommandTest.php
@@ -32,7 +32,7 @@ class CompletionCommandTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         static::setAppNamespace();
@@ -42,7 +42,7 @@ class CompletionCommandTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Router::reload();

--- a/tests/TestCase/Command/Helper/BannerHelperTest.php
+++ b/tests/TestCase/Command/Helper/BannerHelperTest.php
@@ -45,7 +45,7 @@ class BannerHelperTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Command/Helper/ProgressHelperTest.php
+++ b/tests/TestCase/Command/Helper/ProgressHelperTest.php
@@ -45,7 +45,7 @@ class ProgressHelperTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Command/Helper/TableHelperTest.php
+++ b/tests/TestCase/Command/Helper/TableHelperTest.php
@@ -45,7 +45,7 @@ class TableHelperTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Command/I18nCommandTest.php
+++ b/tests/TestCase/Command/I18nCommandTest.php
@@ -35,7 +35,7 @@ class I18nCommandTest extends TestCase
     /**
      * setup method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -46,7 +46,7 @@ class I18nCommandTest extends TestCase
     /**
      * Teardown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/Command/I18nExtractCommandTest.php
+++ b/tests/TestCase/Command/I18nExtractCommandTest.php
@@ -36,7 +36,7 @@ class I18nExtractCommandTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setAppNamespace();
@@ -50,7 +50,7 @@ class I18nExtractCommandTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -48,7 +48,7 @@ class PluginAssetsCommandsTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -66,7 +66,7 @@ class PluginAssetsCommandsTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->clearPlugins();

--- a/tests/TestCase/Command/PluginListCommandTest.php
+++ b/tests/TestCase/Command/PluginListCommandTest.php
@@ -36,7 +36,7 @@ class PluginListCommandTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Command/PluginLoadCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadCommandTest.php
@@ -41,7 +41,7 @@ class PluginLoadCommandTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -54,7 +54,7 @@ class PluginLoadCommandTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/Command/PluginLoadedCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadedCommandTest.php
@@ -31,7 +31,7 @@ class PluginLoadedCommandTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Command/PluginUnloadCommandTest.php
+++ b/tests/TestCase/Command/PluginUnloadCommandTest.php
@@ -41,7 +41,7 @@ class PluginUnloadCommandTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -67,7 +67,7 @@ class PluginUnloadCommandTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -33,7 +33,7 @@ class RoutesCommandTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setAppNamespace();
@@ -42,7 +42,7 @@ class RoutesCommandTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Router::reload();

--- a/tests/TestCase/Command/SchemaCacheCommandsTest.php
+++ b/tests/TestCase/Command/SchemaCacheCommandsTest.php
@@ -50,7 +50,7 @@ class SchemaCacheCommandsTest extends TestCase
     /**
      * setup method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setAppNamespace();
@@ -67,7 +67,7 @@ class SchemaCacheCommandsTest extends TestCase
     /**
      * Teardown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->connection->cacheMetadata(false);
         parent::tearDown();

--- a/tests/TestCase/Command/ServerCommandTest.php
+++ b/tests/TestCase/Command/ServerCommandTest.php
@@ -32,7 +32,7 @@ class ServerCommandTest extends TestCase
     /**
      * setup method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->command = new ServerCommand();

--- a/tests/TestCase/Console/Command/HelpCommandTest.php
+++ b/tests/TestCase/Console/Command/HelpCommandTest.php
@@ -30,7 +30,7 @@ class HelpCommandTest extends TestCase
     /**
      * setup method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setAppNamespace();
@@ -40,7 +40,7 @@ class HelpCommandTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->clearPlugins();

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -33,7 +33,7 @@ use TestPlugin\Command\SampleCommand as PluginSampleCommand;
  */
 class CommandCollectionTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Configure::write('App.namespace', 'TestApp');

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -57,7 +57,7 @@ class CommandRunnerTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Configure::write('App.namespace', 'TestApp');

--- a/tests/TestCase/Console/ConsoleInputTest.php
+++ b/tests/TestCase/Console/ConsoleInputTest.php
@@ -34,7 +34,7 @@ class ConsoleInputTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -54,7 +54,7 @@ class ConsoleIoTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         static::setAppNamespace();
@@ -74,7 +74,7 @@ class ConsoleIoTest extends TestCase
     /**
      * teardown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         if (is_dir(TMP . 'shell_test')) {

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -37,7 +37,7 @@ class ConsoleOptionParserTest extends TestCase
      */
     private $io;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->io = new ConsoleIo(new StubConsoleOutput(), new StubConsoleOutput(), new StubConsoleInput([]));

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -35,7 +35,7 @@ class ConsoleOutputTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->output = $this->getMockBuilder(ConsoleOutput::class)
@@ -47,7 +47,7 @@ class ConsoleOutputTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->output);

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -38,7 +38,7 @@ class HelperRegistryTest extends TestCase
     /**
      * setUp
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         static::setAppNamespace();
@@ -54,7 +54,7 @@ class HelperRegistryTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->helpers);
         parent::tearDown();

--- a/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -30,7 +30,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
     /**
      * setUp
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Controller/Component/CheckHttpCacheComponentTest.php
+++ b/tests/TestCase/Controller/Component/CheckHttpCacheComponentTest.php
@@ -40,7 +40,7 @@ class CheckHttpCacheComponentTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         static::setAppNamespace();

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -47,7 +47,7 @@ class FlashComponentTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         static::setAppNamespace();
@@ -60,7 +60,7 @@ class FlashComponentTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->Session->destroy();

--- a/tests/TestCase/Controller/Component/FormProtectionComponentTest.php
+++ b/tests/TestCase/Controller/Component/FormProtectionComponentTest.php
@@ -48,7 +48,7 @@ class FormProtectionComponentTest extends TestCase
      *
      * Initializes environment state.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -42,7 +42,7 @@ class ComponentRegistryTest extends TestCase
     /**
      * setUp
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $controller = new Controller(new ServerRequest());
@@ -52,7 +52,7 @@ class ComponentRegistryTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->Components);

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -39,7 +39,7 @@ class ComponentTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         static::setAppNamespace();

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -52,7 +52,7 @@ class ControllerFactoryTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         static::setAppNamespace();

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -75,7 +75,7 @@ class ControllerTest extends TestCase
     /**
      * reset environment.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -86,7 +86,7 @@ class ControllerTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->clearPlugins();

--- a/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
@@ -32,7 +32,7 @@ class AuthSecurityExceptionTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->authSecurityException = new AuthSecurityException();

--- a/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
@@ -32,7 +32,7 @@ class SecurityExceptionTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->securityException = new SecurityException();

--- a/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
@@ -53,7 +53,7 @@ class IniConfigTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->path = CONFIG;

--- a/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
@@ -53,7 +53,7 @@ class JsonConfigTest extends TestCase
     /**
      * Setup.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->path = CONFIG;

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -53,7 +53,7 @@ class PhpConfigTest extends TestCase
     /**
      * Setup.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->path = CONFIG;

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -31,7 +31,7 @@ class ConfigureTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Cache::disable();
@@ -40,7 +40,7 @@ class ConfigureTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         if (file_exists(TMP . 'cache/persistent/cake_core_core_paths')) {

--- a/tests/TestCase/Core/InstanceConfigTraitTest.php
+++ b/tests/TestCase/Core/InstanceConfigTraitTest.php
@@ -33,7 +33,7 @@ class InstanceConfigTraitTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->object = new TestInstanceConfig();

--- a/tests/TestCase/Core/PluginConfigTest.php
+++ b/tests/TestCase/Core/PluginConfigTest.php
@@ -31,7 +31,7 @@ class PluginConfigTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->clearPlugins();
@@ -48,7 +48,7 @@ class PluginConfigTest extends TestCase
     /**
      * Reverts the changes done to the environment while testing
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->clearPlugins();

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -29,7 +29,7 @@ class PluginTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->clearPlugins();
@@ -38,7 +38,7 @@ class PluginTest extends TestCase
     /**
      * Reverts the changes done to the environment while testing
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->clearPlugins();

--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -37,7 +37,7 @@ class StaticConfigTraitTest extends TestCase
     /**
      * setup method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->subject = new class {
@@ -48,7 +48,7 @@ class StaticConfigTraitTest extends TestCase
     /**
      * teardown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->subject);
         parent::tearDown();

--- a/tests/TestCase/Database/ColumnSchemaAwareTypeTest.php
+++ b/tests/TestCase/Database/ColumnSchemaAwareTypeTest.php
@@ -17,7 +17,7 @@ class ColumnSchemaAwareTypeTest extends TestCase
      */
     protected $connection;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -87,7 +87,7 @@ class ConnectionTest extends TestCase
      */
     protected $defaultLogger;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
@@ -95,7 +95,7 @@ class ConnectionTest extends TestCase
         static::setAppNamespace();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->connection->disableSavePoints();

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -31,7 +31,7 @@ class MysqlTest extends TestCase
     /**
      * setup
      */
-    public function setup(): void
+    protected function setup(): void
     {
         parent::setUp();
         $config = ConnectionManager::getConfig('test');

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -43,7 +43,7 @@ class SqlserverTest extends TestCase
     /**
      * Set up
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->missingExtension = !defined('PDO::SQLSRV_ENCODING_UTF8');

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -50,7 +50,7 @@ class DriverTest extends TestCase
     /**
      * Setup.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -64,7 +64,7 @@ class DriverTest extends TestCase
             ->getMock();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Log::drop('queries');

--- a/tests/TestCase/Database/Expression/CommonTableExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CommonTableExpressionTest.php
@@ -29,13 +29,13 @@ class CommonTableExpressionTest extends TestCase
      */
     protected $connection;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->connection);

--- a/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
@@ -37,7 +37,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
      */
     protected $connection;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');

--- a/tests/TestCase/Database/ExpressionTypeCastingTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingTest.php
@@ -34,7 +34,7 @@ class ExpressionTypeCastingTest extends TestCase
     /**
      * Setups a mock for FunctionsBuilder
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         TypeFactory::set('test', new TestType());

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -35,7 +35,7 @@ class FunctionsBuilderTest extends TestCase
     /**
      * Setups a mock for FunctionsBuilder
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->functions = new FunctionsBuilder();

--- a/tests/TestCase/Database/Query/DeleteQueryTest.php
+++ b/tests/TestCase/Database/Query/DeleteQueryTest.php
@@ -52,14 +52,14 @@ class DeleteQueryTest extends TestCase
      */
     protected $autoQuote;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
         $this->autoQuote = $this->connection->getDriver()->isAutoQuotingEnabled();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->connection->getDriver()->enableAutoQuoting($this->autoQuote);

--- a/tests/TestCase/Database/Query/InsertQueryTest.php
+++ b/tests/TestCase/Database/Query/InsertQueryTest.php
@@ -48,14 +48,14 @@ class InsertQueryTest extends TestCase
      */
     protected $autoQuote;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
         $this->autoQuote = $this->connection->getDriver()->isAutoQuotingEnabled();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->connection->getDriver()->enableAutoQuoting($this->autoQuote);

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -85,14 +85,14 @@ class SelectQueryTest extends TestCase
      */
     protected $autoQuote;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
         $this->autoQuote = $this->connection->getDriver()->isAutoQuotingEnabled();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->connection->getDriver()->enableAutoQuoting($this->autoQuote);

--- a/tests/TestCase/Database/Query/UpdateQueryTest.php
+++ b/tests/TestCase/Database/Query/UpdateQueryTest.php
@@ -56,14 +56,14 @@ class UpdateQueryTest extends TestCase
      */
     protected $autoQuote;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
         $this->autoQuote = $this->connection->getDriver()->isAutoQuotingEnabled();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->connection->getDriver()->enableAutoQuoting($this->autoQuote);

--- a/tests/TestCase/Database/QueryCompilerTest.php
+++ b/tests/TestCase/Database/QueryCompilerTest.php
@@ -41,7 +41,7 @@ class QueryCompilerTest extends TestCase
 
     protected ValueBinder $binder;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -51,7 +51,7 @@ class QueryTest extends TestCase
 
     protected Query $query;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
@@ -59,7 +59,7 @@ class QueryTest extends TestCase
         $this->query = $this->newQuery();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->connection->getDriver()->enableAutoQuoting($this->autoQuote);

--- a/tests/TestCase/Database/QueryTests/AggregatesQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/AggregatesQueryTest.php
@@ -40,13 +40,13 @@ class AggregatesQueryTest extends TestCase
      */
     protected $skipTests = false;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
@@ -48,7 +48,7 @@ class CaseExpressionQueryTest extends TestCase
      */
     protected $query;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -56,7 +56,7 @@ class CaseExpressionQueryTest extends TestCase
         $this->query = new SelectQuery($this->connection);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
@@ -47,7 +47,7 @@ class CommonTableExpressionQueryTest extends TestCase
      */
     protected $autoQuote;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
@@ -59,7 +59,7 @@ class CommonTableExpressionQueryTest extends TestCase
         );
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->connection);

--- a/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
@@ -58,7 +58,7 @@ class TupleComparisonQueryTest extends TestCase
      */
     protected $query;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -66,7 +66,7 @@ class TupleComparisonQueryTest extends TestCase
         $this->query = new SelectQuery($this->connection);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/Database/QueryTests/WindowQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/WindowQueryTest.php
@@ -50,7 +50,7 @@ class WindowQueryTest extends TestCase
      */
     protected $skipTests = false;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
@@ -67,7 +67,7 @@ class WindowQueryTest extends TestCase
         }
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/TestCase/Database/Schema/CollectionTest.php
+++ b/tests/TestCase/Database/Schema/CollectionTest.php
@@ -44,7 +44,7 @@ class CollectionTest extends TestCase
     /**
      * Setup function
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
@@ -55,7 +55,7 @@ class CollectionTest extends TestCase
     /**
      * Teardown function
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->connection->cacheMetadata(false);
         parent::tearDown();

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -41,13 +41,13 @@ class TableSchemaTest extends TestCase
 
     protected $_map;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->_map = TypeFactory::getMap();
         parent::setUp();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         TypeFactory::clear();
         TypeFactory::setMap($this->_map);

--- a/tests/TestCase/Database/SchemaCacheTest.php
+++ b/tests/TestCase/Database/SchemaCacheTest.php
@@ -49,7 +49,7 @@ class SchemaCacheTest extends TestCase
     /**
      * setup method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -63,7 +63,7 @@ class SchemaCacheTest extends TestCase
     /**
      * Teardown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->connection->cacheMetadata(false);
         parent::tearDown();

--- a/tests/TestCase/Database/Type/BinaryTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryTypeTest.php
@@ -40,7 +40,7 @@ class BinaryTypeTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->type = TypeFactory::build('binary');

--- a/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
@@ -41,7 +41,7 @@ class BinaryUuidTypeTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->type = new BinaryUuidType();

--- a/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -40,7 +40,7 @@ class BoolTypeTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->type = TypeFactory::build('boolean');

--- a/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
@@ -41,7 +41,7 @@ class DateTimeFractionalTypeTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->type = new DateTimeFractionalType();

--- a/tests/TestCase/Database/Type/DateTimeTimezoneTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTimezoneTypeTest.php
@@ -41,7 +41,7 @@ class DateTimeTimezoneTypeTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->type = new DateTimeTimezoneType();

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -57,7 +57,7 @@ class DateTimeTypeTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->type = new DateTimeType();

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -49,7 +49,7 @@ class DateTypeTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->type = new DateType();
@@ -61,7 +61,7 @@ class DateTypeTest extends TestCase
     /**
      * Teardown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         date_default_timezone_set($this->originalTimeZone);

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -48,7 +48,7 @@ class DecimalTypeTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->type = new DecimalType();
@@ -61,7 +61,7 @@ class DecimalTypeTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         I18n::setLocale(I18n::getDefaultLocale());

--- a/tests/TestCase/Database/Type/EnumTypeTest.php
+++ b/tests/TestCase/Database/Type/EnumTypeTest.php
@@ -75,7 +75,7 @@ class EnumTypeTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->driver = ConnectionManager::get('test')->getDriver();
@@ -94,7 +94,7 @@ class EnumTypeTest extends TestCase
     /**
      * Restores Type class state
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -46,7 +46,7 @@ class FloatTypeTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->type = new FloatType();
@@ -57,7 +57,7 @@ class FloatTypeTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         I18n::setLocale(I18n::getDefaultLocale());

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -41,7 +41,7 @@ class IntegerTypeTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->type = TypeFactory::build('integer');

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -41,7 +41,7 @@ class JsonTypeTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->type = TypeFactory::build('json');

--- a/tests/TestCase/Database/Type/StringTypeTest.php
+++ b/tests/TestCase/Database/Type/StringTypeTest.php
@@ -41,7 +41,7 @@ class StringTypeTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->type = TypeFactory::build('string');

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -46,7 +46,7 @@ class TimeTypeTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->type = new TimeType();
@@ -56,7 +56,7 @@ class TimeTypeTest extends TestCase
     /**
      * Teardown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         I18n::setLocale(I18n::getDefaultLocale());

--- a/tests/TestCase/Database/Type/UuidTypeTest.php
+++ b/tests/TestCase/Database/Type/UuidTypeTest.php
@@ -39,7 +39,7 @@ class UuidTypeTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->type = TypeFactory::build('uuid');

--- a/tests/TestCase/Database/TypeFactoryTest.php
+++ b/tests/TestCase/Database/TypeFactoryTest.php
@@ -41,7 +41,7 @@ class TypeFactoryTest extends TestCase
     /**
      * Backup original Type class state
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->_originalMap = TypeFactory::getMap();
         parent::setUp();
@@ -50,7 +50,7 @@ class TypeFactoryTest extends TestCase
     /**
      * Restores Type class state
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -43,7 +43,7 @@ trait PaginatorTestTrait
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -77,7 +77,7 @@ trait PaginatorTestTrait
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->getTableLocator()->clear();

--- a/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
@@ -23,7 +23,7 @@ use Cake\ORM\Entity;
 
 class SimplePaginatorTest extends NumericPaginatorTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Datasource/QueryCacherTest.php
+++ b/tests/TestCase/Datasource/QueryCacherTest.php
@@ -35,7 +35,7 @@ class QueryCacherTest extends TestCase
     /**
      * Setup method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Cache::setConfig('queryCache', ['className' => 'Array']);
@@ -46,7 +46,7 @@ class QueryCacherTest extends TestCase
     /**
      * Teardown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Cache::drop('queryCache');

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -56,7 +56,7 @@ class DebuggerTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Configure::write('debug', true);
@@ -68,7 +68,7 @@ class DebuggerTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         if ($this->restoreError) {

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -32,7 +32,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class ErrorTrapTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -44,7 +44,7 @@ class ExceptionTrapTest extends TestCase
 
     private $triggered = false;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->memoryLimit = ini_get('memory_limit');

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -54,7 +54,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -70,7 +70,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
     /**
      * Teardown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Log::drop('error_test');

--- a/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
+++ b/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
@@ -75,7 +75,7 @@ class WebExceptionRendererTest extends TestCase
     /**
      * setup create a request object to get out of router later.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Configure::write('Config.language', 'eng');
@@ -89,7 +89,7 @@ class WebExceptionRendererTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->clearPlugins();

--- a/tests/TestCase/Event/EventDispatcherTraitTest.php
+++ b/tests/TestCase/Event/EventDispatcherTraitTest.php
@@ -33,7 +33,7 @@ class EventDispatcherTraitTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Form/FormProtectorTest.php
+++ b/tests/TestCase/Form/FormProtectorTest.php
@@ -36,7 +36,7 @@ class FormProtectorTest extends TestCase
      */
     protected $sessionId = 'cli';
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -49,7 +49,7 @@ class BaseApplicationTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         static::setAppNamespace();

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -37,7 +37,7 @@ class CurlTest extends TestCase
      */
     protected $caFile;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->skipIf(!function_exists('curl_init'), 'Skipping as ext/curl is not installed.');

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -34,7 +34,7 @@ class StreamTest extends TestCase
      */
     protected $stream;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->stream = $this->getMockBuilder(Stream::class)
@@ -44,7 +44,7 @@ class StreamTest extends TestCase
         stream_wrapper_register('http', CakeStreamWrapper::class);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         stream_wrapper_restore('http');

--- a/tests/TestCase/Http/Client/Auth/DigestTest.php
+++ b/tests/TestCase/Http/Client/Auth/DigestTest.php
@@ -41,7 +41,7 @@ class DigestTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Http/Client/Auth/OauthTest.php
+++ b/tests/TestCase/Http/Client/Auth/OauthTest.php
@@ -40,7 +40,7 @@ class OauthTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->privateKeyString = file_get_contents(TEST_APP . DS . 'config' . DS . 'key.pem');

--- a/tests/TestCase/Http/FlashMessageTest.php
+++ b/tests/TestCase/Http/FlashMessageTest.php
@@ -37,7 +37,7 @@ class FlashMessageTest extends TestCase
      */
     protected $Session;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -46,7 +46,7 @@ class FlashMessageTest extends TestCase
         $this->Flash = new FlashMessage($this->Session);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
@@ -45,7 +45,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setup();
 

--- a/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
@@ -33,14 +33,14 @@ use UnexpectedValueException;
  */
 class HttpsEnforcerMiddlewareTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
         Configure::write('debug', false);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/Http/MiddlewareApplicationTest.php
+++ b/tests/TestCase/Http/MiddlewareApplicationTest.php
@@ -30,7 +30,7 @@ class MiddlewareApplicationTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         static::setAppNamespace();

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -38,7 +38,7 @@ class MiddlewareQueueTest extends TestCase
     /**
      * setUp
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -48,7 +48,7 @@ class MiddlewareQueueTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         static::setAppNamespace($this->previousNamespace);

--- a/tests/TestCase/Http/ResponseEmitterTest.php
+++ b/tests/TestCase/Http/ResponseEmitterTest.php
@@ -37,7 +37,7 @@ class ResponseEmitterTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -65,7 +65,7 @@ class ResponseEmitterTest extends TestCase
     /**
      * teardown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($GLOBALS['mockedHeadersSent']);

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -50,7 +50,7 @@ class ResponseTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->server = $_SERVER;
@@ -59,7 +59,7 @@ class ResponseTest extends TestCase
     /**
      * teardown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $_SERVER = $this->server;

--- a/tests/TestCase/Http/RunnerTest.php
+++ b/tests/TestCase/Http/RunnerTest.php
@@ -55,7 +55,7 @@ class RunnerTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -61,7 +61,7 @@ class ServerTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->server = $_SERVER;

--- a/tests/TestCase/Http/Session/CacheSessionTest.php
+++ b/tests/TestCase/Http/Session/CacheSessionTest.php
@@ -38,7 +38,7 @@ class CacheSessionTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Cache::setConfig(['session_test' => ['engine' => 'File']]);
@@ -48,7 +48,7 @@ class CacheSessionTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Cache::clear('session_test');

--- a/tests/TestCase/Http/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Http/Session/DatabaseSessionTest.php
@@ -42,7 +42,7 @@ class DatabaseSessionTest extends TestCase
     /**
      * setUp
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         static::setAppNamespace();
@@ -52,7 +52,7 @@ class DatabaseSessionTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->storage);
         parent::tearDown();

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -33,7 +33,7 @@ class DateTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -51,7 +51,7 @@ class DateTest extends TestCase
     /**
      * Teardown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         DateTime::setDefaultLocale(null);

--- a/tests/TestCase/I18n/DateTimeTest.php
+++ b/tests/TestCase/I18n/DateTimeTest.php
@@ -38,7 +38,7 @@ class DateTimeTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->now = DateTime::getTestNow();
@@ -47,7 +47,7 @@ class DateTimeTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         DateTime::setTestNow($this->now);

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -39,7 +39,7 @@ class I18nTest extends TestCase
     /**
      * Set Up
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
     }
@@ -47,7 +47,7 @@ class I18nTest extends TestCase
     /**
      * Tear down method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         I18n::clear();

--- a/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
  */
 class MessagesFileLoaderTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/I18n/Middleware/LocaleSelectorMiddlewareTest.php
+++ b/tests/TestCase/I18n/Middleware/LocaleSelectorMiddlewareTest.php
@@ -36,7 +36,7 @@ class LocaleSelectorMiddlewareTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->locale = Locale::getDefault();
@@ -45,7 +45,7 @@ class LocaleSelectorMiddlewareTest extends TestCase
     /**
      * Resets the default locale
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Locale::setDefault($this->locale);

--- a/tests/TestCase/I18n/NumberTest.php
+++ b/tests/TestCase/I18n/NumberTest.php
@@ -36,7 +36,7 @@ class NumberTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->Number = new Number();
@@ -45,7 +45,7 @@ class NumberTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->Number);

--- a/tests/TestCase/I18n/Parser/MoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/MoFileParserTest.php
@@ -35,7 +35,7 @@ class MoFileParserTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/I18n/Parser/PoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/PoFileParserTest.php
@@ -41,7 +41,7 @@ class PoFileParserTest extends TestCase
     /**
      * Set Up
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->path = Configure::read('App.paths.locales.0');
@@ -50,7 +50,7 @@ class PoFileParserTest extends TestCase
     /**
      * Tear down method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         I18n::clear();

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -35,7 +35,7 @@ class TimeTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->now = DateTime::getTestNow();
@@ -44,7 +44,7 @@ class TimeTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         DateTime::setTestNow($this->now);

--- a/tests/TestCase/Log/Engine/BaseLogTest.php
+++ b/tests/TestCase/Log/Engine/BaseLogTest.php
@@ -38,7 +38,7 @@ class BaseLogTest extends TestCase
      * Setting up the test case.
      * Creates a stub logger implementing the log() function missing from abstract class BaseLog.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -31,14 +31,14 @@ use TestPlugin\Log\Engine\TestPluginLog;
  */
 class LogTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Log::reset();
         $this->clearPlugins();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Log::reset();

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -46,7 +46,7 @@ class MailerTest extends TestCase
     /**
      * setUp
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -67,7 +67,7 @@ class MailerTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -37,7 +37,7 @@ class MessageTest extends TestCase
      */
     protected $message;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Mailer/Transport/DebugTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/DebugTransportTest.php
@@ -35,7 +35,7 @@ class DebugTransportTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->DebugTransport = new DebugTransport();

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -36,7 +36,7 @@ class MailTransportTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->MailTransport = $this->getMockBuilder(MailTransport::class)

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -56,7 +56,7 @@ class SmtpTransportTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->socket = $this->getMockBuilder(Socket::class)

--- a/tests/TestCase/Mailer/TransportFactoryTest.php
+++ b/tests/TestCase/Mailer/TransportFactoryTest.php
@@ -32,7 +32,7 @@ class TransportFactoryTest extends TestCase
      */
     protected $transports;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->transports = [
@@ -49,7 +49,7 @@ class TransportFactoryTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         TransportFactory::drop('debug');

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -35,7 +35,7 @@ class SocketTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->Socket = new Socket(['timeout' => 1]);
@@ -44,7 +44,7 @@ class SocketTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->Socket);

--- a/tests/TestCase/ORM/Association/BelongsToManySaveAssociatedOnlyEntitiesAppendTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManySaveAssociatedOnlyEntitiesAppendTest.php
@@ -40,7 +40,7 @@ class BelongsToManySaveAssociatedOnlyEntitiesAppendTest extends TestCase
     /**
      * Set up
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->tag = $this->getMockBuilder(Table::class)

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -78,7 +78,7 @@ class BelongsToManyTest extends TestCase
     /**
      * Set up
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->tag = $this->getMockBuilder(Table::class)
@@ -105,7 +105,7 @@ class BelongsToManyTest extends TestCase
         ]);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         ConnectionManager::drop('test_read_write');

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -60,7 +60,7 @@ class BelongsToTest extends TestCase
     /**
      * Set up
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->company = $this->getTableLocator()->get('Companies', [

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -80,7 +80,7 @@ class HasManyTest extends TestCase
     /**
      * Set up
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setAppNamespace('TestApp');

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -59,7 +59,7 @@ class HasOneTest extends TestCase
     /**
      * Set up
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->user = $this->getTableLocator()->get('Users');

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -42,7 +42,7 @@ class AssociationCollectionTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->associations = new AssociationCollection();

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -46,7 +46,7 @@ class AssociationTest extends TestCase
     /**
      * Set up
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->source = new TestTable();

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -76,7 +76,7 @@ class CounterCacheBehaviorTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
@@ -113,7 +113,7 @@ class CounterCacheBehaviorTest extends TestCase
     /**
      * teardown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -74,7 +74,7 @@ class TranslateBehaviorEavTest extends TestCase
         parent::tearDownAfterClass();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         I18n::setLocale(I18n::getDefaultLocale());

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -42,7 +42,7 @@ class TreeBehaviorTest extends TestCase
      */
     protected $table;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->table = $this->getTableLocator()->get('NumberTrees');

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -53,7 +53,7 @@ class BehaviorRegistryTest extends TestCase
     /**
      * setup method.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->Table = new Table(['table' => 'articles']);
@@ -65,7 +65,7 @@ class BehaviorRegistryTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->clearPlugins();
         unset($this->Table, $this->EventManager, $this->Behaviors);

--- a/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
+++ b/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
@@ -16,7 +16,7 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
 
     protected array $typeMap;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->typeMap = TypeFactory::getMap();
 

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -78,7 +78,7 @@ class EagerLoaderTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');

--- a/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
+++ b/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
@@ -37,7 +37,7 @@ class LocatorAwareTraitTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -52,7 +52,7 @@ class TableLocatorTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         static::setAppNamespace();
@@ -63,7 +63,7 @@ class TableLocatorTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->clearPlugins();
         parent::tearDown();

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -73,7 +73,7 @@ class MarshallerTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->articles = $this->getTableLocator()->get('Articles');
@@ -101,7 +101,7 @@ class MarshallerTest extends TestCase
     /**
      * Teardown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->articles, $this->comments, $this->users, $this->tags);

--- a/tests/TestCase/ORM/Query/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/Query/CompositeKeysTest.php
@@ -55,7 +55,7 @@ class CompositeKeysTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -83,7 +83,7 @@ class SelectQueryTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');

--- a/tests/TestCase/ORM/ResultSetFactoryTest.php
+++ b/tests/TestCase/ORM/ResultSetFactoryTest.php
@@ -59,7 +59,7 @@ class ResultSetFactoryTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -49,7 +49,7 @@ class ResultSetTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -53,7 +53,7 @@ class LinkConstraintTest extends TestCase
     /**
      * Setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Configure::write('App.namespace', 'TestApp');
@@ -62,7 +62,7 @@ class LinkConstraintTest extends TestCase
     /**
      * Tear down.
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->getTableLocator()->clear();

--- a/tests/TestCase/ORM/TableComplexIdTest.php
+++ b/tests/TestCase/ORM/TableComplexIdTest.php
@@ -37,7 +37,7 @@ class TableComplexIdTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         static::setAppNamespace();
@@ -46,7 +46,7 @@ class TableComplexIdTest extends TestCase
     /**
      * teardown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->getTableLocator()->clear();

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -37,7 +37,7 @@ class TableRegistryTest extends TestCase
      * Remember original instance to set it back on tearDown() just to make sure
      * other tests are not broken.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->_originalLocator = TableRegistry::getTableLocator();
@@ -46,7 +46,7 @@ class TableRegistryTest extends TestCase
     /**
      * tear down
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         TableRegistry::setTableLocator($this->_originalLocator);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -120,7 +120,7 @@ class TableTest extends TestCase
      */
     protected $articlesTypeMap;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
@@ -205,7 +205,7 @@ class TableTest extends TestCase
     /**
      * teardown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->clearPlugins();

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -39,7 +39,7 @@ class TableUuidTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         static::setAppNamespace();

--- a/tests/TestCase/Routing/AssetTest.php
+++ b/tests/TestCase/Routing/AssetTest.php
@@ -35,7 +35,7 @@ class AssetTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -54,7 +54,7 @@ class AssetTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
@@ -30,7 +30,7 @@ class AssetMiddlewareTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->loadPlugins(['TestPlugin', 'Company/TestPluginThree']);
@@ -39,7 +39,7 @@ class AssetMiddlewareTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->clearPlugins();
         parent::tearDown();

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -50,7 +50,7 @@ class RoutingMiddlewareTest extends TestCase
     /**
      * Setup method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Routing/Route/PluginShortRouteTest.php
+++ b/tests/TestCase/Routing/Route/PluginShortRouteTest.php
@@ -29,7 +29,7 @@ class PluginShortRouteTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Configure::write('Routing', ['prefixes' => []]);

--- a/tests/TestCase/Routing/Route/RedirectRouteTest.php
+++ b/tests/TestCase/Routing/Route/RedirectRouteTest.php
@@ -35,7 +35,7 @@ class RedirectRouteTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Router::reload();

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -35,7 +35,7 @@ class RouteTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Configure::write('Routing', ['prefixes' => []]);

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -44,7 +44,7 @@ class RouteBuilderTest extends TestCase
     /**
      * Setup method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->collection = new RouteCollection();
@@ -53,7 +53,7 @@ class RouteBuilderTest extends TestCase
     /**
      * Teardown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->clearPlugins();

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -36,7 +36,7 @@ class RouteCollectionTest extends TestCase
     /**
      * Setup method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->collection = new RouteCollection();

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -42,7 +42,7 @@ class RouterTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -53,7 +53,7 @@ class RouterTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->clearPlugins();

--- a/tests/TestCase/TestSuite/EmailTraitTest.php
+++ b/tests/TestCase/TestSuite/EmailTraitTest.php
@@ -38,7 +38,7 @@ class EmailTraitTest extends TestCase
     /**
      * setUp
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -61,7 +61,7 @@ class EmailTraitTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/TestSuite/Fixture/SchemaLoaderTest.php
+++ b/tests/TestCase/TestSuite/Fixture/SchemaLoaderTest.php
@@ -38,7 +38,7 @@ class SchemaLoaderTest extends TestCase
 
     protected $truncateDbFile = TMP . 'schema_loader_test.sqlite';
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -50,7 +50,7 @@ class SchemaLoaderTest extends TestCase
         $this->loader = new SchemaLoader();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -58,7 +58,7 @@ class IntegrationTestTraitTest extends TestCase
     /**
      * Setup method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         static::setAppNamespace();

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -46,7 +46,7 @@ use function Cake\Core\deprecationWarning;
  */
 class TestCaseTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->clearPlugins();

--- a/tests/TestCase/TestSuite/TestEmailTransportTest.php
+++ b/tests/TestCase/TestSuite/TestEmailTransportTest.php
@@ -27,7 +27,7 @@ class TestEmailTransportTest extends TestCase
     /**
      * setUp
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -56,7 +56,7 @@ class TestEmailTransportTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -44,7 +44,7 @@ class TestFixtureTest extends TestCase
     /**
      * Set up
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Log::reset();
@@ -53,7 +53,7 @@ class TestFixtureTest extends TestCase
     /**
      * Tear down
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Log::reset();

--- a/tests/TestCase/TestSuite/TestSessionTest.php
+++ b/tests/TestCase/TestSuite/TestSessionTest.php
@@ -31,7 +31,7 @@ class TestSessionTest extends TestCase
      */
     protected $session;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Utility/Crypto/OpenSslTest.php
+++ b/tests/TestCase/Utility/Crypto/OpenSslTest.php
@@ -32,7 +32,7 @@ class OpenSslTest extends TestCase
     /**
      * Setup function.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->skipIf(!function_exists('openssl_encrypt'), 'No openssl skipping tests');

--- a/tests/TestCase/Utility/FilesystemTest.php
+++ b/tests/TestCase/Utility/FilesystemTest.php
@@ -31,7 +31,7 @@ class FilesystemTest extends TestCase
 
     protected $vfsPath;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -38,14 +38,14 @@ class TextTest extends TestCase
      */
     protected $encoding;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->encoding = mb_internal_encoding();
         $this->Text = new Text();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         mb_internal_encoding($this->encoding);

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -41,7 +41,7 @@ class XmlTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Configure::write('App.encoding', 'UTF-8');

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -45,7 +45,7 @@ class CellTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         static::setAppNamespace();
@@ -59,7 +59,7 @@ class CellTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->View);

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -27,7 +27,7 @@ class ArrayContextTest extends TestCase
     /**
      * setup method.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
     }

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -29,7 +29,7 @@ class FormContextTest extends TestCase
     /**
      * setup method.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
     }

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -34,7 +34,7 @@ class BreadcrumbsHelperTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $view = new View();

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -42,7 +42,7 @@ class FlashHelperTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $session = new Session();
@@ -108,7 +108,7 @@ class FlashHelperTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->View, $this->Flash);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -93,7 +93,7 @@ class FormHelperTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -142,7 +142,7 @@ class FormHelperTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->Form, $this->View);

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -65,7 +65,7 @@ class HtmlHelperTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -93,7 +93,7 @@ class HtmlHelperTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->clearPlugins();

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -36,7 +36,7 @@ class NumberHelperTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->View = new View();
@@ -47,7 +47,7 @@ class NumberHelperTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->clearPlugins();

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -50,7 +50,7 @@ class PaginatorHelperTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Configure::write('Config.language', 'eng');
@@ -85,7 +85,7 @@ class PaginatorHelperTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->View, $this->Paginator);

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -39,7 +39,7 @@ class TextHelperTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->View = new View();
@@ -50,7 +50,7 @@ class TextHelperTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->Text, $this->View);
         parent::tearDown();

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -43,7 +43,7 @@ class TimeHelperTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->View = new View();
@@ -53,7 +53,7 @@ class TimeHelperTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         DateTime::setDefaultLocale(null);

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -50,7 +50,7 @@ class UrlHelperTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -70,7 +70,7 @@ class UrlHelperTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -50,7 +50,7 @@ class HelperRegistryTest extends TestCase
     /**
      * setUp
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->View = new View();
@@ -61,7 +61,7 @@ class HelperRegistryTest extends TestCase
     /**
      * tearDown
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->clearPlugins();
         unset($this->Helpers, $this->View);

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -43,7 +43,7 @@ class HelperTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -54,7 +54,7 @@ class HelperTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Configure::delete('Asset');

--- a/tests/TestCase/View/JsonViewTest.php
+++ b/tests/TestCase/View/JsonViewTest.php
@@ -32,7 +32,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  */
 class JsonViewTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Configure::write('debug', false);

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -32,7 +32,7 @@ class StringTemplateTest extends TestCase
     /**
      * setUp
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->template = new StringTemplate();

--- a/tests/TestCase/View/StringTemplateTraitTest.php
+++ b/tests/TestCase/View/StringTemplateTraitTest.php
@@ -33,7 +33,7 @@ class StringTemplateTraitTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->Template = new TestStringTemplate();

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -86,7 +86,7 @@ class ViewTest extends TestCase
     /**
      * setUp method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -108,7 +108,7 @@ class ViewTest extends TestCase
     /**
      * tearDown method
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->clearPlugins();

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -34,7 +34,7 @@ class ViewVarsTraitTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/View/Widget/BasicWidgetTest.php
+++ b/tests/TestCase/View/Widget/BasicWidgetTest.php
@@ -36,7 +36,7 @@ class BasicWidgetTest extends TestCase
      */
     protected $templates;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $templates = [

--- a/tests/TestCase/View/Widget/ButtonWidgetTest.php
+++ b/tests/TestCase/View/Widget/ButtonWidgetTest.php
@@ -36,7 +36,7 @@ class ButtonWidgetTest extends TestCase
      */
     protected $templates;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $templates = [

--- a/tests/TestCase/View/Widget/CheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/CheckboxWidgetTest.php
@@ -40,7 +40,7 @@ class CheckboxWidgetTest extends TestCase
     /**
      * setup method.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $templates = [

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -43,7 +43,7 @@ class DateTimeWidgetTest extends TestCase
      */
     protected $DateTime;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $templates = [

--- a/tests/TestCase/View/Widget/FileWidgetTest.php
+++ b/tests/TestCase/View/Widget/FileWidgetTest.php
@@ -39,7 +39,7 @@ class FileWidgetTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $templates = [

--- a/tests/TestCase/View/Widget/LabelWidgetTest.php
+++ b/tests/TestCase/View/Widget/LabelWidgetTest.php
@@ -39,7 +39,7 @@ class LabelWidgetTest extends TestCase
     /**
      * setup method.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $templates = [

--- a/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
@@ -41,7 +41,7 @@ class MultiCheckboxWidgetTest extends TestCase
     /**
      * setup method.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $templates = [

--- a/tests/TestCase/View/Widget/RadioWidgetTest.php
+++ b/tests/TestCase/View/Widget/RadioWidgetTest.php
@@ -41,7 +41,7 @@ class RadioWidgetTest extends TestCase
     /**
      * setup method.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $templates = [

--- a/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
+++ b/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
@@ -41,7 +41,7 @@ class SelectBoxWidgetTest extends TestCase
     /**
      * setup method.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $templates = [

--- a/tests/TestCase/View/Widget/TextareaWidgetTest.php
+++ b/tests/TestCase/View/Widget/TextareaWidgetTest.php
@@ -39,7 +39,7 @@ class TextareaWidgetTest extends TestCase
     /**
      * setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $templates = [

--- a/tests/TestCase/View/Widget/WidgetLocatorTest.php
+++ b/tests/TestCase/View/Widget/WidgetLocatorTest.php
@@ -45,7 +45,7 @@ class WidgetLocatorTest extends TestCase
     /**
      * setup method
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->templates = new StringTemplate();

--- a/tests/TestCase/View/XmlViewTest.php
+++ b/tests/TestCase/View/XmlViewTest.php
@@ -33,7 +33,7 @@ class XmlViewTest extends TestCase
 {
     protected array $fixtures = ['core.Authors'];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Configure::write('debug', false);


### PR DESCRIPTION
Hello ! 🙌 I hope this fix will helps !


## what i have done.

- change property scope public into protected. [discuss the issue ](https://github.com/cakephp/cakephp/issues/18214)

## Reason
- In the Testcase class inheriting from the PHPUnit package, the setUp method is defined as protected not public. Therefore, using inherited Testcase shouldn't use property type public.

## Test Results.
- Before fix test results
![スクリーンショット 2025-03-01 10 54 28](https://github.com/user-attachments/assets/e8c43e80-78c5-4a06-8b24-21a3c2c980fd)

- After fix test results
![スクリーンショット 2025-03-01 11 04 39](https://github.com/user-attachments/assets/cddedea0-a759-4e9b-abcd-725d04e5c6b2)
