### PR TITLE
Add EntityTrait::patch() for mass assigning fields.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -211,10 +211,28 @@ parameters:
 			path: src/Mailer/MailerAwareTrait.php
 
 		-
+			message: '#^Call to function method_exists\(\) with Cake\\Datasource\\EntityInterface and ''patch'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/ORM/Association/BelongsTo.php
+
+		-
 			message: '#^PHPDoc tag @var with type callable\(\)\: mixed is not subtype of native type Closure\(string\)\: string\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: src/ORM/Association/DependentDeleteHelper.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Cake\\Datasource\\EntityInterface and ''patch'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/ORM/Association/HasMany.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Cake\\Datasource\\EntityInterface and ''patch'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/ORM/Association/HasOne.php
 
 		-
 			message: '#^Trait Cake\\ORM\\Behavior\\Translate\\TranslateTrait is used zero times and is not analysed\.$#'
@@ -223,10 +241,22 @@ parameters:
 			path: src/ORM/Behavior/Translate/TranslateTrait.php
 
 		-
+			message: '#^Call to function method_exists\(\) with Cake\\Datasource\\EntityInterface and ''patch'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/ORM/Behavior/TreeBehavior.php
+
+		-
 			message: '#^Unsafe usage of new static\(\)\.$#'
 			identifier: new.static
 			count: 2
 			path: src/ORM/EagerLoader.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Cake\\Datasource\\EntityInterface and ''patch'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: src/ORM/Marshaller.php
 
 		-
 			message: '#^Method Cake\\ORM\\Query\\SelectQuery\:\:find\(\) should return static\(Cake\\ORM\\Query\\SelectQuery\<TSubject of array\|Cake\\Datasource\\EntityInterface\>\) but returns Cake\\ORM\\Query\\SelectQuery\<TSubject of array\|Cake\\Datasource\\EntityInterface\>\.$#'
@@ -239,6 +269,12 @@ parameters:
 			identifier: return.phpDocType
 			count: 1
 			path: src/ORM/Query/SelectQuery.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Cake\\Datasource\\EntityInterface and ''patch'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/ORM/Table.php
 
 		-
 			message: '#^PHPDoc tag @var with type class\-string\<Cake\\Datasource\\RulesChecker\> is not subtype of native type ''Cake\\\\Datasource\\\\RulesChecker''\|class\-string\<Cake\\ORM\\RulesChecker\>\.$#'

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -27,6 +27,7 @@ use Stringable;
  * @property mixed $id Alias for commonly used primary key.
  * @template-extends \ArrayAccess<string, mixed>
  * @method bool hasValue(string $field)
+ * @method static patch(array $values, array $options = [])
  */
 interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
 {

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -153,7 +153,12 @@ class BelongsTo extends Association
             $foreignKeys,
             $targetEntity->extract((array)$this->getBindingKey()),
         );
-        $entity->set($properties, ['guard' => false]);
+
+        if (method_exists($entity, 'patch')) {
+            $entity = $entity->patch($properties, ['guard' => false]);
+        } else {
+            $entity->set($properties, ['guard' => false]);
+        }
 
         return $entity;
     }

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -843,8 +843,12 @@ class BelongsToMany extends Association
             // or if we are updating an existing link.
             if ($changedKeys) {
                 $joint->setNew(true);
-                $joint->unset($junction->getPrimaryKey())
-                    ->set(array_merge($sourceKeys, $targetKeys), ['guard' => false]);
+                $joint->unset($junction->getPrimaryKey());
+                if (method_exists($joint, 'patch')) {
+                    $joint->patch(array_merge($sourceKeys, $targetKeys), ['guard' => false]);
+                } else {
+                    $joint->set(array_merge($sourceKeys, $targetKeys), ['guard' => false]);
+                }
             }
             $saved = $junction->save($joint, $options);
 

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -228,7 +228,11 @@ class HasMany extends Association
             }
 
             if ($foreignKeyReference !== $entity->extract($foreignKey)) {
-                $entity->set($foreignKeyReference, ['guard' => false]);
+                if (method_exists($entity, 'patch')) {
+                    $entity->patch($foreignKeyReference, ['guard' => false]);
+                } else {
+                    $entity->set($foreignKeyReference, ['guard' => false]);
+                }
             }
 
             if ($table->save($entity, $options)) {

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -131,7 +131,11 @@ class HasOne extends Association
             $foreignKeys,
             $entity->extract((array)$this->getBindingKey()),
         );
