### PR TITLE
Backport: Make NullEngine return the original keys like other engines

### DIFF
--- a/src/Cache/Engine/NullEngine.php
+++ b/src/Cache/Engine/NullEngine.php
@@ -62,7 +62,13 @@ class NullEngine extends CacheEngine
      */
     public function getMultiple($keys, $default = null): iterable
     {
-        return [];
+        $result = [];
+
+        foreach ($keys as $key) {
+            $result[$key] = $default;
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/NullEngineTest.php
+++ b/tests/TestCase/Cache/Engine/NullEngineTest.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.7.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Cache\Engine;
+
+use Cake\Cache\Cache;
+use Cake\Cache\Engine\NullEngine;
+use Cake\TestSuite\TestCase;
+
+/**
+ * ArrayEngineTest class
+ */
+class NullEngineTest extends TestCase
+{
+    /**
+     * setUp method
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::enable();
+        Cache::clearAll();
+
+        Cache::drop('null');
+        Cache::setConfig('null', [
+            'className' => NullEngine::class,
+        ]);
+    }
+
+    public function testReadMany(): void
+    {
+        $keys = [
+            'key1',
+            'key2',
+            'key3',
+        ];
+
+        $result1 = Cache::readMany($keys, 'null');
+
+        $this->assertSame([
+            'key1' => null,
+            'key2' => null,
+            'key3' => null,
+        ], $result1);
+
+        $e = new \Exception('Cache key not found');
+        $result2 = Cache::pool('null')->getMultiple($keys, $e);
+
+        $this->assertSame([
+            'key1' => $e,
+            'key2' => $e,
+            'key3' => $e,
+        ], $result2);
+    }
+}

--- a/tests/TestCase/Cache/Engine/NullEngineTest.php
+++ b/tests/TestCase/Cache/Engine/NullEngineTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Cache\Engine;
 use Cake\Cache\Cache;
 use Cake\Cache\Engine\NullEngine;
 use Cake\TestSuite\TestCase;
+use Exception;
 
 /**
  * ArrayEngineTest class
@@ -56,7 +57,7 @@ class NullEngineTest extends TestCase
             'key3' => null,
         ], $result1);
 
-        $e = new \Exception('Cache key not found');
+        $e = new Exception('Cache key not found');
         $result2 = Cache::pool('null')->getMultiple($keys, $e);
 
         $this->assertSame([


### PR DESCRIPTION
Backport of #18250 