### PR TITLE
Fix passing context to validator method on behaviors.

### DIFF
--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3481,6 +3481,34 @@ class TableTest extends TestCase
     }
 
     /**
+     * https://github.com/cakephp/cakephp/issues/18273
+     */
+    public function testValidatorWithMethodInBehavior(): void
+    {
+        $table = new Table();
+        $table->addBehavior('Validation');
+
+        $table->getValidator('default')->add(
+            'name',
+            'customValidationRule',
+            ['rule' => 'customValidationRule', 'provider' => 'table'],
+        );
+
+        $result = $table->getValidator('default')->validate([
+            'name' => 'test',
+        ], true);
+
+        $this->assertSame(
+            [
+                'name' => [
+                    'customValidationRule' => 'The provided value is invalid',
+                ],
+            ],
+            $result,
+        );
+    }
+
+    /**
      * Tests that a InvalidArgumentException is thrown if the custom validator method does not exist.
      */
     public function testValidatorWithMissingMethod(): void

--- a/tests/test_app/TestApp/Model/Behavior/ValidationBehavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/ValidationBehavior.php
@@ -35,4 +35,9 @@ class ValidationBehavior extends Behavior
     {
         return $validator->add('name', 'behaviorRule');
     }
+
+    public function customValidationRule(mixed $value, array $context): bool
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
Reflection is used to determine if the validation method has a $context arg. For table methods which are available by proxing to a behavior, we need to generate the callable using the behavior instance instead of the table, so that the actual behavior method is reflected.

Fixes #18273

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
