### PR TITLE
5.x Fix secure postLink() data post

### DIFF
--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -390,9 +390,7 @@ class FormProtector
 
         $locked = [];
         foreach ($fields as $key => $value) {
-            if (is_bool($value)) {
-                $value = (string)$value;
-            } elseif (is_numeric($value)) {
+            if (is_numeric($value) || is_bool($value)) {
                 $value = (string)$value;
             }
 

--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -390,9 +390,12 @@ class FormProtector
 
         $locked = [];
         foreach ($fields as $key => $value) {
-            if (is_numeric($value)) {
+            if (is_bool($value)) {
+                $value = (string)$value;
+            } elseif (is_numeric($value)) {
                 $value = (string)$value;
             }
+
             if (!is_int($key)) {
                 $locked[$key] = $value;
                 unset($fields[$key]);

--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -390,7 +390,11 @@ class FormProtector
 
         $locked = [];
         foreach ($fields as $key => $value) {
-            if (is_numeric($value) || is_bool($value)) {
+            if ($value === true) {
+                $value = '1';
+            } elseif ($value === false) {
+                $value = '0';
+            } elseif (is_numeric($value)) {
                 $value = (string)$value;
             }
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -49,7 +49,6 @@ use InvalidArgumentException;
 use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
-use SimpleXMLElement;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Enum\ArticleStatus;
 use TestApp\Model\Enum\ArticleStatusLabel;
@@ -2249,7 +2248,7 @@ class FormHelperTest extends TestCase
             ->withAttribute('csrfToken', 'testKey'));
 
         $options = [
-            'data' => ['string' => 'value', 'boolean' => true],
+            'data' => ['string' => 'value', 'boolean' => true, 'falsey' => false],
         ];
         $result = $this->Form->postLink('title', '/articles/add', $options);
 
@@ -2271,9 +2270,11 @@ class FormHelperTest extends TestCase
 
         // Create a simulated request
         // boolean is `'1'` because that is what the request
+        // same with falsey being '0'
         // data will be.
         $data = [
             'boolean' => '1',
+            'falsey' => '0',
             'string' => 'value',
             '_Token' => $token,
         ];

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -23,6 +23,7 @@ use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use Cake\Database\Type\EnumType;
 use Cake\Form\Form;
+use Cake\Form\FormProtector;
 use Cake\Http\ServerRequest;
 use Cake\I18n\Date;
 use Cake\I18n\DateTime;
@@ -42,10 +43,13 @@ use Cake\View\View;
 use Cake\View\Widget\LabelWidget;
 use Cake\View\Widget\WidgetInterface;
 use Cake\View\Widget\WidgetLocator;
+use DOMDocument;
+use DOMXPath;
 use InvalidArgumentException;
 use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
+use SimpleXMLElement;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Enum\ArticleStatus;
 use TestApp\Model\Enum\ArticleStatusLabel;
@@ -2233,6 +2237,51 @@ class FormHelperTest extends TestCase
         ];
         $result = $this->Form->getFormProtector()->__debugInfo()['fields'];
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test that postLink() with additional data generates a valid secure token.
+     */
+    public function testFormSecuredControlPostLink(): void
+    {
+        $this->View->setRequest($this->View->getRequest()
+            ->withAttribute('formTokenData', [])
+            ->withAttribute('csrfToken', 'testKey'));
+
+        $options = [
+            'data' => ['string' => 'value', 'boolean' => true],
+        ];
+        $result = $this->Form->postLink('title', '/articles/add', $options);
+
+        // Because postLink() creates a standalone form protector
+        // we can't inspect its internal state at all.
+        // Use the generated HTML to extract token data so we
+        // can craft a request.
+        $dom = new DOMDocument();
+        $dom->loadHTML($result);
+        $xpath = new DOMXPath($dom);
+        $inputs = $xpath->query("//form//input[contains(@name,'_Token')]");
+        $token = [];
+        foreach ($inputs as $item) {
+            $name = $item->getAttribute('name');
+            [, $field] = explode('[', $name);
+            $field = trim($field, ']');
+            $token[$field] = $item->getAttribute('value');
+        }
+
+        // Create a simulated request
+        // boolean is `'1'` because that is what the request
+        // data will be.
+        $data = [
+            'boolean' => '1',
+            'string' => 'value',
+            '_Token' => $token,
+        ];
+        $formProtector = new FormProtector([]);
+        $this->assertTrue(
+            $formProtector->validate($data, '/articles/add', 'cli'),
+            $formProtector->getError() ?? 'no formprotector->getError'
+        );
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/18223

Not sure how a test case would look like

I tried

```php
    public function testFormSecuredControlPostLink(): void
    {
        $this->View->setRequest($this->View->getRequest()
            ->withAttribute('formTokenData', [])
            ->withAttribute('csrfToken', 'testKey'));

        $options = [
            'data' => ['string' => 'value', 'boolean' => true],
        ];
        $this->Form->postLink('title', '/articles/add', $options);

        //$this->Form->create();
        $data = $options['data'] + [
            '_Token' => $this->Form->getFormProtector()->buildTokenData(),
        ];

        $this->assertTrue($this->Form->getFormProtector()->validate($data, '', ''));
    }
```
but that doesnt quite work out.