### PR TITLE
Fix method and finder map population when using BehaviorRegistry::set()

### DIFF
--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -212,6 +212,24 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
     }
 
     /**
+     * Set an object directly into the registry by name.
+     *
+     * @param string $name The name of the object to set in the registry.
+     * @param \Cake\ORM\Behavior $object instance to store in the registry
+     * @return $this
+     */
+    public function set(string $name, object $object)
+    {
+        parent::set($name, $object);
+
+        $methods = $this->_getMethods($object, $object::class, $name);
+        $this->_methodMap += $methods['methods'];
+        $this->_finderMap += $methods['finders'];
+
+        return $this;
+    }
+
+    /**
      * Remove an object from the registry.
      *
      * If this registry has an event manager, the object will be detached from any events as well.

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -221,6 +221,14 @@ class BehaviorRegistryTest extends TestCase
         $this->assertTrue($this->Behaviors->hasFinder('renamed'));
     }
 
+    public function testSet()
+    {
+        $this->Behaviors->set('Sluggable', new SluggableBehavior($this->Table, ['replacement' => '_']));
+
+        $this->assertEquals(['replacement' => '_'], $this->Behaviors->get('Sluggable')->getConfig());
+        $this->assertTrue($this->Behaviors->hasMethod('slugify'));
+    }
+
     /**
      * test hasMethod()
      */


### PR DESCRIPTION
Closes #18263

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
