### PR TITLE
Expand schema reflection for MySQL

### DIFF
--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -95,7 +95,24 @@ class MysqlSchemaDialect extends SchemaDialect
     }
 
     /**
-     * @inheritDoc
+     * Get a list of column metadata as a array
+     *
+     * Each item in the array will contain the following:
+     *
+     * - name : the name of the column.
+     * - type : the abstract type of the column.
+     * - length : the length of the column.
+     * - default : the default value of the column or null.
+     * - null : boolean indicating whether the column can be null.
+     * - comment : the column comment or null.
+     *
+     * The following keys will be set as required:
+     *
+     * - autoIncrement : set for columns that are an integer primary key.
+     * - onUpdate : set for datetime/timestamp columns with `ON UPDATE` clauses.
+     *
+     * @param string $tableName The name of the table to describe columns on.
+     * @return array
      */
     public function describeColumns(string $tableName): array
     {
@@ -118,6 +135,11 @@ class MysqlSchemaDialect extends SchemaDialect
             ];
             if (isset($row['Extra']) && $row['Extra'] === 'auto_increment') {
                 $field['autoIncrement'] = true;
+            }
+            if ($row['Extra'] === 'on update CURRENT_TIMESTAMP') {
+                $field['onUpdate'] = 'CURRENT_TIMESTAMP';
+            } elseif ($row['Extra'] === 'on update current_timestamp()') {
+                $field['onUpdate'] = 'CURRENT_TIMESTAMP';
             }
             $columns[] = $field;
         }

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -310,6 +310,7 @@ SQL;
                 location POINT,
                 created DATETIME,
                 created_with_precision DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3),
+                updated DATETIME ON UPDATE CURRENT_TIMESTAMP,
                 KEY `author_idx` (`author_id`),
                 CONSTRAINT `length_idx` UNIQUE KEY(`title`(4)),
                 FOREIGN KEY `author_idx` (`author_id`) REFERENCES `schema_authors`(`id`) ON UPDATE CASCADE ON DELETE RESTRICT,
@@ -457,6 +458,14 @@ SQL;
                 'precision' => 3,
                 'comment' => null,
             ],
+            'updated' => [
+                'type' => 'datetime',
+                'null' => true,
+                'default' => null,
+                'length' => null,
+                'precision' => null,
+                'comment' => null,
+            ],
         ];
 
         $driver = ConnectionManager::get('test')->getDriver();
@@ -478,7 +487,10 @@ SQL;
             );
         }
 
-        // Compare with describeColumns as well
+        // Compare with describeColumns which has some more platform specific keys
+        // that are also public API.
+        $expected['updated']['onUpdate'] = 'CURRENT_TIMESTAMP';
+
         $columns = $dialect->describeColumns('schema_articles');
         foreach ($columns as $column) {
             $this->assertArrayHasKey($column['name'], $expected);
@@ -499,6 +511,7 @@ SQL;
 
         $config = $connection->getDriver()->config();
         $dialect = $connection->getDriver()->schemaDialect();
+
         $result = $dialect->describe($config['database'] . '.schema_articles');
         $this->assertInstanceOf(TableSchema::class, $result);
     }


### PR DESCRIPTION
We needed a few more attributes to reach parity with what migrations will need. Any additional keys should be considered public API but will not be exposed in CakePHP's Database/Table object. This should probably change in the future.