### PR TITLE
add PHPUnit 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^5.2",
+        "http-interop/http-factory-tests": "dev-main",
         "mikey179/vfsstream": "^1.6.10",
         "mockery/mockery": "^1.6",
         "paragonie/csp-builder": "^2.3 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -58,11 +58,10 @@
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^5.2",
-        "http-interop/http-factory-tests": "^2.0",
         "mikey179/vfsstream": "^1.6.10",
         "mockery/mockery": "^1.6",
         "paragonie/csp-builder": "^2.3 || ^3.0",
-        "phpunit/phpunit": "^10.5.5 || ^11.1.3"
+        "phpunit/phpunit": "^10.5.5 || ^11.1.3 || ^12.0.9"
     },
     "suggest": {
         "ext-curl": "To enable more efficient network calls in Http\\Client.",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,9 +18,9 @@
             <directory>tests/TestCase/Database/</directory>
             <directory>tests/TestCase/ORM/</directory>
         </testsuite>
-<!--        <testsuite name="http-interop-http-factory">-->
-<!--            <directory>./vendor/http-interop/http-factory-tests/test</directory>-->
-<!--        </testsuite>-->
+        <testsuite name="http-interop-http-factory">
+            <directory>./vendor/http-interop/http-factory-tests/test</directory>
+        </testsuite>
         <testsuite name="globalfunctions">
             <file>tests/TestCase/Collection/FunctionsGlobalTest.php</file>
             <file>tests/TestCase/Core/FunctionsGlobalTest.php</file>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,9 +18,9 @@
             <directory>tests/TestCase/Database/</directory>
             <directory>tests/TestCase/ORM/</directory>
         </testsuite>
-        <testsuite name="http-interop-http-factory">
-            <directory>./vendor/http-interop/http-factory-tests/test</directory>
-        </testsuite>
+<!--        <testsuite name="http-interop-http-factory">-->
+<!--            <directory>./vendor/http-interop/http-factory-tests/test</directory>-->
+<!--        </testsuite>-->
         <testsuite name="globalfunctions">
             <file>tests/TestCase/Collection/FunctionsGlobalTest.php</file>
             <file>tests/TestCase/Core/FunctionsGlobalTest.php</file>

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -21,6 +21,7 @@ use Cake\Database\Driver\Sqlite;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use TestApp\Database\Schema\CompatDialect;
 
 /**
@@ -229,16 +230,18 @@ class SchemaDialectTest extends TestCase
      * Test that SchemaDialect implementations without describeColumns etc
      * implemented still work with describe().
      */
+    #[WithoutErrorHandler]
     public function testBackwardsCompatibility(): void
     {
-        /** @var \Cake\Database\Driver $driver */
-        $driver = ConnectionManager::get('test')->getDriver();
-        $this->skipIf(!($driver instanceof Sqlite), 'requires sqlite connection');
-        $dialect = new CompatDialect($driver);
-        $table = $dialect->describe('orders');
-
-        $this->assertNotEmpty($table->columns());
-        $this->assertNotEmpty($table->indexes());
-        $this->assertNotEmpty($table->constraints());
+        $this->deprecated(function () {
+            /** @var \Cake\Database\Driver $driver */
+            $driver = ConnectionManager::get('test')->getDriver();
+            $this->skipIf(!($driver instanceof Sqlite), 'requires sqlite connection');
+            $dialect = new CompatDialect($driver);
+            $table = $dialect->describe('orders');
+            $this->assertNotEmpty($table->columns());
+            $this->assertNotEmpty($table->indexes());
+            $this->assertNotEmpty($table->constraints());
+        });
     }
 }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -800,7 +800,7 @@ class TranslateBehaviorEavTest extends TestCase
         $this->assertNotEmpty($entity->author->name);
 
         $expected = $table->get(1, ...['contain' => ['Authors']]);
-        $this->assertEqualsCanonicalizing($expected, $result);
+        $this->assertEqualsCanonicalizing($expected->toArray(), $result->toArray());
         $this->assertNotEmpty($entity->author);
         $this->assertNotEmpty($entity->author->name);
     }

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1801,7 +1801,7 @@ class MarshallerTest extends TestCase
         $this->assertCount(1, $result->comments);
         $this->assertTrue($result->isDirty('comments'), 'Updated prop should be dirty');
         $this->assertInstanceOf(Entity::class, $result->comments[0]);
-        $this->assertNotEquals('Nope', $result->comments[0]);
+        $this->assertNotEquals('Nope', $result->comments[0]->comment);
     }
 
     /**

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -1520,7 +1520,7 @@ class QueryRegressionTest extends TestCase
         $tags = $articles->getAssociation('articlesTags')->getTarget()->belongsTo('tags');
 
         $tags->getTarget()->getEventManager()->on('Model.beforeFind', function ($e, $query) {
-            return $query->formatResults(function ($results) {
+            $query->formatResults(function ($results) {
                 return $results->map(function (Entity $tag) {
                     $tag->name .= ' - visited';
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -4279,7 +4279,7 @@ class TableTest extends TestCase
 
         $article = $table->find('all')->where(['id' => 1])->contain(['Tags'])->first();
         $this->assertEquals($article->tags[2]->id, $tags[0]->id);
-        $this->assertEqualsCanonicalizing($article->tags[3], $tags[1]);
+        $this->assertEqualsCanonicalizing($article->tags[3]->toArray(), $tags[1]->toArray());
     }
 
     /**

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -33,6 +33,7 @@ use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestStatus\Skipped;
 use PHPUnit\Framework\TestStatus\Success;
+use PHPUnit\Runner\Version;
 use TestApp\Model\Entity\Tag;
 use TestApp\Model\Table\PostsTable;
 use TestApp\Model\Table\SecondaryPostsTable;
@@ -374,6 +375,8 @@ class TestCaseTest extends TestCase
      */
     public function testGetMockForModel(): void
     {
+        $this->skipIf(version_compare(Version::id(), '12.0.0', '>='), 'This test is not compatible with PHPUnit 12');
+
         static::setAppNamespace();
         // No methods will be mocked if $methods argument of getMockForModel() is empty.
         $Posts = $this->getMockForModel('Posts');


### PR DESCRIPTION
HTTP Factory Tests need to add PHPUnit 12 support first to make this work.
https://github.com/http-interop/http-factory-tests/pull/53

There were also some cake internal deprecations which were not adjusted accordingly till now (first commit)

The only major thing that has changed is the fact, that `MockBuilder::addMethods()` does not exist anymore.

Therefore I just skipped the only test, that contains this logic.