### PR TITLE
Avoid TypeError for str_contains()

### DIFF
--- a/src/Http/UriFactory.php
+++ b/src/Http/UriFactory.php
@@ -21,6 +21,7 @@ use Laminas\Diactoros\Uri;
 use Laminas\Diactoros\UriFactory as DiactorosUriFactory;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
+use RuntimeException;
 use function Laminas\Diactoros\marshalHeadersFromSapi;
 
 /**
@@ -170,6 +171,9 @@ class UriFactory implements UriFactoryInterface
         $webrootDir = $base . '/';
 
         $docRoot = $server['DOCUMENT_ROOT'] ?? null;
+        if ($docRoot === null) {
+            throw new RuntimeException("`\$server['DOCUMENT_ROOT']` cannot be null");
+        }
         if (
             ($base || $docRoot && !str_contains($docRoot, $webroot))
             && !str_contains($webrootDir, '/' . $webroot . '/')

--- a/src/Http/UriFactory.php
+++ b/src/Http/UriFactory.php
@@ -171,7 +171,7 @@ class UriFactory implements UriFactoryInterface
 
         $docRoot = $server['DOCUMENT_ROOT'] ?? null;
         if (
-            (!empty($base) || !str_contains($docRoot, $webroot))
+            ($base || $docRoot && !str_contains($docRoot, $webroot))
             && !str_contains($webrootDir, '/' . $webroot . '/')
         ) {
             $webrootDir .= $webroot . '/';

--- a/src/Http/UriFactory.php
+++ b/src/Http/UriFactory.php
@@ -175,7 +175,7 @@ class UriFactory implements UriFactoryInterface
             throw new RuntimeException("`\$server['DOCUMENT_ROOT']` cannot be null");
         }
         if (
-            ($base || $docRoot && !str_contains($docRoot, $webroot))
+            ($base || !str_contains($docRoot, $webroot))
             && !str_contains($webrootDir, '/' . $webroot . '/')
         ) {
             $webrootDir .= $webroot . '/';


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/18237
best to check for a non empty input before trying a str_contains() on it.

I am a bit surprised that our STAN tools dont report on sth like this.