-        $targetEntity->set($properties, ['guard' => false]);
+        if (method_exists($targetEntity, 'patch')) {
+            $targetEntity = $targetEntity->patch($properties, ['guard' => false]);
+        } else {
+            $targetEntity->set($properties, ['guard' => false]);
+        }
 
         if (!$this->getTarget()->save($targetEntity, $options)) {
             $targetEntity->unset(array_keys($properties));

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -507,7 +507,11 @@ class EavStrategy implements TranslateStrategyInterface
             } else {
                 $translation['model'] = $this->_config['referenceName'];
                 unset($translation['foreign_key IS']);
-                $contents[$i]->set($translation, ['setter' => false, 'guard' => false]);
+                if (method_exists($contents[$i], 'patch')) {
+                    $contents[$i]->patch($translation, ['setter' => false, 'guard' => false]);
+                } else {
+                    $contents[$i]->set($translation, ['setter' => false, 'guard' => false]);
+                }
                 $contents[$i]->setNew(true);
             }
         }

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -420,7 +420,11 @@ class ShadowTableStrategy implements TranslateStrategyInterface
         }
 
         if ($translation) {
-            $translation->set($values);
+            if (method_exists($translation, 'patch')) {
+                $translation->patch($values);
+            } else {
+                $translation->set($values);
+            }
         } else {
             $translation = new ($this->translationTable->getEntityClass())(
                 $where + $values,
@@ -616,7 +620,11 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                 if ($key !== null) {
                     $update['id'] = $key;
                 }
-                $translation->set($update, ['guard' => false]);
+                if (method_exists($translation, 'patch')) {
+                    $translation->patch($update, ['guard' => false]);
+                } else {
+                    $translation->set($update, ['guard' => false]);
+                }
             }
         }
 

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -949,7 +949,11 @@ class TreeBehavior extends Behavior
         }
 
         $fresh = $this->_table->get($entity->get($this->_getPrimaryKey()));
-        $entity->set($fresh->extract($fields), ['guard' => false]);
+        if (method_exists($entity, 'patch')) {
+            $entity->patch($fresh->extract($fields), ['guard' => false]);
+        } else {
+            $entity->set($fresh->extract($fields), ['guard' => false]);
+        }
 
         foreach ($fields as $field) {
             $entity->setDirty($field, false);

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -75,7 +75,7 @@ class Entity implements EntityInterface, InvalidPropertyInterface
                 return;
             }
 
-            $this->set($properties, [
+            $this->patch($properties, [
                 'setter' => $options['useSetters'],
                 'guard' => $options['guard'],
             ]);

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -243,7 +243,11 @@ class Marshaller
                 }
             }
         } else {
-            $entity->set($properties, ['asOriginal' => true]);
+            if (method_exists($entity, 'patch')) {
+                $entity->patch($properties, ['asOriginal' => true]);
+            } else {
+                $entity->set($properties, ['asOriginal' => true]);
+            }
         }
 
         // Don't flag clean association entities as
