### PR TITLE
Fix regression on mapType().

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -528,7 +528,7 @@ class Response implements ResponseInterface, Stringable
     public function mapType(array|string $ctype): array|string|null
     {
         if (is_array($ctype)) {
-            return array_map('\Cake\Http\MimeType::getExtension', $ctype);
+            return array_map($this->mapType(...), $ctype);
         }
 
         return MimeType::getExtension($ctype);

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -355,8 +355,36 @@ class ResponseTest extends TestCase
         $this->assertSame('xml', $response->mapType('text/xml'));
         $this->assertSame('html', $response->mapType('*/*'));
         $this->assertSame('csv', $response->mapType('application/vnd.ms-excel'));
+
         $expected = ['json', 'xhtml', 'css'];
         $result = $response->mapType(['application/json', 'application/xhtml+xml', 'text/css']);
+        $this->assertEquals($expected, $result);
+
+        $array = [
+            '1.0' => [
+                'text/csv',
+                'text/xml',
+            ],
+            '0.8' => [
+                'application/json',
+            ],
+            '0.7' => [
+                'application/xml',
+            ],
+        ];
+        $expected = [
+            '1.0' => [
+                'csv',
+                'xml',
+            ],
+            '0.8' => [
+                'json',
+            ],
+            '0.7' => [
+                'xml',
+            ],
+        ];
+        $result = $response->mapType($array);
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
```php
$content = new ContentTypeNegotiation();
$accept = $content->parseAccept($request);
$accepts = $response->mapType($accept);		
```
and apparently a result for parseAccept as
```
[
  '1.0' => [
    (int) 0 => 'text/csv'
  ],
  '0.8' => [
    (int) 0 => 'application/json'
  ],
  '0.7' => [
    (int) 0 => 'application/xml'
  ]
]
```
worked before

and now breaks here as the array_map() is not handling this anymore.
The RequestHandler (now in Shim plugin) is using this and would otherwise break hard here, as would user land code.

Resolves https://github.com/cakephp/cakephp/pull/18012/files#r2027275120 and regression introduced here.

See also https://github.com/dereuromark/cakephp-shim/actions/runs/14247147318/job/39930880606