### PR TITLE
Throw exception when using plugin prefixed names.

### DIFF
--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -344,7 +344,12 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      */
     public function set(string $name, object $object)
     {
-        [, $objName] = pluginSplit($name);
+        if (str_contains($name, '.')) {
+            throw new CakeException(
+                'Plugin prefixed names are not supported for ObjectRegistry::set().'
+                . '  Use an alias without the plugin prefix.',
+            );
+        }
 
         // Just call unload if the object was loaded before
         if (array_key_exists($name, $this->_loaded)) {
@@ -353,7 +358,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
         if ($this instanceof EventDispatcherInterface && $object instanceof EventListenerInterface) {
             $this->getEventManager()->on($object);
         }
-        $this->_loaded[$objName] = $object;
+        $this->_loaded[$name] = $object;
 
         return $this;
     }
@@ -368,9 +373,18 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      */
     public function unload(string $name)
     {
-        if (empty($this->_loaded[$name])) {
-            [$plugin, $name] = pluginSplit($name);
-            $this->_throwMissingClassError($name, $plugin);
+        if (str_contains($name, '.')) {
+            throw new CakeException(
+                'Plugin prefixed names are not supported for ObjectRegistry::unload().'
+                . '  Use an alias without the plugin prefix.',
+            );
+        }
+
+        if (!isset($this->_loaded[$name])) {
+            throw new CakeException(sprintf(
+                'Object with alias `%s` was not found in the registry.',
+                $name,
+            ));
         }
 
         $object = $this->_loaded[$name];

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -22,6 +22,7 @@ use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Controller\Exception\MissingComponentException;
 use Cake\Core\Container;
+use Cake\Core\Exception\CakeException;
 use Cake\Event\EventManager;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -262,9 +263,19 @@ class ComponentRegistryTest extends TestCase
      */
     public function testUnloadUnknown(): void
     {
-        $this->expectException(MissingComponentException::class);
-        $this->expectExceptionMessage('Component class `FooComponent` could not be found.');
+        $this->expectException(CakeException::class);
+        $this->expectExceptionMessage('Object with alias `Foo` was not found in the registry.');
         $this->Components->unload('Foo');
+    }
+
+    public function testUnloadException(): void
+    {
+        $this->expectException(CakeException::class);
+        $this->expectExceptionMessage(
+            'Plugin prefixed names are not supported for ObjectRegistry::unload().'
+                . '  Use an alias without the plugin prefix.',
+        );
+        $this->Components->unload('Foo.Bar');
     }
 
     /**
@@ -281,6 +292,18 @@ class ComponentRegistryTest extends TestCase
         $this->assertEquals($this->Components, $result);
         $this->assertTrue(isset($this->Components->FormProtection), 'Should be present');
         $this->assertCount(1, $eventManager->listeners('Controller.startup'));
+    }
+
+    public function testSetException(): void
+    {
+        $this->expectException(CakeException::class);
+        $this->expectExceptionMessage(
+            'Plugin prefixed names are not supported for ObjectRegistry::set().'
+                . '  Use an alias without the plugin prefix.',
+        );
+
+        $other = new OtherComponent($this->Components);
+        $this->Components->set('TestPlugin.Other', $other);
     }
 
     /**


### PR DESCRIPTION
ObjectRegistry does not store objects with plugin prefixed names. So accepting prefix names for it's load() and set() will lead to incorrect results. Throwing an explicit exception is better than try to use the name after silently dropping the prefix as there's no guarantee that the object loaded using the same plugin prefix.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