@@ -603,7 +607,11 @@ class Marshaller
 
         $entity->setErrors($errors);
         if (!isset($options['fields'])) {
-            $entity->set($properties);
+            if (method_exists($entity, 'patch')) {
+                $entity->patch($properties);
+            } else {
+                $entity->set($properties);
+            }
 
             foreach ($properties as $field => $value) {
                 if ($value instanceof EntityInterface) {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2172,7 +2172,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $success = false;
         if ($statement->rowCount() !== 0) {
             $success = $entity;
-            $entity->set($filteredKeys, ['guard' => false]);
+
+            if (method_exists($entity, 'patch')) {
+                $entity = $entity->patch($filteredKeys, ['guard' => false]);
+            } else {
+                $entity->set($filteredKeys, ['guard' => false]);
+            }
+
             $schema = $this->getSchema();
             $driver = $this->getConnection()->getDriver();
             foreach ($primary as $key => $v) {

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -1244,7 +1244,7 @@ class TranslateBehaviorEavTest extends TestCase
 
         $article = $table->get(1);
         foreach ($translations as $lang => $data) {
-            $article->translation($lang)->set($data, ['guard' => false]);
+            $article->translation($lang)->patch($data, ['guard' => false]);
         }
 
         $table->save($article);

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -54,30 +54,39 @@ class EntityTest extends TestCase
         $this->assertSame('bar', $entity->getOriginal('foo'));
     }
 
+    #[WithoutErrorHandler]
+    public function testEntitySetDeprecated(): void
+    {
+        $this->deprecated(function () {
+            $entity = new Entity();
+            $entity->set(['foo' => 'bar']);
+        });
+    }
+
     /**
      * Tests setting multiple properties without custom setters
      */
-    public function testSetMultiplePropertiesNoSetters(): void
+    public function testPatchPropertiesNoSetters(): void
     {
         $entity = new Entity();
         $entity->setAccess('*', true);
 
-        $entity->set(['foo' => 'bar', 'id' => 1], ['asOriginal' => true]);
+        $entity->patch(['foo' => 'bar', 'id' => 1], ['asOriginal' => true]);
         $this->assertSame('bar', $entity->foo);
         $this->assertSame(1, $entity->id);
 
-        $entity->set(['foo' => 'baz', 'id' => 2, 'thing' => 3]);
+        $entity->patch(['foo' => 'baz', 'id' => 2, 'thing' => 3]);
         $this->assertSame('baz', $entity->foo);
         $this->assertSame(2, $entity->id);
         $this->assertSame(3, $entity->thing);
         $this->assertSame('bar', $entity->getOriginal('foo'));
         $this->assertSame(1, $entity->getOriginal('id'));
 
-        $entity->set(['foo', 'bar']);
+        $entity->patch(['foo', 'bar']);
         $this->assertSame('foo', $entity->get('0'));
         $this->assertSame('bar', $entity->get('1'));
 
-        $entity->set(['sample']);
+        $entity->patch(['sample']);
         $this->assertSame('sample', $entity->get('0'));
     }
 
@@ -87,7 +96,7 @@ class EntityTest extends TestCase
         $this->expectExceptionMessage('Cannot set an empty field');
 
         $entity = new Entity();
-        $entity->set(['' => 'value']);
+        $entity->set('', 'value');
     }
 
     /**
@@ -104,7 +113,7 @@ class EntityTest extends TestCase
         $this->assertSame(0, $entity->getOriginal('zero'));
         $this->assertSame('', $entity->getOriginal('empty'));
 
-        $entity->set(['false' => 'y', 'null' => 'y', 'zero' => 'y', 'empty' => '']);
+        $entity->patch(['false' => 'y', 'null' => 'y', 'zero' => 'y', 'empty' => '']);
         $this->assertNull($entity->getOriginal('null'));
         $this->assertFalse($entity->getOriginal('false'));
         $this->assertSame(0, $entity->getOriginal('zero'));
@@ -217,7 +226,7 @@ class EntityTest extends TestCase
             }
         };
         $entity->setAccess('*', true);
-        $entity->set(['name' => 'Jones', 'stuff' => ['a', 'b']]);
+        $entity->patch(['name' => 'Jones', 'stuff' => ['a', 'b']]);
         $this->assertSame('Dr. Jones', $entity->name);
         $this->assertEquals(['c', 'd'], $entity->stuff);
     }
@@ -246,7 +255,7 @@ class EntityTest extends TestCase
         $entity->set('stuff', 'Thing', ['setter' => false]);
         $this->assertSame('Thing', $entity->stuff);
 
-        $entity->set(['name' => 'foo', 'stuff' => 'bar'], ['setter' => false]);
+        $entity->patch(['name' => 'foo', 'stuff' => 'bar'], ['setter' => false]);
         $this->assertSame('bar', $entity->stuff);
     }
 
@@ -256,11 +265,11 @@ class EntityTest extends TestCase
     public function testConstructor(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
-            ->onlyMethods(['set'])
+            ->onlyMethods(['patch'])
             ->disableOriginalConstructor()
             ->getMock();
         $entity->expects($this->exactly(2))
-            ->method('set')
+            ->method('patch')
             ->with(
                 ...self::withConsecutive(
                     [
@@ -281,11 +290,11 @@ class EntityTest extends TestCase
     public function testConstructorWithGuard(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
-            ->onlyMethods(['set'])
+            ->onlyMethods(['patch'])
             ->disableOriginalConstructor()
             ->getMock();
         $entity->expects($this->once())
-            ->method('set')
+            ->method('patch')
             ->with(['foo' => 'bar'], ['setter' => true, 'guard' => true]);
         $entity->__construct(['foo' => 'bar'], ['guard' => true]);
     }
@@ -1000,7 +1009,7 @@ class EntityTest extends TestCase
             }
         };
         $entity->setAccess('*', true);
-        $entity->set(['name' => 'Mark', 'email' => 'mark@example.com']);
+        $entity->patch(['name' => 'Mark', 'email' => 'mark@example.com']);
         $expected = ['name' => 'Jose', 'email' => 'mark@example.com'];
         $this->assertEquals($expected, $entity->toArray());
     }
@@ -1068,7 +1077,7 @@ class EntityTest extends TestCase
             }
         };
         $entity->setAccess('*', true);
-        $entity->set(['email' => 'mark@example.com']);
+        $entity->patch(['email' => 'mark@example.com']);
 
         $entity->setVirtual(['name']);
         $expected = ['name' => 'Jose', 'email' => 'mark@example.com'];
@@ -1214,7 +1223,7 @@ class EntityTest extends TestCase
         $this->assertFalse($hasErrors);
 
         $nestedEntity = new Entity();
-        $entity->set([
+        $entity->patch([
             'nested' => $nestedEntity,
         ]);
         $hasErrors = $entity->hasErrors();
@@ -1415,12 +1424,12 @@ class EntityTest extends TestCase
         $options = ['guard' => true];
         $entity->setAccess('*', false);
         $entity->setAccess('foo', true);
-        $entity->set(['bar' => 3, 'foo' => 4], $options);
+        $entity->patch(['bar' => 3, 'foo' => 4], $options);
         $this->assertSame(2, $entity->get('bar'));
         $this->assertSame(4, $entity->get('foo'));
 
         $entity->setAccess('bar', true);
-        $entity->set(['bar' => 3, 'foo' => 5], $options);
+        $entity->patch(['bar' => 3, 'foo' => 5], $options);
         $this->assertSame(3, $entity->get('bar'));
         $this->assertSame(5, $entity->get('foo'));
     }
@@ -1434,7 +1443,7 @@ class EntityTest extends TestCase
         $entity->setAccess('*', false);
         $entity->setAccess('title', true);
 
-        $entity->set(['title' => 'test', 'body' => 'Nope']);
+        $entity->patch(['title' => 'test', 'body' => 'Nope']);
         $this->assertSame('test', $entity->title);
         $this->assertNull($entity->body);
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2847,7 +2847,7 @@ class TableTest extends TestCase
         $entity = $table->get(1);
 
         $entity->setAccess('*', true);
-        $entity->set($entity->toArray());
+        $entity->patch($entity->toArray());
         $this->assertSame($entity, $table->save($entity));
     }
 
@@ -5629,7 +5629,7 @@ class TableTest extends TestCase
             ['author_id' => 2, 'title' => 'First Article'],
             function ($article) use (&$callbackExecuted): void {
                 $this->assertInstanceOf(EntityInterface::class, $article);
-                $article->set(['published' => 'N', 'body' => 'New body']);
+                $article->patch(['published' => 'N', 'body' => 'New body']);
                 $callbackExecuted = true;
             },
         );

--- a/tests/test_app/TestApp/Model/Entity/NonExtending.php
+++ b/tests/test_app/TestApp/Model/Entity/NonExtending.php
@@ -24,7 +24,7 @@ class NonExtending implements EntityInterface
         ];
 
         if ($properties) {
-            $this->set($properties, [
+            $this->patch($properties, [
                 'setter' => $options['useSetters'],
                 'guard' => $options['guard'],
             ]);


### PR DESCRIPTION
Passing multiple field values to EntityTrait::set() is deprecated.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
