### PR TITLE
18263 - Fix method and finder map population when using BehaviorRegistry::set()

### DIFF
--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -204,6 +204,24 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
     }
 
     /**
+     * Set an object directly into the registry by name.
+     *
+     * @param string $name The name of the object to set in the registry.
+     * @param \Cake\ORM\Behavior $object instance to store in the registry
+     * @return $this
+     */
+    public function set(string $name, object $object)
+    {
+        parent::set($name, $object);
+
+        $methods = $this->_getMethods($object, get_class($object), $name);
+        $this->_methodMap += $methods['methods'];
+        $this->_finderMap += $methods['finders'];
+
+        return $this;
+    }
+
+    /**
      * Remove an object from the registry.
      *
      * If this registry has an event manager, the object will be detached from any events as well.

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -24,6 +24,7 @@ use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use LogicException;
 use RuntimeException;
+use TestApp\Model\Behavior\SluggableBehavior;
 
 /**
  * Test case for BehaviorRegistry.
@@ -207,6 +208,17 @@ class BehaviorRegistryTest extends TestCase
             ],
         ]);
         $this->assertTrue($this->Behaviors->hasFinder('renamed'));
+    }
+
+    /**
+     * Test set()
+     */
+    public function testSet(): void
+    {
+        $this->Behaviors->set('Sluggable', new SluggableBehavior($this->Table, ['replacement' => '_']));
+
+        $this->assertEquals(['replacement' => '_'], $this->Behaviors->get('Sluggable')->getConfig());
+        $this->assertTrue($this->Behaviors->hasMethod('slugify'));
     }
 
     /**


### PR DESCRIPTION
@dereuromark I think coding standard are failing because phive is not able to install tools...not sure if upgrading that pipeline to use php 8.0 would fix the issue but I guess it would. 

I see it was failing before so let me know how to proceed on that