### PR TITLE
Cleanup ObjectRegistry::set() and ObjectRegistry::unload().

### DIFF
--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -344,8 +344,6 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      */
     public function set(string $name, object $object)
     {
-        [, $objName] = pluginSplit($name);
-
         // Just call unload if the object was loaded before
         if (array_key_exists($name, $this->_loaded)) {
             $this->unload($name);
@@ -353,7 +351,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
         if ($this instanceof EventDispatcherInterface && $object instanceof EventListenerInterface) {
             $this->getEventManager()->on($object);
         }
-        $this->_loaded[$objName] = $object;
+        $this->_loaded[$name] = $object;
 
         return $this;
     }
@@ -368,9 +366,8 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      */
     public function unload(string $name)
     {
-        if (empty($this->_loaded[$name])) {
-            [$plugin, $name] = pluginSplit($name);
-            $this->_throwMissingClassError($name, $plugin);
+        if (!isset($this->_loaded[$name])) {
+            throw new CakeException(sprintf('Object named `%s` is not loaded.', $name));
         }
 
         $object = $this->_loaded[$name];

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -22,6 +22,7 @@ use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Controller\Exception\MissingComponentException;
 use Cake\Core\Container;
+use Cake\Core\Exception\CakeException;
 use Cake\Event\EventManager;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -262,8 +263,8 @@ class ComponentRegistryTest extends TestCase
      */
     public function testUnloadUnknown(): void
     {
-        $this->expectException(MissingComponentException::class);
-        $this->expectExceptionMessage('Component class `FooComponent` could not be found.');
+        $this->expectException(CakeException::class);
+        $this->expectExceptionMessage('Object named `Foo` is not loaded.');
         $this->Components->unload('Foo');
     }
 

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -249,8 +249,8 @@ class HelperRegistryTest extends TestCase
      */
     public function testUnloadUnknown(): void
     {
-        $this->expectException(MissingHelperException::class);
-        $this->expectExceptionMessage('Helper class `FooHelper` could not be found.');
+        $this->expectException(CakeException::class);
+        $this->expectExceptionMessage('Object named `Foo` is not loaded.');
         $this->Helpers->unload('Foo');
     }
 


### PR DESCRIPTION
Drop use of pluginSplit(). Plugin prefixed names are only used in ObjectRegistry::load() to expand the name to FQCN. After that the registry does not hold any info of the plugin name, so trying to split the provided name into plugin and object name in the above methods doesn't make sense.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
