### PR TITLE
Fix SQL UPDATE with columns containing spaces

### DIFF
--- a/src/Database/Query/UpdateQuery.php
+++ b/src/Database/Query/UpdateQuery.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Query;
 
+use Cake\Database\Expression\ComparisonExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
@@ -116,7 +117,17 @@ class UpdateQuery extends Query
             return $this;
         }
 
-        if (is_array($key) || $key instanceof ExpressionInterface) {
+        if (is_array($key)) {
+            /** @var \Cake\Database\Expression\QueryExpression $setExpr */
+            $setExpr = $this->_parts['set'];
+            foreach ($key as $k => $v) {
+                $setExpr->add(new ComparisonExpression( $k, $v));
+            }
+
+            return $this;
+        }
+
+        if ($key instanceof ExpressionInterface) {
             $types = (array)$value;
             /** @var \Cake\Database\Expression\QueryExpression $setExpr */
             $setExpr = $this->_parts['set'];

--- a/src/Database/Query/UpdateQuery.php
+++ b/src/Database/Query/UpdateQuery.php
@@ -118,10 +118,11 @@ class UpdateQuery extends Query
         }
 
         if (is_array($key)) {
+            $typeMap = $this->getTypeMap()->setTypes($value ?? []);
             /** @var \Cake\Database\Expression\QueryExpression $setExpr */
             $setExpr = $this->_parts['set'];
             foreach ($key as $k => $v) {
-                $setExpr->add(new ComparisonExpression( $k, $v));
+                $setExpr->add(new ComparisonExpression($k, $v, $typeMap->type($k)));
             }
 
             return $this;


### PR DESCRIPTION
The set clause of update queries are always a ComparisonExpression. No need to to use the QueryExpression::_parseCondition method.

I am required to work with a DB I have no control of the schema of.

The DB was not designed by IT staff so the user chose "natural" wording for the column names. 
Having quotedIdentifiers on fixes the issue with SELECT statements but not with UPDATE. quotedIdentifiers seems to be applied after the query is built and not on the column names before the query is built.

This leads to queries like this:

`UPDATE [personal_dades_laborals] SET [Data] INICI '15/3/20' , [Paga] INCLOSA '0' WHERE [id] = 253`

With this patch applied the query is now fixed:

`UPDATE [personal_dades_laborals] SET [Data Inici] = '15/3/20' , [Paga inclosa] = '0' WHERE [id] = 253`

This will not fix the problem for these columns used in a WHERE statement.