### PR TITLE
Backport: Treat null as a valid cache value on MemcachedEngine::getMultiple

### DIFF
--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -365,7 +365,7 @@ class MemcachedEngine extends CacheEngine
         $values = $this->_Memcached->getMulti($cacheKeys);
         $return = [];
         foreach ($cacheKeys as $original => $prefixed) {
-            $return[$original] = $values[$prefixed] ?? $default;
+            $return[$original] = array_key_exists($prefixed, $values) ? $values[$prefixed] : $default;
         }
 
         return $return;


### PR DESCRIPTION
Backport of #18253
