### PR TITLE
Fix usage of deprecated method in ReconnectStrategy.php

### DIFF
--- a/src/Database/Retry/ReconnectStrategy.php
+++ b/src/Database/Retry/ReconnectStrategy.php
@@ -109,7 +109,7 @@ class ReconnectStrategy implements RetryStrategyInterface
         }
 
         try {
-            $this->connection->connect();
+            $this->connection->getDriver()->connect();
             if ($this->connection->isQueryLoggingEnabled()) {
                 $this->connection->log('[RECONNECT]');
             }


### PR DESCRIPTION
Fixes the notice:
> notice: If you cannot use automatic connection management, use $connection->getDriver()->connect() instead.
/path-to-app/vendor/cakephp/cakephp/src/Database/Retry/ReconnectStrategy.php, line: 112
