### PR TITLE
Begin adding SchemaDialect::columnDefinitionSql

### DIFF
--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -356,6 +356,25 @@ abstract class SchemaDialect
     abstract public function truncateTableSql(TableSchema $schema): array;
 
     /**
+     * Create a SQL snippet for a column based on the array shape
+     * that `describeColumns()` creates.
+     *
+     * @param array $data The column metadata
+     * @return string Generated SQL fragment for a column
+     */
+    public function columnDefinitionSql(array $column): string
+    {
+        deprecationWarning(
+            '5.2.0',
+            'SchemaDialect subclasses need to implement `columnDefinitionSql` before 6.0.0',
+        );
+        $table = new TableSchema('placeholder');
+        $table->addColumn($column['name'], $column);
+
+        return $this->columnSql($table, $column['name']);
+    }
+
+    /**
      * Get the list of tables, excluding any views, available in the current connection.
      *
      * @return array<string> The list of tables in the connected database/schema.

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -359,7 +359,7 @@ abstract class SchemaDialect
      * Create a SQL snippet for a column based on the array shape
      * that `describeColumns()` creates.
      *
-     * @param array $data The column metadata
+     * @param array $column The column metadata
      * @return string Generated SQL fragment for a column
      */
     public function columnDefinitionSql(array $column): string

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -179,6 +179,21 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         'polygon' => [
             'srid' => null,
         ],
+        'datetime' => [
+            'onUpdate' => null,
+        ],
+        'datetimefractional' => [
+            'onUpdate' => null,
+        ],
+        'timestamp' => [
+            'onUpdate' => null,
+        ],
+        'timestampfractional' => [
+            'onUpdate' => null,
+        ],
+        'timestamptimezone' => [
+            'onUpdate' => null,
+        ],
     ];
 
     /**

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -458,6 +458,7 @@ SQL;
                 'length' => null,
                 'precision' => 6,
                 'comment' => null,
+                'onUpdate' => null,
             ],
             'created_without_precision' => [
                 'type' => 'timestamp',
@@ -466,6 +467,7 @@ SQL;
                 'length' => null,
                 'precision' => 0,
                 'comment' => null,
+                'onUpdate' => null,
             ],
             'created_with_precision' => [
                 'type' => 'timestampfractional',
@@ -474,6 +476,7 @@ SQL;
                 'length' => null,
                 'precision' => 3,
                 'comment' => null,
+                'onUpdate' => null,
             ],
             'created_with_timezone' => [
                 'type' => 'timestamptimezone',
@@ -482,6 +485,7 @@ SQL;
                 'length' => null,
                 'precision' => 6,
                 'comment' => null,
+                'onUpdate' => null,
             ],
         ];
         $this->assertEquals(['id'], $result->getPrimaryKey());
@@ -583,6 +587,7 @@ SQL;
                 'length' => null,
                 'precision' => 6,
                 'comment' => null,
+                'onUpdate' => null,
             ],
         ];
         $this->assertEquals(['id'], $result->getPrimaryKey());

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -1133,10 +1133,13 @@ SQL;
     public function testColumnSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
-        $schema = new SqliteSchemaDialect($driver);
+        $dialect = new SqliteSchemaDialect($driver);
 
         $table = (new TableSchema('articles'))->addColumn($name, $data);
-        $this->assertEquals($expected, $schema->columnSql($table, $name));
+        $this->assertEquals($expected, $dialect->columnSql($table, $name));
+
+        $data['name'] = $name;
+        $this->assertEquals($expected, $dialect->columnDefinitionSql($data));
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -454,6 +454,7 @@ SQL;
                 'length' => null,
                 'precision' => null,
                 'comment' => null,
+                'onUpdate' => null,
             ],
             'field1' => [
                 'type' => 'string',

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -466,6 +466,7 @@ SQL;
                 'length' => null,
                 'precision' => null,
                 'comment' => null,
+                'onUpdate' => null,
             ],
             'created2' => [
                 'type' => 'datetimefractional',
@@ -474,6 +475,7 @@ SQL;
                 'length' => null,
                 'precision' => 7,
                 'comment' => null,
+                'onUpdate' => null,
             ],
             'created2_with_default' => [
                 'type' => 'datetimefractional',
@@ -482,6 +484,7 @@ SQL;
                 'length' => null,
                 'precision' => 7,
                 'comment' => null,
+                'onUpdate' => null,
             ],
             'created2_with_precision' => [
                 'type' => 'datetimefractional',
@@ -490,6 +493,7 @@ SQL;
                 'length' => null,
                 'precision' => 3,
                 'comment' => null,
+                'onUpdate' => null,
             ],
             'created2_without_precision' => [
                 'type' => 'datetime',
@@ -498,6 +502,7 @@ SQL;
                 'length' => null,
                 'precision' => 0,
                 'comment' => null,
+                'onUpdate' => null,
             ],
             'field1' => [
                 'type' => 'string',


### PR DESCRIPTION
In order to remove duplication between migrations and cakephp/database, we need a method to generate column SQL fragments for DDL operations. The current method in SchemaDialect isn't well suited for this as it requires an `TableSchema` instance which we don't always have in migrations.

This new with consumes the output of describeColumns() which migrations will also start using. I've also added `onUpdate` to `TableSchema` reflection for datetime/timestamp columns so that schema generation is consistent between the two APIs. These changes only contain an implementation for MySQL. Other drivers will be implemented in follow up pull requests.
 