### PR TITLE
Include comments in generated column sql

### DIFF
--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -840,6 +840,9 @@ class SqliteSchemaDialect extends SchemaDialect
         if (isset($column['default'])) {
             $out .= ' DEFAULT ' . $this->_driver->schemaValue($column['default']);
         }
+        if (isset($column['comment']) && $column['comment']) {
+            $out .= " /* {$column['comment']} */";
+        }
 
         return $out;
     }

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -917,8 +917,8 @@ SQL;
             // Text
             [
                 'body',
-                ['type' => 'text', 'null' => false],
-                '"body" TEXT NOT NULL',
+                ['type' => 'text', 'null' => false, 'comment' => 'a comment'],
+                '"body" TEXT NOT NULL /* a comment */',
             ],
             [
                 'body',


### PR DESCRIPTION
I've started to update migrations to use the new reflection code, and found this gap. I suspect there will be a few more of these as I go.