### PR TITLE
Fix Route::parseRequest() not being able to emit query parameters

### DIFF
--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -157,7 +157,7 @@ class RouteCollection
                 }
                 if ($uri->getQuery()) {
                     parse_str($uri->getQuery(), $queryParameters);
-                    $r['?'] = $queryParameters;
+                    $r['?'] = array_merge($r['?'] ?? [], $queryParameters);
                 }
 
                 return $r;

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -25,6 +25,7 @@ use Cake\Routing\RouteCollection;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
+use TestApp\Routing\Route\AddQueryParamRoute;
 
 class RouteCollectionTest extends TestCase
 {
@@ -340,6 +341,31 @@ class RouteCollectionTest extends TestCase
             'plugin' => null,
             '_matchedRoute' => '/{id}',
             '?' => ['one' => 'two'],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test parseRequest() handling query strings.
+     */
+    public function testParseRequestQueryStringFromRoute(): void
+    {
+        $routes = new RouteBuilder($this->collection, '/');
+        $routes->connect(
+            '/test',
+            ['controller' => 'Articles', 'action' => 'view'],
+            ['routeClass' => AddQueryParamRoute::class],
+        );
+        $request = new ServerRequest(['url' => '/test?y=2']);
+        $result = $this->collection->parseRequest($request);
+        unset($result['_route']);
+        $expected = [
+            'controller' => 'Articles',
+            'action' => 'view',
+            'pass' => [],
+            'plugin' => null,
+            '_matchedRoute' => '/test',
+            '?' => ['x' => '1', 'y' => '2'],
         ];
         $this->assertEquals($expected, $result);
     }

--- a/tests/test_app/TestApp/Routing/Route/AddQueryParamRoute.php
+++ b/tests/test_app/TestApp/Routing/Route/AddQueryParamRoute.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Routing\Route;
+
+use Cake\Routing\Route\Route;
+use Psr\Http\Message\ServerRequestInterface;
+
+class AddQueryParamRoute extends Route
+{
+    public function parseRequest(ServerRequestInterface $request): ?array
+    {
+        $params = parent::parseRequest($request);
+        if (is_array($params)) {
+            $params['?']['x'] = '1';
+        }
+
+        return $params;
+    }
+}


### PR DESCRIPTION
If the result of a `parseRequest()` call includes a `?` key, that value should be merged with the actual query string parameters. This is useful when building simpler aliases for URLs with complex query string parameters.

This could also be backported to 4.x

Fixes #18245