### PR TITLE
Allow null for Number helper methods that are commonly used for bake.

### DIFF
--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -58,13 +58,17 @@ class NumberHelper extends Helper
      * - `after` - The string to place after decimal numbers, e.g. ']'
      * - `escape` - Whether to escape html in resulting string
      *
-     * @param string|float|int $number A floating point number.
+     * @param string|float|int|null $number A floating point number.
      * @param array<string, mixed> $options An array with options.
      * @return string Formatted number
      * @link https://book.cakephp.org/5/en/views/helpers/number.html#formatting-numbers
      */
-    public function format(string|float|int $number, array $options = []): string
+    public function format(string|float|int|null $number, array $options = []): string
     {
+        if ($number === null) {
+            return $options['default'] ?? '';
+        }
+
         $formatted = Number::format($number, $options);
         $options += ['escape' => true];
 
@@ -92,13 +96,17 @@ class NumberHelper extends Helper
      *   currency code.
      * - `escape` - Whether to escape html in resulting string
      *
-     * @param string|float $number Value to format.
+     * @param string|float|null $number Value to format.
      * @param string|null $currency International currency name such as 'USD', 'EUR', 'JPY', 'CAD'
      * @param array<string, mixed> $options Options list.
      * @return string Number formatted as a currency.
      */
-    public function currency(string|float $number, ?string $currency = null, array $options = []): string
+    public function currency(string|float|null $number, ?string $currency = null, array $options = []): string
     {
+        if ($number === null) {
+            return $options['default'] ?? '';
+        }
+
         $formatted = Number::currency($number, $currency, $options);
         $options += ['escape' => true];
 

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -65,7 +65,7 @@ class NumberHelper extends Helper
      */
     public function format(string|float|int|null $number, array $options = []): string
     {
-        if ($number === null || $number === '') {
+        if ($number === null) {
             return $options['default'] ?? '';
         }
 
@@ -103,7 +103,7 @@ class NumberHelper extends Helper
      */
     public function currency(string|float|null $number, ?string $currency = null, array $options = []): string
     {
-        if ($number === null || $number === '') {
+        if ($number === null) {
             return $options['default'] ?? '';
         }
 

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -65,7 +65,7 @@ class NumberHelper extends Helper
      */
     public function format(string|float|int|null $number, array $options = []): string
     {
-        if ($number === null) {
+        if ($number === null || $number === '') {
             return $options['default'] ?? '';
         }
 
@@ -103,7 +103,7 @@ class NumberHelper extends Helper
      */
     public function currency(string|float|null $number, ?string $currency = null, array $options = []): string
     {
-        if ($number === null) {
+        if ($number === null || $number === '') {
             return $options['default'] ?? '';
         }
 

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -56,7 +56,8 @@ class NumberHelper extends Helper
      * - `locale` - The locale name to use for formatting the number, e.g. fr_FR
      * - `before` - The string to place before whole numbers, e.g. '['
      * - `after` - The string to place after decimal numbers, e.g. ']'
-     * - `escape` - Whether to escape html in resulting string
+     * - `escape` - Whether to escape HTML in resulting string
+     * - `default` - The default value in case passed value is null
      *
      * @param string|float|int|null $number A floating point number.
      * @param array<string, mixed> $options An array with options.
@@ -94,7 +95,8 @@ class NumberHelper extends Helper
      * - `pattern` - An ICU number pattern to use for formatting the number. e.g #,##0.00
      * - `useIntlCode` - Whether to replace the currency symbol with the international
      *   currency code.
-     * - `escape` - Whether to escape html in resulting string
+     * - `escape` - Whether to escape HTML in resulting string
+     * - `default` - The default value in case passed value is null
      *
      * @param string|float|null $number Value to format.
      * @param string|null $currency International currency name such as 'USD', 'EUR', 'JPY', 'CAD'

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -89,13 +89,13 @@ class NumberHelperTest extends TestCase
         $result = $helper->format($value);
         $this->assertSame('', $result);
 
-        $value = '';
-        $result = $helper->format($value);
-        $this->assertSame('', $result);
-
-        $value = null;
         $result = $helper->format($value, ['default' => '-']);
         $this->assertSame('-', $result);
+
+        // We should revisit this for 6.x
+        $value = '';
+        $result = $helper->format($value);
+        $this->assertSame('0', $result);
     }
 
     /**
@@ -109,12 +109,12 @@ class NumberHelperTest extends TestCase
         $result = $helper->currency($value);
         $this->assertSame('', $result);
 
-        $value = '';
-        $result = $helper->currency($value);
-        $this->assertSame('', $result);
-
-        $value = null;
         $result = $helper->currency($value, null, ['default' => '-']);
         $this->assertSame('-', $result);
+
+        // We should revisit this for 6.x
+        $value = '';
+        $result = $helper->currency($value);
+        $this->assertSame('$0.00', $result);
     }
 }

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -91,7 +91,7 @@ class NumberHelperTest extends TestCase
 
         $value = '';
         $result = $helper->format($value);
-        $this->assertSame('0', $result); // Should be ''
+        $this->assertSame('', $result);
 
         $value = null;
         $result = $helper->format($value, ['default' => '-']);
@@ -99,7 +99,7 @@ class NumberHelperTest extends TestCase
     }
 
     /**
-     * test format() and empty values
+     * test currency() and empty values
      */
     public function testCurrencyEmpty(): void
     {
@@ -111,7 +111,7 @@ class NumberHelperTest extends TestCase
 
         $value = '';
         $result = $helper->currency($value);
-        $this->assertSame('$0.00', $result); // Should be ''
+        $this->assertSame('', $result);
 
         $value = null;
         $result = $helper->currency($value, null, ['default' => '-']);

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -115,6 +115,6 @@ class NumberHelperTest extends TestCase
         // We should revisit this for 6.x
         $value = '';
         $result = $helper->currency($value);
-        $this->assertSame('$0.00', $result);
+        $this->assertNotEmpty($result);
     }
 }

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -77,4 +77,44 @@ class NumberHelperTest extends TestCase
         $helper = new NumberHelper($this->View);
         $this->assertNotNull($helper->{$method}($arg));
     }
+
+    /**
+     * test format() and empty values
+     */
+    public function testFormatEmpty(): void
+    {
+        $helper = new NumberHelper($this->View);
+
+        $value = null;
+        $result = $helper->format($value);
+        $this->assertSame('', $result);
+
+        $value = '';
+        $result = $helper->format($value);
+        $this->assertSame('0', $result); // Should be ''
+
+        $value = null;
+        $result = $helper->format($value, ['default' => '-']);
+        $this->assertSame('-', $result);
+    }
+
+    /**
+     * test format() and empty values
+     */
+    public function testCurrencyEmpty(): void
+    {
+        $helper = new NumberHelper($this->View);
+
+        $value = null;
+        $result = $helper->currency($value);
+        $this->assertSame('', $result);
+
+        $value = '';
+        $result = $helper->currency($value);
+        $this->assertSame('$0.00', $result); // Should be ''
+
+        $value = null;
+        $result = $helper->currency($value, null, ['default' => '-']);
+        $this->assertSame('-', $result);
+    }
 }


### PR DESCRIPTION
Further discussion on https://github.com/cakephp/cakephp/issues/18269

As noted in the tests (2nd commit), I think empty string defaulting to 0 / 0.00 seems wrong to me, too.
Not sure if that is in the scope here to fix up, since we touch the signature anyway..
I guess it could be, since those are mainly theoretical input values, as the normalized "empty" value would be either numeric or null in most DBs.