### PR TITLE
Fix type error.

### DIFF
--- a/src/Http/UriFactory.php
+++ b/src/Http/UriFactory.php
@@ -169,7 +169,7 @@ class UriFactory implements UriFactoryInterface
         }
         $webrootDir = $base . '/';
 
-        $docRoot = $server['DOCUMENT_ROOT'] ?? null;
+        $docRoot = $server['DOCUMENT_ROOT'] ?? '';
         if (
             (!empty($base) || !str_contains($docRoot, $webroot))
             && !str_contains($webrootDir, '/' . $webroot . '/')

--- a/src/Http/UriFactory.php
+++ b/src/Http/UriFactory.php
@@ -171,7 +171,7 @@ class UriFactory implements UriFactoryInterface
 
         $docRoot = $server['DOCUMENT_ROOT'] ?? '';
         if (
-            (!empty($base) || !str_contains($docRoot, $webroot))
+            ($base || !str_contains($docRoot, $webroot))
             && !str_contains($webrootDir, '/' . $webroot . '/')
         ) {
             $webrootDir .= $webroot . '/';

--- a/tests/TestCase/Http/UriFactoryTest.php
+++ b/tests/TestCase/Http/UriFactoryTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Http;
 
+use Cake\Core\Configure;
 use Cake\Http\UriFactory;
 use Cake\TestSuite\TestCase;
 use Laminas\Diactoros\Uri;
@@ -31,5 +32,17 @@ class UriFactoryTest extends TestCase
         $uri = $factory->createUri('https://cakephp.org');
 
         $this->assertInstanceOf(Uri::class, $uri);
+    }
+
+    public function testMarshalUriAndBaseFromSapi()
+    {
+        Configure::write('App.baseUrl', '/index.php');
+        $result = UriFactory::marshalUriAndBaseFromSapi([]);
+
+        $this->assertInstanceOf(Uri::class, $result['uri']);
+        $this->assertSame('/index.php', $result['base']);
+        $this->assertSame('/webroot/', $result['webroot']);
+
+        Configure::delete('App.baseUrl');
     }
 }


### PR DESCRIPTION
When UriFactory::marshalUriAndBaseFromSapi() is called with explicit server params and DOCUMENT_ROOT is not set, default to empty string instead of null.

Closes #18237

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
