### PR TITLE
Fix issue iterating ResultSet with xdebug breakpoints.

### DIFF
--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -38,8 +38,18 @@ class ResultSet extends Collection implements ResultSetInterface
      */
     public function __debugInfo(): array
     {
+        $key = $this->key();
+        $items = $this->toArray();
+
+        $this->rewind();
+        // Move the internal pointer to the previous position otherwise it creates problems with Xdebug
+        // https://github.com/cakephp/cakephp/issues/18234
+        while ($this->key() !== $key) {
+            $this->next();
+        }
+
         return [
-            'items' => $this->toArray(),
+            'items' => $items,
         ];
     }
 }


### PR DESCRIPTION
Closes #18234

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
