### PR TITLE
Treat null as a valid cache value on MemcachedEngine::getMultiple

### DIFF
--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -367,7 +367,7 @@ class MemcachedEngine extends CacheEngine
         $values = $this->_Memcached->getMulti($cacheKeys);
         $return = [];
         foreach ($cacheKeys as $original => $prefixed) {
-            $return[$original] = $values[$prefixed] ?? $default;
+            $return[$original] = array_key_exists($prefixed, $values) ? $values[$prefixed] : $default;
         }
 
         return $return;


### PR DESCRIPTION
Currently when caching `null` as value in memcached, when reading using readMany it is treated as not present in the cache while it is.

This fixes that behavior allowing to cache `null` as value.