### PR TITLE
6.x: remove underscore prefix from methods

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,7 +19,7 @@ parameters:
 			path: src/Collection/Iterator/NoChildrenIterator.php
 
 		-
-			message: '#^Parameter \#1 \$args of method Cake\\Command\\RoutesGenerateCommand\:\:_splitArgs\(\) expects array\<string\>, array\<int, array\<string\>\|string\> given\.$#'
+			message: '#^Parameter \#1 \$args of method Cake\\Command\\RoutesGenerateCommand\:\:splitArgs\(\) expects array\<string\>, array\<int, array\<string\>\|string\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Command/RoutesGenerateCommand.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -79,7 +79,7 @@
       <code><![CDATA[static::$_jsonEncodeFormat]]></code>
     </ImpureFunctionCall>
     <ImpureMethodCall>
-      <code><![CDATA[_formatObject]]></code>
+      <code><![CDATA[formatObject]]></code>
       <code><![CDATA[dateAgoInWords]]></code>
       <code><![CDATA[diffFormatter]]></code>
       <code><![CDATA[getDefaultLocale]]></code>
@@ -98,7 +98,7 @@
       <code><![CDATA[static::$_jsonEncodeFormat]]></code>
     </ImpureFunctionCall>
     <ImpureMethodCall>
-      <code><![CDATA[_formatObject]]></code>
+      <code><![CDATA[formatObject]]></code>
       <code><![CDATA[diffFormatter]]></code>
       <code><![CDATA[getDefaultLocale]]></code>
       <code><![CDATA[timeAgoInWords]]></code>
@@ -117,7 +117,7 @@
       <code><![CDATA[static::$_jsonEncodeFormat]]></code>
     </ImpureFunctionCall>
     <ImpureMethodCall>
-      <code><![CDATA[_formatObject]]></code>
+      <code><![CDATA[formatObject]]></code>
       <code><![CDATA[getDefaultLocale]]></code>
       <code><![CDATA[toNative]]></code>
     </ImpureMethodCall>

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -137,7 +137,7 @@ class Cache
      * @throws \RuntimeException If loading of the engine failed.
      * @return void
      */
-    protected static function _buildEngine(string $name): void
+    protected static function buildEngine(string $name): void
     {
         $registry = static::getRegistry();
 
@@ -213,7 +213,7 @@ class Cache
             return $registry->{$config};
         }
 
-        static::_buildEngine($config);
+        static::buildEngine($config);
 
         return $registry->{$config};
     }

--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -335,7 +335,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      * @return string Prefixed key with potentially unsafe characters replaced.
      * @throws \Cake\Cache\Exception\InvalidArgumentException If key's value is invalid.
      */
-    protected function _key(string $key): string
+    protected function key(string $key): string
     {
         $this->ensureValidKey($key);
 

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -38,7 +38,7 @@ class CacheRegistry extends ObjectRegistry
      * @param string $class Partial classname to resolve.
      * @return class-string<\Cake\Cache\CacheEngine>|null Either the correct classname or null.
      */
-    protected function _resolveClassName(string $class): ?string
+    protected function resolveClassName(string $class): ?string
     {
         /** @var class-string<\Cake\Cache\CacheEngine>|null */
         return App::className($class, 'Cache/Engine', 'Engine');
@@ -54,7 +54,7 @@ class CacheRegistry extends ObjectRegistry
      * @return void
      * @throws \BadMethodCallException
      */
-    protected function _throwMissingClassError(string $class, ?string $plugin): void
+    protected function throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new BadMethodCallException(sprintf('Cache engine `%s` is not available.', $class));
     }
@@ -70,7 +70,7 @@ class CacheRegistry extends ObjectRegistry
      * @return \Cake\Cache\CacheEngine The constructed CacheEngine class.
      * @throws \Cake\Core\Exception\CakeException When the cache engine cannot be initialized.
      */
-    protected function _create(object|string $class, string $alias, array $config): CacheEngine
+    protected function create(object|string $class, string $alias, array $config): CacheEngine
     {
         if (is_object($class)) {
             $instance = $class;

--- a/src/Cache/Engine/ApcuEngine.php
+++ b/src/Cache/Engine/ApcuEngine.php
@@ -64,7 +64,7 @@ class ApcuEngine extends CacheEngine
      */
     public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $duration = $this->duration($ttl);
 
         return apcu_store($key, $value, $duration);
@@ -81,7 +81,7 @@ class ApcuEngine extends CacheEngine
      */
     public function get(string $key, mixed $default = null): mixed
     {
-        $value = apcu_fetch($this->_key($key), $success);
+        $value = apcu_fetch($this->key($key), $success);
         if ($success === false) {
             return $default;
         }
@@ -99,7 +99,7 @@ class ApcuEngine extends CacheEngine
      */
     public function increment(string $key, int $offset = 1): int|false
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         return apcu_inc($key, $offset);
     }
@@ -114,7 +114,7 @@ class ApcuEngine extends CacheEngine
      */
     public function decrement(string $key, int $offset = 1): int|false
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         return apcu_dec($key, $offset);
     }
@@ -128,7 +128,7 @@ class ApcuEngine extends CacheEngine
      */
     public function delete(string $key): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         return apcu_delete($key);
     }
@@ -173,7 +173,7 @@ class ApcuEngine extends CacheEngine
      */
     public function add(string $key, mixed $value): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $duration = $this->_config['duration'];
 
         return apcu_add($key, $value, $duration);

--- a/src/Cache/Engine/ArrayEngine.php
+++ b/src/Cache/Engine/ArrayEngine.php
@@ -52,7 +52,7 @@ class ArrayEngine extends CacheEngine
      */
     public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $expires = time() + $this->duration($ttl);
         $this->data[$key] = ['exp' => $expires, 'val' => $value];
 
@@ -69,7 +69,7 @@ class ArrayEngine extends CacheEngine
      */
     public function get(string $key, mixed $default = null): mixed
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
         if (!isset($this->data[$key])) {
             return $default;
         }
@@ -98,7 +98,7 @@ class ArrayEngine extends CacheEngine
         if ($this->get($key) === null) {
             $this->set($key, 0);
         }
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $this->data[$key]['val'] += $offset;
 
         return $this->data[$key]['val'];
@@ -116,7 +116,7 @@ class ArrayEngine extends CacheEngine
         if ($this->get($key) === null) {
             $this->set($key, 0);
         }
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $this->data[$key]['val'] -= $offset;
 
         return $this->data[$key]['val'];
@@ -130,7 +130,7 @@ class ArrayEngine extends CacheEngine
      */
     public function delete(string $key): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
         unset($this->data[$key]);
 
         return true;

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -98,7 +98,7 @@ class FileEngine extends CacheEngine
             $this->_groupPrefix = str_replace('_', DIRECTORY_SEPARATOR, $this->_groupPrefix);
         }
 
-        return $this->_active();
+        return $this->active();
     }
 
     /**
@@ -117,9 +117,9 @@ class FileEngine extends CacheEngine
             return false;
         }
 
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
-        if ($this->_setKey($key, true) === false) {
+        if ($this->setKey($key, true) === false) {
             return false;
         }
 
@@ -157,9 +157,9 @@ class FileEngine extends CacheEngine
      */
     public function get(string $key, mixed $default = null): mixed
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
-        if (!$this->_init || $this->_setKey($key) === false) {
+        if (!$this->_init || $this->setKey($key) === false) {
             return $default;
         }
 
@@ -209,9 +209,9 @@ class FileEngine extends CacheEngine
      */
     public function delete(string $key): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
-        if ($this->_setKey($key) === false || !$this->_init) {
+        if ($this->setKey($key) === false || !$this->_init) {
             return false;
         }
 
@@ -239,7 +239,7 @@ class FileEngine extends CacheEngine
         }
         unset($this->_File);
 
-        $this->_clearDirectory($this->_config['path']);
+        $this->clearDirectory($this->_config['path']);
 
         $directory = new RecursiveDirectoryIterator(
             $this->_config['path'],
@@ -265,7 +265,7 @@ class FileEngine extends CacheEngine
 
             $path = $realPath . DIRECTORY_SEPARATOR;
             if (!in_array($path, $cleared, true)) {
-                $this->_clearDirectory($path);
+                $this->clearDirectory($path);
                 $cleared[] = $path;
             }
 
@@ -286,7 +286,7 @@ class FileEngine extends CacheEngine
      * @param string $path The path to search.
      * @return void
      */
-    protected function _clearDirectory(string $path): void
+    protected function clearDirectory(string $path): void
     {
         if (!is_dir($path)) {
             return;
@@ -357,7 +357,7 @@ class FileEngine extends CacheEngine
      * @param bool $createKey Whether the key should be created if it doesn't exists, or not
      * @return bool true if the cache key could be set, false otherwise
      */
-    protected function _setKey(string $key, bool $createKey = false): bool
+    protected function setKey(string $key, bool $createKey = false): bool
     {
         $groups = null;
         if ($this->_groupPrefix) {
@@ -407,7 +407,7 @@ class FileEngine extends CacheEngine
      *
      * @return bool
      */
-    protected function _active(): bool
+    protected function active(): bool
     {
         $dir = new SplFileInfo($this->_config['path']);
         $path = $dir->getPathname();
@@ -433,9 +433,9 @@ class FileEngine extends CacheEngine
     /**
      * @inheritDoc
      */
-    protected function _key(string $key): string
+    protected function key(string $key): string
     {
-        $key = parent::_key($key);
+        $key = parent::key($key);
 
         return rawurlencode($key);
     }

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -144,7 +144,7 @@ class MemcachedEngine extends CacheEngine
         } else {
             $this->_Memcached = new Memcached();
         }
-        $this->_setOptions();
+        $this->setOptions();
 
         $serverList = $this->_Memcached->getServerList();
         if ($serverList) {
@@ -207,7 +207,7 @@ class MemcachedEngine extends CacheEngine
      * @throws \Cake\Cache\Exception\InvalidArgumentException When the Memcached extension is not built
      *   with the desired serializer engine.
      */
-    protected function _setOptions(): void
+    protected function setOptions(): void
     {
         $this->_Memcached->setOption(Memcached::OPT_LIBKETAMA_COMPATIBLE, true);
 
@@ -307,7 +307,7 @@ class MemcachedEngine extends CacheEngine
     {
         $duration = $this->duration($ttl);
 
-        return $this->_Memcached->set($this->_key($key), $value, $duration);
+        return $this->_Memcached->set($this->key($key), $value, $duration);
     }
 
     /**
@@ -323,7 +323,7 @@ class MemcachedEngine extends CacheEngine
     {
         $cacheData = [];
         foreach ($values as $key => $value) {
-            $cacheData[$this->_key($key)] = $value;
+            $cacheData[$this->key($key)] = $value;
         }
         $duration = $this->duration($ttl);
 
@@ -340,7 +340,7 @@ class MemcachedEngine extends CacheEngine
      */
     public function get(string $key, mixed $default = null): mixed
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $value = $this->_Memcached->get($key);
         if ($this->_Memcached->getResultCode() == Memcached::RES_NOTFOUND) {
             return $default;
@@ -361,7 +361,7 @@ class MemcachedEngine extends CacheEngine
     {
         $cacheKeys = [];
         foreach ($keys as $key) {
-            $cacheKeys[$key] = $this->_key($key);
+            $cacheKeys[$key] = $this->key($key);
         }
 
         $values = $this->_Memcached->getMulti($cacheKeys);
@@ -386,7 +386,7 @@ class MemcachedEngine extends CacheEngine
      */
     public function increment(string $key, int $offset = 1): int|false
     {
-        return $this->_Memcached->increment($this->_key($key), $offset);
+        return $this->_Memcached->increment($this->key($key), $offset);
     }
 
     /**
@@ -398,7 +398,7 @@ class MemcachedEngine extends CacheEngine
      */
     public function decrement(string $key, int $offset = 1): int|false
     {
-        return $this->_Memcached->decrement($this->_key($key), $offset);
+        return $this->_Memcached->decrement($this->key($key), $offset);
     }
 
     /**
@@ -410,7 +410,7 @@ class MemcachedEngine extends CacheEngine
      */
     public function delete(string $key): bool
     {
-        return $this->_Memcached->delete($this->_key($key));
+        return $this->_Memcached->delete($this->key($key));
     }
 
     /**
@@ -424,7 +424,7 @@ class MemcachedEngine extends CacheEngine
     {
         $cacheKeys = [];
         foreach ($keys as $key) {
-            $cacheKeys[] = $this->_key($key);
+            $cacheKeys[] = $this->key($key);
         }
 
         return (bool)$this->_Memcached->deleteMulti($cacheKeys);
@@ -461,7 +461,7 @@ class MemcachedEngine extends CacheEngine
     public function add(string $key, mixed $value): bool
     {
         $duration = $this->_config['duration'];
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         return $this->_Memcached->add($key, $value, $duration);
     }

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -92,7 +92,7 @@ class RedisEngine extends CacheEngine
 
         parent::init($config);
 
-        return $this->_connect();
+        return $this->connect();
     }
 
     /**
@@ -100,7 +100,7 @@ class RedisEngine extends CacheEngine
      *
      * @return bool True if Redis server was connected
      */
-    protected function _connect(): bool
+    protected function connect(): bool
     {
         $tls = $this->_config['tls'] === true ? 'tls://' : '';
 
@@ -118,13 +118,13 @@ class RedisEngine extends CacheEngine
         }
 
         try {
-            $this->_Redis = $this->_createRedisInstance();
+            $this->_Redis = $this->createRedisInstance();
             if (!empty($this->_config['unix_socket'])) {
                 $return = $this->_Redis->connect($this->_config['unix_socket']);
             } elseif (empty($this->_config['persistent'])) {
-                $return = $this->_connectTransient($tls . $this->_config['server'], $ssl);
+                $return = $this->connectTransient($tls . $this->_config['server'], $ssl);
             } else {
-                $return = $this->_connectPersistent($tls . $this->_config['server'], $ssl);
+                $return = $this->connectPersistent($tls . $this->_config['server'], $ssl);
             }
         } catch (RedisException $e) {
             if (class_exists(Log::class)) {
@@ -151,7 +151,7 @@ class RedisEngine extends CacheEngine
      * @throws \RedisException
      * @return bool True if Redis server was connected
      */
-    protected function _connectTransient(string $server, array $ssl): bool
+    protected function connectTransient(string $server, array $ssl): bool
     {
         if ($ssl === []) {
             return $this->_Redis->connect(
@@ -180,7 +180,7 @@ class RedisEngine extends CacheEngine
      * @throws \RedisException
      * @return bool True if Redis server was connected
      */
-    protected function _connectPersistent(string $server, array $ssl): bool
+    protected function connectPersistent(string $server, array $ssl): bool
     {
         $persistentId = $this->_config['port'] . $this->_config['timeout'] . $this->_config['database'];
 
@@ -216,7 +216,7 @@ class RedisEngine extends CacheEngine
      */
     public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $value = $this->serialize($value);
 
         $duration = $this->duration($ttl);
@@ -237,7 +237,7 @@ class RedisEngine extends CacheEngine
      */
     public function get(string $key, mixed $default = null): mixed
     {
-        $value = $this->_Redis->get($this->_key($key));
+        $value = $this->_Redis->get($this->key($key));
         if ($value === false) {
             return $default;
         }
@@ -255,7 +255,7 @@ class RedisEngine extends CacheEngine
     public function increment(string $key, int $offset = 1): int|false
     {
         $duration = $this->_config['duration'];
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         $value = $this->_Redis->incrBy($key, $offset);
         if ($duration > 0) {
@@ -275,7 +275,7 @@ class RedisEngine extends CacheEngine
     public function decrement(string $key, int $offset = 1): int|false
     {
         $duration = $this->_config['duration'];
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         $value = $this->_Redis->decrBy($key, $offset);
         if ($duration > 0) {
@@ -293,7 +293,7 @@ class RedisEngine extends CacheEngine
      */
     public function delete(string $key): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         return (int)$this->_Redis->del($key) > 0;
     }
@@ -308,7 +308,7 @@ class RedisEngine extends CacheEngine
      */
     public function deleteAsync(string $key): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         return (int)$this->_Redis->unlink($key) > 0;
     }
@@ -385,7 +385,7 @@ class RedisEngine extends CacheEngine
     public function add(string $key, mixed $value): bool
     {
         $duration = $this->_config['duration'];
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $value = $this->serialize($value);
 
         if ($this->_Redis->set($key, $value, ['nx', 'ex' => $duration])) {
@@ -468,7 +468,7 @@ class RedisEngine extends CacheEngine
      *
      * @return \Redis
      */
-    protected function _createRedisInstance(): Redis
+    protected function createRedisInstance(): Redis
     {
         return new Redis();
     }

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -312,7 +312,7 @@ trait CollectionTrait
      */
     public function groupBy(callable|string $path, bool $preserveKeys = false): CollectionInterface
     {
-        $callback = $this->_propertyExtractor($path);
+        $callback = $this->propertyExtractor($path);
         $group = [];
         foreach ($this->optimizeUnwrap() as $key => $value) {
             $pathValue = $callback($value);
@@ -344,7 +344,7 @@ trait CollectionTrait
      */
     public function indexBy(callable|string $path): CollectionInterface
     {
-        $callback = $this->_propertyExtractor($path);
+        $callback = $this->propertyExtractor($path);
         $group = [];
         foreach ($this->optimizeUnwrap() as $value) {
             $pathValue = $callback($value);
@@ -371,7 +371,7 @@ trait CollectionTrait
      */
     public function countBy(callable|string $path): CollectionInterface
     {
-        $callback = $this->_propertyExtractor($path);
+        $callback = $this->propertyExtractor($path);
 
         $mapper = fn($value, $key, MapReduce $mr) => $mr->emitIntermediate($value, $callback($value));
         $reducer = fn($values, $key, MapReduce $mr) => $mr->emit(count($values), $key);
@@ -388,7 +388,7 @@ trait CollectionTrait
             return array_sum($this->toList());
         }
 
-        $callback = $this->_propertyExtractor($path);
+        $callback = $this->propertyExtractor($path);
         $sum = 0;
         foreach ($this->optimizeUnwrap() as $k => $v) {
             $sum += $callback($v, $k);
@@ -437,7 +437,7 @@ trait CollectionTrait
      */
     public function match(array $conditions): CollectionInterface
     {
-        return $this->filter($this->_createMatcherFilter($conditions));
+        return $this->filter($this->createMatcherFilter($conditions));
     }
 
     /**
@@ -643,9 +643,9 @@ trait CollectionTrait
         callable|string|null $groupPath = null,
     ): CollectionInterface {
         $options = [
-            'keyPath' => $this->_propertyExtractor($keyPath),
-            'valuePath' => $this->_propertyExtractor($valuePath),
-            'groupPath' => $groupPath ? $this->_propertyExtractor($groupPath) : null,
+            'keyPath' => $this->propertyExtractor($keyPath),
+            'valuePath' => $this->propertyExtractor($valuePath),
+            'groupPath' => $groupPath ? $this->propertyExtractor($groupPath) : null,
         ];
 
         $mapper = function ($value, $key, MapReduce $mapReduce) use ($options) {
@@ -714,8 +714,8 @@ trait CollectionTrait
         string $nestingKey = 'children',
     ): CollectionInterface {
         $parents = [];
-        $idPath = $this->_propertyExtractor($idPath);
-        $parentPath = $this->_propertyExtractor($parentPath);
+        $idPath = $this->propertyExtractor($idPath);
+        $parentPath = $this->propertyExtractor($parentPath);
         $isObject = true;
 
         $mapper = function ($row, $key, MapReduce $mapReduce) use (&$parents, $idPath, $parentPath, $nestingKey): void {
@@ -872,7 +872,7 @@ trait CollectionTrait
     public function stopWhen(callable|array $condition): CollectionInterface
     {
         if (!is_callable($condition)) {
-            $condition = $this->_createMatcherFilter($condition);
+            $condition = $this->createMatcherFilter($condition);
         }
 
         return new StoppableIterator($this->unwrap(), $condition);

--- a/src/Collection/ExtractTrait.php
+++ b/src/Collection/ExtractTrait.php
@@ -34,7 +34,7 @@ trait ExtractTrait
      * of doing that.
      * @return \Closure
      */
-    protected function _propertyExtractor(callable|string $path): Closure
+    protected function propertyExtractor(callable|string $path): Closure
     {
         if (!is_string($path)) {
             return $path(...);
@@ -43,7 +43,7 @@ trait ExtractTrait
         $parts = explode('.', $path);
 
         if (str_contains($path, '{*}')) {
-            return fn($element) => $this->_extract($element, $parts);
+            return fn($element) => $this->extractColumn($element, $parts);
         }
 
         return function ($element) use ($parts) {
@@ -51,7 +51,7 @@ trait ExtractTrait
                 return null;
             }
 
-            return $this->_simpleExtract($element, $parts);
+            return $this->simpleExtract($element, $parts);
         };
     }
 
@@ -64,7 +64,7 @@ trait ExtractTrait
      * @param array<string> $parts Path to extract from.
      * @return mixed
      */
-    protected function _extract(ArrayAccess|array $data, array $parts): mixed
+    protected function extractColumn(ArrayAccess|array $data, array $parts): mixed
     {
         $value = null;
         $collectionTransform = false;
@@ -107,7 +107,7 @@ trait ExtractTrait
      * @param array<string> $parts Path to extract from.
      * @return mixed
      */
-    protected function _simpleExtract(ArrayAccess|array $data, array $parts): mixed
+    protected function simpleExtract(ArrayAccess|array $data, array $parts): mixed
     {
         $value = null;
         foreach ($parts as $column) {
@@ -130,11 +130,11 @@ trait ExtractTrait
      * value to be compared the item with.
      * @return \Closure
      */
-    protected function _createMatcherFilter(array $conditions): Closure
+    protected function createMatcherFilter(array $conditions): Closure
     {
         $matchers = [];
         foreach ($conditions as $property => $value) {
-            $extractor = $this->_propertyExtractor($property);
+            $extractor = $this->propertyExtractor($property);
             $matchers[] = function ($v) use ($extractor, $value): bool {
                 return $extractor($v) == $value;
             };

--- a/src/Collection/Iterator/ExtractIterator.php
+++ b/src/Collection/Iterator/ExtractIterator.php
@@ -58,7 +58,7 @@ class ExtractIterator extends Collection
      */
     public function __construct(iterable $items, callable|string $path)
     {
-        $this->_extractor = $this->_propertyExtractor($path);
+        $this->_extractor = $this->propertyExtractor($path);
         parent::__construct($items);
     }
 

--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -132,7 +132,7 @@ class MapReduce implements IteratorAggregate
     public function getIterator(): Traversable
     {
         if (!$this->_executed) {
-            $this->_execute();
+            $this->execute();
         }
 
         return new ArrayIterator($this->_result);
@@ -181,7 +181,7 @@ class MapReduce implements IteratorAggregate
      * @throws \LogicException if emitIntermediate was called but no reducer function
      * was provided
      */
-    protected function _execute(): void
+    protected function execute(): void
     {
         $mapper = $this->_mapper;
         foreach ($this->_data as $key => $val) {

--- a/src/Collection/Iterator/NestIterator.php
+++ b/src/Collection/Iterator/NestIterator.php
@@ -55,7 +55,7 @@ class NestIterator extends Collection implements RecursiveIterator
      */
     public function getChildren(): RecursiveIterator
     {
-        $property = $this->_propertyExtractor($this->_nestKey);
+        $property = $this->propertyExtractor($this->_nestKey);
 
         return new static($property($this->current()), $this->_nestKey);
     }
@@ -68,7 +68,7 @@ class NestIterator extends Collection implements RecursiveIterator
      */
     public function hasChildren(): bool
     {
-        $property = $this->_propertyExtractor($this->_nestKey);
+        $property = $this->propertyExtractor($this->_nestKey);
         $children = $property($this->current());
 
         if (is_array($children)) {

--- a/src/Collection/Iterator/SortIterator.php
+++ b/src/Collection/Iterator/SortIterator.php
@@ -73,7 +73,7 @@ class SortIterator extends Collection
             $items = iterator_to_array((new Collection($items))->unwrap(), false);
         }
 
-        $callback = $this->_propertyExtractor($callback);
+        $callback = $this->propertyExtractor($callback);
         $results = [];
         foreach ($items as $key => $val) {
             $val = $callback($val);

--- a/src/Collection/Iterator/TreePrinter.php
+++ b/src/Collection/Iterator/TreePrinter.php
@@ -80,8 +80,8 @@ class TreePrinter extends RecursiveIteratorIterator implements CollectionInterfa
         int $mode = RecursiveIteratorIterator::SELF_FIRST,
     ) {
         parent::__construct($items, $mode);
-        $this->_value = $this->_propertyExtractor($valuePath);
-        $this->_key = $this->_propertyExtractor($keyPath);
+        $this->_value = $this->propertyExtractor($valuePath);
+        $this->_key = $this->propertyExtractor($keyPath);
         $this->_spacer = $spacer;
     }
 
@@ -94,7 +94,7 @@ class TreePrinter extends RecursiveIteratorIterator implements CollectionInterfa
     {
         $extractor = $this->_key;
 
-        return $extractor($this->_fetchCurrent(), parent::key(), $this);
+        return $extractor($this->fetchCurrent(), parent::key(), $this);
     }
 
     /**
@@ -105,7 +105,7 @@ class TreePrinter extends RecursiveIteratorIterator implements CollectionInterfa
     public function current(): string
     {
         $extractor = $this->_value;
-        $current = $this->_fetchCurrent();
+        $current = $this->fetchCurrent();
         $spacer = str_repeat($this->_spacer, $this->getDepth());
 
         return $spacer . $extractor($current, parent::key(), $this);
@@ -127,7 +127,7 @@ class TreePrinter extends RecursiveIteratorIterator implements CollectionInterfa
      *
      * @return mixed
      */
-    protected function _fetchCurrent(): mixed
+    protected function fetchCurrent(): mixed
     {
         if ($this->_current !== null) {
             return $this->_current;

--- a/src/Command/Helper/TableHelper.php
+++ b/src/Command/Helper/TableHelper.php
@@ -41,13 +41,13 @@ class TableHelper extends Helper
      * @param array $rows The rows on which the columns width will be calculated on.
      * @return array<int>
      */
-    protected function _calculateWidths(array $rows): array
+    protected function calculateWidths(array $rows): array
     {
         $widths = [];
         foreach ($rows as $line) {
             foreach (array_values($line) as $k => $v) {
                 /** @psalm-suppress InvalidCast */
-                $columnLength = $this->_cellWidth((string)$v);
+                $columnLength = $this->cellWidth((string)$v);
                 if ($columnLength >= ($widths[$k] ?? 0)) {
                     $widths[$k] = $columnLength;
                 }
@@ -63,7 +63,7 @@ class TableHelper extends Helper
      * @param string $text The text to calculate a width for.
      * @return int The width of the textual content in visible characters.
      */
-    protected function _cellWidth(string $text): int
+    protected function cellWidth(string $text): int
     {
         if ($text === '') {
             return 0;
@@ -86,7 +86,7 @@ class TableHelper extends Helper
      * @param array<int> $widths The widths of each column to output.
      * @return void
      */
-    protected function _rowSeparator(array $widths): void
+    protected function rowSeparator(array $widths): void
     {
         $out = '';
         foreach ($widths as $column) {
@@ -104,7 +104,7 @@ class TableHelper extends Helper
      * @param array<string, mixed> $options Options to be passed.
      * @return void
      */
-    protected function _render(array $row, array $widths, array $options = []): void
+    protected function render(array $row, array $widths, array $options = []): void
     {
         if ($row === []) {
             return;
@@ -113,9 +113,9 @@ class TableHelper extends Helper
         $out = '';
         foreach (array_values($row) as $i => $column) {
             $column = (string)$column;
-            $pad = $widths[$i] - $this->_cellWidth($column);
+            $pad = $widths[$i] - $this->cellWidth($column);
             if (!empty($options['style'])) {
-                $column = $this->_addStyle($column, $options['style']);
+                $column = $this->addStyle($column, $options['style']);
             }
             if ($column !== '' && preg_match('#(.*)<text-right>.+</text-right>(.*)#', $column, $matches)) {
                 if ($matches[1] !== '' || $matches[2] !== '') {
@@ -149,12 +149,12 @@ class TableHelper extends Helper
         $this->_io->setStyle('text-right', ['text' => null]);
 
         $config = $this->getConfig();
-        $widths = $this->_calculateWidths($args);
+        $widths = $this->calculateWidths($args);
 
-        $this->_rowSeparator($widths);
+        $this->rowSeparator($widths);
         if ($config['headers'] === true) {
-            $this->_render(array_shift($args), $widths, ['style' => $config['headerStyle']]);
-            $this->_rowSeparator($widths);
+            $this->render(array_shift($args), $widths, ['style' => $config['headerStyle']]);
+            $this->rowSeparator($widths);
         }
 
         if (!$args) {
@@ -162,13 +162,13 @@ class TableHelper extends Helper
         }
 
         foreach ($args as $line) {
-            $this->_render($line, $widths);
+            $this->render($line, $widths);
             if ($config['rowSeparator'] === true) {
-                $this->_rowSeparator($widths);
+                $this->rowSeparator($widths);
             }
         }
         if ($config['rowSeparator'] !== true) {
-            $this->_rowSeparator($widths);
+            $this->rowSeparator($widths);
         }
     }
 
@@ -179,7 +179,7 @@ class TableHelper extends Helper
      * @param string $style The style to be applied
      * @return string
      */
-    protected function _addStyle(string $text, string $style): string
+    protected function addStyle(string $text, string $style): string
     {
         return '<' . $style . '>' . $text . '</' . $style . '>';
     }

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -138,7 +138,7 @@ class I18nExtractCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The io instance.
      * @return void
      */
-    protected function _getPaths(ConsoleIo $io): void
+    protected function getPaths(ConsoleIo $io): void
     {
         /** @psalm-suppress UndefinedConstant */
         $defaultPaths = array_merge(
@@ -200,7 +200,7 @@ class I18nExtractCommand extends Command
                 $this->_paths = [Plugin::classPath($plugin), Plugin::templatePath($plugin)];
             }
         } elseif (!$args->getOption('paths')) {
-            $this->_getPaths($io);
+            $this->getPaths($io);
         }
 
         if ($args->hasOption('extract-core')) {
@@ -214,7 +214,7 @@ class I18nExtractCommand extends Command
             $this->_extractCore = strtolower($response) === 'y';
         }
 
-        if ($args->hasOption('exclude-plugins') && $this->_isExtractingApp()) {
+        if ($args->hasOption('exclude-plugins') && $this->isExtractingApp()) {
             $this->_exclude = array_merge($this->_exclude, array_values(App::path('plugins')));
         }
 
@@ -244,7 +244,7 @@ class I18nExtractCommand extends Command
 
                     return static::CODE_ERROR;
                 }
-                if ($this->_isPathUsable($response)) {
+                if ($this->isPathUsable($response)) {
                     $this->_output = $response . DIRECTORY_SEPARATOR;
                     break;
                 }
@@ -273,17 +273,17 @@ class I18nExtractCommand extends Command
         $this->_markerError = (bool)$args->getOption('marker-error');
 
         if (!$this->_files) {
-            $this->_searchFiles();
+            $this->searchFiles();
         }
 
         $this->_output = rtrim($this->_output, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
-        if (!$this->_isPathUsable($this->_output)) {
+        if (!$this->isPathUsable($this->_output)) {
             $io->err(sprintf('The output directory `%s` was not found or writable.', $this->_output));
 
             return static::CODE_ERROR;
         }
 
-        $this->_extract($args, $io);
+        $this->extract($args, $io);
 
         return static::CODE_SUCCESS;
     }
@@ -298,7 +298,7 @@ class I18nExtractCommand extends Command
      * @param array<string, mixed> $details Context and plural form if any, file and line references
      * @return void
      */
-    protected function _addTranslation(string $domain, string $msgid, array $details = []): void
+    protected function addTranslation(string $domain, string $msgid, array $details = []): void
     {
         $context = $details['msgctxt'] ?? '';
 
@@ -325,7 +325,7 @@ class I18nExtractCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The io instance
      * @return void
      */
-    protected function _extract(Arguments $args, ConsoleIo $io): void
+    protected function extract(Arguments $args, ConsoleIo $io): void
     {
         $io->out();
         $io->out();
@@ -337,9 +337,9 @@ class I18nExtractCommand extends Command
         }
         $io->out('Output Directory: ' . $this->_output);
         $io->hr();
-        $this->_extractTokens($args, $io);
-        $this->_buildFiles($args);
-        $this->_writeFiles($args, $io);
+        $this->extractTokens($args, $io);
+        $this->buildFiles($args);
+        $this->writeFiles($args, $io);
         $this->_paths = [];
         $this->_files = [];
         $this->_storage = [];
@@ -416,7 +416,7 @@ class I18nExtractCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The io instance
      * @return void
      */
-    protected function _extractTokens(Arguments $args, ConsoleIo $io): void
+    protected function extractTokens(Arguments $args, ConsoleIo $io): void
     {
         $progress = $io->helper('progress');
         assert($progress instanceof ProgressHelper);
@@ -455,7 +455,7 @@ class I18nExtractCommand extends Command
                 unset($allTokens);
 
                 foreach ($functions as $functionName => $map) {
-                    $this->_parse($io, $functionName, $map);
+                    $this->parse($io, $functionName, $map);
                 }
             }
 
@@ -474,7 +474,7 @@ class I18nExtractCommand extends Command
      * @param array $map Array containing what variables it will find (e.g: domain, singular, plural)
      * @return void
      */
-    protected function _parse(ConsoleIo $io, string $functionName, array $map): void
+    protected function parse(ConsoleIo $io, string $functionName, array $map): void
     {
         $count = 0;
         $tokenCount = count($this->_tokens);
@@ -502,7 +502,7 @@ class I18nExtractCommand extends Command
                 }
 
                 $mapCount = count($map);
-                $strings = $this->_getStrings($position, $mapCount);
+                $strings = $this->getStrings($position, $mapCount);
 
                 if ($mapCount === count($strings)) {
                     $singular = '';
@@ -520,9 +520,9 @@ class I18nExtractCommand extends Command
                     if (isset($context)) {
                         $details['msgctxt'] = $context;
                     }
-                    $this->_addTranslation($domain, $singular, $details);
+                    $this->addTranslation($domain, $singular, $details);
                 } else {
-                    $this->_markerError($io, $this->_file, $line, $functionName, $count);
+                    $this->markerError($io, $this->_file, $line, $functionName, $count);
                 }
             }
             $count++;
@@ -535,7 +535,7 @@ class I18nExtractCommand extends Command
      * @param \Cake\Console\Arguments $args Console arguments
      * @return void
      */
-    protected function _buildFiles(Arguments $args): void
+    protected function buildFiles(Arguments $args): void
     {
         $paths = $this->_paths;
         /** @psalm-suppress UndefinedConstant */
@@ -582,9 +582,9 @@ class I18nExtractCommand extends Command
                     }
 
                     if ($domain !== 'default' && $this->_merge) {
-                        $this->_store('default', $header, $sentence);
+                        $this->store('default', $header, $sentence);
                     } else {
-                        $this->_store($domain, $header, $sentence);
+                        $this->store($domain, $header, $sentence);
                     }
                 }
             }
@@ -599,7 +599,7 @@ class I18nExtractCommand extends Command
      * @param string $sentence The sentence to store.
      * @return void
      */
-    protected function _store(string $domain, string $header, string $sentence): void
+    protected function store(string $domain, string $header, string $sentence): void
     {
         $this->_storage[$domain] ??= [];
 
@@ -617,7 +617,7 @@ class I18nExtractCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return void
      */
-    protected function _writeFiles(Arguments $args, ConsoleIo $io): void
+    protected function writeFiles(Arguments $args, ConsoleIo $io): void
     {
         $io->out();
         $overwriteAll = false;
@@ -625,7 +625,7 @@ class I18nExtractCommand extends Command
             $overwriteAll = true;
         }
         foreach ($this->_storage as $domain => $sentences) {
-            $output = $this->_writeHeader($domain);
+            $output = $this->writeHeader($domain);
             $headerLength = strlen($output);
             foreach ($sentences as $sentence => $header) {
                 $output .= $header . $sentence;
@@ -668,7 +668,7 @@ class I18nExtractCommand extends Command
      * @param string $domain Domain
      * @return string Translation template header
      */
-    protected function _writeHeader(string $domain): string
+    protected function writeHeader(string $domain): string
     {
         $projectIdVersion = $domain === 'cake' ? 'CakePHP ' . Configure::version() : 'PROJECT VERSION';
 
@@ -724,7 +724,7 @@ class I18nExtractCommand extends Command
      * @param int $target Number of strings to extract
      * @return array Strings extracted
      */
-    protected function _getStrings(int &$position, int $target): array
+    protected function getStrings(int &$position, int $target): array
     {
         $strings = [];
         $count = 0;
@@ -743,13 +743,13 @@ class I18nExtractCommand extends Command
                     || $this->_tokens[$position] === '.'
                 ) {
                     if ($this->_tokens[$position][0] === T_CONSTANT_ENCAPSED_STRING) {
-                        $string .= $this->_formatString($this->_tokens[$position][1]);
+                        $string .= $this->formatString($this->_tokens[$position][1]);
                     }
                     $position++;
                 }
                 $strings[] = $string;
             } elseif ($this->_tokens[$position][0] === T_CONSTANT_ENCAPSED_STRING) {
-                $strings[] = $this->_formatString($this->_tokens[$position][1]);
+                $strings[] = $this->formatString($this->_tokens[$position][1]);
             } elseif ($this->_tokens[$position][0] === T_LNUMBER) {
                 $strings[] = $this->_tokens[$position][1];
             }
@@ -765,7 +765,7 @@ class I18nExtractCommand extends Command
      * @param string $string String to format
      * @return string Formatted string
      */
-    protected function _formatString(string $string): string
+    protected function formatString(string $string): string
     {
         $quote = substr($string, 0, 1);
         $string = substr($string, 1, -1);
@@ -789,7 +789,7 @@ class I18nExtractCommand extends Command
      * @param int $count Count
      * @return void
      */
-    protected function _markerError(ConsoleIo $io, string $file, int $line, string $marker, int $count): void
+    protected function markerError(ConsoleIo $io, string $file, int $line, string $marker, int $count): void
     {
         if (!str_contains($this->_file, CAKE_CORE_INCLUDE_PATH)) {
             $this->_countMarkerError++;
@@ -827,7 +827,7 @@ class I18nExtractCommand extends Command
      *
      * @return void
      */
-    protected function _searchFiles(): void
+    protected function searchFiles(): void
     {
         $pattern = false;
         if ($this->_exclude) {
@@ -866,7 +866,7 @@ class I18nExtractCommand extends Command
      *
      * @return bool
      */
-    protected function _isExtractingApp(): bool
+    protected function isExtractingApp(): bool
     {
         /** @psalm-suppress UndefinedConstant */
         return $this->_paths === [APP];
@@ -878,7 +878,7 @@ class I18nExtractCommand extends Command
      * @param string $path Path to folder
      * @return bool true if it exists and is writable, false otherwise
      */
-    protected function _isPathUsable(string $path): bool
+    protected function isPathUsable(string $path): bool
     {
         if (!is_dir($path)) {
             mkdir($path, 0770, true);

--- a/src/Command/PluginAssetsCopyCommand.php
+++ b/src/Command/PluginAssetsCopyCommand.php
@@ -62,7 +62,7 @@ class PluginAssetsCopyCommand extends Command
 
         $name = $args->getArgument('name');
         $overwrite = (bool)$args->getOption('overwrite');
-        $this->_process($this->_list($name), true, $overwrite);
+        $this->process($this->list($name), true, $overwrite);
 
         return static::CODE_SUCCESS;
     }

--- a/src/Command/PluginAssetsRemoveCommand.php
+++ b/src/Command/PluginAssetsRemoveCommand.php
@@ -60,14 +60,14 @@ class PluginAssetsRemoveCommand extends Command
         $this->args = $args;
 
         $name = $args->getArgument('name');
-        $plugins = $this->_list($name);
+        $plugins = $this->list($name);
 
         foreach ($plugins as $plugin => $config) {
             $this->io->out();
             $this->io->out('For plugin: ' . $plugin);
             $this->io->hr();
 
-            $this->_remove($config);
+            $this->remove($config);
         }
 
         $this->io->out();

--- a/src/Command/PluginAssetsSymlinkCommand.php
+++ b/src/Command/PluginAssetsSymlinkCommand.php
@@ -63,7 +63,7 @@ class PluginAssetsSymlinkCommand extends Command
 
         $name = $args->getArgument('name');
         $overwrite = (bool)$args->getOption('overwrite');
-        $this->_process($this->_list($name), false, $overwrite);
+        $this->process($this->list($name), false, $overwrite);
 
         return static::CODE_SUCCESS;
     }

--- a/src/Command/PluginAssetsTrait.php
+++ b/src/Command/PluginAssetsTrait.php
@@ -51,7 +51,7 @@ trait PluginAssetsTrait
      *   If null all plugins will be processed.
      * @return array<string, mixed> List of plugins with meta data.
      */
-    protected function _list(?string $name = null): array
+    protected function list(?string $name = null): array
     {
         if ($name === null) {
             $pluginsList = Plugin::loaded();
@@ -102,7 +102,7 @@ trait PluginAssetsTrait
      * @param bool $overwrite Overwrite existing files.
      * @return void
      */
-    protected function _process(array $plugins, bool $copy = false, bool $overwrite = false): void
+    protected function process(array $plugins, bool $copy = false, bool $overwrite = false): void
     {
         foreach ($plugins as $plugin => $config) {
             $this->io->out();
@@ -112,7 +112,7 @@ trait PluginAssetsTrait
             if (
                 $config['namespaced'] &&
                 !is_dir($config['destDir']) &&
-                !$this->_createDirectory($config['destDir'])
+                !$this->createDirectory($config['destDir'])
             ) {
                 continue;
             }
@@ -120,7 +120,7 @@ trait PluginAssetsTrait
             $dest = $config['destDir'] . $config['link'];
 
             if (file_exists($dest)) {
-                if ($overwrite && !$this->_remove($config)) {
+                if ($overwrite && !$this->remove($config)) {
                     continue;
                 }
                 if (!$overwrite) {
@@ -133,7 +133,7 @@ trait PluginAssetsTrait
             }
 
             if (!$copy) {
-                $result = $this->_createSymlink(
+                $result = $this->createSymlink(
                     $config['srcPath'],
                     $dest,
                 );
@@ -142,7 +142,7 @@ trait PluginAssetsTrait
                 }
             }
 
-            $this->_copyDirectory(
+            $this->copyDirectory(
                 $config['srcPath'],
                 $dest,
             );
@@ -158,7 +158,7 @@ trait PluginAssetsTrait
      * @param array<string, mixed> $config Plugin config.
      * @return bool
      */
-    protected function _remove(array $config): bool
+    protected function remove(array $config): bool
     {
         if ($config['namespaced'] && !is_dir($config['destDir'])) {
             $this->io->verbose(
@@ -210,7 +210,7 @@ trait PluginAssetsTrait
      * @param string $dir Directory name
      * @return bool
      */
-    protected function _createDirectory(string $dir): bool
+    protected function createDirectory(string $dir): bool
     {
         $old = umask(0);
         // phpcs:disable
@@ -236,7 +236,7 @@ trait PluginAssetsTrait
      * @param string $link Link name
      * @return bool
      */
-    protected function _createSymlink(string $target, string $link): bool
+    protected function createSymlink(string $target, string $link): bool
     {
         // phpcs:disable
         $result = @symlink($target, $link);
@@ -258,7 +258,7 @@ trait PluginAssetsTrait
      * @param string $destination Destination directory
      * @return bool
      */
-    protected function _copyDirectory(string $source, string $destination): bool
+    protected function copyDirectory(string $source, string $destination): bool
     {
         $fs = new Filesystem();
         if ($fs->copyDir($source, $destination)) {

--- a/src/Command/RoutesGenerateCommand.php
+++ b/src/Command/RoutesGenerateCommand.php
@@ -53,7 +53,7 @@ class RoutesGenerateCommand extends Command
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         try {
-            $args = $this->_splitArgs($args->getArguments());
+            $args = $this->splitArgs($args->getArguments());
             $url = Router::url($args);
             $io->out("> {$url}");
             $io->out();
@@ -73,7 +73,7 @@ class RoutesGenerateCommand extends Command
      * @param array<string> $args The arguments to split.
      * @return array<string|bool>
      */
-    protected function _splitArgs(array $args): array
+    protected function splitArgs(array $args): array
     {
         $out = [];
         foreach ($args as $arg) {

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -414,7 +414,7 @@ class ConsoleIo
      */
     public function ask(string $prompt, ?string $default = null): string
     {
-        return $this->_getInput($prompt, null, $default);
+        return $this->getInput($prompt, null, $default);
     }
 
     /**
@@ -493,7 +493,7 @@ class ConsoleIo
         );
         $in = '';
         while ($in === '' || !in_array($in, $options, true)) {
-            $in = $this->_getInput($prompt, $printOptions, $default);
+            $in = $this->getInput($prompt, $printOptions, $default);
         }
 
         return $in;
@@ -507,7 +507,7 @@ class ConsoleIo
      * @param string|null $default Default input value. Pass null to omit.
      * @return string Either the default value, or the user-provided input.
      */
-    protected function _getInput(string $prompt, ?string $options, ?string $default): string
+    protected function getInput(string $prompt, ?string $options, ?string $default): string
     {
         if (!$this->interactive) {
             return (string)$default;

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -568,16 +568,16 @@ class ConsoleOptionParser
             }
             if ($afterDoubleDash) {
                 // only positional arguments after --
-                $args = $this->_parseArg($token, $args);
+                $args = $this->parseArg($token, $args);
                 continue;
             }
 
             if (str_starts_with($token, '--')) {
-                $params = $this->_parseLongOption($token, $params);
+                $params = $this->parseLongOption($token, $params);
             } elseif (str_starts_with($token, '-')) {
-                $params = $this->_parseShortOption($token, $params);
+                $params = $this->parseShortOption($token, $params);
             } else {
-                $args = $this->_parseArg($token, $args);
+                $args = $this->parseArg($token, $args);
             }
         }
 
@@ -681,7 +681,7 @@ class ConsoleOptionParser
      * @param array<string, mixed> $params The params to append the parsed value into
      * @return array Params with $option added in.
      */
-    protected function _parseLongOption(string $option, array $params): array
+    protected function parseLongOption(string $option, array $params): array
     {
         $name = substr($option, 2);
         if (str_contains($name, '=')) {
@@ -689,7 +689,7 @@ class ConsoleOptionParser
             array_unshift($this->_tokens, $value);
         }
 
-        return $this->_parseOption($name, $params);
+        return $this->parseOption($name, $params);
     }
 
     /**
@@ -702,7 +702,7 @@ class ConsoleOptionParser
      * @return array<string, mixed> Params with $option added in.
      * @throws \Cake\Console\Exception\ConsoleException When unknown short options are encountered.
      */
-    protected function _parseShortOption(string $option, array $params): array
+    protected function parseShortOption(string $option, array $params): array
     {
         $key = substr($option, 1);
         if (strlen($key) > 1) {
@@ -725,7 +725,7 @@ class ConsoleOptionParser
         }
         $name = $this->_shortOptions[$key];
 
-        return $this->_parseOption($name, $params);
+        return $this->parseOption($name, $params);
     }
 
     /**
@@ -736,7 +736,7 @@ class ConsoleOptionParser
      * @return array<string, mixed> Params with $option added in.
      * @throws \Cake\Console\Exception\ConsoleException
      */
-    protected function _parseOption(string $name, array $params): array
+    protected function parseOption(string $name, array $params): array
     {
         if (!isset($this->_options[$name])) {
             throw new MissingOptionException(
@@ -747,9 +747,9 @@ class ConsoleOptionParser
         }
         $option = $this->_options[$name];
         $isBoolean = $option->isBoolean();
-        $nextValue = $this->_nextToken();
+        $nextValue = $this->nextToken();
         $emptyNextValue = (empty($nextValue) && $nextValue !== '0');
-        if (!$isBoolean && !$emptyNextValue && !$this->_optionExists($nextValue)) {
+        if (!$isBoolean && !$emptyNextValue && !$this->optionExists($nextValue)) {
             array_shift($this->_tokens);
             $value = $nextValue;
         } elseif ($isBoolean) {
@@ -778,7 +778,7 @@ class ConsoleOptionParser
      * @param string $name The name of the option.
      * @return bool
      */
-    protected function _optionExists(string $name): bool
+    protected function optionExists(string $name): bool
     {
         if (str_starts_with($name, '--')) {
             return isset($this->_options[substr($name, 2)]);
@@ -799,7 +799,7 @@ class ConsoleOptionParser
      * @return array<string> Args
      * @throws \Cake\Console\Exception\ConsoleException
      */
-    protected function _parseArg(string $argument, array $args): array
+    protected function parseArg(string $argument, array $args): array
     {
         if (!$this->_args) {
             $args[] = $argument;
@@ -833,7 +833,7 @@ class ConsoleOptionParser
      *
      * @return string next token or ''
      */
-    protected function _nextToken(): string
+    protected function nextToken(): string
     {
         return $this->_tokens[0] ?? '';
     }

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -221,7 +221,7 @@ class ConsoleOutput
             $message = implode(static::LF, $message);
         }
 
-        return $this->_write($this->styleText($message . str_repeat(static::LF, $newlines)));
+        return $this->writeMessage($this->styleText($message . str_repeat(static::LF, $newlines)));
     }
 
     /**
@@ -237,7 +237,7 @@ class ConsoleOutput
         }
         if ($this->_outputAs !== static::PLAIN) {
             /** @var \Closure $replaceTags */
-            $replaceTags = $this->_replaceTags(...);
+            $replaceTags = $this->replaceTags(...);
 
             $output = preg_replace_callback(
                 '/<(?P<tag>[a-z0-9-_.]+)>(?P<text>.*?)<\/(\1)>/ims',
@@ -261,7 +261,7 @@ class ConsoleOutput
      * @param array<string, string> $matches An array of matches to replace.
      * @return string
      */
-    protected function _replaceTags(array $matches): string
+    protected function replaceTags(array $matches): string
     {
         $style = $this->getStyle($matches['tag']);
         if (!$style) {
@@ -291,7 +291,7 @@ class ConsoleOutput
      * @param string $message Message to write.
      * @return int The number of bytes returned from writing to output.
      */
-    protected function _write(string $message): int
+    protected function writeMessage(string $message): int
     {
         if (!isset($this->_output)) {
             return 0;

--- a/src/Console/HelpFormatter.php
+++ b/src/Console/HelpFormatter.php
@@ -95,12 +95,12 @@ class HelpFormatter
             $out[] = '';
         }
         $out[] = '<info>Usage:</info>';
-        $out[] = $this->_generateUsage();
+        $out[] = $this->generateUsage();
         $out[] = '';
 
         $options = $parser->options();
         if ($options) {
-            $max = $this->_getMaxLength($options) + 8;
+            $max = $this->getMaxLength($options) + 8;
             $out[] = '<info>Options:</info>';
             $out[] = '';
             foreach ($options as $option) {
@@ -115,7 +115,7 @@ class HelpFormatter
 
         $arguments = $parser->arguments();
         if ($arguments) {
-            $max = $this->_getMaxLength($arguments) + 2;
+            $max = $this->getMaxLength($arguments) + 2;
             $out[] = '<info>Arguments:</info>';
             $out[] = '';
             foreach ($arguments as $argument) {
@@ -143,7 +143,7 @@ class HelpFormatter
      *
      * @return string
      */
-    protected function _generateUsage(): string
+    protected function generateUsage(): string
     {
         $usage = [$this->_alias . ' ' . $this->_parser->getCommand()];
         $options = [];
@@ -172,7 +172,7 @@ class HelpFormatter
      * @param array<\Cake\Console\ConsoleInputOption|\Cake\Console\ConsoleInputArgument> $collection The collection to find a max length of.
      * @return int
      */
-    protected function _getMaxLength(array $collection): int
+    protected function getMaxLength(array $collection): int
     {
         $max = 0;
         foreach ($collection as $item) {

--- a/src/Console/HelperRegistry.php
+++ b/src/Console/HelperRegistry.php
@@ -54,7 +54,7 @@ class HelperRegistry extends ObjectRegistry
      * @param string $class Partial classname to resolve.
      * @return class-string<\Cake\Console\Helper>|null Either the correct class name or null.
      */
-    protected function _resolveClassName(string $class): ?string
+    protected function resolveClassName(string $class): ?string
     {
         /** @var class-string<\Cake\Console\Helper>|null */
         return App::className($class, 'Command/Helper', 'Helper');
@@ -71,7 +71,7 @@ class HelperRegistry extends ObjectRegistry
      * @return void
      * @throws \Cake\Console\Exception\MissingHelperException
      */
-    protected function _throwMissingClassError(string $class, ?string $plugin): void
+    protected function throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new MissingHelperException([
             'class' => $class,
@@ -89,7 +89,7 @@ class HelperRegistry extends ObjectRegistry
      * @param array<string, mixed> $config An array of settings to use for the helper.
      * @return \Cake\Console\Helper The constructed helper class.
      */
-    protected function _create(object|string $class, string $alias, array $config): Helper
+    protected function create(object|string $class, string $alias, array $config): Helper
     {
         if (is_object($class)) {
             return $class;

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -91,7 +91,7 @@ class FlashComponent extends Component
      * Proxy method to FlashMessage instance.
      *
      * @param array<string, mixed>|string $key The key to set, or a complete array of configs.
-     * @param mixed $value The value to set.
+     * @param mixed|null $value The value to set.
      * @param bool $merge Whether to recursively merge or overwrite existing config, defaults to true.
      * @return $this
      * @throws \Cake\Core\Exception\CakeException When trying to set a key that is invalid.
@@ -107,7 +107,7 @@ class FlashComponent extends Component
      * Proxy method to FlashMessage instance.
      *
      * @param string|null $key The key to get or null for the whole config.
-     * @param mixed $default The return value when the key does not exist.
+     * @param mixed|null $default The return value when the key does not exist.
      * @return mixed Configuration data at the named key or null if the key does not exist.
      */
     public function getConfig(?string $key = null, mixed $default = null): mixed
@@ -131,7 +131,7 @@ class FlashComponent extends Component
      * Proxy method to FlashMessage instance.
      *
      * @param array<string, mixed>|string $key The key to set, or a complete array of configs.
-     * @param mixed $value The value to set.
+     * @param mixed|null $value The value to set.
      * @return $this
      */
     public function configShallow(array|string $key, mixed $value = null): static

--- a/src/Controller/Component/FormProtectionComponent.php
+++ b/src/Controller/Component/FormProtectionComponent.php
@@ -73,7 +73,7 @@ class FormProtectionComponent extends Component
      *
      * @return string
      */
-    protected function _getSessionId(): string
+    protected function getSessionId(): string
     {
         $session = $this->getController()->getRequest()->getSession();
         $session->start();
@@ -100,7 +100,7 @@ class FormProtectionComponent extends Component
             && $hasData
             && $this->_config['validate']
         ) {
-            $sessionId = $this->_getSessionId();
+            $sessionId = $this->getSessionId();
             $url = Router::url($request->getRequestTarget());
 
             $formProtector = new FormProtector($this->_config);

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -108,7 +108,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      * @param string $class Partial classname to resolve.
      * @return class-string<\Cake\Controller\Component>|null Either the correct class name or null.
      */
-    protected function _resolveClassName(string $class): ?string
+    protected function resolveClassName(string $class): ?string
     {
         /** @var class-string<\Cake\Controller\Component>|null */
         return App::className($class, 'Controller/Component', 'Component');
@@ -125,7 +125,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      * @return void
      * @throws \Cake\Controller\Exception\MissingComponentException
      */
-    protected function _throwMissingClassError(string $class, ?string $plugin): void
+    protected function throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new MissingComponentException([
             'class' => $class . 'Component',
@@ -144,7 +144,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      * @param array<string, mixed> $config An array of config to use for the component.
      * @return \Cake\Controller\Component The constructed component class.
      */
-    protected function _create(object|string $class, string $alias, array $config): Component
+    protected function create(object|string $class, string $alias, array $config): Component
     {
         if (is_object($class)) {
             return $class;

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -682,7 +682,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     {
         $builder = $this->viewBuilder();
         if (!$builder->getTemplatePath()) {
-            $builder->setTemplatePath($this->_templatePath());
+            $builder->setTemplatePath($this->templatePath());
         }
 
         $this->autoRender = false;
@@ -804,7 +804,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @return string
      */
-    protected function _templatePath(): string
+    protected function templatePath(): string
     {
         $templatePath = $this->name;
         if ($this->request->getParam('prefix')) {

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -66,13 +66,13 @@ class App
         if ($base !== null) {
             $base = str_replace('/', '\\', rtrim($base, '\\'));
 
-            if (static::_classExistsInBase($fullname, $base)) {
+            if (static::classExistsInBase($fullname, $base)) {
                 /** @var class-string */
                 return $base . $fullname;
             }
         }
 
-        if ($plugin || !static::_classExistsInBase($fullname, 'Cake')) {
+        if ($plugin || !static::classExistsInBase($fullname, 'Cake')) {
             return null;
         }
 
@@ -157,7 +157,7 @@ class App
      * @param string $namespace Namespace.
      * @return bool
      */
-    protected static function _classExistsInBase(string $name, string $namespace): bool
+    protected static function classExistsInBase(string $name, string $namespace): bool
     {
         return class_exists($namespace . $name);
     }

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -325,7 +325,7 @@ class Configure
      */
     public static function load(string $key, string $config = 'default', bool $merge = true): bool
     {
-        $engine = static::_getEngine($config);
+        $engine = static::getEngine($config);
         if (!$engine) {
             throw new CakeException(
                 sprintf(
@@ -378,7 +378,7 @@ class Configure
      */
     public static function dump(string $key, string $config = 'default', array $keys = []): bool
     {
-        $engine = static::_getEngine($config);
+        $engine = static::getEngine($config);
         if (!$engine) {
             throw new CakeException(sprintf('There is no `%s` config engine.', $config));
         }
@@ -397,7 +397,7 @@ class Configure
      * @param string $config The name of the configured adapter
      * @return \Cake\Core\Configure\ConfigEngineInterface|null Engine instance or null
      */
-    protected static function _getEngine(string $config): ?ConfigEngineInterface
+    protected static function getEngine(string $config): ?ConfigEngineInterface
     {
         if (!isset(static::$_engines[$config])) {
             if ($config !== 'default') {

--- a/src/Core/Configure/Engine/IniConfig.php
+++ b/src/Core/Configure/Engine/IniConfig.php
@@ -97,7 +97,7 @@ class IniConfig implements ConfigEngineInterface
      */
     public function read(string $key): array
     {
-        $file = $this->_getFilePath($key, true);
+        $file = $this->getFilePath($key, true);
 
         $contents = parse_ini_file($file, true);
         if ($contents === false) {
@@ -105,14 +105,14 @@ class IniConfig implements ConfigEngineInterface
         }
 
         if ($this->_section && isset($contents[$this->_section])) {
-            $values = $this->_parseNestedValues($contents[$this->_section]);
+            $values = $this->parseNestedValues($contents[$this->_section]);
         } else {
             $values = [];
             foreach ($contents as $section => $attribs) {
                 if (is_array($attribs)) {
-                    $values[$section] = $this->_parseNestedValues($attribs);
+                    $values[$section] = $this->parseNestedValues($attribs);
                 } else {
-                    $parse = $this->_parseNestedValues([$attribs]);
+                    $parse = $this->parseNestedValues([$attribs]);
                     $values[$section] = array_shift($parse);
                 }
             }
@@ -127,7 +127,7 @@ class IniConfig implements ConfigEngineInterface
      * @param array $values Values to be exploded.
      * @return array Array of values exploded
      */
-    protected function _parseNestedValues(array $values): array
+    protected function parseNestedValues(array $values): array
     {
         foreach ($values as $key => $value) {
             if ($value === '1') {
@@ -167,7 +167,7 @@ class IniConfig implements ConfigEngineInterface
             if (is_array($value)) {
                 $kValues = Hash::flatten($value, '.');
                 foreach ($kValues as $k2 => $v) {
-                    $result[] = "{$k2} = " . $this->_value($v);
+                    $result[] = "{$k2} = " . $this->value($v);
                 }
             }
             if ($isSection) {
@@ -176,7 +176,7 @@ class IniConfig implements ConfigEngineInterface
         }
         $contents = trim(implode("\n", $result));
 
-        $filename = $this->_getFilePath($key);
+        $filename = $this->getFilePath($key);
 
         return file_put_contents($filename, $contents) > 0;
     }
@@ -187,7 +187,7 @@ class IniConfig implements ConfigEngineInterface
      * @param mixed $value Value to export.
      * @return string String value for ini file.
      */
-    protected function _value(mixed $value): string
+    protected function value(mixed $value): string
     {
         return match ($value) {
             null => 'null',

--- a/src/Core/Configure/Engine/JsonConfig.php
+++ b/src/Core/Configure/Engine/JsonConfig.php
@@ -74,7 +74,7 @@ class JsonConfig implements ConfigEngineInterface
      */
     public function read(string $key): array
     {
-        $file = $this->_getFilePath($key, true);
+        $file = $this->getFilePath($key, true);
 
         $jsonContent = file_get_contents($file);
         if ($jsonContent === false) {
@@ -109,7 +109,7 @@ class JsonConfig implements ConfigEngineInterface
      */
     public function dump(string $key, array $data): bool
     {
-        $filename = $this->_getFilePath($key);
+        $filename = $this->getFilePath($key);
 
         return file_put_contents($filename, json_encode($data, JSON_PRETTY_PRINT)) > 0;
     }

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -79,7 +79,7 @@ class PhpConfig implements ConfigEngineInterface
      */
     public function read(string $key): array
     {
-        $file = $this->_getFilePath($key, true);
+        $file = $this->getFilePath($key, true);
 
         $return = include $file;
         if (is_array($return)) {
@@ -102,7 +102,7 @@ class PhpConfig implements ConfigEngineInterface
     {
         $contents = '<?php' . "\n" . 'return ' . var_export($data, true) . ';';
 
-        $filename = $this->_getFilePath($key);
+        $filename = $this->getFilePath($key);
 
         return file_put_contents($filename, $contents) > 0;
     }

--- a/src/Core/Configure/FileConfigTrait.php
+++ b/src/Core/Configure/FileConfigTrait.php
@@ -42,7 +42,7 @@ trait FileConfigTrait
      * @throws \Cake\Core\Exception\CakeException When files don't exist or when
      *  files contain '..' as this could lead to abusive reads.
      */
-    protected function _getFilePath(string $key, bool $checkExists = false): string
+    protected function getFilePath(string $key, bool $checkExists = false): string
     {
         if (str_contains($key, '..')) {
             throw new CakeException('Cannot load/dump configuration files with ../ in them.');

--- a/src/Core/ConventionsTrait.php
+++ b/src/Core/ConventionsTrait.php
@@ -29,7 +29,7 @@ trait ConventionsTrait
      * @param string $name Model class name
      * @return string Singular model key
      */
-    protected function _fixtureName(string $name): string
+    protected function fixtureName(string $name): string
     {
         return Inflector::camelize($name);
     }
@@ -40,7 +40,7 @@ trait ConventionsTrait
      * @param string $name Name
      * @return string Camelized and plural model name
      */
-    protected function _entityName(string $name): string
+    protected function entityName(string $name): string
     {
         return Inflector::singularize(Inflector::camelize($name));
     }
@@ -53,7 +53,7 @@ trait ConventionsTrait
      * @param string $name Model class name
      * @return string Singular model key
      */
-    protected function _modelKey(string $name): string
+    protected function modelKey(string $name): string
     {
         [, $name] = pluginSplit($name);
 
@@ -66,7 +66,7 @@ trait ConventionsTrait
      * @param string $key Foreign key
      * @return string Model name
      */
-    protected function _modelNameFromKey(string $key): string
+    protected function modelNameFromKey(string $key): string
     {
         $key = str_replace('_id', '', $key);
 
@@ -79,7 +79,7 @@ trait ConventionsTrait
      * @param string $name Name to use
      * @return string Variable name
      */
-    protected function _singularName(string $name): string
+    protected function singularName(string $name): string
     {
         return Inflector::variable(Inflector::singularize($name));
     }
@@ -90,7 +90,7 @@ trait ConventionsTrait
      * @param string $name Name to use
      * @return string Plural name for views
      */
-    protected function _variableName(string $name): string
+    protected function variableName(string $name): string
     {
         return Inflector::variable($name);
     }
@@ -101,7 +101,7 @@ trait ConventionsTrait
      * @param string $name Controller name
      * @return string Singular human name
      */
-    protected function _singularHumanName(string $name): string
+    protected function singularHumanName(string $name): string
     {
         return Inflector::humanize(Inflector::underscore(Inflector::singularize($name)));
     }
@@ -112,7 +112,7 @@ trait ConventionsTrait
      * @param string $name name
      * @return string Camelized name
      */
-    protected function _camelize(string $name): string
+    protected function camelize(string $name): string
     {
         return Inflector::camelize($name);
     }
@@ -123,7 +123,7 @@ trait ConventionsTrait
      * @param string $name Controller name
      * @return string Plural human name
      */
-    protected function _pluralHumanName(string $name): string
+    protected function pluralHumanName(string $name): string
     {
         return Inflector::humanize(Inflector::underscore($name));
     }
@@ -134,7 +134,7 @@ trait ConventionsTrait
      * @param string $pluginName Name of the plugin you want ie. DebugKit
      * @return string Path to the correct plugin.
      */
-    protected function _pluginPath(string $pluginName): string
+    protected function pluginPath(string $pluginName): string
     {
         if (Plugin::isLoaded($pluginName)) {
             return Plugin::path($pluginName);
@@ -149,7 +149,7 @@ trait ConventionsTrait
      * @param string $pluginName Plugin name
      * @return string Plugin's namespace
      */
-    protected function _pluginNamespace(string $pluginName): string
+    protected function pluginNamespace(string $pluginName): string
     {
         return str_replace('/', '\\', $pluginName);
     }

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -77,7 +77,7 @@ trait InstanceConfigTrait
             $this->_configInitialized = true;
         }
 
-        $this->_configWrite($key, $value, $merge);
+        $this->configWrite($key, $value, $merge);
 
         return $this;
     }
@@ -122,7 +122,7 @@ trait InstanceConfigTrait
             $this->_configInitialized = true;
         }
 
-        return $this->_configRead($key) ?? $default;
+        return $this->configRead($key) ?? $default;
     }
 
     /**
@@ -177,7 +177,7 @@ trait InstanceConfigTrait
             $this->_configInitialized = true;
         }
 
-        $this->_configWrite($key, $value, 'shallow');
+        $this->configWrite($key, $value, 'shallow');
 
         return $this;
     }
@@ -188,7 +188,7 @@ trait InstanceConfigTrait
      * @param string|null $key Key to read.
      * @return mixed
      */
-    protected function _configRead(?string $key): mixed
+    protected function configRead(?string $key): mixed
     {
         if ($key === null) {
             return $this->_config;
@@ -222,10 +222,10 @@ trait InstanceConfigTrait
      * @return void
      * @throws \Cake\Core\Exception\CakeException if attempting to clobber existing config
      */
-    protected function _configWrite(array|string $key, mixed $value, string|bool $merge = false): void
+    protected function configWrite(array|string $key, mixed $value, string|bool $merge = false): void
     {
         if (is_string($key) && $value === null) {
-            $this->_configDelete($key);
+            $this->configDelete($key);
 
             return;
         }
@@ -243,7 +243,7 @@ trait InstanceConfigTrait
 
         if (is_array($key)) {
             foreach ($key as $k => $val) {
-                $this->_configWrite($k, $val);
+                $this->configWrite($k, $val);
             }
 
             return;
@@ -278,7 +278,7 @@ trait InstanceConfigTrait
      * @return void
      * @throws \Cake\Core\Exception\CakeException if attempting to clobber existing config
      */
-    protected function _configDelete(string $key): void
+    protected function configDelete(string $key): void
     {
         if (!str_contains($key, '.')) {
             unset($this->_config[$key]);

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -105,14 +105,14 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
 
         $className = $name;
         if (is_string($name)) {
-            $className = $this->_resolveClassName($name);
+            $className = $this->resolveClassName($name);
             if ($className === null) {
                 [$plugin, $name] = pluginSplit($name);
-                $this->_throwMissingClassError($name, $plugin);
+                $this->throwMissingClassError($name, $plugin);
             }
         }
 
-        $instance = $this->_create($className, $objName, $config);
+        $instance = $this->create($className, $objName, $config);
         $this->_loaded[$objName] = $instance;
 
         return $instance;
@@ -176,7 +176,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * @return class-string|null The resolved name or null for failure.
      * @psalm-return class-string<TObject>|null
      */
-    abstract protected function _resolveClassName(string $class): ?string;
+    abstract protected function resolveClassName(string $class): ?string;
 
     /**
      * Throw an exception when the requested object name is missing.
@@ -186,7 +186,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * @return void
      * @throws \Exception
      */
-    abstract protected function _throwMissingClassError(string $class, ?string $plugin): void;
+    abstract protected function throwMissingClassError(string $class, ?string $plugin): void;
 
     /**
      * Create an instance of a given classname.
@@ -201,7 +201,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * @psalm-param TObject|class-string<TObject> $class
      * @psalm-return TObject
      */
-    abstract protected function _create(object|string $class, string $alias, array $config): object;
+    abstract protected function create(object|string $class, string $alias, array $config): object;
 
     /**
      * Get the list of loaded objects.

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -97,7 +97,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
 
         $loaded = isset($this->_loaded[$objName]);
         if ($loaded && $config !== []) {
-            $this->_checkDuplicate($objName, $config);
+            $this->checkDuplicate($objName, $config);
         }
         if ($loaded) {
             return $this->_loaded[$objName];
@@ -134,7 +134,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * @return void
      * @throws \Cake\Core\Exception\CakeException When a duplicate is found.
      */
-    protected function _checkDuplicate(string $name, array $config): void
+    protected function checkDuplicate(string $name, array $config): void
     {
         $existing = $this->_loaded[$name];
         $msg = sprintf('The `%s` alias has already been loaded.', $name);

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -545,17 +545,17 @@ abstract class Driver implements LoggerAwareInterface
         }
 
         $query = match (true) {
-            $query instanceof SelectQuery => $this->_selectQueryTranslator($query),
-            $query instanceof InsertQuery => $this->_insertQueryTranslator($query),
-            $query instanceof UpdateQuery => $this->_updateQueryTranslator($query),
-            $query instanceof DeleteQuery => $this->_deleteQueryTranslator($query),
+            $query instanceof SelectQuery => $this->selectQueryTranslator($query),
+            $query instanceof InsertQuery => $this->insertQueryTranslator($query),
+            $query instanceof UpdateQuery => $this->updateQueryTranslator($query),
+            $query instanceof DeleteQuery => $this->deleteQueryTranslator($query),
             default => throw new InvalidArgumentException(sprintf(
                 'Instance of SelectQuery, UpdateQuery, InsertQuery, DeleteQuery expected. Found `%s` instead.',
                 get_debug_type($query),
             )),
         };
 
-        $translators = $this->_expressionTranslators();
+        $translators = $this->expressionTranslators();
         if (!$translators) {
             return $query;
         }
@@ -578,7 +578,7 @@ abstract class Driver implements LoggerAwareInterface
      *
      * @return array<class-string, string>
      */
-    protected function _expressionTranslators(): array
+    protected function expressionTranslators(): array
     {
         return [];
     }
@@ -589,9 +589,9 @@ abstract class Driver implements LoggerAwareInterface
      * @param \Cake\Database\Query\SelectQuery<mixed> $query The query to translate
      * @return \Cake\Database\Query\SelectQuery<mixed> The modified query
      */
-    protected function _selectQueryTranslator(SelectQuery $query): SelectQuery
+    protected function selectQueryTranslator(SelectQuery $query): SelectQuery
     {
-        return $this->_transformDistinct($query);
+        return $this->transformDistinct($query);
     }
 
     /**
@@ -601,7 +601,7 @@ abstract class Driver implements LoggerAwareInterface
      * @param \Cake\Database\Query\SelectQuery<mixed> $query The query to be transformed
      * @return \Cake\Database\Query\SelectQuery<mixed>
      */
-    protected function _transformDistinct(SelectQuery $query): SelectQuery
+    protected function transformDistinct(SelectQuery $query): SelectQuery
     {
         if (is_array($query->clause('distinct'))) {
             $query->groupBy($query->clause('distinct'), true);
@@ -623,7 +623,7 @@ abstract class Driver implements LoggerAwareInterface
      * @param \Cake\Database\Query\DeleteQuery $query The query to translate
      * @return \Cake\Database\Query\DeleteQuery The modified query
      */
-    protected function _deleteQueryTranslator(DeleteQuery $query): DeleteQuery
+    protected function deleteQueryTranslator(DeleteQuery $query): DeleteQuery
     {
         $hadAlias = false;
         $tables = [];
@@ -641,7 +641,7 @@ abstract class Driver implements LoggerAwareInterface
             return $query;
         }
 
-        return $this->_removeAliasesFromConditions($query);
+        return $this->removeAliasesFromConditions($query);
     }
 
     /**
@@ -655,9 +655,9 @@ abstract class Driver implements LoggerAwareInterface
      * @param \Cake\Database\Query\UpdateQuery $query The query to translate
      * @return \Cake\Database\Query\UpdateQuery The modified query
      */
-    protected function _updateQueryTranslator(UpdateQuery $query): UpdateQuery
+    protected function updateQueryTranslator(UpdateQuery $query): UpdateQuery
     {
-        return $this->_removeAliasesFromConditions($query);
+        return $this->removeAliasesFromConditions($query);
     }
 
     /**
@@ -671,7 +671,7 @@ abstract class Driver implements LoggerAwareInterface
      * @psalm-param T $query
      * @psalm-return T
      */
-    protected function _removeAliasesFromConditions(UpdateQuery|DeleteQuery $query): UpdateQuery|DeleteQuery
+    protected function removeAliasesFromConditions(UpdateQuery|DeleteQuery $query): UpdateQuery|DeleteQuery
     {
         if ($query->clause('join')) {
             throw new DatabaseException(
@@ -720,7 +720,7 @@ abstract class Driver implements LoggerAwareInterface
      * @param \Cake\Database\Query\InsertQuery $query The query to translate
      * @return \Cake\Database\Query\InsertQuery The modified query
      */
-    protected function _insertQueryTranslator(InsertQuery $query): InsertQuery
+    protected function insertQueryTranslator(InsertQuery $query): InsertQuery
     {
         return $query;
     }

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -221,7 +221,7 @@ class Postgres extends Driver
     /**
      * @inheritDoc
      */
-    protected function _transformDistinct(SelectQuery $query): SelectQuery
+    protected function transformDistinct(SelectQuery $query): SelectQuery
     {
         return $query;
     }
@@ -229,7 +229,7 @@ class Postgres extends Driver
     /**
      * @inheritDoc
      */
-    protected function _insertQueryTranslator(InsertQuery $query): InsertQuery
+    protected function insertQueryTranslator(InsertQuery $query): InsertQuery
     {
         if (!$query->clause('epilog')) {
             $query->epilog('RETURNING *');
@@ -241,12 +241,12 @@ class Postgres extends Driver
     /**
      * @inheritDoc
      */
-    protected function _expressionTranslators(): array
+    protected function expressionTranslators(): array
     {
         return [
-            IdentifierExpression::class => '_transformIdentifierExpression',
-            FunctionExpression::class => '_transformFunctionExpression',
-            StringExpression::class => '_transformStringExpression',
+            IdentifierExpression::class => 'transformIdentifierExpression',
+            FunctionExpression::class => 'transformFunctionExpression',
+            StringExpression::class => 'transformStringExpression',
         ];
     }
 
@@ -256,7 +256,7 @@ class Postgres extends Driver
      * @param \Cake\Database\Expression\IdentifierExpression $expression The expression to transform.
      * @return void
      */
-    protected function _transformIdentifierExpression(IdentifierExpression $expression): void
+    protected function transformIdentifierExpression(IdentifierExpression $expression): void
     {
         $collation = $expression->getCollation();
         if ($collation) {
@@ -273,7 +273,7 @@ class Postgres extends Driver
      *   to postgres SQL.
      * @return void
      */
-    protected function _transformFunctionExpression(FunctionExpression $expression): void
+    protected function transformFunctionExpression(FunctionExpression $expression): void
     {
         switch ($expression->getName()) {
             case 'CONCAT':
@@ -348,7 +348,7 @@ class Postgres extends Driver
      * @param \Cake\Database\Expression\StringExpression $expression The string expression to transform.
      * @return void
      */
-    protected function _transformStringExpression(StringExpression $expression): void
+    protected function transformStringExpression(StringExpression $expression): void
     {
         // use trim() to work around expression being transformed multiple times
         $expression->setCollation('"' . trim($expression->getCollation(), '"') . '"');

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -221,11 +221,11 @@ class Sqlite extends Driver
     /**
      * @inheritDoc
      */
-    protected function _expressionTranslators(): array
+    protected function expressionTranslators(): array
     {
         return [
-            FunctionExpression::class => '_transformFunctionExpression',
-            TupleComparison::class => '_transformTupleComparison',
+            FunctionExpression::class => 'transformFunctionExpression',
+            TupleComparison::class => 'transformTupleComparison',
         ];
     }
 
@@ -236,7 +236,7 @@ class Sqlite extends Driver
      * @param \Cake\Database\Expression\FunctionExpression $expression The function expression to convert to TSQL.
      * @return void
      */
-    protected function _transformFunctionExpression(FunctionExpression $expression): void
+    protected function transformFunctionExpression(FunctionExpression $expression): void
     {
         switch ($expression->getName()) {
             case 'CONCAT':

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -306,7 +306,7 @@ class Sqlserver extends Driver
     /**
      * @inheritDoc
      */
-    protected function _selectQueryTranslator(SelectQuery $query): SelectQuery
+    protected function selectQueryTranslator(SelectQuery $query): SelectQuery
     {
         $limit = $query->clause('limit');
         $offset = $query->clause('offset');
@@ -320,10 +320,10 @@ class Sqlserver extends Driver
         }
 
         if ($this->version() < 11 && $offset !== null) {
-            return $this->_pagingSubquery($query, $limit, $offset);
+            return $this->pagingSubquery($query, $limit, $offset);
         }
 
-        return $this->_transformDistinct($query);
+        return $this->transformDistinct($query);
     }
 
     /**
@@ -337,7 +337,7 @@ class Sqlserver extends Driver
      * @param int|null $offset The number of rows to offset.
      * @return \Cake\Database\Query\SelectQuery<mixed> Modified query object.
      */
-    protected function _pagingSubquery(SelectQuery $original, ?int $limit, ?int $offset): SelectQuery
+    protected function pagingSubquery(SelectQuery $original, ?int $limit, ?int $offset): SelectQuery
     {
         $field = '_cake_paging_._cake_page_rownum_';
 
@@ -404,7 +404,7 @@ class Sqlserver extends Driver
     /**
      * @inheritDoc
      */
-    protected function _transformDistinct(SelectQuery $query): SelectQuery
+    protected function transformDistinct(SelectQuery $query): SelectQuery
     {
         if (!is_array($query->clause('distinct'))) {
             return $query;
@@ -455,11 +455,11 @@ class Sqlserver extends Driver
     /**
      * @inheritDoc
      */
-    protected function _expressionTranslators(): array
+    protected function expressionTranslators(): array
     {
         return [
-            FunctionExpression::class => '_transformFunctionExpression',
-            TupleComparison::class => '_transformTupleComparison',
+            FunctionExpression::class => 'transformFunctionExpression',
+            TupleComparison::class => 'transformTupleComparison',
         ];
     }
 
@@ -470,7 +470,7 @@ class Sqlserver extends Driver
      * @param \Cake\Database\Expression\FunctionExpression $expression The function expression to convert to TSQL.
      * @return void
      */
-    protected function _transformFunctionExpression(FunctionExpression $expression): void
+    protected function transformFunctionExpression(FunctionExpression $expression): void
     {
         switch ($expression->getName()) {
             case 'CONCAT':

--- a/src/Database/Driver/TupleComparisonTranslatorTrait.php
+++ b/src/Database/Driver/TupleComparisonTranslatorTrait.php
@@ -49,7 +49,7 @@ trait TupleComparisonTranslatorTrait
      * @param \Cake\Database\Query $query The query to update.
      * @return void
      */
-    protected function _transformTupleComparison(TupleComparison $expression, Query $query): void
+    protected function transformTupleComparison(TupleComparison $expression, Query $query): void
     {
         $fields = $expression->getField();
 

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -61,8 +61,8 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
     public function __construct(ExpressionInterface|string $field, mixed $from, mixed $to, ?string $type = null)
     {
         if ($type !== null) {
-            $from = $this->_castToExpression($from, $type);
-            $to = $this->_castToExpression($to, $type);
+            $from = $this->castToExpression($from, $type);
+            $to = $this->castToExpression($to, $type);
         }
 
         $this->_field = $field;
@@ -91,7 +91,7 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
                 $parts[$name] = $part->sql($binder);
                 continue;
             }
-            $parts[$name] = $this->_bindValue($part, $binder, $this->_type);
+            $parts[$name] = $this->bindValue($part, $binder, $this->_type);
         }
         assert(is_string($field));
 
@@ -120,7 +120,7 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
      * @param string|null $type The type of $value
      * @return string generated placeholder
      */
-    protected function _bindValue(mixed $value, ValueBinder $binder, ?string $type): string
+    protected function bindValue(mixed $value, ValueBinder $binder, ?string $type): string
     {
         $placeholder = $binder->placeholder('c');
         $binder->bind($placeholder, $value, $type);

--- a/src/Database/Expression/CaseExpressionTrait.php
+++ b/src/Database/Expression/CaseExpressionTrait.php
@@ -84,7 +84,7 @@ trait CaseExpressionTrait
             $type !== null &&
             !($value instanceof ExpressionInterface)
         ) {
-            $value = $this->_castToExpression($value, $type);
+            $value = $this->castToExpression($value, $type);
         }
 
         if ($value === null) {

--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -96,11 +96,11 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
      */
     public function setValue(mixed $value): void
     {
-        $value = $this->_castToExpression($value, $this->_type);
+        $value = $this->castToExpression($value, $this->_type);
 
         $isMultiple = $this->_type && str_contains($this->_type, '[]');
         if ($isMultiple) {
-            [$value, $this->_valueExpressions] = $this->_collectExpressions($value);
+            [$value, $this->_valueExpressions] = $this->collectExpressions($value);
         }
 
         $this->_isMultiple = $isMultiple;
@@ -156,7 +156,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
             $template = '%s %s (%s)';
             $value = $this->_value->sql($binder);
         } else {
-            [$template, $value] = $this->_stringExpression($binder);
+            [$template, $value] = $this->stringExpression($binder);
         }
         assert(is_string($field));
 
@@ -209,7 +209,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
      * @param \Cake\Database\ValueBinder $binder The value binder to use.
      * @return array First position containing the template and the second a placeholder
      */
-    protected function _stringExpression(ValueBinder $binder): array
+    protected function stringExpression(ValueBinder $binder): array
     {
         $template = '%s ';
 
@@ -223,7 +223,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
             if ($type !== null) {
                 $type = str_replace('[]', '', $type);
             }
-            $value = $this->_flattenValue($this->_value, $binder, $type);
+            $value = $this->flattenValue($this->_value, $binder, $type);
 
             // To avoid SQL errors when comparing a field to a list of empty values,
             // better just throw an exception here
@@ -236,7 +236,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
             }
         } else {
             $template .= '%s %s';
-            $value = $this->_bindValue($this->_value, $binder, $this->_type);
+            $value = $this->bindValue($this->_value, $binder, $this->_type);
         }
 
         return [$template, $value];
@@ -250,7 +250,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
      * @param string|null $type The type of $value
      * @return string generated placeholder
      */
-    protected function _bindValue(mixed $value, ValueBinder $binder, ?string $type = null): string
+    protected function bindValue(mixed $value, ValueBinder $binder, ?string $type = null): string
     {
         $placeholder = $binder->placeholder('c');
         $binder->bind($placeholder, $value, $type);
@@ -267,7 +267,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
      * @param string|null $type the type to cast values to
      * @return string
      */
-    protected function _flattenValue(iterable $value, ValueBinder $binder, ?string $type = null): string
+    protected function flattenValue(iterable $value, ValueBinder $binder, ?string $type = null): string
     {
         $parts = [];
         if (is_array($value)) {
@@ -292,7 +292,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
      * @param \Cake\Database\ExpressionInterface|iterable $values The rows to insert
      * @return array
      */
-    protected function _collectExpressions(ExpressionInterface|iterable $values): array
+    protected function collectExpressions(ExpressionInterface|iterable $values): array
     {
         if ($values instanceof ExpressionInterface) {
             return [$values, []];

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -127,7 +127,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
             $type = $typeMap->type($k);
 
             if ($type !== null && !$p instanceof ExpressionInterface) {
-                $p = $this->_castToExpression($p, $type);
+                $p = $this->castToExpression($p, $type);
             }
 
             if ($p instanceof ExpressionInterface) {

--- a/src/Database/Expression/OrderByExpression.php
+++ b/src/Database/Expression/OrderByExpression.php
@@ -67,7 +67,7 @@ class OrderByExpression extends QueryExpression
      * @param array $types list of types associated on fields referenced in $conditions
      * @return void
      */
-    protected function _addConditions(array $conditions, array $types): void
+    protected function addConditions(array $conditions, array $types): void
     {
         foreach ($conditions as $key => $val) {
             if (

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -128,7 +128,7 @@ class QueryExpression implements ExpressionInterface, Countable
             return $this;
         }
 
-        $this->_addConditions($conditions, $types);
+        $this->addConditions($conditions, $types);
 
         return $this;
     }
@@ -145,7 +145,7 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     public function eq(ExpressionInterface|string $field, mixed $value, ?string $type = null): static
     {
-        $type ??= $this->_calculateType($field);
+        $type ??= $this->calculateType($field);
 
         return $this->add(new ComparisonExpression($field, $value, $type, '='));
     }
@@ -162,7 +162,7 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     public function notEq(ExpressionInterface|string $field, mixed $value, ?string $type = null): static
     {
-        $type ??= $this->_calculateType($field);
+        $type ??= $this->calculateType($field);
 
         return $this->add(new ComparisonExpression($field, $value, $type, '!='));
     }
@@ -177,7 +177,7 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     public function gt(ExpressionInterface|string $field, mixed $value, ?string $type = null): static
     {
-        $type ??= $this->_calculateType($field);
+        $type ??= $this->calculateType($field);
 
         return $this->add(new ComparisonExpression($field, $value, $type, '>'));
     }
@@ -192,7 +192,7 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     public function lt(ExpressionInterface|string $field, mixed $value, ?string $type = null): static
     {
-        $type ??= $this->_calculateType($field);
+        $type ??= $this->calculateType($field);
 
         return $this->add(new ComparisonExpression($field, $value, $type, '<'));
     }
@@ -207,7 +207,7 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     public function gte(ExpressionInterface|string $field, mixed $value, ?string $type = null): static
     {
-        $type ??= $this->_calculateType($field);
+        $type ??= $this->calculateType($field);
 
         return $this->add(new ComparisonExpression($field, $value, $type, '>='));
     }
@@ -222,7 +222,7 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     public function lte(ExpressionInterface|string $field, mixed $value, ?string $type = null): static
     {
-        $type ??= $this->_calculateType($field);
+        $type ??= $this->calculateType($field);
 
         return $this->add(new ComparisonExpression($field, $value, $type, '<='));
     }
@@ -269,7 +269,7 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     public function like(ExpressionInterface|string $field, mixed $value, ?string $type = null): static
     {
-        $type ??= $this->_calculateType($field);
+        $type ??= $this->calculateType($field);
 
         return $this->add(new ComparisonExpression($field, $value, $type, 'LIKE'));
     }
@@ -284,7 +284,7 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     public function notLike(ExpressionInterface|string $field, mixed $value, ?string $type = null): static
     {
-        $type ??= $this->_calculateType($field);
+        $type ??= $this->calculateType($field);
 
         return $this->add(new ComparisonExpression($field, $value, $type, 'NOT LIKE'));
     }
@@ -303,7 +303,7 @@ class QueryExpression implements ExpressionInterface, Countable
         ExpressionInterface|array|string $values,
         ?string $type = null,
     ): static {
-        $type ??= $this->_calculateType($field);
+        $type ??= $this->calculateType($field);
         $type = $type ?: 'string';
         $type .= '[]';
         $values = $values instanceof ExpressionInterface ? $values : (array)$values;
@@ -357,7 +357,7 @@ class QueryExpression implements ExpressionInterface, Countable
         ExpressionInterface|array|string $values,
         ?string $type = null,
     ): static {
-        $type ??= $this->_calculateType($field);
+        $type ??= $this->calculateType($field);
         $type = $type ?: 'string';
         $type .= '[]';
         $values = $values instanceof ExpressionInterface ? $values : (array)$values;
@@ -421,7 +421,7 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     public function between(ExpressionInterface|string $field, mixed $from, mixed $to, ?string $type = null): static
     {
-        $type ??= $this->_calculateType($field);
+        $type ??= $this->calculateType($field);
 
         return $this->add(new BetweenExpression($field, $from, $to, $type));
     }
@@ -608,7 +608,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param array<int|string, string> $types list of types associated on fields referenced in $conditions
      * @return void
      */
-    protected function _addConditions(array $conditions, array $types): void
+    protected function addConditions(array $conditions, array $types): void
     {
         $operators = ['and', 'or', 'xor'];
 
@@ -660,7 +660,7 @@ class QueryExpression implements ExpressionInterface, Countable
             }
 
             if (!$numericKey) {
-                $this->_conditions[] = $this->_parseCondition($k, $c);
+                $this->_conditions[] = $this->parseCondition($k, $c);
             }
         }
     }
@@ -678,7 +678,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @return \Cake\Database\ExpressionInterface|string
      * @throws \InvalidArgumentException If operator is invalid or missing on NULL usage.
      */
-    protected function _parseCondition(string $condition, mixed $value): ExpressionInterface|string
+    protected function parseCondition(string $condition, mixed $value): ExpressionInterface|string
     {
         $expression = trim($condition);
         $operator = '=';
@@ -759,7 +759,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param \Cake\Database\ExpressionInterface|string $field The field name to get a type for.
      * @return string|null The computed type or null, if the type is unknown.
      */
-    protected function _calculateType(ExpressionInterface|string $field): ?string
+    protected function calculateType(ExpressionInterface|string $field): ?string
     {
         $field = $field instanceof IdentifierExpression ? $field->getIdentifier() : $field;
         if (!is_string($field)) {

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -106,7 +106,7 @@ class TupleComparison extends ComparisonExpression
             $fields[] = $field instanceof ExpressionInterface ? $field->sql($binder) : $field;
         }
 
-        $values = $this->_stringifyValues($binder);
+        $values = $this->stringifyValues($binder);
 
         $field = implode(', ', $fields);
 
@@ -120,7 +120,7 @@ class TupleComparison extends ComparisonExpression
      * @param \Cake\Database\ValueBinder $binder The value binder to convert expressions with.
      * @return string
      */
-    protected function _stringifyValues(ValueBinder $binder): string
+    protected function stringifyValues(ValueBinder $binder): string
     {
         $values = [];
         $parts = $this->getValue();
@@ -146,7 +146,7 @@ class TupleComparison extends ComparisonExpression
                 foreach ($value as $k => $val) {
                     $valType = $type && isset($type[$k]) ? $type[$k] : $type;
                     assert($valType === null || is_scalar($valType));
-                    $bound[] = $this->_bindValue($val, $binder, $valType);
+                    $bound[] = $this->bindValue($val, $binder, $valType);
                 }
 
                 $values[] = sprintf('(%s)', implode(',', $bound));
@@ -155,7 +155,7 @@ class TupleComparison extends ComparisonExpression
 
             $valType = $type && isset($type[$i]) ? $type[$i] : $type;
             assert($valType === null || is_scalar($valType));
-            $values[] = $this->_bindValue($value, $binder, $valType);
+            $values[] = $this->bindValue($value, $binder, $valType);
         }
 
         return implode(', ', $values);
@@ -164,7 +164,7 @@ class TupleComparison extends ComparisonExpression
     /**
      * @inheritDoc
      */
-    protected function _bindValue(mixed $value, ValueBinder $binder, ?string $type = null): string
+    protected function bindValue(mixed $value, ValueBinder $binder, ?string $type = null): string
     {
         $placeholder = $binder->placeholder('tuple');
         $binder->bind($placeholder, $value, $type);
@@ -179,7 +179,7 @@ class TupleComparison extends ComparisonExpression
     {
         $fields = (array)$this->getField();
         foreach ($fields as $field) {
-            $this->_traverseValue($field, $callback);
+            $this->traverseValue($field, $callback);
         }
 
         $value = $this->getValue();
@@ -193,10 +193,10 @@ class TupleComparison extends ComparisonExpression
         foreach ($value as $val) {
             if ($this->isMulti()) {
                 foreach ($val as $v) {
-                    $this->_traverseValue($v, $callback);
+                    $this->traverseValue($v, $callback);
                 }
             } else {
-                $this->_traverseValue($val, $callback);
+                $this->traverseValue($val, $callback);
             }
         }
 
@@ -211,7 +211,7 @@ class TupleComparison extends ComparisonExpression
      * @param \Closure $callback The callback to use when traversing
      * @return void
      */
-    protected function _traverseValue(mixed $value, Closure $callback): void
+    protected function traverseValue(mixed $value, Closure $callback): void
     {
         if ($value instanceof ExpressionInterface) {
             $callback($value);

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -142,7 +142,7 @@ class ValuesExpression implements ExpressionInterface
      *
      * @return array
      */
-    protected function _columnNames(): array
+    protected function columnNames(): array
     {
         $columns = [];
         foreach ($this->_columns as $col) {
@@ -177,7 +177,7 @@ class ValuesExpression implements ExpressionInterface
     public function getValues(): array
     {
         if (!$this->_castedExpressions) {
-            $this->_processExpressions();
+            $this->processExpressions();
         }
 
         return $this->_values;
@@ -218,10 +218,10 @@ class ValuesExpression implements ExpressionInterface
         }
 
         if (!$this->_castedExpressions) {
-            $this->_processExpressions();
+            $this->processExpressions();
         }
 
-        $columns = $this->_columnNames();
+        $columns = $this->columnNames();
         $defaults = array_fill_keys($columns, null);
         $placeholders = [];
 
@@ -269,7 +269,7 @@ class ValuesExpression implements ExpressionInterface
         }
 
         if (!$this->_castedExpressions) {
-            $this->_processExpressions();
+            $this->processExpressions();
         }
 
         foreach ($this->_values as $v) {
@@ -295,12 +295,12 @@ class ValuesExpression implements ExpressionInterface
      *
      * @return void
      */
-    protected function _processExpressions(): void
+    protected function processExpressions(): void
     {
         $types = [];
         $typeMap = $this->getTypeMap();
 
-        $columns = $this->_columnNames();
+        $columns = $this->columnNames();
         foreach ($columns as $c) {
             if (!is_string($c) && !is_int($c)) {
                 continue;
@@ -308,7 +308,7 @@ class ValuesExpression implements ExpressionInterface
             $types[$c] = $typeMap->type($c);
         }
 
-        $types = $this->_requiresToExpressionCasting($types);
+        $types = $this->requiresToExpressionCasting($types);
 
         if (!$types) {
             return;

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -263,7 +263,7 @@ class WhenThenExpression implements ExpressionInterface
             is_string($this->whenType) &&
             !($when instanceof ExpressionInterface)
         ) {
-            $when = $this->_castToExpression($when, $this->whenType);
+            $when = $this->castToExpression($when, $this->whenType);
         }
         if ($when instanceof Query) {
             $when = sprintf('(%s)', $when->sql($binder));

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -114,10 +114,10 @@ class IdentifierQuoter
         $query->setValueBinder(null);
 
         match (true) {
-            $query instanceof InsertQuery => $this->_quoteInsert($query),
-            $query instanceof SelectQuery => $this->_quoteSelect($query),
-            $query instanceof UpdateQuery => $this->_quoteUpdate($query),
-            $query instanceof DeleteQuery => $this->_quoteDelete($query),
+            $query instanceof InsertQuery => $this->quoteInsert($query),
+            $query instanceof SelectQuery => $this->quoteSelect($query),
+            $query instanceof UpdateQuery => $this->quoteUpdate($query),
+            $query instanceof DeleteQuery => $this->quoteDelete($query),
             default =>
                 throw new DatabaseException(sprintf(
                     'Instance of SelectQuery, UpdateQuery, InsertQuery, DeleteQuery expected. Found `%s` instead.',
@@ -139,9 +139,9 @@ class IdentifierQuoter
     public function quoteExpression(ExpressionInterface $expression): void
     {
         match (true) {
-            $expression instanceof FieldInterface => $this->_quoteComparison($expression),
-            $expression instanceof OrderByExpression => $this->_quoteOrderBy($expression),
-            $expression instanceof IdentifierExpression => $this->_quoteIdentifierExpression($expression),
+            $expression instanceof FieldInterface => $this->quoteComparison($expression),
+            $expression instanceof OrderByExpression => $this->quoteOrderBy($expression),
+            $expression instanceof IdentifierExpression => $this->quoteIdentifierExpression($expression),
             default => null // Nothing to do if there is no match
         };
     }
@@ -153,7 +153,7 @@ class IdentifierQuoter
      * @param array $parts Query clauses.
      * @return void
      */
-    protected function _quoteParts(Query $query, array $parts): void
+    protected function quoteParts(Query $query, array $parts): void
     {
         foreach ($parts as $part) {
             $contents = $query->clause($part);
@@ -162,7 +162,7 @@ class IdentifierQuoter
                 continue;
             }
 
-            $result = $this->_basicQuoter($contents);
+            $result = $this->basicQuoter($contents);
             if ($result) {
                 $part = match ($part) {
                     'group' => 'groupBy',
@@ -181,7 +181,7 @@ class IdentifierQuoter
      * @param array<string, mixed> $part the part of the query to quote
      * @return array<string, mixed>
      */
-    protected function _basicQuoter(array $part): array
+    protected function basicQuoter(array $part): array
     {
         $result = [];
         foreach ($part as $alias => $value) {
@@ -200,7 +200,7 @@ class IdentifierQuoter
      * @param array $joins The joins to quote.
      * @return array<string, array>
      */
-    protected function _quoteJoins(array $joins): array
+    protected function quoteJoins(array $joins): array
     {
         $result = [];
         foreach ($joins as $value) {
@@ -226,13 +226,13 @@ class IdentifierQuoter
      * @param \Cake\Database\Query\SelectQuery<mixed> $query The query to quote.
      * @return void
      */
-    protected function _quoteSelect(SelectQuery $query): void
+    protected function quoteSelect(SelectQuery $query): void
     {
-        $this->_quoteParts($query, ['select', 'distinct', 'from', 'group']);
+        $this->quoteParts($query, ['select', 'distinct', 'from', 'group']);
 
         $joins = $query->clause('join');
         if ($joins) {
-            $joins = $this->_quoteJoins($joins);
+            $joins = $this->quoteJoins($joins);
             $query->join($joins, [], true);
         }
     }
@@ -243,13 +243,13 @@ class IdentifierQuoter
      * @param \Cake\Database\Query\DeleteQuery $query The query to quote.
      * @return void
      */
-    protected function _quoteDelete(DeleteQuery $query): void
+    protected function quoteDelete(DeleteQuery $query): void
     {
-        $this->_quoteParts($query, ['from']);
+        $this->quoteParts($query, ['from']);
 
         $joins = $query->clause('join');
         if ($joins) {
-            $joins = $this->_quoteJoins($joins);
+            $joins = $this->quoteJoins($joins);
             $query->join($joins, [], true);
         }
     }
@@ -260,7 +260,7 @@ class IdentifierQuoter
      * @param \Cake\Database\Query\InsertQuery $query The insert query to quote.
      * @return void
      */
-    protected function _quoteInsert(InsertQuery $query): void
+    protected function quoteInsert(InsertQuery $query): void
     {
         $insert = $query->clause('insert');
         if (!isset($insert[0]) || !isset($insert[1])) {
@@ -282,7 +282,7 @@ class IdentifierQuoter
      * @param \Cake\Database\Query\UpdateQuery $query The update query to quote.
      * @return void
      */
-    protected function _quoteUpdate(UpdateQuery $query): void
+    protected function quoteUpdate(UpdateQuery $query): void
     {
         $table = $query->clause('update')[0];
 
@@ -297,7 +297,7 @@ class IdentifierQuoter
      * @param \Cake\Database\Expression\FieldInterface $expression The expression to quote.
      * @return void
      */
-    protected function _quoteComparison(FieldInterface $expression): void
+    protected function quoteComparison(FieldInterface $expression): void
     {
         $field = $expression->getField();
         if (is_string($field)) {
@@ -322,7 +322,7 @@ class IdentifierQuoter
      * @param \Cake\Database\Expression\OrderByExpression $expression The expression to quote.
      * @return void
      */
-    protected function _quoteOrderBy(OrderByExpression $expression): void
+    protected function quoteOrderBy(OrderByExpression $expression): void
     {
         $expression->iterateParts(function ($part, &$field) {
             if (is_string($field)) {
@@ -344,7 +344,7 @@ class IdentifierQuoter
      * @param \Cake\Database\Expression\IdentifierExpression $expression The identifiers to quote.
      * @return void
      */
-    protected function _quoteIdentifierExpression(IdentifierExpression $expression): void
+    protected function quoteIdentifierExpression(IdentifierExpression $expression): void
     {
         $expression->setIdentifier(
             $this->quoteIdentifier($expression->getIdentifier()),

--- a/src/Database/PostgresCompiler.php
+++ b/src/Database/PostgresCompiler.php
@@ -33,14 +33,14 @@ class PostgresCompiler extends QueryCompiler
      *
      * @var bool
      */
-    protected bool $_quotedSelectAliases = true;
+    protected bool $quotedSelectAliases = true;
 
     /**
      * {@inheritDoc}
      *
      * @var array<string, string>
      */
-    protected array $_templates = [
+    protected array $templates = [
         'delete' => 'DELETE',
         'where' => ' WHERE %s',
         'group' => ' GROUP BY %s',
@@ -61,7 +61,7 @@ class PostgresCompiler extends QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string
      */
-    protected function _buildHavingPart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildHavingPart(array $parts, Query $query, ValueBinder $binder): string
     {
         $selectParts = $query->clause('select');
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -171,7 +171,7 @@ abstract class Query implements ExpressionInterface, Stringable
      */
     public function setConnection(Connection $connection): static
     {
-        $this->_dirty();
+        $this->dirty();
         $this->_connection = $connection;
 
         return $this;
@@ -407,7 +407,7 @@ abstract class Query implements ExpressionInterface, Stringable
         }
 
         $this->_parts['with'][] = $cte;
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -436,7 +436,7 @@ abstract class Query implements ExpressionInterface, Stringable
      */
     public function modifier(ExpressionInterface|array|string $modifiers, bool $overwrite = false): static
     {
-        $this->_dirty();
+        $this->dirty();
         if ($overwrite) {
             $this->_parts['modifier'] = [];
         }
@@ -487,7 +487,7 @@ abstract class Query implements ExpressionInterface, Stringable
             $this->_parts['from'] = array_merge($this->_parts['from'], $tables);
         }
 
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -608,7 +608,7 @@ abstract class Query implements ExpressionInterface, Stringable
             $this->_parts['join'] = array_merge($this->_parts['join'], $joins);
         }
 
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -625,7 +625,7 @@ abstract class Query implements ExpressionInterface, Stringable
     public function removeJoin(string $name): static
     {
         unset($this->_parts['join'][$name]);
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -672,7 +672,7 @@ abstract class Query implements ExpressionInterface, Stringable
         ExpressionInterface|Closure|array|string $conditions = [],
         array $types = [],
     ): static {
-        $this->join($this->_makeJoin($table, $conditions, static::JOIN_TYPE_LEFT), $types);
+        $this->join($this->makeJoin($table, $conditions, static::JOIN_TYPE_LEFT), $types);
 
         return $this;
     }
@@ -697,7 +697,7 @@ abstract class Query implements ExpressionInterface, Stringable
         ExpressionInterface|Closure|array|string $conditions = [],
         array $types = [],
     ): static {
-        $this->join($this->_makeJoin($table, $conditions, static::JOIN_TYPE_RIGHT), $types);
+        $this->join($this->makeJoin($table, $conditions, static::JOIN_TYPE_RIGHT), $types);
 
         return $this;
     }
@@ -722,7 +722,7 @@ abstract class Query implements ExpressionInterface, Stringable
         ExpressionInterface|Closure|array|string $conditions = [],
         array $types = [],
     ): static {
-        $this->join($this->_makeJoin($table, $conditions, static::JOIN_TYPE_INNER), $types);
+        $this->join($this->makeJoin($table, $conditions, static::JOIN_TYPE_INNER), $types);
 
         return $this;
     }
@@ -736,7 +736,7 @@ abstract class Query implements ExpressionInterface, Stringable
      * @param string $type the join type to use
      * @return array<string, array{table: string|\Cake\Database\Query\SelectQuery, conditions: \Cake\Database\ExpressionInterface|\Closure|array|string, type: string}>
      */
-    protected function _makeJoin(
+    protected function makeJoin(
         array|string $table,
         ExpressionInterface|Closure|array|string $conditions,
         string $type,
@@ -899,7 +899,7 @@ abstract class Query implements ExpressionInterface, Stringable
         if ($overwrite) {
             $this->_parts['where'] = $this->newExpr();
         }
-        $this->_conjugate('where', $conditions, 'AND', $types);
+        $this->conjugate('where', $conditions, 'AND', $types);
 
         return $this;
     }
@@ -1098,7 +1098,7 @@ abstract class Query implements ExpressionInterface, Stringable
      */
     public function andWhere(ExpressionInterface|Closure|array|string $conditions, array $types = []): static
     {
-        $this->_conjugate('where', $conditions, 'AND', $types);
+        $this->conjugate('where', $conditions, 'AND', $types);
 
         return $this;
     }
@@ -1175,7 +1175,7 @@ abstract class Query implements ExpressionInterface, Stringable
         }
 
         $this->_parts['order'] ??= new OrderByExpression();
-        $this->_conjugate('order', $fields, '', []);
+        $this->conjugate('order', $fields, '', []);
 
         return $this;
     }
@@ -1288,7 +1288,7 @@ abstract class Query implements ExpressionInterface, Stringable
      */
     public function limit(ExpressionInterface|int|null $limit): static
     {
-        $this->_dirty();
+        $this->dirty();
         $this->_parts['limit'] = $limit;
 
         return $this;
@@ -1314,7 +1314,7 @@ abstract class Query implements ExpressionInterface, Stringable
      */
     public function offset(ExpressionInterface|int|null $offset): static
     {
-        $this->_dirty();
+        $this->dirty();
         $this->_parts['offset'] = $offset;
 
         return $this;
@@ -1360,7 +1360,7 @@ abstract class Query implements ExpressionInterface, Stringable
      */
     public function epilog(ExpressionInterface|string|null $expression = null): static
     {
-        $this->_dirty();
+        $this->dirty();
         $this->_parts['epilog'] = $expression;
 
         return $this;
@@ -1381,7 +1381,7 @@ abstract class Query implements ExpressionInterface, Stringable
      */
     public function comment(?string $expression = null): static
     {
-        $this->_dirty();
+        $this->dirty();
         $this->_parts['comment'] = $expression;
 
         return $this;
@@ -1529,7 +1529,7 @@ abstract class Query implements ExpressionInterface, Stringable
     public function traverseExpressions(Closure $callback): static
     {
         foreach ($this->_parts as $part) {
-            $this->_expressionsVisitor($part, $callback);
+            $this->expressionsVisitor($part, $callback);
         }
 
         return $this;
@@ -1544,18 +1544,18 @@ abstract class Query implements ExpressionInterface, Stringable
      *   found inside this query.
      * @return void
      */
-    protected function _expressionsVisitor(mixed $expression, Closure $callback): void
+    protected function expressionsVisitor(mixed $expression, Closure $callback): void
     {
         if (is_array($expression)) {
             foreach ($expression as $e) {
-                $this->_expressionsVisitor($e, $callback);
+                $this->expressionsVisitor($e, $callback);
             }
 
             return;
         }
 
         if ($expression instanceof ExpressionInterface) {
-            $expression->traverse(fn($exp) => $this->_expressionsVisitor($exp, $callback));
+            $expression->traverse(fn($exp) => $this->expressionsVisitor($exp, $callback));
 
             if (!$expression instanceof self) {
                 $callback($expression);
@@ -1625,7 +1625,7 @@ abstract class Query implements ExpressionInterface, Stringable
      * @param array<string, string> $types Associative array of type names used to bind values to query
      * @return void
      */
-    protected function _conjugate(
+    protected function conjugate(
         string $part,
         ExpressionInterface|Closure|array|string|null $append,
         string $conjunction,
@@ -1652,7 +1652,7 @@ abstract class Query implements ExpressionInterface, Stringable
         }
 
         $this->_parts[$part] = $expression;
-        $this->_dirty();
+        $this->dirty();
     }
 
     /**
@@ -1661,7 +1661,7 @@ abstract class Query implements ExpressionInterface, Stringable
      *
      * @return void
      */
-    protected function _dirty(): void
+    protected function dirty(): void
     {
         $this->_dirty = true;
 

--- a/src/Database/Query/DeleteQuery.php
+++ b/src/Database/Query/DeleteQuery.php
@@ -59,7 +59,7 @@ class DeleteQuery extends Query
      */
     public function delete(?string $table = null): static
     {
-        $this->_dirty();
+        $this->dirty();
         if ($table !== null) {
             $this->from($table);
         }

--- a/src/Database/Query/InsertQuery.php
+++ b/src/Database/Query/InsertQuery.php
@@ -63,7 +63,7 @@ class InsertQuery extends Query
         if (!$columns) {
             throw new InvalidArgumentException('At least 1 column is required to perform an insert.');
         }
-        $this->_dirty();
+        $this->dirty();
         $this->_parts['insert'][1] = $columns;
         if (!$this->_parts['values']) {
             $this->_parts['values'] = new ValuesExpression($columns, $this->getTypeMap()->setTypes($types));
@@ -84,7 +84,7 @@ class InsertQuery extends Query
      */
     public function into(string $table): static
     {
-        $this->_dirty();
+        $this->dirty();
         $this->_parts['insert'][0] = $table;
 
         return $this;
@@ -110,7 +110,7 @@ class InsertQuery extends Query
             );
         }
 
-        $this->_dirty();
+        $this->dirty();
         if ($data instanceof ValuesExpression) {
             $this->_parts['values'] = $data;
 

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -178,7 +178,7 @@ class SelectQuery extends Query implements IteratorAggregate
             $this->_parts['select'] = array_merge($this->_parts['select'], $fields);
         }
 
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -228,7 +228,7 @@ class SelectQuery extends Query implements IteratorAggregate
         }
 
         $this->_parts['distinct'] = $on;
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -349,7 +349,7 @@ class SelectQuery extends Query implements IteratorAggregate
             $this->_parts['join'] = array_merge($this->_parts['join'], $joins);
         }
 
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -366,7 +366,7 @@ class SelectQuery extends Query implements IteratorAggregate
     public function removeJoin(string $name): static
     {
         unset($this->_parts['join'][$name]);
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -413,7 +413,7 @@ class SelectQuery extends Query implements IteratorAggregate
         ExpressionInterface|Closure|array|string $conditions = [],
         array $types = [],
     ): static {
-        $this->join($this->_makeJoin($table, $conditions, static::JOIN_TYPE_LEFT), $types);
+        $this->join($this->makeJoin($table, $conditions, static::JOIN_TYPE_LEFT), $types);
 
         return $this;
     }
@@ -438,7 +438,7 @@ class SelectQuery extends Query implements IteratorAggregate
         ExpressionInterface|Closure|array|string $conditions = [],
         array $types = [],
     ): static {
-        $this->join($this->_makeJoin($table, $conditions, static::JOIN_TYPE_RIGHT), $types);
+        $this->join($this->makeJoin($table, $conditions, static::JOIN_TYPE_RIGHT), $types);
 
         return $this;
     }
@@ -463,7 +463,7 @@ class SelectQuery extends Query implements IteratorAggregate
         ExpressionInterface|Closure|array|string $conditions = [],
         array $types = [],
     ): static {
-        $this->join($this->_makeJoin($table, $conditions, static::JOIN_TYPE_INNER), $types);
+        $this->join($this->makeJoin($table, $conditions, static::JOIN_TYPE_INNER), $types);
 
         return $this;
     }
@@ -477,7 +477,7 @@ class SelectQuery extends Query implements IteratorAggregate
      * @param string $type the join type to use
      * @return array
      */
-    protected function _makeJoin(
+    protected function makeJoin(
         array|string $table,
         ExpressionInterface|Closure|array|string $conditions,
         string $type,
@@ -535,7 +535,7 @@ class SelectQuery extends Query implements IteratorAggregate
         }
 
         $this->_parts['group'] = array_merge($this->_parts['group'], array_values($fields));
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -563,7 +563,7 @@ class SelectQuery extends Query implements IteratorAggregate
         if ($overwrite) {
             $this->_parts['having'] = $this->newExpr();
         }
-        $this->_conjugate('having', $conditions, 'AND', $types);
+        $this->conjugate('having', $conditions, 'AND', $types);
 
         return $this;
     }
@@ -584,7 +584,7 @@ class SelectQuery extends Query implements IteratorAggregate
      */
     public function andHaving(ExpressionInterface|Closure|array|string $conditions, array $types = []): static
     {
-        $this->_conjugate('having', $conditions, 'AND', $types);
+        $this->conjugate('having', $conditions, 'AND', $types);
 
         return $this;
     }
@@ -613,7 +613,7 @@ class SelectQuery extends Query implements IteratorAggregate
         }
 
         $this->_parts['window'][] = ['name' => new IdentifierExpression($name), 'window' => $window];
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -688,7 +688,7 @@ class SelectQuery extends Query implements IteratorAggregate
             'all' => false,
             'query' => $query,
         ];
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -723,7 +723,7 @@ class SelectQuery extends Query implements IteratorAggregate
             'all' => true,
             'query' => $query,
         ];
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -761,7 +761,7 @@ class SelectQuery extends Query implements IteratorAggregate
             'all' => false,
             'query' => $query,
         ];
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -796,7 +796,7 @@ class SelectQuery extends Query implements IteratorAggregate
             'all' => true,
             'query' => $query,
         ];
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -854,7 +854,7 @@ class SelectQuery extends Query implements IteratorAggregate
      */
     public function decorateResults(?Closure $callback, bool $overwrite = false): static
     {
-        $this->_dirty();
+        $this->dirty();
         if ($overwrite) {
             $this->_resultDecorators = [];
         }
@@ -890,7 +890,7 @@ class SelectQuery extends Query implements IteratorAggregate
      */
     public function enableBufferedResults(): static
     {
-        $this->_dirty();
+        $this->dirty();
         $this->bufferedResults = true;
 
         return $this;
@@ -906,7 +906,7 @@ class SelectQuery extends Query implements IteratorAggregate
      */
     public function disableBufferedResults(): static
     {
-        $this->_dirty();
+        $this->dirty();
         $this->bufferedResults = false;
 
         return $this;
@@ -939,7 +939,7 @@ class SelectQuery extends Query implements IteratorAggregate
     public function setSelectTypeMap(TypeMap|array $typeMap): static
     {
         $this->_selectTypeMap = is_array($typeMap) ? new TypeMap($typeMap) : $typeMap;
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -475,7 +475,7 @@ class SelectQuery extends Query implements IteratorAggregate
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions The conditions
      * to use for joining.
      * @param string $type the join type to use
-     * @return array
+     * @return array<string, array{table: string|\Cake\Database\Query\SelectQuery, conditions: \Cake\Database\ExpressionInterface|\Closure|array|string, type: string}>
      */
     protected function makeJoin(
         array|string $table,

--- a/src/Database/Query/UpdateQuery.php
+++ b/src/Database/Query/UpdateQuery.php
@@ -62,7 +62,7 @@ class UpdateQuery extends Query
      */
     public function update(ExpressionInterface|string $table): static
     {
-        $this->_dirty();
+        $this->dirty();
         $this->_parts['update'][0] = $table;
 
         return $this;

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -34,7 +34,7 @@ class QueryCompiler
      *
      * @var array<string, string>
      */
-    protected array $_templates = [
+    protected array $templates = [
         'delete' => 'DELETE',
         'where' => ' WHERE %s',
         'group' => ' GROUP BY %s ',
@@ -51,7 +51,7 @@ class QueryCompiler
      *
      * @var array<string>
      */
-    protected array $_selectParts = [
+    protected array $selectParts = [
         'comment', 'with', 'select', 'from', 'join', 'where', 'group', 'having', 'window', 'order',
         'limit', 'offset', 'union', 'epilog', 'intersect',
     ];
@@ -61,28 +61,28 @@ class QueryCompiler
      *
      * @var array<string>
      */
-    protected array $_updateParts = ['comment', 'with', 'update', 'set', 'where', 'epilog'];
+    protected array $updateParts = ['comment', 'with', 'update', 'set', 'where', 'epilog'];
 
     /**
      * The list of query clauses to traverse for generating a DELETE statement
      *
      * @var array<string>
      */
-    protected array $_deleteParts = ['comment', 'with', 'delete', 'modifier', 'from', 'where', 'epilog'];
+    protected array $deleteParts = ['comment', 'with', 'delete', 'modifier', 'from', 'where', 'epilog'];
 
     /**
      * The list of query clauses to traverse for generating an INSERT statement
      *
      * @var array<string>
      */
-    protected array $_insertParts = ['comment', 'with', 'insert', 'values', 'epilog'];
+    protected array $insertParts = ['comment', 'with', 'insert', 'values', 'epilog'];
 
     /**
      * Indicate whether aliases in SELECT clause need to be always quoted.
      *
      * @var bool
      */
-    protected bool $_quotedSelectAliases = false;
+    protected bool $quotedSelectAliases = false;
 
     /**
      * Returns the SQL representation of the provided query after generating
@@ -97,8 +97,8 @@ class QueryCompiler
         $sql = '';
         $type = $query->type();
         $query->traverseParts(
-            $this->_sqlCompiler($sql, $query, $binder),
-            $this->{"_{$type}Parts"},
+            $this->sqlCompiler($sql, $query, $binder),
+            $this->{"{$type}Parts"},
         );
 
         // Propagate bound parameters from sub-queries if the
@@ -124,7 +124,7 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return \Closure
      */
-    protected function _sqlCompiler(string &$sql, Query $query, ValueBinder $binder): Closure
+    protected function sqlCompiler(string &$sql, Query $query, ValueBinder $binder): Closure
     {
         return function ($part, $partName) use (&$sql, $query, $binder): void {
             if (
@@ -138,13 +138,13 @@ class QueryCompiler
             if ($part instanceof ExpressionInterface) {
                 $part = [$part->sql($binder)];
             }
-            if (isset($this->_templates[$partName])) {
-                $part = $this->_stringifyExpressions((array)$part, $binder);
-                $sql .= sprintf($this->_templates[$partName], implode(', ', $part));
+            if (isset($this->templates[$partName])) {
+                $part = $this->stringifyExpressions((array)$part, $binder);
+                $sql .= sprintf($this->templates[$partName], implode(', ', $part));
 
                 return;
             }
-            $sql .= $this->{'_build' . $partName . 'Part'}($part, $query, $binder);
+            $sql .= $this->{'build' . $partName . 'Part'}($part, $query, $binder);
         };
     }
 
@@ -158,7 +158,7 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string
      */
-    protected function _buildWithPart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildWithPart(array $parts, Query $query, ValueBinder $binder): string
     {
         $recursive = false;
         $expressions = [];
@@ -183,7 +183,7 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string
      */
-    protected function _buildSelectPart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildSelectPart(array $parts, Query $query, ValueBinder $binder): string
     {
         $driver = $query->getConnection()->getDriver($query->getConnectionRole());
         $select = 'SELECT%s %s%s';
@@ -194,11 +194,11 @@ class QueryCompiler
             $select = '(SELECT%s %s%s';
         }
         $distinct = $query->clause('distinct');
-        $modifiers = $this->_buildModifierPart($query->clause('modifier'), $query, $binder);
+        $modifiers = $this->buildModifierPart($query->clause('modifier'), $query, $binder);
 
-        $quoteIdentifiers = $driver->isAutoQuotingEnabled() || $this->_quotedSelectAliases;
+        $quoteIdentifiers = $driver->isAutoQuotingEnabled() || $this->quotedSelectAliases;
         $normalized = [];
-        $parts = $this->_stringifyExpressions($parts, $binder);
+        $parts = $this->stringifyExpressions($parts, $binder);
         foreach ($parts as $k => $p) {
             if (!is_numeric($k)) {
                 $p .= ' AS ';
@@ -216,7 +216,7 @@ class QueryCompiler
         }
 
         if (is_array($distinct)) {
-            $distinct = $this->_stringifyExpressions($distinct, $binder);
+            $distinct = $this->stringifyExpressions($distinct, $binder);
             $distinct = sprintf('DISTINCT ON (%s) ', implode(', ', $distinct));
         }
 
@@ -233,11 +233,11 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string
      */
-    protected function _buildFromPart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildFromPart(array $parts, Query $query, ValueBinder $binder): string
     {
         $select = ' FROM %s';
         $normalized = [];
-        $parts = $this->_stringifyExpressions($parts, $binder);
+        $parts = $this->stringifyExpressions($parts, $binder);
         foreach ($parts as $k => $p) {
             if (!is_numeric($k)) {
                 $p = $p . ' ' . $k;
@@ -259,7 +259,7 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string
      */
-    protected function _buildJoinPart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildJoinPart(array $parts, Query $query, ValueBinder $binder): string
     {
         $joins = '';
         foreach ($parts as $join) {
@@ -298,7 +298,7 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string
      */
-    protected function _buildWindowPart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildWindowPart(array $parts, Query $query, ValueBinder $binder): string
     {
         $windows = [];
         foreach ($parts as $window) {
@@ -320,7 +320,7 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string
      */
-    protected function _buildSetPart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildSetPart(array $parts, Query $query, ValueBinder $binder): string
     {
         $set = [];
         foreach ($parts as $part) {
@@ -347,7 +347,7 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $binder
      * @return string
      */
-    protected function _buildSetOperationPart(
+    protected function buildSetOperationPart(
         string $operation,
         array $parts,
         Query $query,
@@ -388,9 +388,9 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string
      */
-    protected function _buildIntersectPart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildIntersectPart(array $parts, Query $query, ValueBinder $binder): string
     {
-        return $this->_buildSetOperationPart('INTERSECT', $parts, $query, $binder);
+        return $this->buildSetOperationPart('INTERSECT', $parts, $query, $binder);
     }
 
     /**
@@ -403,9 +403,9 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string
      */
-    protected function _buildUnionPart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildUnionPart(array $parts, Query $query, ValueBinder $binder): string
     {
-        return $this->_buildSetOperationPart('UNION', $parts, $query, $binder);
+        return $this->buildSetOperationPart('UNION', $parts, $query, $binder);
     }
 
     /**
@@ -416,7 +416,7 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string SQL fragment.
      */
-    protected function _buildInsertPart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildInsertPart(array $parts, Query $query, ValueBinder $binder): string
     {
         if (!isset($parts[0])) {
             throw new DatabaseException(
@@ -425,8 +425,8 @@ class QueryCompiler
             );
         }
         $table = $parts[0];
-        $columns = $this->_stringifyExpressions($parts[1], $binder);
-        $modifiers = $this->_buildModifierPart($query->clause('modifier'), $query, $binder);
+        $columns = $this->stringifyExpressions($parts[1], $binder);
+        $modifiers = $this->buildModifierPart($query->clause('modifier'), $query, $binder);
 
         return sprintf('INSERT%s INTO %s (%s)', $modifiers, $table, implode(', ', $columns));
     }
@@ -439,9 +439,9 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string SQL fragment.
      */
-    protected function _buildValuesPart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildValuesPart(array $parts, Query $query, ValueBinder $binder): string
     {
-        return implode('', $this->_stringifyExpressions($parts, $binder));
+        return implode('', $this->stringifyExpressions($parts, $binder));
     }
 
     /**
@@ -452,10 +452,10 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string SQL fragment.
      */
-    protected function _buildUpdatePart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildUpdatePart(array $parts, Query $query, ValueBinder $binder): string
     {
-        $table = $this->_stringifyExpressions($parts, $binder);
-        $modifiers = $this->_buildModifierPart($query->clause('modifier'), $query, $binder);
+        $table = $this->stringifyExpressions($parts, $binder);
+        $modifiers = $this->buildModifierPart($query->clause('modifier'), $query, $binder);
 
         return sprintf('UPDATE%s %s', $modifiers, implode(',', $table));
     }
@@ -468,13 +468,13 @@ class QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string SQL fragment.
      */
-    protected function _buildModifierPart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildModifierPart(array $parts, Query $query, ValueBinder $binder): string
     {
         if ($parts === []) {
             return '';
         }
 
-        return ' ' . implode(' ', $this->_stringifyExpressions($parts, $binder, false));
+        return ' ' . implode(' ', $this->stringifyExpressions($parts, $binder, false));
     }
 
     /**
@@ -486,7 +486,7 @@ class QueryCompiler
      * @param bool $wrap Whether to wrap each expression object with parenthesis
      * @return array
      */
-    protected function _stringifyExpressions(array $expressions, ValueBinder $binder, bool $wrap = true): array
+    protected function stringifyExpressions(array $expressions, ValueBinder $binder, bool $wrap = true): array
     {
         $result = [];
         foreach ($expressions as $k => $expression) {

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -124,7 +124,7 @@ class MysqlSchemaDialect extends SchemaDialect
             throw new DatabaseException("Could not describe columns on `{$tableName}`", null, $e);
         }
         foreach ($statement->fetchAll('assoc') as $row) {
-            $field = $this->_convertColumn($row['Type']);
+            $field = $this->convertColumn($row['Type']);
             $field += [
                 'name' => $row['Field'],
                 'null' => $row['Null'] === 'YES',
@@ -255,7 +255,7 @@ class MysqlSchemaDialect extends SchemaDialect
      * @return array<string, mixed> Array of column information.
      * @throws \Cake\Database\Exception\DatabaseException When column type cannot be parsed.
      */
-    protected function _convertColumn(string $column): array
+    protected function convertColumn(string $column): array
     {
         preg_match('/([a-z]+)(?:\(([0-9,]+)\))?\s*([a-z]+)?/i', $column, $matches);
         if (!$matches) {
@@ -275,7 +275,7 @@ class MysqlSchemaDialect extends SchemaDialect
             $precision = (int)$precision;
         }
 
-        $type = $this->_applyTypeSpecificColumnConversion(
+        $type = $this->applyTypeSpecificColumnConversion(
             $col,
             compact('length', 'precision', 'scale'),
         );
@@ -376,7 +376,7 @@ class MysqlSchemaDialect extends SchemaDialect
      */
     public function convertColumnDescription(TableSchema $schema, array $row): void
     {
-        $field = $this->_convertColumn($row['Type']);
+        $field = $this->convertColumn($row['Type']);
         $field += [
             'null' => $row['Null'] === 'YES',
             'default' => $row['Default'],
@@ -475,8 +475,8 @@ class MysqlSchemaDialect extends SchemaDialect
             'type' => TableSchema::CONSTRAINT_FOREIGN,
             'columns' => [$row['COLUMN_NAME']],
             'references' => [$row['REFERENCED_TABLE_NAME'], $row['REFERENCED_COLUMN_NAME']],
-            'update' => $this->_convertOnClause($row['UPDATE_RULE']),
-            'delete' => $this->_convertOnClause($row['DELETE_RULE']),
+            'update' => $this->convertOnClause($row['UPDATE_RULE']),
+            'delete' => $this->convertOnClause($row['DELETE_RULE']),
         ];
         $name = $row['CONSTRAINT_NAME'];
         $schema->addConstraint($name, $data);
@@ -506,8 +506,8 @@ class MysqlSchemaDialect extends SchemaDialect
                     'type' => TableSchema::CONSTRAINT_FOREIGN,
                     'columns' => [],
                     'references' => [$row['REFERENCED_TABLE_NAME'], []],
-                    'update' => $this->_convertOnClause($row['UPDATE_RULE'] ?? ''),
-                    'delete' => $this->_convertOnClause($row['DELETE_RULE'] ?? ''),
+                    'update' => $this->convertOnClause($row['UPDATE_RULE'] ?? ''),
+                    'delete' => $this->convertOnClause($row['DELETE_RULE'] ?? ''),
                     'length' => [],
                 ];
             }
@@ -766,7 +766,7 @@ class MysqlSchemaDialect extends SchemaDialect
         assert($data !== null);
 
         // TODO deprecrate Type defined schema mappings?
-        $sql = $this->_getTypeSpecificColumnSql($data['type'], $schema, $name);
+        $sql = $this->getTypeSpecificColumnSql($data['type'], $schema, $name);
         if ($sql !== null) {
             return $sql;
         }
@@ -814,7 +814,7 @@ class MysqlSchemaDialect extends SchemaDialect
         }
         $out .= $this->_driver->quoteIdentifier($name);
 
-        return $this->_keySql($out, $data);
+        return $this->keySql($out, $data);
     }
 
     /**
@@ -874,7 +874,7 @@ class MysqlSchemaDialect extends SchemaDialect
         }
         $out .= $this->_driver->quoteIdentifier($name);
 
-        return $this->_keySql($out, $data);
+        return $this->keySql($out, $data);
     }
 
     /**
@@ -884,7 +884,7 @@ class MysqlSchemaDialect extends SchemaDialect
      * @param array $data Key data.
      * @return string
      */
-    protected function _keySql(string $prefix, array $data): string
+    protected function keySql(string $prefix, array $data): string
     {
         $columns = array_map(
             $this->_driver->quoteIdentifier(...),
@@ -900,9 +900,9 @@ class MysqlSchemaDialect extends SchemaDialect
                 ' FOREIGN KEY (%s) REFERENCES %s (%s) ON UPDATE %s ON DELETE %s',
                 implode(', ', $columns),
                 $this->_driver->quoteIdentifier($data['references'][0]),
-                $this->_convertConstraintColumns($data['references'][1]),
-                $this->_foreignOnClause($data['update']),
-                $this->_foreignOnClause($data['delete']),
+                $this->convertConstraintColumns($data['references'][1]),
+                $this->foreignOnClause($data['update']),
+                $this->foreignOnClause($data['delete']),
             );
         }
 

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -116,7 +116,7 @@ class PostgresSchemaDialect extends SchemaDialect
      * @throws \Cake\Database\Exception\DatabaseException when column cannot be parsed.
      * @return array<string, mixed> Array of column information.
      */
-    protected function _convertColumn(string $column): array
+    protected function convertColumn(string $column): array
     {
         preg_match('/([a-z\s]+)(?:\(([a-z0-9,]+)(?:,\s*([0-9]+))?\))?/i', $column, $matches);
         if (!$matches) {
@@ -131,7 +131,7 @@ class PostgresSchemaDialect extends SchemaDialect
             $length = (int)$matches[2];
         }
 
-        $type = $this->_applyTypeSpecificColumnConversion(
+        $type = $this->applyTypeSpecificColumnConversion(
             $col,
             compact('length', 'precision', 'scale'),
         );
@@ -209,7 +209,7 @@ class PostgresSchemaDialect extends SchemaDialect
      */
     public function convertColumnDescription(TableSchema $schema, array $row): void
     {
-        $field = $this->_convertColumn($row['type']);
+        $field = $this->convertColumn($row['type']);
 
         if ($field['type'] === TableSchemaInterface::TYPE_BOOLEAN) {
             if ($row['default'] === 'true') {
@@ -224,7 +224,7 @@ class PostgresSchemaDialect extends SchemaDialect
         }
 
         $field += [
-            'default' => $this->_defaultValue($row['default']),
+            'default' => $this->defaultValue($row['default']),
             'null' => $row['null'] === 'YES',
             'collate' => $row['collation_name'],
             'comment' => $row['comment'],
@@ -282,7 +282,7 @@ class PostgresSchemaDialect extends SchemaDialect
         $statement = $this->_driver->execute($sql, [$name, $schema, $config['database']]);
         $columns = [];
         foreach ($statement->fetchAll('assoc') as $row) {
-            $field = $this->_convertColumn($row['type']);
+            $field = $this->convertColumn($row['type']);
             if ($field['type'] === TableSchemaInterface::TYPE_BOOLEAN) {
                 if ($row['default'] === 'true') {
                     $row['default'] = 1;
@@ -296,7 +296,7 @@ class PostgresSchemaDialect extends SchemaDialect
 
             $field += [
                 'name' => $row['name'],
-                'default' => $this->_defaultValue($row['default']),
+                'default' => $this->defaultValue($row['default']),
                 'null' => $row['null'] === 'YES',
                 'collate' => $row['collation_name'],
                 'comment' => $row['comment'],
@@ -337,7 +337,7 @@ class PostgresSchemaDialect extends SchemaDialect
      * @param string|int|null $default The default value.
      * @return string|int|null
      */
-    protected function _defaultValue(string|int|null $default): string|int|null
+    protected function defaultValue(string|int|null $default): string|int|null
     {
         if (is_numeric($default) || $default === null) {
             return $default;
@@ -408,7 +408,7 @@ class PostgresSchemaDialect extends SchemaDialect
             $type = TableSchema::CONSTRAINT_UNIQUE;
         }
         if ($type === TableSchema::CONSTRAINT_PRIMARY || $type === TableSchema::CONSTRAINT_UNIQUE) {
-            $this->_convertConstraint($schema, $name, $type, $row);
+            $this->convertConstraint($schema, $name, $type, $row);
 
             return;
         }
@@ -466,7 +466,7 @@ class PostgresSchemaDialect extends SchemaDialect
      * @param array $row The metadata record to update with.
      * @return void
      */
-    protected function _convertConstraint(TableSchema $schema, string $name, string $type, array $row): void
+    protected function convertConstraint(TableSchema $schema, string $name, string $type, array $row): void
     {
         $constraint = $schema->getConstraint($name);
         if (!$constraint) {
@@ -499,8 +499,8 @@ class PostgresSchemaDialect extends SchemaDialect
             'type' => TableSchema::CONSTRAINT_FOREIGN,
             'columns' => $row['column_name'],
             'references' => [$row['references_table'], $row['references_field']],
-            'update' => $this->_convertOnClause($row['on_update']),
-            'delete' => $this->_convertOnClause($row['on_delete']),
+            'update' => $this->convertOnClause($row['on_update']),
+            'delete' => $this->convertOnClause($row['on_delete']),
         ];
         $schema->addConstraint($row['name'], $data);
     }
@@ -522,8 +522,8 @@ class PostgresSchemaDialect extends SchemaDialect
                     'type' => TableSchema::CONSTRAINT_FOREIGN,
                     'columns' => [],
                     'references' => [$row['references_table'], []],
-                    'update' => $this->_convertOnClause($row['on_update']),
-                    'delete' => $this->_convertOnClause($row['on_delete']),
+                    'update' => $this->convertOnClause($row['on_update']),
+                    'delete' => $this->convertOnClause($row['on_delete']),
                 ];
             }
             // column indexes start at 1
@@ -587,7 +587,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
-    protected function _convertOnClause(string $clause): string
+    protected function convertOnClause(string $clause): string
     {
         if ($clause === 'r') {
             return TableSchema::ACTION_RESTRICT;
@@ -610,7 +610,7 @@ class PostgresSchemaDialect extends SchemaDialect
         $data = $schema->getColumn($name);
         assert($data !== null);
 
-        $sql = $this->_getTypeSpecificColumnSql($data['type'], $schema, $name);
+        $sql = $this->getTypeSpecificColumnSql($data['type'], $schema, $name);
         if ($sql !== null) {
             return $sql;
         }
@@ -826,7 +826,7 @@ class PostgresSchemaDialect extends SchemaDialect
             $out .= ' UNIQUE';
         }
 
-        return $this->_keySql($out, $data);
+        return $this->keySql($out, $data);
     }
 
     /**
@@ -836,7 +836,7 @@ class PostgresSchemaDialect extends SchemaDialect
      * @param array<string, mixed> $data Key data.
      * @return string
      */
-    protected function _keySql(string $prefix, array $data): string
+    protected function keySql(string $prefix, array $data): string
     {
         $columns = array_map(
             $this->_driver->quoteIdentifier(...),
@@ -847,9 +847,9 @@ class PostgresSchemaDialect extends SchemaDialect
                 ' FOREIGN KEY (%s) REFERENCES %s (%s) ON UPDATE %s ON DELETE %s DEFERRABLE INITIALLY IMMEDIATE',
                 implode(', ', $columns),
                 $this->_driver->quoteIdentifier($data['references'][0]),
-                $this->_convertConstraintColumns($data['references'][1]),
-                $this->_foreignOnClause($data['update']),
-                $this->_foreignOnClause($data['delete']),
+                $this->convertConstraintColumns($data['references'][1]),
+                $this->foreignOnClause($data['update']),
+                $this->foreignOnClause($data['delete']),
             );
         }
 

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -67,7 +67,7 @@ abstract class SchemaDialect
      * @param string $on The on clause
      * @return string
      */
-    protected function _foreignOnClause(string $on): string
+    protected function foreignOnClause(string $on): string
     {
         if ($on === TableSchema::ACTION_SET_NULL) {
             return 'SET NULL';
@@ -94,7 +94,7 @@ abstract class SchemaDialect
      * @param string $clause The on clause to convert.
      * @return string
      */
-    protected function _convertOnClause(string $clause): string
+    protected function convertOnClause(string $clause): string
     {
         if ($clause === 'CASCADE' || $clause === 'RESTRICT') {
             return strtolower($clause);
@@ -113,7 +113,7 @@ abstract class SchemaDialect
      * @param array<string>|string $references The referenced columns of a foreign key constraint statement
      * @return string
      */
-    protected function _convertConstraintColumns(array|string $references): string
+    protected function convertConstraintColumns(array|string $references): string
     {
         if (is_string($references)) {
             return $this->_driver->quoteIdentifier($references);
@@ -135,7 +135,7 @@ abstract class SchemaDialect
      * @return string|null An SQL fragment, or `null` in case no corresponding type was found or the type didn't provide
      *  custom column SQL.
      */
-    protected function _getTypeSpecificColumnSql(
+    protected function getTypeSpecificColumnSql(
         string $columnType,
         TableSchemaInterface $schema,
         string $column,
@@ -161,7 +161,7 @@ abstract class SchemaDialect
      * @return array|null Array of column information, or `null` in case no corresponding type was found or the type
      *  didn't provide custom column information.
      */
-    protected function _applyTypeSpecificColumnConversion(string $columnType, array $definition): ?array
+    protected function applyTypeSpecificColumnConversion(string $columnType, array $definition): ?array
     {
         if (!TypeFactory::getMap($columnType)) {
             return null;

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -43,7 +43,7 @@ class SqliteSchemaDialect extends SchemaDialect
      * @throws \Cake\Database\Exception\DatabaseException when unable to parse column type
      * @return array<string, mixed> Array of column information.
      */
-    protected function _convertColumn(string $column): array
+    protected function convertColumn(string $column): array
     {
         if ($column === '') {
             return ['type' => TableSchemaInterface::TYPE_TEXT, 'length' => null];
@@ -72,7 +72,7 @@ class SqliteSchemaDialect extends SchemaDialect
             $precision = (int)$precision;
         }
 
-        $type = $this->_applyTypeSpecificColumnConversion(
+        $type = $this->applyTypeSpecificColumnConversion(
             $col,
             compact('length', 'precision', 'scale'),
         );
@@ -207,10 +207,10 @@ class SqliteSchemaDialect extends SchemaDialect
      */
     public function convertColumnDescription(TableSchema $schema, array $row): void
     {
-        $field = $this->_convertColumn($row['type']);
+        $field = $this->convertColumn($row['type']);
         $field += [
             'null' => !$row['notnull'],
-            'default' => $this->_defaultValue($row['dflt_value']),
+            'default' => $this->defaultValue($row['dflt_value']),
         ];
         $primary = $schema->getConstraint('primary');
 
@@ -272,11 +272,11 @@ class SqliteSchemaDialect extends SchemaDialect
         $primary = [];
         foreach ($statement->fetchAll('assoc') as $i => $row) {
             $name = $row['name'];
-            $field = $this->_convertColumn($row['type']);
+            $field = $this->convertColumn($row['type']);
             $field += [
                 'name' => $name,
                 'null' => !$row['notnull'],
-                'default' => $this->_defaultValue($row['dflt_value']),
+                'default' => $this->defaultValue($row['dflt_value']),
                 'comment' => null,
                 'length' => null,
             ];
@@ -304,7 +304,7 @@ class SqliteSchemaDialect extends SchemaDialect
      * @param string|int|null $default The default value.
      * @return string|int|null
      */
-    protected function _defaultValue(string|int|null $default): string|int|null
+    protected function defaultValue(string|int|null $default): string|int|null
     {
         if ($default === 'NULL' || $default === null) {
             return null;
@@ -590,8 +590,8 @@ class SqliteSchemaDialect extends SchemaDialect
         } else {
             $data['references'] = [$foreignKey['table'], $data['references']];
         }
-        $data['update'] = $this->_convertOnClause($foreignKey['on_update'] ?? '');
-        $data['delete'] = $this->_convertOnClause($foreignKey['on_delete'] ?? '');
+        $data['update'] = $this->convertOnClause($foreignKey['on_update'] ?? '');
+        $data['delete'] = $this->convertOnClause($foreignKey['on_delete'] ?? '');
 
         $name = implode('_', $data['columns']) . '_' . $row['id'] . '_fk';
 
@@ -622,8 +622,8 @@ class SqliteSchemaDialect extends SchemaDialect
                     'type' => TableSchema::CONSTRAINT_FOREIGN,
                     'columns' => [],
                     'references' => [$row['table'], []],
-                    'update' => $this->_convertOnClause($row['on_update'] ?? ''),
-                    'delete' => $this->_convertOnClause($row['on_delete'] ?? ''),
+                    'update' => $this->convertOnClause($row['on_update'] ?? ''),
+                    'delete' => $this->convertOnClause($row['on_delete'] ?? ''),
                     'length' => [],
                 ];
             }
@@ -672,7 +672,7 @@ class SqliteSchemaDialect extends SchemaDialect
         $data = $schema->getColumn($name);
         assert($data !== null);
 
-        $sql = $this->_getTypeSpecificColumnSql($data['type'], $schema, $name);
+        $sql = $this->getTypeSpecificColumnSql($data['type'], $schema, $name);
         if ($sql !== null) {
             return $sql;
         }
@@ -883,9 +883,9 @@ class SqliteSchemaDialect extends SchemaDialect
             $clause = sprintf(
                 ' REFERENCES %s (%s) ON UPDATE %s ON DELETE %s',
                 $this->_driver->quoteIdentifier($data['references'][0]),
-                $this->_convertConstraintColumns($data['references'][1]),
-                $this->_foreignOnClause($data['update']),
-                $this->_foreignOnClause($data['delete']),
+                $this->convertConstraintColumns($data['references'][1]),
+                $this->foreignOnClause($data['update']),
+                $this->foreignOnClause($data['delete']),
             );
         }
         $columns = array_map(

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -121,7 +121,7 @@ class SqlserverSchemaDialect extends SchemaDialect
      * @return array<string, mixed> Array of column information.
      * @link https://technet.microsoft.com/en-us/library/ms187752.aspx
      */
-    protected function _convertColumn(
+    protected function convertColumn(
         string $col,
         ?int $length = null,
         ?int $precision = null,
@@ -129,7 +129,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     ): array {
         $col = strtolower($col);
 
-        $type = $this->_applyTypeSpecificColumnConversion(
+        $type = $this->applyTypeSpecificColumnConversion(
             $col,
             compact('length', 'precision', 'scale'),
         );
@@ -234,7 +234,7 @@ class SqlserverSchemaDialect extends SchemaDialect
      */
     public function convertColumnDescription(TableSchema $schema, array $row): void
     {
-        $field = $this->_convertColumn(
+        $field = $this->convertColumn(
             $row['type'],
             $row['char_length'] !== null ? (int)$row['char_length'] : null,
             $row['precision'] !== null ? (int)$row['precision'] : null,
@@ -247,7 +247,7 @@ class SqlserverSchemaDialect extends SchemaDialect
 
         $field += [
             'null' => $row['null'] === '1',
-            'default' => $this->_defaultValue($field['type'], $row['default']),
+            'default' => $this->defaultValue($field['type'], $row['default']),
             'collate' => $row['collation_name'],
         ];
         $schema->addColumn($row['name'], $field);
@@ -283,7 +283,7 @@ class SqlserverSchemaDialect extends SchemaDialect
         $statement = $this->_driver->execute($sql, [$name, $schema]);
         $columns = [];
         foreach ($statement->fetchAll('assoc') as $row) {
-            $field = $this->_convertColumn(
+            $field = $this->convertColumn(
                 $row['type'],
                 $row['char_length'] !== null ? (int)$row['char_length'] : null,
                 $row['precision'] !== null ? (int)$row['precision'] : null,
@@ -297,7 +297,7 @@ class SqlserverSchemaDialect extends SchemaDialect
             $field += [
                 'name' => $row['name'],
                 'null' => $row['null'] === '1',
-                'default' => $this->_defaultValue($field['type'], $row['default']),
+                'default' => $this->defaultValue($field['type'], $row['default']),
                 'comment' => $row['comment'] ?? null,
                 'collate' => $row['collation_name'],
             ];
@@ -317,7 +317,7 @@ class SqlserverSchemaDialect extends SchemaDialect
      * @param string|null $default The default value.
      * @return string|int|null
      */
-    protected function _defaultValue(string $type, ?string $default): string|int|null
+    protected function defaultValue(string $type, ?string $default): string|int|null
     {
         if ($default === null) {
             return null;
@@ -496,8 +496,8 @@ class SqlserverSchemaDialect extends SchemaDialect
                     'type' => TableSchema::CONSTRAINT_FOREIGN,
                     'columns' => [],
                     'references' => [$row['reference_table'], []],
-                    'update' => $this->_convertOnClause($row['update_type']),
-                    'delete' => $this->_convertOnClause($row['delete_type']),
+                    'update' => $this->convertOnClause($row['update_type']),
+                    'delete' => $this->convertOnClause($row['delete_type']),
                 ];
             }
             $keys[$name]['columns'][] = $row['column'];
@@ -535,8 +535,8 @@ class SqlserverSchemaDialect extends SchemaDialect
             'type' => TableSchema::CONSTRAINT_FOREIGN,
             'columns' => [$row['column']],
             'references' => [$row['reference_table'], $row['reference_column']],
-            'update' => $this->_convertOnClause($row['update_type']),
-            'delete' => $this->_convertOnClause($row['delete_type']),
+            'update' => $this->convertOnClause($row['update_type']),
+            'delete' => $this->convertOnClause($row['delete_type']),
         ];
         $name = $row['foreign_key_name'];
         $schema->addConstraint($name, $data);
@@ -553,17 +553,17 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
-    protected function _foreignOnClause(string $on): string
+    protected function foreignOnClause(string $on): string
     {
-        $parent = parent::_foreignOnClause($on);
+        $parent = parent::foreignOnClause($on);
 
-        return $parent === 'RESTRICT' ? parent::_foreignOnClause(TableSchema::ACTION_NO_ACTION) : $parent;
+        return $parent === 'RESTRICT' ? parent::foreignOnClause(TableSchema::ACTION_NO_ACTION) : $parent;
     }
 
     /**
      * @inheritDoc
      */
-    protected function _convertOnClause(string $clause): string
+    protected function convertOnClause(string $clause): string
     {
         return match ($clause) {
             'NO_ACTION' => TableSchema::ACTION_NO_ACTION,
@@ -582,7 +582,7 @@ class SqlserverSchemaDialect extends SchemaDialect
         $data = $schema->getColumn($name);
         assert($data !== null);
 
-        $sql = $this->_getTypeSpecificColumnSql($data['type'], $schema, $name);
+        $sql = $this->getTypeSpecificColumnSql($data['type'], $schema, $name);
         if ($sql !== null) {
             return $sql;
         }
@@ -813,7 +813,7 @@ class SqlserverSchemaDialect extends SchemaDialect
             $out .= ' UNIQUE';
         }
 
-        return $this->_keySql($out, $data);
+        return $this->keySql($out, $data);
     }
 
     /**
@@ -823,7 +823,7 @@ class SqlserverSchemaDialect extends SchemaDialect
      * @param array $data Key data.
      * @return string
      */
-    protected function _keySql(string $prefix, array $data): string
+    protected function keySql(string $prefix, array $data): string
     {
         $columns = array_map(
             $this->_driver->quoteIdentifier(...),
@@ -834,9 +834,9 @@ class SqlserverSchemaDialect extends SchemaDialect
                 ' FOREIGN KEY (%s) REFERENCES %s (%s) ON UPDATE %s ON DELETE %s',
                 implode(', ', $columns),
                 $this->_driver->quoteIdentifier($data['references'][0]),
-                $this->_convertConstraintColumns($data['references'][1]),
-                $this->_foreignOnClause($data['update']),
-                $this->_foreignOnClause($data['delete']),
+                $this->convertConstraintColumns($data['references'][1]),
+                $this->foreignOnClause($data['update']),
+                $this->foreignOnClause($data['delete']),
             );
         }
 

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -603,7 +603,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         }
 
         if ($attrs['type'] === static::CONSTRAINT_FOREIGN) {
-            $attrs = $this->_checkForeignKey($attrs);
+            $attrs = $this->checkForeignKey($attrs);
 
             if (isset($this->_constraints[$name])) {
                 $this->_constraints[$name]['columns'] = array_unique(array_merge(
@@ -664,7 +664,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      * @return array<string, mixed>
      * @throws \Cake\Database\Exception\DatabaseException When foreign key definition is not valid.
      */
-    protected function _checkForeignKey(array $attrs): array
+    protected function checkForeignKey(array $attrs): array
     {
         if (count($attrs['references']) < 2) {
             throw new DatabaseException('References must contain a table and column.');

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -32,7 +32,7 @@ class SqlserverCompiler extends QueryCompiler
      *
      * @var array<string, string>
      */
-    protected array $_templates = [
+    protected array $templates = [
         'delete' => 'DELETE',
         'where' => ' WHERE %s',
         'group' => ' GROUP BY %s',
@@ -47,7 +47,7 @@ class SqlserverCompiler extends QueryCompiler
      *
      * @var array<string>
      */
-    protected array $_selectParts = [
+    protected array $selectParts = [
         'comment', 'with', 'select', 'from', 'join', 'where', 'group', 'having', 'window', 'order',
         'offset', 'limit', 'union', 'epilog', 'intersect',
     ];
@@ -62,7 +62,7 @@ class SqlserverCompiler extends QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string
      */
-    protected function _buildWithPart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildWithPart(array $parts, Query $query, ValueBinder $binder): string
     {
         $expressions = [];
         foreach ($parts as $cte) {
@@ -84,7 +84,7 @@ class SqlserverCompiler extends QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string
      */
-    protected function _buildInsertPart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildInsertPart(array $parts, Query $query, ValueBinder $binder): string
     {
         if (!isset($parts[0])) {
             throw new DatabaseException(
@@ -93,8 +93,8 @@ class SqlserverCompiler extends QueryCompiler
             );
         }
         $table = $parts[0];
-        $columns = $this->_stringifyExpressions($parts[1], $binder);
-        $modifiers = $this->_buildModifierPart($query->clause('modifier'), $query, $binder);
+        $columns = $this->stringifyExpressions($parts[1], $binder);
+        $modifiers = $this->buildModifierPart($query->clause('modifier'), $query, $binder);
 
         return sprintf(
             'INSERT%s INTO %s (%s) OUTPUT INSERTED.*',
@@ -111,7 +111,7 @@ class SqlserverCompiler extends QueryCompiler
      * @param \Cake\Database\Query $query The query that is being compiled
      * @return string
      */
-    protected function _buildLimitPart(int $limit, Query $query): string
+    protected function buildLimitPart(int $limit, Query $query): string
     {
         if ($query->clause('offset') === null) {
             return '';
@@ -130,7 +130,7 @@ class SqlserverCompiler extends QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string
      */
-    protected function _buildHavingPart(array $parts, Query $query, ValueBinder $binder): string
+    protected function buildHavingPart(array $parts, Query $query, ValueBinder $binder): string
     {
         $selectParts = $query->clause('select');
 

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -318,9 +318,9 @@ class DateTimeType extends BaseType implements BatchCastingInterface
 
             if (is_string($value)) {
                 if ($this->_useLocaleMarshal) {
-                    $dateTime = $this->_parseLocaleValue($value);
+                    $dateTime = $this->parseLocaleValue($value);
                 } else {
-                    $dateTime = $this->_parseValue($value);
+                    $dateTime = $this->parseValue($value);
                 }
 
                 if ($dateTime) {
@@ -428,7 +428,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
      * @param string $value The value to parse and convert to an object.
      * @return \Cake\I18n\DateTime|null
      */
-    protected function _parseLocaleValue(string $value): ?DateTime
+    protected function parseLocaleValue(string $value): ?DateTime
     {
         /** @var class-string<\Cake\I18n\DateTime> $class */
         $class = $this->_className;
@@ -443,7 +443,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
      * @param string $value The value to parse and convert to an object.
      * @return \Cake\I18n\DateTime|\DateTimeImmutable|null
      */
-    protected function _parseValue(string $value): DateTime|DateTimeImmutable|null
+    protected function parseValue(string $value): DateTime|DateTimeImmutable|null
     {
         $class = $this->_className;
 

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -401,7 +401,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
      * See `Cake\I18n\Time::parseDateTime()` for accepted formats.
      *
      * @param array|string $format The locale-aware format
-     * @see \Cake\I18n\Time::parseDateTime()
+     * @see \Cake\I18n\Time::doParseDateTime()
      * @return $this
      */
     public function setLocaleFormat(array|string $format): static

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -173,10 +173,10 @@ class DateType extends BaseType implements BatchCastingInterface
 
             if (is_string($value)) {
                 if ($this->_useLocaleMarshal) {
-                    return $this->_parseLocaleValue($value);
+                    return $this->parseLocaleValue($value);
                 }
 
-                return $this->_parseValue($value);
+                return $this->parseValue($value);
             }
         } catch (Exception) {
             return null;
@@ -249,7 +249,7 @@ class DateType extends BaseType implements BatchCastingInterface
      * @param string $value
      * @return \Cake\I18n\Date|null
      */
-    protected function _parseLocaleValue(string $value): ?Date
+    protected function parseLocaleValue(string $value): ?Date
     {
         /** @var class-string<\Cake\I18n\Date> $class */
         $class = $this->_className;
@@ -264,7 +264,7 @@ class DateType extends BaseType implements BatchCastingInterface
      * @param string $value The value to parse and convert to an object.
      * @return \Cake\Chronos\ChronosDate|null
      */
-    protected function _parseValue(string $value): ?ChronosDate
+    protected function parseValue(string $value): ?ChronosDate
     {
         $class = $this->_className;
         foreach ($this->_marshalFormats as $format) {

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -130,7 +130,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
             return null;
         }
         if (is_string($value) && $this->_useLocaleParser) {
-            return $this->_parseValue($value);
+            return $this->parseValue($value);
         }
         if (is_numeric($value)) {
             return (string)$value;
@@ -177,7 +177,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
      * @param string $value The value to parse and convert to an float.
      * @return string
      */
-    protected function _parseValue(string $value): string
+    protected function parseValue(string $value): string
     {
         $class = static::$numberClass;
 

--- a/src/Database/Type/ExpressionTypeCasterTrait.php
+++ b/src/Database/Type/ExpressionTypeCasterTrait.php
@@ -33,7 +33,7 @@ trait ExpressionTypeCasterTrait
      * @param string|null $type The type name
      * @return mixed
      */
-    protected function _castToExpression(mixed $value, ?string $type = null): mixed
+    protected function castToExpression(mixed $value, ?string $type = null): mixed
     {
         if ($type === null) {
             return $value;
@@ -64,7 +64,7 @@ trait ExpressionTypeCasterTrait
      * @param array $types List of type names
      * @return array
      */
-    protected function _requiresToExpressionCasting(array $types): array
+    protected function requiresToExpressionCasting(array $types): array
     {
         $result = [];
         $types = array_filter($types);

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -111,7 +111,7 @@ class FloatType extends BaseType implements BatchCastingInterface
             return null;
         }
         if (is_string($value) && $this->_useLocaleParser) {
-            return $this->_parseValue($value);
+            return $this->parseValue($value);
         }
         if (is_numeric($value)) {
             return (float)$value;
@@ -157,7 +157,7 @@ class FloatType extends BaseType implements BatchCastingInterface
      * @param string $value The value to parse and convert to an float.
      * @return float
      */
-    protected function _parseValue(string $value): float
+    protected function parseValue(string $value): float
     {
         $class = static::$numberClass;
 

--- a/src/Database/Type/TimeType.php
+++ b/src/Database/Type/TimeType.php
@@ -95,10 +95,10 @@ class TimeType extends BaseType implements BatchCastingInterface
 
         if (is_string($value)) {
             if ($this->_useLocaleMarshal) {
-                return $this->_parseLocalTimeValue($value);
+                return $this->parseLocalTimeValue($value);
             }
 
-            return $this->_parseTimeValue($value);
+            return $this->parseTimeValue($value);
         }
 
         if (!is_array($value)) {
@@ -198,7 +198,7 @@ class TimeType extends BaseType implements BatchCastingInterface
      * @param string $value The value to parse and convert to an object.
      * @return \Cake\Chronos\ChronosTime|null
      */
-    protected function _parseTimeValue(string $value): ?ChronosTime
+    protected function parseTimeValue(string $value): ?ChronosTime
     {
         try {
             return $this->_className::parse($value);
@@ -214,7 +214,7 @@ class TimeType extends BaseType implements BatchCastingInterface
      * @param string $value The value to parse and convert to an object.
      * @return \Cake\Chronos\ChronosTime|null
      */
-    protected function _parseLocalTimeValue(string $value): ?ChronosTime
+    protected function parseLocalTimeValue(string $value): ?ChronosTime
     {
         assert(is_a($this->_className, Time::class, true));
 

--- a/src/Datasource/ConnectionRegistry.php
+++ b/src/Datasource/ConnectionRegistry.php
@@ -37,7 +37,7 @@ class ConnectionRegistry extends ObjectRegistry
      * @param string $class Partial classname to resolve.
      * @return class-string<\Cake\Datasource\ConnectionInterface>|null Either the correct class name or null.
      */
-    protected function _resolveClassName(string $class): ?string
+    protected function resolveClassName(string $class): ?string
     {
         /** @var class-string<\Cake\Datasource\ConnectionInterface>|null */
         return App::className($class, 'Datasource');
@@ -53,7 +53,7 @@ class ConnectionRegistry extends ObjectRegistry
      * @return void
      * @throws \Cake\Datasource\Exception\MissingDatasourceException
      */
-    protected function _throwMissingClassError(string $class, ?string $plugin): void
+    protected function throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new MissingDatasourceException([
             'class' => $class,
@@ -74,7 +74,7 @@ class ConnectionRegistry extends ObjectRegistry
      * @param array<string, mixed> $config An array of settings to use for the datasource.
      * @return \Cake\Datasource\ConnectionInterface A connection with the correct settings.
      */
-    protected function _create(object|string $class, string $alias, array $config): ConnectionInterface
+    protected function create(object|string $class, string $alias, array $config): ConnectionInterface
     {
         if (is_string($class)) {
             unset($config['className']);

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -299,7 +299,7 @@ trait EntityTrait
             }
 
             if ($options['setter']) {
-                $setter = static::_accessor($name, 'set');
+                $setter = static::accessor($name, 'set');
                 if ($setter) {
                     $value = $this->{$setter}($value);
                 }
@@ -373,7 +373,7 @@ trait EntityTrait
             $value = &$this->_fields[$field];
         }
 
-        $method = static::_accessor($field, 'get');
+        $method = static::accessor($field, 'get');
         if ($method) {
             // Must be variable before returning: Only variable references should be returned by reference.
             $result = $this->{$method}($value);
@@ -488,7 +488,7 @@ trait EntityTrait
     public function has(array|string $field): bool
     {
         foreach ((array)$field as $prop) {
-            if (!array_key_exists($prop, $this->_fields) && !static::_accessor($prop, 'get')) {
+            if (!array_key_exists($prop, $this->_fields) && !static::accessor($prop, 'get')) {
                 return false;
             }
         }
@@ -746,7 +746,7 @@ trait EntityTrait
      * @param string $type the accessor type ('get' or 'set')
      * @return string method name or empty string (no method available)
      */
-    protected static function _accessor(string $property, string $type): string
+    protected static function accessor(string $property, string $type): string
     {
         $class = static::class;
 
@@ -1020,7 +1020,7 @@ trait EntityTrait
         $this->_hasBeenVisited = true;
         try {
             foreach ($this->_fields as $field) {
-                if ($this->_readHasErrors($field)) {
+                if ($this->readHasErrors($field)) {
                     return true;
                 }
             }
@@ -1052,7 +1052,7 @@ trait EntityTrait
                     return is_array($value) || $value instanceof EntityInterface;
                 })
                 ->map(function ($value) {
-                    return $this->_readError($value);
+                    return $this->readError($value);
                 })
                 ->filter()
                 ->toArray();
@@ -1071,7 +1071,7 @@ trait EntityTrait
      */
     public function getError(string $field): array
     {
-        return $this->_errors[$field] ?? $this->_nestedErrors($field);
+        return $this->_errors[$field] ?? $this->nestedErrors($field);
     }
 
     /**
@@ -1146,7 +1146,7 @@ trait EntityTrait
      * @param string $field the field in this entity to check for errors
      * @return array Errors in nested entity if any
      */
-    protected function _nestedErrors(string $field): array
+    protected function nestedErrors(string $field): array
     {
         // Only one path element, check for nested entity with error.
         if (!str_contains($field, '.')) {
@@ -1156,7 +1156,7 @@ trait EntityTrait
 
             $entity = $this->get($field);
             if ($entity instanceof EntityInterface || is_iterable($entity)) {
-                return $this->_readError($entity);
+                return $this->readError($entity);
             }
 
             return [];
@@ -1196,7 +1196,7 @@ trait EntityTrait
             }
         }
         if (count($path) <= 1) {
-            return $this->_readError($entity, array_pop($path));
+            return $this->readError($entity, array_pop($path));
         }
 
         return [];
@@ -1208,7 +1208,7 @@ trait EntityTrait
      * @param \Cake\Datasource\EntityInterface|array $object The object to read errors from.
      * @return bool
      */
-    protected function _readHasErrors(mixed $object): bool
+    protected function readHasErrors(mixed $object): bool
     {
         if ($object instanceof EntityInterface && $object->hasErrors()) {
             return true;
@@ -1216,7 +1216,7 @@ trait EntityTrait
 
         if (is_array($object)) {
             foreach ($object as $value) {
-                if ($this->_readHasErrors($value)) {
+                if ($this->readHasErrors($value)) {
                     return true;
                 }
             }
@@ -1232,7 +1232,7 @@ trait EntityTrait
      * @param string|null $path The field name for errors.
      * @return array
      */
-    protected function _readError(EntityInterface|iterable $object, ?string $path = null): array
+    protected function readError(EntityInterface|iterable $object, ?string $path = null): array
     {
         if ($path !== null && $object instanceof EntityInterface) {
             return $object->getError($path);

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -67,7 +67,7 @@ trait ModelAwareTrait
      * @param string $name Class name.
      * @return void
      */
-    protected function _setModelClass(string $name): void
+    protected function setModelClass(string $name): void
     {
         $this->modelClass ??= $name;
     }

--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -549,7 +549,7 @@ class NumericPaginator implements PaginatorInterface
 
             $order = isset($options['order']) && is_array($options['order']) ? $options['order'] : [];
             if ($order && $options['sort'] && !str_contains($options['sort'], '.')) {
-                $order = $this->_removeAliases($order, $object->getAlias());
+                $order = $this->removeAliases($order, $object->getAlias());
             }
 
             $options['order'] = [$options['sort'] => $direction] + $order;
@@ -585,7 +585,7 @@ class NumericPaginator implements PaginatorInterface
             $options['sort'] = key($options['order']);
         }
 
-        $options['order'] = $this->_prefix($object, $options['order'], $sortAllowed);
+        $options['order'] = $this->prefix($object, $options['order'], $sortAllowed);
 
         return $options;
     }
@@ -597,7 +597,7 @@ class NumericPaginator implements PaginatorInterface
      * @param string $model Current model alias
      * @return array<string, mixed> $fields Unaliased fields where applicable
      */
-    protected function _removeAliases(array $fields, string $model): array
+    protected function removeAliases(array $fields, string $model): array
     {
         $result = [];
         foreach ($fields as $field => $sort) {
@@ -634,7 +634,7 @@ class NumericPaginator implements PaginatorInterface
      * @param bool $allowed Whether the field was allowed.
      * @return array Final order array.
      */
-    protected function _prefix(RepositoryInterface $object, array $order, bool $allowed = false): array
+    protected function prefix(RepositoryInterface $object, array $order, bool $allowed = false): array
     {
         $tableAlias = $object->getAlias();
         $tableOrder = [];

--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -66,8 +66,8 @@ class QueryCacher
      */
     public function fetch(object $query): mixed
     {
-        $key = $this->_resolveKey($query);
-        $storage = $this->_resolveCacher();
+        $key = $this->resolveKey($query);
+        $storage = $this->resolveCacher();
         $result = $storage->get($key);
         if (!$result) {
             return null;
@@ -85,8 +85,8 @@ class QueryCacher
      */
     public function store(object $query, Traversable $results): bool
     {
-        $key = $this->_resolveKey($query);
-        $storage = $this->_resolveCacher();
+        $key = $this->resolveKey($query);
+        $storage = $this->resolveCacher();
 
         return $storage->set($key, $results);
     }
@@ -98,7 +98,7 @@ class QueryCacher
      * @return string
      * @throws \Cake\Core\Exception\CakeException
      */
-    protected function _resolveKey(object $query): string
+    protected function resolveKey(object $query): string
     {
         if (is_string($this->_key)) {
             return $this->_key;
@@ -118,7 +118,7 @@ class QueryCacher
      *
      * @return \Psr\SimpleCache\CacheInterface
      */
-    protected function _resolveCacher(): CacheInterface
+    protected function resolveCacher(): CacheInterface
     {
         if (is_string($this->_config)) {
             return Cache::pool($this->_config);

--- a/src/Datasource/RulesChecker.php
+++ b/src/Datasource/RulesChecker.php
@@ -140,9 +140,9 @@ class RulesChecker
     {
         if (is_string($name)) {
             $this->checkName($name, $this->_rules);
-            $this->_rules[$name] = $this->_addError($rule, $name, $options);
+            $this->_rules[$name] = $this->addError($rule, $name, $options);
         } else {
-            $this->_rules[] = $this->_addError($rule, $name, $options);
+            $this->_rules[] = $this->addError($rule, $name, $options);
         }
 
         return $this;
@@ -185,9 +185,9 @@ class RulesChecker
     {
         if (is_string($name)) {
             $this->checkName($name, $this->_createRules);
-            $this->_createRules[$name] = $this->_addError($rule, $name, $options);
+            $this->_createRules[$name] = $this->addError($rule, $name, $options);
         } else {
-            $this->_createRules[] = $this->_addError($rule, $name, $options);
+            $this->_createRules[] = $this->addError($rule, $name, $options);
         }
 
         return $this;
@@ -230,9 +230,9 @@ class RulesChecker
     {
         if (is_string($name)) {
             $this->checkName($name, $this->_updateRules);
-            $this->_updateRules[$name] = $this->_addError($rule, $name, $options);
+            $this->_updateRules[$name] = $this->addError($rule, $name, $options);
         } else {
-            $this->_updateRules[] = $this->_addError($rule, $name, $options);
+            $this->_updateRules[] = $this->addError($rule, $name, $options);
         }
 
         return $this;
@@ -275,9 +275,9 @@ class RulesChecker
     {
         if (is_string($name)) {
             $this->checkName($name, $this->_deleteRules);
-            $this->_deleteRules[$name] = $this->_addError($rule, $name, $options);
+            $this->_deleteRules[$name] = $this->addError($rule, $name, $options);
         } else {
-            $this->_deleteRules[] = $this->_addError($rule, $name, $options);
+            $this->_deleteRules[] = $this->addError($rule, $name, $options);
         }
 
         return $this;
@@ -328,7 +328,7 @@ class RulesChecker
      */
     public function checkCreate(EntityInterface $entity, array $options = []): bool
     {
-        return $this->_checkRules(
+        return $this->checkRules(
             $entity,
             $options,
             array_merge(array_values($this->_rules), array_values($this->_createRules)),
@@ -345,7 +345,7 @@ class RulesChecker
      */
     public function checkUpdate(EntityInterface $entity, array $options = []): bool
     {
-        return $this->_checkRules(
+        return $this->checkRules(
             $entity,
             $options,
             array_merge(array_values($this->_rules), array_values($this->_updateRules)),
@@ -362,7 +362,7 @@ class RulesChecker
      */
     public function checkDelete(EntityInterface $entity, array $options = []): bool
     {
-        return $this->_checkRules(
+        return $this->checkRules(
             $entity,
             $options,
             array_merge(array_values($this->_rules), array_values($this->_deleteRules)),
@@ -378,7 +378,7 @@ class RulesChecker
      * @param array<\Cake\Datasource\RuleInvoker> $rules The list of rules that must be checked.
      * @return bool
      */
-    protected function _checkRules(EntityInterface $entity, array $options = [], array $rules = []): bool
+    protected function checkRules(EntityInterface $entity, array $options = [], array $rules = []): bool
     {
         $success = true;
         $options += $this->_options;
@@ -398,7 +398,7 @@ class RulesChecker
      * @param array<string, mixed> $options The options containing the error message and field.
      * @return \Cake\Datasource\RuleInvoker
      */
-    protected function _addError(callable $rule, array|string|null $name = null, array $options = []): RuleInvoker
+    protected function addError(callable $rule, array|string|null $name = null, array $options = []): RuleInvoker
     {
         if (is_array($name)) {
             $options = $name;

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -501,7 +501,7 @@ class Debugger
             if (!isset($data[$i])) {
                 continue;
             }
-            $string = str_replace(["\r\n", "\n"], '', static::_highlight($data[$i]));
+            $string = str_replace(["\r\n", "\n"], '', static::highlight($data[$i]));
             if ($i === $line) {
                 $lines[] = '<span class="code-highlight">' . $string . '</span>';
             } else {
@@ -519,7 +519,7 @@ class Debugger
      * @param string $str The string to convert.
      * @return string
      */
-    protected static function _highlight(string $str): string
+    protected static function highlight(string $str): string
     {
         $added = false;
         if (!str_contains($str, '<?php')) {

--- a/src/Event/Decorator/AbstractDecorator.php
+++ b/src/Event/Decorator/AbstractDecorator.php
@@ -55,7 +55,7 @@ abstract class AbstractDecorator
      */
     public function __invoke(): mixed
     {
-        return $this->_call(func_get_args());
+        return $this->call(func_get_args());
     }
 
     /**
@@ -64,7 +64,7 @@ abstract class AbstractDecorator
      * @param array $args Arguments for the callable.
      * @return mixed
      */
-    protected function _call(array $args): mixed
+    protected function call(array $args): mixed
     {
         $callable = $this->_callable;
 

--- a/src/Event/Decorator/ConditionDecorator.php
+++ b/src/Event/Decorator/ConditionDecorator.php
@@ -36,7 +36,7 @@ class ConditionDecorator extends AbstractDecorator
             return null;
         }
 
-        return $this->_call($args);
+        return $this->call($args);
     }
 
     /**
@@ -48,8 +48,8 @@ class ConditionDecorator extends AbstractDecorator
      */
     public function canTrigger(EventInterface $event): bool
     {
-        $if = $this->_evaluateCondition('if', $event);
-        $unless = $this->_evaluateCondition('unless', $event);
+        $if = $this->evaluateCondition('if', $event);
+        $unless = $this->evaluateCondition('unless', $event);
 
         return $if && !$unless;
     }
@@ -62,7 +62,7 @@ class ConditionDecorator extends AbstractDecorator
      * @param \Cake\Event\EventInterface<TSubject> $event Event object
      * @return bool
      */
-    protected function _evaluateCondition(string $condition, EventInterface $event): bool
+    protected function evaluateCondition(string $condition, EventInterface $event): bool
     {
         if (!isset($this->_options[$condition])) {
             return $condition !== 'unless';

--- a/src/Event/Decorator/SubjectFilterDecorator.php
+++ b/src/Event/Decorator/SubjectFilterDecorator.php
@@ -39,7 +39,7 @@ class SubjectFilterDecorator extends AbstractDecorator
             return null;
         }
 
-        return $this->_call($args);
+        return $this->call($args);
     }
 
     /**

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -105,7 +105,7 @@ class EventManager implements EventManagerInterface
         ?callable $callable = null,
     ): static {
         if ($eventKey instanceof EventListenerInterface) {
-            $this->_attachSubscriber($eventKey);
+            $this->attachSubscriber($eventKey);
 
             return $this;
         }
@@ -141,7 +141,7 @@ class EventManager implements EventManagerInterface
      * @param \Cake\Event\EventListenerInterface $subscriber Event listener.
      * @return void
      */
-    protected function _attachSubscriber(EventListenerInterface $subscriber): void
+    protected function attachSubscriber(EventListenerInterface $subscriber): void
     {
         foreach ($subscriber->implementedEvents() as $eventKey => $handlers) {
             foreach ($this->normalizeHandlers($subscriber, $handlers) as $handler) {
@@ -158,7 +158,7 @@ class EventManager implements EventManagerInterface
         EventListenerInterface|callable|null $callable = null,
     ): static {
         if ($eventKey instanceof EventListenerInterface) {
-            $this->_detachSubscriber($eventKey);
+            $this->detachSubscriber($eventKey);
 
             return $this;
         }
@@ -172,7 +172,7 @@ class EventManager implements EventManagerInterface
         }
 
         if ($callable instanceof EventListenerInterface) {
-            $this->_detachSubscriber($callable, $eventKey);
+            $this->detachSubscriber($callable, $eventKey);
 
             return $this;
         }
@@ -207,7 +207,7 @@ class EventManager implements EventManagerInterface
      * @param string|null $eventKey optional event key name to unsubscribe the listener from
      * @return void
      */
-    protected function _detachSubscriber(EventListenerInterface $subscriber, ?string $eventKey = null): void
+    protected function detachSubscriber(EventListenerInterface $subscriber, ?string $eventKey = null): void
     {
         $events = $subscriber->implementedEvents();
         if ($eventKey && empty($events[$eventKey])) {
@@ -311,7 +311,7 @@ class EventManager implements EventManagerInterface
                 break;
             }
 
-            $this->_callListener($listener['callable'], $event);
+            $this->callListener($listener['callable'], $event);
         }
 
         return $event;
@@ -325,7 +325,7 @@ class EventManager implements EventManagerInterface
      * @param \Cake\Event\EventInterface<TSubject> $event Event instance.
      * @return void
      */
-    protected function _callListener(callable $listener, EventInterface $event): void
+    protected function callListener(callable $listener, EventInterface $event): void
     {
         $result = $listener($event, ...array_values($event->getData()));
 

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -159,7 +159,7 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
      */
     public function getSchema(): Schema
     {
-        $this->_schema ??= $this->_buildSchema(new $this->_schemaClass());
+        $this->_schema ??= $this->buildSchema(new $this->_schemaClass());
 
         return $this->_schema;
     }
@@ -174,7 +174,7 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
      * @param \Cake\Form\Schema $schema The schema to customize.
      * @return \Cake\Form\Schema The schema to use.
      */
-    protected function _buildSchema(Schema $schema): Schema
+    protected function buildSchema(Schema $schema): Schema
     {
         return $schema;
     }
@@ -265,12 +265,12 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
         $options += ['validate' => true];
 
         if ($options['validate'] === false) {
-            return $this->_execute($data);
+            return $this->doExecute($data);
         }
 
         $validator = $options['validate'] === true ? static::DEFAULT_VALIDATOR : $options['validate'];
 
-        return $this->validate($data, $validator) && $this->_execute($data);
+        return $this->validate($data, $validator) && $this->doExecute($data);
     }
 
     /**
@@ -281,7 +281,7 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
      * @param array $data Form data.
      * @return bool
      */
-    protected function _execute(array $data): bool
+    protected function doExecute(array $data): bool
     {
         return true;
     }

--- a/src/Form/README.md
+++ b/src/Form/README.md
@@ -18,7 +18,7 @@ use Cake\Validation\Validator;
 class ContactForm extends Form
 {
 
-    protected function _buildSchema(Schema $schema)
+    protected function buildSchema(Schema $schema)
     {
         return $schema->addField('name', 'string')
             ->addField('email', ['type' => 'string'])
@@ -36,7 +36,7 @@ class ContactForm extends Form
             ]);
     }
 
-    protected function _execute(array $data)
+    protected function execute(array $data)
     {
         // Send an email.
         return true;

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -298,7 +298,7 @@ class Client implements EventDispatcherInterface, ClientInterface
      */
     public function get(string $url, array|string $data = [], array $options = []): Response
     {
-        $options = $this->_mergeOptions($options);
+        $options = $this->mergeOptions($options);
         $body = null;
         if (is_array($data) && isset($data['_content'])) {
             $body = $data['_content'];
@@ -306,7 +306,7 @@ class Client implements EventDispatcherInterface, ClientInterface
         }
         $url = $this->buildUrl($url, $data, $options);
 
-        return $this->_doRequest(
+        return $this->doRequest(
             Request::METHOD_GET,
             $url,
             $body,
@@ -324,10 +324,10 @@ class Client implements EventDispatcherInterface, ClientInterface
      */
     public function post(string $url, mixed $data = [], array $options = []): Response
     {
-        $options = $this->_mergeOptions($options);
+        $options = $this->mergeOptions($options);
         $url = $this->buildUrl($url, [], $options);
 
-        return $this->_doRequest(Request::METHOD_POST, $url, $data, $options);
+        return $this->doRequest(Request::METHOD_POST, $url, $data, $options);
     }
 
     /**
@@ -340,10 +340,10 @@ class Client implements EventDispatcherInterface, ClientInterface
      */
     public function put(string $url, mixed $data = [], array $options = []): Response
     {
-        $options = $this->_mergeOptions($options);
+        $options = $this->mergeOptions($options);
         $url = $this->buildUrl($url, [], $options);
 
-        return $this->_doRequest(Request::METHOD_PUT, $url, $data, $options);
+        return $this->doRequest(Request::METHOD_PUT, $url, $data, $options);
     }
 
     /**
@@ -356,10 +356,10 @@ class Client implements EventDispatcherInterface, ClientInterface
      */
     public function patch(string $url, mixed $data = [], array $options = []): Response
     {
-        $options = $this->_mergeOptions($options);
+        $options = $this->mergeOptions($options);
         $url = $this->buildUrl($url, [], $options);
 
-        return $this->_doRequest(Request::METHOD_PATCH, $url, $data, $options);
+        return $this->doRequest(Request::METHOD_PATCH, $url, $data, $options);
     }
 
     /**
@@ -372,10 +372,10 @@ class Client implements EventDispatcherInterface, ClientInterface
      */
     public function options(string $url, mixed $data = [], array $options = []): Response
     {
-        $options = $this->_mergeOptions($options);
+        $options = $this->mergeOptions($options);
         $url = $this->buildUrl($url, [], $options);
 
-        return $this->_doRequest(Request::METHOD_OPTIONS, $url, $data, $options);
+        return $this->doRequest(Request::METHOD_OPTIONS, $url, $data, $options);
     }
 
     /**
@@ -388,10 +388,10 @@ class Client implements EventDispatcherInterface, ClientInterface
      */
     public function trace(string $url, mixed $data = [], array $options = []): Response
     {
-        $options = $this->_mergeOptions($options);
+        $options = $this->mergeOptions($options);
         $url = $this->buildUrl($url, [], $options);
 
-        return $this->_doRequest(Request::METHOD_TRACE, $url, $data, $options);
+        return $this->doRequest(Request::METHOD_TRACE, $url, $data, $options);
     }
 
     /**
@@ -404,10 +404,10 @@ class Client implements EventDispatcherInterface, ClientInterface
      */
     public function delete(string $url, mixed $data = [], array $options = []): Response
     {
-        $options = $this->_mergeOptions($options);
+        $options = $this->mergeOptions($options);
         $url = $this->buildUrl($url, [], $options);
 
-        return $this->_doRequest(Request::METHOD_DELETE, $url, $data, $options);
+        return $this->doRequest(Request::METHOD_DELETE, $url, $data, $options);
     }
 
     /**
@@ -420,10 +420,10 @@ class Client implements EventDispatcherInterface, ClientInterface
      */
     public function head(string $url, array $data = [], array $options = []): Response
     {
-        $options = $this->_mergeOptions($options);
+        $options = $this->mergeOptions($options);
         $url = $this->buildUrl($url, $data, $options);
 
-        return $this->_doRequest(Request::METHOD_HEAD, $url, '', $options);
+        return $this->doRequest(Request::METHOD_HEAD, $url, '', $options);
     }
 
     /**
@@ -435,9 +435,9 @@ class Client implements EventDispatcherInterface, ClientInterface
      * @param array<string, mixed> $options The options to use. Contains auth, proxy, etc.
      * @return \Cake\Http\Client\Response
      */
-    protected function _doRequest(string $method, string $url, mixed $data, array $options): Response
+    protected function doRequest(string $method, string $url, mixed $data, array $options): Response
     {
-        $request = $this->_createRequest(
+        $request = $this->createRequest(
             $method,
             $url,
             $data,
@@ -453,7 +453,7 @@ class Client implements EventDispatcherInterface, ClientInterface
      * @param array<string, mixed> $options Options to merge.
      * @return array Options merged with set config.
      */
-    protected function _mergeOptions(array $options): array
+    protected function mergeOptions(array $options): array
     {
         return Hash::merge($this->_config, $options);
     }
@@ -500,7 +500,7 @@ class Client implements EventDispatcherInterface, ClientInterface
             $requestSent = false;
             if ($response === null) {
                 $requestSent = true;
-                $response = $this->_sendRequest($request, $event->getAdapterOptions());
+                $response = $this->doSendRequest($request, $event->getAdapterOptions());
             }
 
             /** @var \Cake\Http\Client\ClientEvent $event */
@@ -582,7 +582,7 @@ class Client implements EventDispatcherInterface, ClientInterface
      * @param array<string, mixed> $options Additional options to use.
      * @return \Cake\Http\Client\Response
      */
-    protected function _sendRequest(RequestInterface $request, array $options): Response
+    protected function doSendRequest(RequestInterface $request, array $options): Response
     {
         $responses = [];
         if (static::$_mockAdapter) {
@@ -659,12 +659,12 @@ class Client implements EventDispatcherInterface, ClientInterface
      * @param array<string, mixed> $options The options to use. Contains auth, proxy, etc.
      * @return \Cake\Http\Client\Request
      */
-    protected function _createRequest(string $method, string $url, mixed $data, array $options): Request
+    protected function createRequest(string $method, string $url, mixed $data, array $options): Request
     {
         /** @var array<non-empty-string, non-empty-string> $headers */
         $headers = (array)($options['headers'] ?? []);
         if (isset($options['type'])) {
-            $headers = array_merge($headers, $this->_typeHeaders($options['type']));
+            $headers = array_merge($headers, $this->typeHeaders($options['type']));
         }
         if (is_string($data) && !isset($headers['Content-Type']) && !isset($headers['content-type'])) {
             $headers['Content-Type'] = 'application/x-www-form-urlencoded';
@@ -676,10 +676,10 @@ class Client implements EventDispatcherInterface, ClientInterface
         /** @var \Cake\Http\Client\Request $request */
         $request = $this->_cookies->addToRequest($request, $cookies);
         if (isset($options['auth'])) {
-            $request = $this->_addAuthentication($request, $options);
+            $request = $this->addAuthentication($request, $options);
         }
         if (isset($options['proxy'])) {
-            return $this->_addProxy($request, $options);
+            return $this->addProxy($request, $options);
         }
 
         return $request;
@@ -695,7 +695,7 @@ class Client implements EventDispatcherInterface, ClientInterface
      * @throws \Cake\Core\Exception\CakeException When an unknown type alias is used.
      * @psalm-return array<non-empty-string, non-empty-string>
      */
-    protected function _typeHeaders(string $type): array
+    protected function typeHeaders(string $type): array
     {
         if (str_contains($type, '/')) {
             return [
@@ -730,11 +730,11 @@ class Client implements EventDispatcherInterface, ClientInterface
      * @param array<string, mixed> $options Array of options containing the 'auth' key.
      * @return \Cake\Http\Client\Request The updated request object.
      */
-    protected function _addAuthentication(Request $request, array $options): Request
+    protected function addAuthentication(Request $request, array $options): Request
     {
         $auth = $options['auth'];
         /** @var \Cake\Http\Client\Auth\Basic $adapter */
-        $adapter = $this->_createAuth($auth, $options);
+        $adapter = $this->createAuth($auth, $options);
 
         return $adapter->authentication($request, $options['auth']);
     }
@@ -749,11 +749,11 @@ class Client implements EventDispatcherInterface, ClientInterface
      * @param array<string, mixed> $options Array of options containing the 'proxy' key.
      * @return \Cake\Http\Client\Request The updated request object.
      */
-    protected function _addProxy(Request $request, array $options): Request
+    protected function addProxy(Request $request, array $options): Request
     {
         $auth = $options['proxy'];
         /** @var \Cake\Http\Client\Auth\Basic $adapter */
-        $adapter = $this->_createAuth($auth, $options);
+        $adapter = $this->createAuth($auth, $options);
 
         return $adapter->proxyAuthentication($request, $options['proxy']);
     }
@@ -769,7 +769,7 @@ class Client implements EventDispatcherInterface, ClientInterface
      * @return object Authentication strategy instance.
      * @throws \Cake\Core\Exception\CakeException when an invalid strategy is chosen.
      */
-    protected function _createAuth(array $auth, array $options): object
+    protected function createAuth(array $auth, array $options): object
     {
         if (empty($auth['type'])) {
             $auth['type'] = 'basic';

--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -77,9 +77,9 @@ class Stream implements AdapterInterface
         $this->_sslContextOptions = [];
         $this->_connectionErrors = [];
 
-        $this->_buildContext($request, $options);
+        $this->buildContext($request, $options);
 
-        return $this->_send($request);
+        return $this->sendRequest($request);
     }
 
     /**
@@ -106,7 +106,7 @@ class Stream implements AdapterInterface
             $end = isset($indexes[$i + 1]) ? $indexes[$i + 1] - $start : null;
             $headerSlice = array_slice($headers, $start, $end);
             $body = $i === $last ? $content : '';
-            $responses[] = $this->_buildResponse($headerSlice, $body);
+            $responses[] = $this->buildResponse($headerSlice, $body);
         }
 
         return $responses;
@@ -119,16 +119,16 @@ class Stream implements AdapterInterface
      * @param array<string, mixed> $options Additional request options.
      * @return void
      */
-    protected function _buildContext(RequestInterface $request, array $options): void
+    protected function buildContext(RequestInterface $request, array $options): void
     {
-        $this->_buildContent($request, $options);
-        $this->_buildHeaders($request, $options);
-        $this->_buildOptions($request, $options);
+        $this->buildContent($request, $options);
+        $this->buildHeaders($request, $options);
+        $this->buildOptions($request, $options);
 
         $url = $request->getUri();
         $scheme = parse_url((string)$url, PHP_URL_SCHEME);
         if ($scheme === 'https') {
-            $this->_buildSslContext($request, $options);
+            $this->buildSslContext($request, $options);
         }
         $this->_context = stream_context_create([
             'http' => $this->_contextOptions,
@@ -145,7 +145,7 @@ class Stream implements AdapterInterface
      * @param array<string, mixed> $options Array of options to use.
      * @return void
      */
-    protected function _buildHeaders(RequestInterface $request, array $options): void
+    protected function buildHeaders(RequestInterface $request, array $options): void
     {
         $headers = [];
         foreach ($request->getHeaders() as $name => $values) {
@@ -164,7 +164,7 @@ class Stream implements AdapterInterface
      * @param array<string, mixed> $options Array of options to use.
      * @return void
      */
-    protected function _buildContent(RequestInterface $request, array $options): void
+    protected function buildContent(RequestInterface $request, array $options): void
     {
         $body = $request->getBody();
         $body->rewind();
@@ -178,7 +178,7 @@ class Stream implements AdapterInterface
      * @param array<string, mixed> $options Array of options to use.
      * @return void
      */
-    protected function _buildOptions(RequestInterface $request, array $options): void
+    protected function buildOptions(RequestInterface $request, array $options): void
     {
         $this->_contextOptions['method'] = $request->getMethod();
         $this->_contextOptions['protocol_version'] = $request->getProtocolVersion();
@@ -203,7 +203,7 @@ class Stream implements AdapterInterface
      * @param array<string, mixed> $options Array of options to use.
      * @return void
      */
-    protected function _buildSslContext(RequestInterface $request, array $options): void
+    protected function buildSslContext(RequestInterface $request, array $options): void
     {
         $sslOptions = [
             'ssl_verify_peer',
@@ -238,7 +238,7 @@ class Stream implements AdapterInterface
      * @return array Array of populated Response objects
      * @throws \Psr\Http\Client\NetworkExceptionInterface
      */
-    protected function _send(RequestInterface $request): array
+    protected function sendRequest(RequestInterface $request): array
     {
         $deadline = false;
         if (isset($this->_contextOptions['timeout']) && $this->_contextOptions['timeout'] > 0) {
@@ -247,7 +247,7 @@ class Stream implements AdapterInterface
         }
 
         $url = $request->getUri();
-        $this->_open((string)$url, $request);
+        $this->open((string)$url, $request);
         $content = '';
         $timedOut = false;
 
@@ -290,7 +290,7 @@ class Stream implements AdapterInterface
      * @param string $body The response body.
      * @return \Cake\Http\Client\Response
      */
-    protected function _buildResponse(array $headers, string $body): Response
+    protected function buildResponse(array $headers, string $body): Response
     {
         return new Response($headers, $body);
     }
@@ -303,7 +303,7 @@ class Stream implements AdapterInterface
      * @return void
      * @throws \Psr\Http\Client\RequestExceptionInterface
      */
-    protected function _open(string $url, RequestInterface $request): void
+    protected function open(string $url, RequestInterface $request): void
     {
         if (!(bool)ini_get('allow_url_fopen')) {
             throw new ClientException('The PHP directive `allow_url_fopen` must be enabled.');

--- a/src/Http/Client/Auth/Basic.php
+++ b/src/Http/Client/Auth/Basic.php
@@ -36,7 +36,7 @@ class Basic
     public function authentication(Request $request, array $credentials): Request
     {
         if (isset($credentials['username'], $credentials['password'])) {
-            $value = $this->_generateHeader($credentials['username'], $credentials['password']);
+            $value = $this->generateHeader($credentials['username'], $credentials['password']);
             $request = $request->withHeader('Authorization', $value);
         }
 
@@ -54,7 +54,7 @@ class Basic
     public function proxyAuthentication(Request $request, array $credentials): Request
     {
         if (isset($credentials['username'], $credentials['password'])) {
-            $value = $this->_generateHeader($credentials['username'], $credentials['password']);
+            $value = $this->generateHeader($credentials['username'], $credentials['password']);
             $request = $request->withHeader('Proxy-Authorization', $value);
         }
 
@@ -68,7 +68,7 @@ class Basic
      * @param string $pass Password.
      * @return string
      */
-    protected function _generateHeader(string $user, string $pass): string
+    protected function generateHeader(string $user, string $pass): string
     {
         return 'Basic ' . base64_encode($user . ':' . $pass);
     }

--- a/src/Http/Client/Auth/Digest.php
+++ b/src/Http/Client/Auth/Digest.php
@@ -127,14 +127,14 @@ class Digest
             return $request;
         }
         if (!isset($credentials['realm'])) {
-            $credentials = $this->_getServerInfo($request, $credentials);
+            $credentials = $this->getServerInfo($request, $credentials);
         }
         if (!isset($credentials['realm'])) {
             return $request;
         }
 
         $this->setAlgorithm($credentials);
-        $value = $this->_generateHeader($request, $credentials);
+        $value = $this->generateHeader($request, $credentials);
 
         return $request->withHeader('Authorization', $value);
     }
@@ -150,7 +150,7 @@ class Digest
      * @param array $credentials Authentication credentials.
      * @return array modified credentials.
      */
-    protected function _getServerInfo(Request $request, array $credentials): array
+    protected function getServerInfo(Request $request, array $credentials): array
     {
         $response = $this->_client->get(
             (string)$request->getUri(),
@@ -187,7 +187,7 @@ class Digest
      * @param array<string, mixed> $credentials Authentication credentials.
      * @return string
      */
-    protected function _generateHeader(Request $request, array $credentials): string
+    protected function generateHeader(Request $request, array $credentials): string
     {
         $path = $request->getRequestTarget();
 

--- a/src/Http/Client/FormDataPart.php
+++ b/src/Http/Client/FormDataPart.php
@@ -189,10 +189,10 @@ class FormDataPart implements Stringable
         if ($this->disposition) {
             $out .= 'Content-Disposition: ' . $this->disposition;
             if ($this->name) {
-                $out .= '; ' . $this->_headerParameterToString('name', $this->name);
+                $out .= '; ' . $this->headerParameterToString('name', $this->name);
             }
             if ($this->filename) {
-                $out .= '; ' . $this->_headerParameterToString('filename', $this->filename);
+                $out .= '; ' . $this->headerParameterToString('filename', $this->filename);
             }
             $out .= "\r\n";
         }
@@ -221,7 +221,7 @@ class FormDataPart implements Stringable
      * @param string $value The value of the header parameter
      * @return string
      */
-    protected function _headerParameterToString(string $name, string $value): string
+    protected function headerParameterToString(string $name, string $value): string
     {
         $transliterated = Text::transliterate(str_replace('"', '', $value));
         $return = sprintf('%s="%s"', $name, $transliterated);

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -127,9 +127,9 @@ class Response extends Message implements ResponseInterface
      */
     public function __construct(array $headers = [], string $body = '')
     {
-        $this->_parseHeaders($headers);
+        $this->parseHeaders($headers);
         if ($this->getHeaderLine('Content-Encoding') === 'gzip') {
-            $body = $this->_decodeGzipBody($body);
+            $body = $this->decodeGzipBody($body);
         }
         $stream = new Stream('php://memory', 'wb+');
         $stream->write($body);
@@ -147,7 +147,7 @@ class Response extends Message implements ResponseInterface
      * @return string
      * @throws \Cake\Core\Exception\CakeException When attempting to decode gzip content without gzinflate.
      */
-    protected function _decodeGzipBody(string $body): string
+    protected function decodeGzipBody(string $body): string
     {
         if (!function_exists('gzinflate')) {
             throw new CakeException('Cannot decompress gzip response body without gzinflate()');
@@ -174,7 +174,7 @@ class Response extends Message implements ResponseInterface
      * @param array<string> $headers Headers to parse.
      * @return void
      */
-    protected function _parseHeaders(array $headers): void
+    protected function parseHeaders(array $headers): void
     {
         foreach ($headers as $value) {
             if (str_starts_with($value, 'HTTP/')) {
@@ -307,7 +307,12 @@ class Response extends Message implements ResponseInterface
      */
     public function getCookies(): array
     {
-        return $this->_getCookies();
+        $out = [];
+        foreach ($this->buildCookieCollection() as $cookie) {
+            $out[$cookie->getName()] = $cookie->toArray();
+        }
+
+        return $out;
     }
 
     /**
@@ -370,28 +375,13 @@ class Response extends Message implements ResponseInterface
     }
 
     /**
-     * Property accessor for `$this->cookies`
-     *
-     * @return array Array of Cookie data.
-     */
-    protected function _getCookies(): array
-    {
-        $out = [];
-        foreach ($this->buildCookieCollection() as $cookie) {
-            $out[$cookie->getName()] = $cookie->toArray();
-        }
-
-        return $out;
-    }
-
-    /**
      * Get the response body as string.
      *
      * @return string
      */
     public function getStringBody(): string
     {
-        return $this->_getBody();
+        return $this->getBodyContents();
     }
 
     /**
@@ -401,21 +391,11 @@ class Response extends Message implements ResponseInterface
      */
     public function getJson(): mixed
     {
-        return $this->_getJson();
-    }
-
-    /**
-     * Get the response body as JSON decoded data.
-     *
-     * @return mixed
-     */
-    protected function _getJson(): mixed
-    {
         if ($this->_json) {
             return $this->_json;
         }
 
-        return $this->_json = json_decode($this->_getBody(), true);
+        return $this->_json = json_decode($this->getBodyContents(), true);
     }
 
     /**
@@ -425,21 +405,11 @@ class Response extends Message implements ResponseInterface
      */
     public function getXml(): ?SimpleXMLElement
     {
-        return $this->_getXml();
-    }
-
-    /**
-     * Get the response body as XML decoded data.
-     *
-     * @return \SimpleXMLElement|null
-     */
-    protected function _getXml(): ?SimpleXMLElement
-    {
         if ($this->_xml !== null) {
             return $this->_xml;
         }
         libxml_use_internal_errors();
-        $data = simplexml_load_string($this->_getBody());
+        $data = simplexml_load_string($this->getBodyContents());
         if (!$data) {
             return null;
         }
@@ -450,11 +420,9 @@ class Response extends Message implements ResponseInterface
     }
 
     /**
-     * Provides magic __get() support.
-     *
      * @return array<string>
      */
-    protected function _getHeaders(): array
+    protected function getParsedHeaders(): array
     {
         $out = [];
         foreach ($this->headers as $key => $values) {
@@ -465,11 +433,9 @@ class Response extends Message implements ResponseInterface
     }
 
     /**
-     * Provides magic __get() support.
-     *
      * @return string
      */
-    protected function _getBody(): string
+    protected function getBodyContents(): string
     {
         $this->stream->rewind();
 

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -159,7 +159,7 @@ class Cookie implements CookieInterface
         $this->validateName($name);
         $this->name = $name;
 
-        $this->_setValue($value);
+        $this->setValue($value);
 
         $this->domain = $domain ?? static::$defaults['domain'];
         $this->httpOnly = $httpOnly ?? static::$defaults['httponly'];
@@ -341,7 +341,7 @@ class Cookie implements CookieInterface
         if ($this->isExpanded) {
             assert(is_array($value), '$value is not an array');
 
-            $value = $this->_flatten($value);
+            $value = $this->flatten($value);
         }
 
         $headerValue = [];
@@ -435,7 +435,7 @@ class Cookie implements CookieInterface
         if ($this->isExpanded) {
             assert(is_array($this->value), '$value is not an array');
 
-            return $this->_flatten($this->value);
+            return $this->flatten($this->value);
         }
 
         assert(is_string($this->value), '$value is not a string');
@@ -449,7 +449,7 @@ class Cookie implements CookieInterface
     public function withValue(array|string|float|int|bool $value): static
     {
         $new = clone $this;
-        $new->_setValue($value);
+        $new->setValue($value);
 
         return $new;
     }
@@ -460,7 +460,7 @@ class Cookie implements CookieInterface
      * @param array|string|float|int|bool $value The value to store.
      * @return void
      */
-    protected function _setValue(array|string|float|int|bool $value): void
+    protected function setValue(array|string|float|int|bool $value): void
     {
         $this->isExpanded = is_array($value);
         $this->value = is_array($value) ? $value : (string)$value;
@@ -675,7 +675,7 @@ class Cookie implements CookieInterface
     {
         if ($this->isExpanded === false) {
             assert(is_string($this->value), '$value is not a string');
-            $this->value = $this->_expand($this->value);
+            $this->value = $this->expand($this->value);
         }
 
         assert(is_array($this->value), '$value is not an array');
@@ -695,7 +695,7 @@ class Cookie implements CookieInterface
         $new = clone $this;
         if ($new->isExpanded === false) {
             assert(is_string($new->value), '$value is not a string');
-            $new->value = $new->_expand($new->value);
+            $new->value = $new->expand($new->value);
         }
 
         assert(is_array($new->value), '$value is not an array');
@@ -715,7 +715,7 @@ class Cookie implements CookieInterface
         $new = clone $this;
         if ($new->isExpanded === false) {
             assert(is_string($new->value), '$value is not a string');
-            $new->value = $new->_expand($new->value);
+            $new->value = $new->expand($new->value);
         }
 
         assert(is_array($new->value), '$value is not an array');
@@ -739,7 +739,7 @@ class Cookie implements CookieInterface
         if ($this->isExpanded === false) {
             assert(is_string($this->value), '$value is not a string');
 
-            $this->value = $this->_expand($this->value);
+            $this->value = $this->expand($this->value);
         }
 
         if ($path === null) {
@@ -798,7 +798,7 @@ class Cookie implements CookieInterface
      * @param array $array Map of key and values
      * @return string A JSON encoded string.
      */
-    protected function _flatten(array $array): string
+    protected function flatten(array $array): string
     {
         return json_encode($array, JSON_THROW_ON_ERROR);
     }
@@ -810,7 +810,7 @@ class Cookie implements CookieInterface
      * @param string $string A string containing JSON encoded data, or a bare string.
      * @return array|string Map of key and values
      */
-    protected function _expand(string $string): array|string
+    protected function expand(string $string): array|string
     {
         $this->isExpanded = true;
         $first = substr($string, 0, 1);

--- a/src/Http/CorsBuilder.php
+++ b/src/Http/CorsBuilder.php
@@ -109,7 +109,7 @@ class CorsBuilder
      */
     public function allowOrigin(array|string $domains): static
     {
-        $allowed = $this->_normalizeDomains((array)$domains);
+        $allowed = $this->normalizeDomains((array)$domains);
         foreach ($allowed as $domain) {
             if (!preg_match($domain['preg'], $this->_origin)) {
                 continue;
@@ -128,7 +128,7 @@ class CorsBuilder
      * @param array<string> $domains Domain names to normalize.
      * @return array<array<string, string>>
      */
-    protected function _normalizeDomains(array $domains): array
+    protected function normalizeDomains(array $domains): array
     {
         $result = [];
         foreach ($domains as $domain) {

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -129,7 +129,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
             && $this->skipCheckCallback !== null
             && call_user_func($this->skipCheckCallback, $request) === true
         ) {
-            $request = $this->_unsetTokenField($request);
+            $request = $this->unsetTokenField($request);
 
             return $handler->handle($request);
         }
@@ -158,12 +158,12 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
             $request = $request->withAttribute('csrfToken', $this->saltToken($token));
             $response = $handler->handle($request);
 
-            return $this->_addTokenCookie($token, $request, $response);
+            return $this->addTokenCookie($token, $request, $response);
         }
 
         if ($hasData) {
-            $this->_validateToken($request);
-            $request = $this->_unsetTokenField($request);
+            $this->validateToken($request);
+            $request = $this->unsetTokenField($request);
         }
 
         return $handler->handle($request);
@@ -191,7 +191,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Message\ServerRequestInterface $request The request object.
      * @return \Psr\Http\Message\ServerRequestInterface
      */
-    protected function _unsetTokenField(ServerRequestInterface $request): ServerRequestInterface
+    protected function unsetTokenField(ServerRequestInterface $request): ServerRequestInterface
     {
         $body = $request->getParsedBody();
         if (is_array($body)) {
@@ -297,7 +297,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      * @param string $token The CSRF token.
      * @return bool
      */
-    protected function _verifyToken(string $token): bool
+    protected function verifyToken(string $token): bool
     {
         // If we have a hexadecimal value we're in a compatibility mode from before
         // tokens were salted on each request.
@@ -326,12 +326,12 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Message\ResponseInterface $response The response.
      * @return \Psr\Http\Message\ResponseInterface $response Modified response.
      */
-    protected function _addTokenCookie(
+    protected function addTokenCookie(
         string $token,
         ServerRequestInterface $request,
         ResponseInterface $response,
     ): ResponseInterface {
-        $cookie = $this->_createCookie($token, $request);
+        $cookie = $this->createCookie($token, $request);
         if ($response instanceof Response) {
             return $response->withCookie($cookie);
         }
@@ -346,7 +346,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      * @return void
      * @throws \Cake\Http\Exception\InvalidCsrfTokenException When the CSRF token is invalid or missing.
      */
-    protected function _validateToken(ServerRequestInterface $request): void
+    protected function validateToken(ServerRequestInterface $request): void
     {
         $cookie = Hash::get($request->getCookieParams(), $this->_config['cookieName']);
 
@@ -354,10 +354,10 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
             throw new InvalidCsrfTokenException(__d('cake', 'Missing or incorrect CSRF cookie type.'));
         }
 
-        if (!$this->_verifyToken($cookie)) {
+        if (!$this->verifyToken($cookie)) {
             $exception = new InvalidCsrfTokenException(__d('cake', 'Missing or invalid CSRF cookie.'));
 
-            $expiredCookie = $this->_createCookie('', $request)->withExpired();
+            $expiredCookie = $this->createCookie('', $request)->withExpired();
             $exception->setHeader('Set-Cookie', $expiredCookie->toHeaderValue());
 
             throw $exception;
@@ -391,7 +391,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Message\ServerRequestInterface $request The request object.
      * @return \Cake\Http\Cookie\CookieInterface
      */
-    protected function _createCookie(string $value, ServerRequestInterface $request): CookieInterface
+    protected function createCookie(string $value, ServerRequestInterface $request): CookieInterface
     {
         return Cookie::create(
             $this->_config['cookieName'],

--- a/src/Http/Middleware/EncryptedCookieMiddleware.php
+++ b/src/Http/Middleware/EncryptedCookieMiddleware.php
@@ -124,7 +124,7 @@ class EncryptedCookieMiddleware implements MiddlewareInterface
         $cookies = $request->getCookieParams();
         foreach ($this->cookieNames as $name) {
             if (isset($cookies[$name])) {
-                $cookies[$name] = $this->_decrypt($cookies[$name], $this->cipherType, $this->key);
+                $cookies[$name] = $this->decrypt($cookies[$name], $this->cipherType, $this->key);
             }
         }
 
@@ -141,7 +141,7 @@ class EncryptedCookieMiddleware implements MiddlewareInterface
     {
         foreach ($response->getCookieCollection() as $cookie) {
             if (in_array($cookie->getName(), $this->cookieNames, true)) {
-                $value = $this->_encrypt($cookie->getValue(), $this->cipherType);
+                $value = $this->encrypt($cookie->getValue(), $this->cipherType);
                 $response = $response->withCookie($cookie->withValue($value));
             }
         }
@@ -161,7 +161,7 @@ class EncryptedCookieMiddleware implements MiddlewareInterface
         $header = [];
         foreach ($cookies as $cookie) {
             if (in_array($cookie->getName(), $this->cookieNames, true)) {
-                $value = $this->_encrypt($cookie->getValue(), $this->cipherType);
+                $value = $this->encrypt($cookie->getValue(), $this->cipherType);
                 $cookie = $cookie->withValue($value);
             }
             $header[] = $cookie->toHeaderValue();

--- a/src/Http/Middleware/EncryptedCookieMiddleware.php
+++ b/src/Http/Middleware/EncryptedCookieMiddleware.php
@@ -108,7 +108,7 @@ class EncryptedCookieMiddleware implements MiddlewareInterface
      *
      * @return string
      */
-    protected function _getCookieEncryptionKey(): string
+    protected function getCookieEncryptionKey(): string
     {
         return $this->key;
     }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -214,13 +214,13 @@ class Response implements ResponseInterface, Stringable
             }
             $this->stream = $options['stream'];
         } else {
-            $this->_createStream();
+            $this->createStream();
         }
         if (isset($options['body'])) {
             $this->stream->write($options['body']);
         }
         if (isset($options['status'])) {
-            $this->_setStatus($options['status']);
+            $this->setStatus($options['status']);
         }
         if (!isset($options['charset'])) {
             $options['charset'] = Configure::read('App.encoding');
@@ -230,7 +230,7 @@ class Response implements ResponseInterface, Stringable
         if (isset($options['type'])) {
             $type = $this->resolveType($options['type']);
         }
-        $this->_setContentType($type);
+        $this->setContentType($type);
         $this->_cookies = new CookieCollection();
     }
 
@@ -239,7 +239,7 @@ class Response implements ResponseInterface, Stringable
      *
      * @return void
      */
-    protected function _createStream(): void
+    protected function createStream(): void
     {
         $this->stream = new Stream($this->_streamTarget, $this->_streamMode);
     }
@@ -251,10 +251,10 @@ class Response implements ResponseInterface, Stringable
      * @param string $type The type to set.
      * @return void
      */
-    protected function _setContentType(string $type): void
+    protected function setContentType(string $type): void
     {
         if (in_array($this->_status, [304, 204], true)) {
-            $this->_clearHeader('Content-Type');
+            $this->clearHeader('Content-Type');
 
             return;
         }
@@ -274,9 +274,9 @@ class Response implements ResponseInterface, Stringable
         }
 
         if ($charset && !str_contains($type, ';')) {
-            $this->_setHeader('Content-Type', "{$type}; charset={$this->_charset}");
+            $this->setHeader('Content-Type', "{$type}; charset={$this->_charset}");
         } else {
-            $this->_setHeader('Content-Type', $type);
+            $this->setHeader('Content-Type', $type);
         }
     }
 
@@ -307,7 +307,7 @@ class Response implements ResponseInterface, Stringable
      * @param string $value Header value.
      * @return void
      */
-    protected function _setHeader(string $header, string $value): void
+    protected function setHeader(string $header, string $value): void
     {
         $normalized = strtolower($header);
         $this->headerNames[$normalized] = $header;
@@ -321,7 +321,7 @@ class Response implements ResponseInterface, Stringable
      * @param string $header Header key.
      * @return void
      */
-    protected function _clearHeader(string $header): void
+    protected function clearHeader(string $header): void
     {
         $normalized = strtolower($header);
         if (!isset($this->headerNames[$normalized])) {
@@ -376,7 +376,7 @@ class Response implements ResponseInterface, Stringable
     public function withStatus(int $code, string $reasonPhrase = ''): static
     {
         $new = clone $this;
-        $new->_setStatus($code, $reasonPhrase);
+        $new->setStatus($code, $reasonPhrase);
 
         return $new;
     }
@@ -389,7 +389,7 @@ class Response implements ResponseInterface, Stringable
      * @return void
      * @throws \InvalidArgumentException For invalid status code arguments.
      */
-    protected function _setStatus(int $code, string $reasonPhrase = ''): void
+    protected function setStatus(int $code, string $reasonPhrase = ''): void
     {
         if ($code < static::STATUS_CODE_MIN || $code > static::STATUS_CODE_MAX) {
             throw new InvalidArgumentException(sprintf(
@@ -406,7 +406,7 @@ class Response implements ResponseInterface, Stringable
 
         // These status codes don't have bodies and can't have content-types.
         if (in_array($code, [304, 204], true)) {
-            $this->_clearHeader('Content-Type');
+            $this->clearHeader('Content-Type');
         }
     }
 
@@ -472,7 +472,7 @@ class Response implements ResponseInterface, Stringable
     {
         $mappedType = $this->resolveType($contentType);
         $new = clone $this;
-        $new->_setContentType($mappedType);
+        $new->setContentType($mappedType);
 
         return $new;
     }
@@ -554,7 +554,7 @@ class Response implements ResponseInterface, Stringable
     {
         $new = clone $this;
         $new->_charset = $charset;
-        $new->_setContentType($this->getType());
+        $new->setContentType($this->getType());
 
         return $new;
     }
@@ -615,7 +615,7 @@ class Response implements ResponseInterface, Stringable
         if ($time !== null) {
             $new->_cacheDirectives['max-age'] = $time;
         }
-        $new->_setCacheControl();
+        $new->setCacheControl();
 
         return $new;
     }
@@ -633,7 +633,7 @@ class Response implements ResponseInterface, Stringable
     {
         $new = clone $this;
         $new->_cacheDirectives['s-maxage'] = $seconds;
-        $new->_setCacheControl();
+        $new->setCacheControl();
 
         return $new;
     }
@@ -651,7 +651,7 @@ class Response implements ResponseInterface, Stringable
     {
         $new = clone $this;
         $new->_cacheDirectives['max-age'] = $seconds;
-        $new->_setCacheControl();
+        $new->setCacheControl();
 
         return $new;
     }
@@ -675,7 +675,7 @@ class Response implements ResponseInterface, Stringable
         } else {
             unset($new->_cacheDirectives['must-revalidate']);
         }
-        $new->_setCacheControl();
+        $new->setCacheControl();
 
         return $new;
     }
@@ -686,7 +686,7 @@ class Response implements ResponseInterface, Stringable
      *
      * @return void
      */
-    protected function _setCacheControl(): void
+    protected function setCacheControl(): void
     {
         $control = '';
         foreach ($this->_cacheDirectives as $key => $val) {
@@ -694,7 +694,7 @@ class Response implements ResponseInterface, Stringable
             $control .= ', ';
         }
         $control = rtrim($control, ', ');
-        $this->_setHeader('Cache-Control', $control);
+        $this->setHeader('Cache-Control', $control);
     }
 
     /**
@@ -715,7 +715,7 @@ class Response implements ResponseInterface, Stringable
      */
     public function withExpires(DateTimeInterface|string|int|null $time): static
     {
-        $date = $this->_getUTCDate($time);
+        $date = $this->getUTCDate($time);
 
         return $this->withHeader('Expires', $date->format(DATE_RFC7231));
     }
@@ -738,7 +738,7 @@ class Response implements ResponseInterface, Stringable
      */
     public function withModified(DateTimeInterface|string|int $time): static
     {
-        $date = $this->_getUTCDate($time);
+        $date = $this->getUTCDate($time);
 
         return $this->withHeader('Last-Modified', $date->format(DATE_RFC7231));
     }
@@ -755,7 +755,7 @@ class Response implements ResponseInterface, Stringable
     public function withNotModified(): static
     {
         $new = $this->withStatus(304);
-        $new->_createStream();
+        $new->createStream();
         $remove = [
             'Allow',
             'Content-Encoding',
@@ -823,7 +823,7 @@ class Response implements ResponseInterface, Stringable
      * @param \DateTimeInterface|string|int|null $time Valid time string or \DateTimeInterface instance.
      * @return \DateTimeInterface
      */
-    protected function _getUTCDate(DateTimeInterface|string|int|null $time = null): DateTimeInterface
+    protected function getUTCDate(DateTimeInterface|string|int|null $time = null): DateTimeInterface
     {
         if ($time instanceof DateTimeInterface) {
             $result = clone $time;
@@ -1137,7 +1137,7 @@ class Response implements ResponseInterface, Stringable
         $new = $new->withHeader('Accept-Ranges', 'bytes');
         $httpRange = (string)env('HTTP_RANGE');
         if ($httpRange) {
-            $new->_fileRange($file, $httpRange);
+            $new->fileRange($file, $httpRange);
         } else {
             $new = $new->withHeader('Content-Length', (string)$fileSize);
         }
@@ -1156,7 +1156,7 @@ class Response implements ResponseInterface, Stringable
     public function withStringBody(?string $string): static
     {
         $new = clone $this;
-        $new->_createStream();
+        $new->createStream();
         $new->stream->write((string)$string);
 
         return $new;
@@ -1206,7 +1206,7 @@ class Response implements ResponseInterface, Stringable
      * @param string $httpRange The range to use.
      * @return void
      */
-    protected function _fileRange(SplFileInfo $file, string $httpRange): void
+    protected function fileRange(SplFileInfo $file, string $httpRange): void
     {
         $fileSize = $file->getSize();
         $lastByte = $fileSize - 1;
@@ -1228,15 +1228,15 @@ class Response implements ResponseInterface, Stringable
         }
 
         if ($start > $end || $end > $lastByte || $start > $lastByte) {
-            $this->_setStatus(416);
-            $this->_setHeader('Content-Range', 'bytes 0-' . $lastByte . '/' . $fileSize);
+            $this->setStatus(416);
+            $this->setHeader('Content-Range', 'bytes 0-' . $lastByte . '/' . $fileSize);
 
             return;
         }
 
-        $this->_setHeader('Content-Length', (string)((int)$end - (int)$start + 1));
-        $this->_setHeader('Content-Range', 'bytes ' . $start . '-' . $end . '/' . $fileSize);
-        $this->_setStatus(206);
+        $this->setHeader('Content-Length', (string)((int)$end - (int)$start + 1));
+        $this->setHeader('Content-Range', 'bytes ' . $start . '-' . $end . '/' . $fileSize);
+        $this->setStatus(206);
         /**
          * @var int $start
          * @var int $end

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -246,7 +246,7 @@ class ServerRequest implements ServerRequestInterface
             'input' => null,
         ];
 
-        $this->_setConfig($config);
+        $this->setConfig($config);
     }
 
     /**
@@ -255,7 +255,7 @@ class ServerRequest implements ServerRequestInterface
      * @param array<string, mixed> $config The config data to use.
      * @return void
      */
-    protected function _setConfig(array $config): void
+    protected function setConfig(array $config): void
     {
         if (empty($config['session'])) {
             $config['session'] = new Session([
@@ -511,10 +511,10 @@ class ServerRequest implements ServerRequestInterface
             throw new InvalidArgumentException(sprintf('No detector set for type `%s`.', $type));
         }
         if ($args) {
-            return $this->_is($type, $args);
+            return $this->isType($type, $args);
         }
 
-        return $this->_detectorCache[$type] ??= $this->_is($type, $args);
+        return $this->_detectorCache[$type] ??= $this->isType($type, $args);
     }
 
     /**
@@ -534,7 +534,7 @@ class ServerRequest implements ServerRequestInterface
      * @param array $args Array of custom detector arguments.
      * @return bool Whether the request is the type you are checking.
      */
-    protected function _is(string $type, array $args): bool
+    protected function isType(string $type, array $args): bool
     {
         $detect = static::$_detectors[$type];
         if ($detect instanceof Closure) {
@@ -542,16 +542,16 @@ class ServerRequest implements ServerRequestInterface
 
             return $detect(...$args);
         }
-        if (isset($detect['env']) && $this->_environmentDetector($detect)) {
+        if (isset($detect['env']) && $this->environmentDetector($detect)) {
             return true;
         }
-        if (isset($detect['header']) && $this->_headerDetector($detect)) {
+        if (isset($detect['header']) && $this->headerDetector($detect)) {
             return true;
         }
-        if (isset($detect['accept']) && $this->_acceptHeaderDetector($detect)) {
+        if (isset($detect['accept']) && $this->acceptHeaderDetector($detect)) {
             return true;
         }
-        if (isset($detect['param']) && $this->_paramDetector($detect)) {
+        if (isset($detect['param']) && $this->paramDetector($detect)) {
             return true;
         }
 
@@ -564,7 +564,7 @@ class ServerRequest implements ServerRequestInterface
      * @param array $detect Detector options array.
      * @return bool Whether the request is the type you are checking.
      */
-    protected function _acceptHeaderDetector(array $detect): bool
+    protected function acceptHeaderDetector(array $detect): bool
     {
         $content = new ContentTypeNegotiation();
         $options = $detect['accept'];
@@ -594,7 +594,7 @@ class ServerRequest implements ServerRequestInterface
      * @param array $detect Detector options array.
      * @return bool Whether the request is the type you are checking.
      */
-    protected function _headerDetector(array $detect): bool
+    protected function headerDetector(array $detect): bool
     {
         foreach ($detect['header'] as $header => $value) {
             $header = $this->getEnv('http_' . $header);
@@ -616,7 +616,7 @@ class ServerRequest implements ServerRequestInterface
      * @param array $detect Detector options array.
      * @return bool Whether the request is the type you are checking.
      */
-    protected function _paramDetector(array $detect): bool
+    protected function paramDetector(array $detect): bool
     {
         $key = $detect['param'];
         if (isset($detect['value'])) {
@@ -637,7 +637,7 @@ class ServerRequest implements ServerRequestInterface
      * @param array $detect Detector options array.
      * @return bool Whether the request is the type you are checking.
      */
-    protected function _environmentDetector(array $detect): bool
+    protected function environmentDetector(array $detect): bool
     {
         if (isset($detect['env'])) {
             if (isset($detect['value'])) {

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -106,7 +106,7 @@ class Session
     public static function create(array $sessionConfig = []): static
     {
         if (isset($sessionConfig['defaults'])) {
-            $sessionConfig = Hash::merge(static::_defaultConfig($sessionConfig['defaults']), $sessionConfig);
+            $sessionConfig = Hash::merge(static::defaultConfig($sessionConfig['defaults']), $sessionConfig);
         }
 
         if (
@@ -142,7 +142,7 @@ class Session
      * @return array
      * @throws \Cake\Core\Exception\CakeException When an invalid name is used.
      */
-    protected static function _defaultConfig(string $name): array
+    protected static function defaultConfig(string $name): array
     {
         $defaults = [
             'php' => [
@@ -367,7 +367,7 @@ class Session
 
         $this->_started = true;
 
-        if ($this->_timedOut()) {
+        if ($this->timedOut()) {
             $this->destroy();
 
             return $this->start();
@@ -420,7 +420,7 @@ class Session
      */
     public function check(?string $name = null): bool
     {
-        if ($this->_hasSession() && !$this->started()) {
+        if ($this->hasSession() && !$this->started()) {
             $this->start();
         }
 
@@ -445,7 +445,7 @@ class Session
      */
     public function read(?string $name = null, mixed $default = null): mixed
     {
-        if ($this->_hasSession() && !$this->started()) {
+        if ($this->hasSession() && !$this->started()) {
             $this->start();
         }
 
@@ -491,7 +491,7 @@ class Session
         $value = $this->read($name);
         if ($value !== null) {
             /** @psalm-suppress InvalidScalarArgument */
-            $this->_overwrite($_SESSION, Hash::remove($_SESSION, $name));
+            $this->overwrite($_SESSION, Hash::remove($_SESSION, $name));
         }
 
         return $value;
@@ -529,7 +529,7 @@ class Session
             $data = Hash::insert($data, $key, $val);
         }
 
-        $this->_overwrite($_SESSION, $data);
+        $this->overwrite($_SESSION, $data);
     }
 
     /**
@@ -565,7 +565,7 @@ class Session
     {
         if ($this->check($name)) {
             /** @psalm-suppress InvalidScalarArgument */
-            $this->_overwrite($_SESSION, Hash::remove($_SESSION, $name));
+            $this->overwrite($_SESSION, Hash::remove($_SESSION, $name));
         }
     }
 
@@ -576,7 +576,7 @@ class Session
      * @param array $new New set of variable => value
      * @return void
      */
-    protected function _overwrite(array &$old, array $new): void
+    protected function overwrite(array &$old, array $new): void
     {
         foreach ($old as $key => $var) {
             if (!isset($new[$key])) {
@@ -596,7 +596,7 @@ class Session
      */
     public function destroy(): void
     {
-        if ($this->_hasSession() && !$this->started()) {
+        if ($this->hasSession() && !$this->started()) {
             $this->start();
         }
 
@@ -629,7 +629,7 @@ class Session
      *
      * @return bool
      */
-    protected function _hasSession(): bool
+    protected function hasSession(): bool
     {
         return !ini_get('session.use_cookies')
             || isset($_COOKIE[session_name()])
@@ -644,7 +644,7 @@ class Session
      */
     public function renew(): void
     {
-        if (!$this->_hasSession() || $this->_isCLI) {
+        if (!$this->hasSession() || $this->_isCLI) {
             return;
         }
 
@@ -669,7 +669,7 @@ class Session
      *
      * @return bool
      */
-    protected function _timedOut(): bool
+    protected function timedOut(): bool
     {
         $time = $this->read('Config.time');
         $result = false;

--- a/src/I18n/Date.php
+++ b/src/I18n/Date.php
@@ -170,7 +170,7 @@ class Date extends ChronosDate implements JsonSerializable, Stringable
             $format = [$format, IntlDateFormatter::NONE];
         }
 
-        return static::_parseDateTime($date, $format);
+        return static::doParseDateTime($date, $format);
     }
 
     /**
@@ -248,7 +248,7 @@ class Date extends ChronosDate implements JsonSerializable, Stringable
         $format = is_int($format) ? [$format, IntlDateFormatter::NONE] : $format;
         $locale = $locale ?: DateTime::getDefaultLocale();
 
-        return $this->_formatObject($this->native, $format, $locale);
+        return $this->formatObject($this->native, $format, $locale);
     }
 
     /**

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -45,7 +45,7 @@ trait DateFormatTrait
      * @param string|null $locale The locale name in which the date should be displayed.
      * @return string
      */
-    protected function _formatObject(
+    protected function formatObject(
         DateTimeInterface $date,
         array|string $format,
         ?string $locale,
@@ -130,7 +130,7 @@ trait DateFormatTrait
      * @param \DateTimeZone|string|null $tz The timezone for the instance
      * @return static|null
      */
-    protected static function _parseDateTime(
+    protected static function doParseDateTime(
         string $time,
         array|string $format,
         DateTimeZone|string|null $tz = null,

--- a/src/I18n/DateTime.php
+++ b/src/I18n/DateTime.php
@@ -285,7 +285,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
         $format ??= static::$_toStringFormat;
         $format = is_int($format) ? [$format, $format] : $format;
 
-        return static::_parseDateTime($time, $format, $tz);
+        return static::doParseDateTime($time, $format, $tz);
     }
 
     /**
@@ -317,7 +317,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
             $format = [$format, IntlDateFormatter::NONE];
         }
 
-        return static::parseDateTime($date, $format);
+        return static::doParseDateTime($date, $format);
     }
 
     /**
@@ -347,7 +347,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
         }
         $format = $format ?: [IntlDateFormatter::NONE, IntlDateFormatter::SHORT];
 
-        return static::parseDateTime($time, $format);
+        return static::doParseDateTime($time, $format);
     }
 
     /**
@@ -444,7 +444,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
         $format = is_int($format) ? [$format, $format] : $format;
         $locale = $locale ?: DateTime::getDefaultLocale();
 
-        return $this->_formatObject($time, $format, $locale);
+        return $this->formatObject($time, $format, $locale);
     }
 
     /**

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -355,7 +355,7 @@ class Number
         $formatter = static::$_formatters[$locale][$type];
         $formatter = clone $formatter;
 
-        return static::_setAttributes($formatter, $options);
+        return static::setAttributes($formatter, $options);
     }
 
     /**
@@ -368,7 +368,7 @@ class Number
      */
     public static function config(string $locale, int $type = NumberFormatter::DECIMAL, array $options = []): void
     {
-        static::$_formatters[$locale][$type] = static::_setAttributes(
+        static::$_formatters[$locale][$type] = static::setAttributes(
             new NumberFormatter($locale, $type),
             $options,
         );
@@ -381,7 +381,7 @@ class Number
      * @param array<string, mixed> $options See Number::formatter() for possible options.
      * @return \NumberFormatter
      */
-    protected static function _setAttributes(NumberFormatter $formatter, array $options = []): NumberFormatter
+    protected static function setAttributes(NumberFormatter $formatter, array $options = []): NumberFormatter
     {
         if (isset($options['places'])) {
             $formatter->setAttribute(NumberFormatter::MIN_FRACTION_DIGITS, $options['places']);

--- a/src/I18n/Parser/MoFileParser.php
+++ b/src/I18n/Parser/MoFileParser.php
@@ -84,9 +84,9 @@ class MoFileParser
         // offset formatRevision
         fread($stream, 4);
 
-        $count = $this->_readLong($stream, $isBigEndian);
-        $offsetId = $this->_readLong($stream, $isBigEndian);
-        $offsetTranslated = $this->_readLong($stream, $isBigEndian);
+        $count = $this->readLong($stream, $isBigEndian);
+        $offsetId = $this->readLong($stream, $isBigEndian);
+        $offsetTranslated = $this->readLong($stream, $isBigEndian);
 
         // Offset to start of translations
         fread($stream, 8);
@@ -99,8 +99,8 @@ class MoFileParser
 
             fseek($stream, $offsetId + $i * 8);
 
-            $length = $this->_readLong($stream, $isBigEndian);
-            $offset = $this->_readLong($stream, $isBigEndian);
+            $length = $this->readLong($stream, $isBigEndian);
+            $offset = $this->readLong($stream, $isBigEndian);
 
             if ($length < 1) {
                 continue;
@@ -118,12 +118,12 @@ class MoFileParser
             }
 
             fseek($stream, $offsetTranslated + $i * 8);
-            $length = $this->_readLong($stream, $isBigEndian);
+            $length = $this->readLong($stream, $isBigEndian);
             if ($length < 1) {
                 throw new CakeException('Length must be > 0');
             }
 
-            $offset = $this->_readLong($stream, $isBigEndian);
+            $offset = $this->readLong($stream, $isBigEndian);
             fseek($stream, $offset);
             $translated = (string)fread($stream, $length);
 
@@ -160,7 +160,7 @@ class MoFileParser
      * @param bool $isBigEndian Whether the current platform is Big Endian
      * @return int
      */
-    protected function _readLong($stream, bool $isBigEndian): int
+    protected function readLong($stream, bool $isBigEndian): int
     {
         /** @var array $result */
         $result = unpack($isBigEndian ? 'N1' : 'V1', (string)fread($stream, 4));

--- a/src/I18n/Parser/PoFileParser.php
+++ b/src/I18n/Parser/PoFileParser.php
@@ -93,12 +93,12 @@ class PoFileParser
 
             if ($line === '') {
                 // Whitespace indicated current item is done
-                $this->_addMessage($messages, $item);
+                $this->addMessage($messages, $item);
                 $item = $defaults;
                 $stage = [];
             } elseif (str_starts_with($line, 'msgid "')) {
                 // We start a new msg so save previous
-                $this->_addMessage($messages, $item);
+                $this->addMessage($messages, $item);
                 $item['ids']['singular'] = substr($line, 7, -1);
                 $stage = ['ids', 'singular'];
             } elseif (str_starts_with($line, 'msgstr "')) {
@@ -136,7 +136,7 @@ class PoFileParser
             }
         }
         // save last item
-        $this->_addMessage($messages, $item);
+        $this->addMessage($messages, $item);
         fclose($stream);
 
         return $messages;
@@ -149,7 +149,7 @@ class PoFileParser
      * @param array $item The current item being inspected
      * @return void
      */
-    protected function _addMessage(array &$messages, array $item): void
+    protected function addMessage(array &$messages, array $item): void
     {
         if (empty($item['ids']['singular']) && empty($item['ids']['plural'])) {
             return;

--- a/src/I18n/RelativeTimeFormatter.php
+++ b/src/I18n/RelativeTimeFormatter.php
@@ -108,7 +108,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
      */
     public function timeAgoInWords(DateTime|Date $time, array $options = []): string
     {
-        $options = $this->_options($options, DateTime::class);
+        $options = $this->options($options, DateTime::class);
         if ($options['timezone']) {
             $time = $time->setTimezone($options['timezone']);
         }
@@ -135,7 +135,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
             return sprintf($options['absoluteString'], $time->i18nFormat($options['format']));
         }
 
-        $diffData = $this->_diffData($futureTime, $pastTime, $backwards, $options);
+        $diffData = $this->diffData($futureTime, $pastTime, $backwards, $options);
         [$fNum, $fWord, $years, $months, $weeks, $days, $hours, $minutes, $seconds] = array_values($diffData);
 
         $relativeDate = [];
@@ -203,7 +203,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
      * @param array<string, mixed> $options An array of options.
      * @return array An array of values.
      */
-    protected function _diffData(string|int $futureTime, string|int $pastTime, bool $backwards, array $options): array
+    protected function diffData(string|int $futureTime, string|int $pastTime, bool $backwards, array $options): array
     {
         $futureTime = (int)$futureTime;
         $pastTime = (int)$pastTime;
@@ -338,7 +338,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
      */
     public function dateAgoInWords(DateTime|Date $date, array $options = []): string
     {
-        $options = $this->_options($options, Date::class);
+        $options = $this->options($options, Date::class);
         if ($date instanceof DateTime && $options['timezone']) {
             $date = $date->setTimezone($options['timezone']);
         }
@@ -365,7 +365,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
             return sprintf($options['absoluteString'], $date->i18nFormat($options['format']));
         }
 
-        $diffData = $this->_diffData($futureTime, $pastTime, $backwards, $options);
+        $diffData = $this->diffData($futureTime, $pastTime, $backwards, $options);
         [$fNum, $fWord, $years, $months, $weeks, $days] = array_values($diffData);
 
         $relativeDate = [];
@@ -417,7 +417,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
      * @return array<string, mixed> Options with defaults applied.
      * @psalm-param class-string<\Cake\I18n\Date>|class-string<\Cake\I18n\DateTime> $class
      */
-    protected function _options(array $options, string $class): array
+    protected function options(array $options, string $class): array
     {
         $options += [
             'from' => $class::now(),

--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -144,7 +144,7 @@ class Time extends ChronosTime implements JsonSerializable, Stringable
             $format = [IntlDateFormatter::NONE, $format];
         }
 
-        return static::_parseDateTime($time, $format);
+        return static::doParseDateTime($time, $format);
     }
 
     /**
@@ -200,7 +200,7 @@ class Time extends ChronosTime implements JsonSerializable, Stringable
         $format = is_int($format) ? [IntlDateFormatter::NONE, $format] : $format;
         $locale = $locale ?: DateTime::getDefaultLocale();
 
-        return $this->_formatObject($this->toNative(), $format, $locale);
+        return $this->formatObject($this->toNative(), $format, $locale);
     }
 
     /**

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -195,7 +195,7 @@ class TranslatorRegistry
         }
 
         if ($this->_cacher === null) {
-            return $this->registry[$name][$locale] = $this->_getTranslator($name, $locale);
+            return $this->registry[$name][$locale] = $this->getTranslator($name, $locale);
         }
 
         // Cache keys cannot contain / if they go to file engine.
@@ -205,7 +205,7 @@ class TranslatorRegistry
         $translator = $this->_cacher->get($key);
 
         if (!$translator) {
-            $translator = $this->_getTranslator($name, $locale);
+            $translator = $this->getTranslator($name, $locale);
             $this->_cacher->set($key, $translator);
         }
 
@@ -220,7 +220,7 @@ class TranslatorRegistry
      * locale.
      * @return \Cake\I18n\Translator A translator object.
      */
-    protected function _getTranslator(string $name, string $locale): Translator
+    protected function getTranslator(string $name, string $locale): Translator
     {
         if ($this->packages->has($name, $locale)) {
             return $this->createInstance($name, $locale);

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -126,9 +126,9 @@ class FileLog extends BaseLog
         $message = $this->interpolate($message, $context);
         $message = $this->formatter->format($level, $message, $context);
 
-        $filename = $this->_getFilename($level);
+        $filename = $this->getFilename($level);
         if ($this->_size) {
-            $this->_rotateFile($filename);
+            $this->rotateFile($filename);
         }
 
         $pathname = $this->_path . $filename;
@@ -159,7 +159,7 @@ class FileLog extends BaseLog
      * @param string $level The level of log.
      * @return string File name
      */
-    protected function _getFilename(string $level): string
+    protected function getFilename(string $level): string
     {
         $debugTypes = ['notice', 'info', 'debug'];
 
@@ -184,7 +184,7 @@ class FileLog extends BaseLog
      * @return bool|null True if rotated successfully or false in case of error.
      *   Null if file doesn't need to be rotated.
      */
-    protected function _rotateFile(string $filename): ?bool
+    protected function rotateFile(string $filename): ?bool
     {
         $filePath = $this->_path . $filename;
         clearstatcache(true, $filePath);

--- a/src/Log/Engine/SyslogLog.php
+++ b/src/Log/Engine/SyslogLog.php
@@ -103,7 +103,7 @@ class SyslogLog extends BaseLog
     {
         if (!$this->_open) {
             $config = $this->_config;
-            $this->_open($config['prefix'], $config['flag'], $config['facility']);
+            $this->open($config['prefix'], $config['flag'], $config['facility']);
             $this->_open = true;
         }
 
@@ -114,7 +114,7 @@ class SyslogLog extends BaseLog
 
         $lines = explode("\n", $this->interpolate($message, $context));
         foreach ($lines as $line) {
-            $this->_write($priority, $this->formatter->format($level, $line, $context));
+            $this->write($priority, $this->formatter->format($level, $line, $context));
         }
     }
 
@@ -127,7 +127,7 @@ class SyslogLog extends BaseLog
      * @param int $facility the stream or facility to log to
      * @return void
      */
-    protected function _open(string $ident, int $options, int $facility): void
+    protected function open(string $ident, int $options, int $facility): void
     {
         openlog($ident, $options, $facility);
     }
@@ -140,7 +140,7 @@ class SyslogLog extends BaseLog
      * @param string $message Message to log.
      * @return bool
      */
-    protected function _write(int $priority, string $message): bool
+    protected function write(int $priority, string $message): bool
     {
         return syslog($priority, $message);
     }

--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -36,7 +36,7 @@ class LogEngineRegistry extends ObjectRegistry
      * @param string $class Partial classname to resolve.
      * @return class-string<\Psr\Log\LoggerInterface>|null Either the correct class name or null.
      */
-    protected function _resolveClassName(string $class): ?string
+    protected function resolveClassName(string $class): ?string
     {
         /** @var class-string<\Psr\Log\LoggerInterface>|null */
         return App::className($class, 'Log/Engine', 'Log');
@@ -52,7 +52,7 @@ class LogEngineRegistry extends ObjectRegistry
      * @return void
      * @throws \Cake\Core\Exception\CakeException
      */
-    protected function _throwMissingClassError(string $class, ?string $plugin): void
+    protected function throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new CakeException(sprintf('Could not load class `%s`.', $class));
     }
@@ -67,7 +67,7 @@ class LogEngineRegistry extends ObjectRegistry
      * @param array<string, mixed> $config An array of settings to use for the logger.
      * @return \Psr\Log\LoggerInterface The constructed logger class.
      */
-    protected function _create(callable|object|string $class, string $alias, array $config): LoggerInterface
+    protected function create(callable|object|string $class, string $alias, array $config): LoggerInterface
     {
         if (is_string($class)) {
             /** @var class-string<\Psr\Log\LoggerInterface> $class */

--- a/src/Mailer/Transport/MailTransport.php
+++ b/src/Mailer/Transport/MailTransport.php
@@ -61,7 +61,7 @@ class MailTransport extends AbstractTransport
         $message = $message->getBodyString($eol);
 
         $params = $this->getConfig('additionalParameters', '');
-        $this->_mail($to, $subject, $message, $headers, $params);
+        $this->mail($to, $subject, $message, $headers, $params);
 
         $headers .= $eol . 'To: ' . $to;
         $headers .= $eol . 'Subject: ' . $subject;
@@ -80,7 +80,7 @@ class MailTransport extends AbstractTransport
      * @throws \Cake\Network\Exception\SocketException if mail could not be sent
      * @return void
      */
-    protected function _mail(
+    protected function mail(
         string $to,
         string $subject,
         string $message,

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -122,8 +122,8 @@ class SmtpTransport extends AbstractTransport
     public function connect(): void
     {
         if (!$this->connected()) {
-            $this->_connect();
-            $this->_auth();
+            $this->doConnect();
+            $this->auth();
         }
     }
 
@@ -151,7 +151,7 @@ class SmtpTransport extends AbstractTransport
             return;
         }
 
-        $this->_disconnect();
+        $this->doDisconnect();
     }
 
     /**
@@ -196,17 +196,17 @@ class SmtpTransport extends AbstractTransport
         $this->checkRecipient($message);
 
         if (!$this->connected()) {
-            $this->_connect();
-            $this->_auth();
+            $this->doConnect();
+            $this->auth();
         } else {
-            $this->_smtpSend('RSET');
+            $this->smtpSend('RSET');
         }
 
-        $this->_sendRcpt($message);
-        $this->_sendData($message);
+        $this->sendRcpt($message);
+        $this->sendData($message);
 
         if (!$this->_config['keepAlive']) {
-            $this->_disconnect();
+            $this->doDisconnect();
         }
 
         /** @var array{headers: string, message: string} */
@@ -219,7 +219,7 @@ class SmtpTransport extends AbstractTransport
      * @param array<string> $responseLines Response lines to parse.
      * @return void
      */
-    protected function _bufferResponseLines(array $responseLines): void
+    protected function bufferResponseLines(array $responseLines): void
     {
         $response = [];
         foreach ($responseLines as $responseLine) {
@@ -238,7 +238,7 @@ class SmtpTransport extends AbstractTransport
      *
      * @return void
      */
-    protected function _parseAuthType(): void
+    protected function parseAuthType(): void
     {
         $authType = $this->getConfig('authType');
         if ($authType !== null) {
@@ -286,13 +286,13 @@ class SmtpTransport extends AbstractTransport
      * @return void
      * @throws \Cake\Network\Exception\SocketException
      */
-    protected function _connect(): void
+    protected function doConnect(): void
     {
-        $this->_generateSocket();
+        $this->generateSocket();
         if (!$this->_socket->connect()) {
             throw new SocketException('Unable to connect to SMTP server.');
         }
-        $this->_smtpSend(null, '220');
+        $this->smtpSend(null, '220');
 
         $config = $this->_config;
 
@@ -310,11 +310,11 @@ class SmtpTransport extends AbstractTransport
         }
 
         try {
-            $this->_smtpSend("EHLO {$host}", '250');
+            $this->smtpSend("EHLO {$host}", '250');
             if ($config['tls']) {
-                $this->_smtpSend('STARTTLS', '220');
+                $this->smtpSend('STARTTLS', '220');
                 $this->_socket->enableCrypto('tls');
-                $this->_smtpSend("EHLO {$host}", '250');
+                $this->smtpSend("EHLO {$host}", '250');
             }
         } catch (SocketException $e) {
             if ($config['tls']) {
@@ -325,13 +325,13 @@ class SmtpTransport extends AbstractTransport
                 );
             }
             try {
-                $this->_smtpSend("HELO {$host}", '250');
+                $this->smtpSend("HELO {$host}", '250');
             } catch (SocketException $e2) {
                 throw new SocketException('SMTP server did not accept the connection.', null, $e2);
             }
         }
 
-        $this->_parseAuthType();
+        $this->parseAuthType();
     }
 
     /**
@@ -340,7 +340,7 @@ class SmtpTransport extends AbstractTransport
      * @return void
      * @throws \Cake\Network\Exception\SocketException
      */
-    protected function _auth(): void
+    protected function auth(): void
     {
         if (!isset($this->_config['username'], $this->_config['password'])) {
             return;
@@ -351,24 +351,24 @@ class SmtpTransport extends AbstractTransport
 
         switch ($this->authType) {
             case self::AUTH_PLAIN:
-                $this->_authPlain($username, $password);
+                $this->authPlain($username, $password);
                 break;
 
             case self::AUTH_LOGIN:
-                $this->_authLogin($username, $password);
+                $this->authLogin($username, $password);
                 break;
 
             case self::AUTH_XOAUTH2:
-                $this->_authXoauth2($username, $password);
+                $this->authXoauth2($username, $password);
                 break;
 
             default:
-                $replyCode = $this->_authPlain($username, $password);
+                $replyCode = $this->authPlain($username, $password);
                 if ($replyCode === '235') {
                     break;
                 }
 
-                $this->_authLogin($username, $password);
+                $this->authLogin($username, $password);
         }
     }
 
@@ -379,9 +379,9 @@ class SmtpTransport extends AbstractTransport
      * @param string $password Password.
      * @return string|null Response code for the command.
      */
-    protected function _authPlain(string $username, string $password): ?string
+    protected function authPlain(string $username, string $password): ?string
     {
-        return $this->_smtpSend(
+        return $this->smtpSend(
             sprintf(
                 'AUTH PLAIN %s',
                 base64_encode(chr(0) . $username . chr(0) . $password),
@@ -397,17 +397,17 @@ class SmtpTransport extends AbstractTransport
      * @param string $password Password.
      * @return void
      */
-    protected function _authLogin(string $username, string $password): void
+    protected function authLogin(string $username, string $password): void
     {
-        $replyCode = $this->_smtpSend('AUTH LOGIN', '334|500|502|504');
+        $replyCode = $this->smtpSend('AUTH LOGIN', '334|500|502|504');
         if ($replyCode === '334') {
             try {
-                $this->_smtpSend(base64_encode($username), '334');
+                $this->smtpSend(base64_encode($username), '334');
             } catch (SocketException $e) {
                 throw new SocketException('SMTP server did not accept the username.', null, $e);
             }
             try {
-                $this->_smtpSend(base64_encode($password), '235');
+                $this->smtpSend(base64_encode($password), '235');
             } catch (SocketException $e) {
                 throw new SocketException('SMTP server did not accept the password.', null, $e);
             }
@@ -429,7 +429,7 @@ class SmtpTransport extends AbstractTransport
      * @see https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth#smtp-protocol-exchange
      * @see https://developers.google.com/gmail/imap/xoauth2-protocol#smtp_protocol_exchange
      */
-    protected function _authXoauth2(string $username, string $token): void
+    protected function authXoauth2(string $username, string $token): void
     {
         $authString = base64_encode(sprintf(
             "user=%s\1auth=Bearer %s\1\1",
@@ -437,7 +437,7 @@ class SmtpTransport extends AbstractTransport
             $token,
         ));
 
-        $this->_smtpSend('AUTH XOAUTH2 ' . $authString, '235');
+        $this->smtpSend('AUTH XOAUTH2 ' . $authString, '235');
     }
 
     /**
@@ -446,7 +446,7 @@ class SmtpTransport extends AbstractTransport
      * @param string $message The email address to send with the command.
      * @return string
      */
-    protected function _prepareFromCmd(string $message): string
+    protected function prepareFromCmd(string $message): string
     {
         return 'MAIL FROM:<' . $message . '>';
     }
@@ -457,7 +457,7 @@ class SmtpTransport extends AbstractTransport
      * @param string $message The email address to send with the command.
      * @return string
      */
-    protected function _prepareRcptCmd(string $message): string
+    protected function prepareRcptCmd(string $message): string
     {
         return 'RCPT TO:<' . $message . '>';
     }
@@ -468,7 +468,7 @@ class SmtpTransport extends AbstractTransport
      * @param \Cake\Mailer\Message $message Message instance
      * @return array
      */
-    protected function _prepareFromAddress(Message $message): array
+    protected function prepareFromAddress(Message $message): array
     {
         $from = $message->getReturnPath();
         if (!$from) {
@@ -484,7 +484,7 @@ class SmtpTransport extends AbstractTransport
      * @param \Cake\Mailer\Message $message Message instance
      * @return array
      */
-    protected function _prepareRecipientAddresses(Message $message): array
+    protected function prepareRecipientAddresses(Message $message): array
     {
         $to = $message->getTo();
         $cc = $message->getCc();
@@ -499,7 +499,7 @@ class SmtpTransport extends AbstractTransport
      * @param \Cake\Mailer\Message $message Message instance
      * @return string
      */
-    protected function _prepareMessage(Message $message): string
+    protected function prepareMessage(Message $message): string
     {
         $lines = $message->getBody();
         $messages = [];
@@ -521,14 +521,14 @@ class SmtpTransport extends AbstractTransport
      * @throws \Cake\Network\Exception\SocketException
      * @return void
      */
-    protected function _sendRcpt(Message $message): void
+    protected function sendRcpt(Message $message): void
     {
-        $from = $this->_prepareFromAddress($message);
-        $this->_smtpSend($this->_prepareFromCmd((string)key($from)));
+        $from = $this->prepareFromAddress($message);
+        $this->smtpSend($this->prepareFromCmd((string)key($from)));
 
-        $messages = $this->_prepareRecipientAddresses($message);
+        $messages = $this->prepareRecipientAddresses($message);
         foreach ($messages as $mail) {
-            $this->_smtpSend($this->_prepareRcptCmd($mail));
+            $this->smtpSend($this->prepareRcptCmd($mail));
         }
     }
 
@@ -539,9 +539,9 @@ class SmtpTransport extends AbstractTransport
      * @return void
      * @throws \Cake\Network\Exception\SocketException
      */
-    protected function _sendData(Message $message): void
+    protected function sendData(Message $message): void
     {
-        $this->_smtpSend('DATA', '354');
+        $this->smtpSend('DATA', '354');
 
         $headers = $message->getHeadersString([
             'from',
@@ -553,9 +553,9 @@ class SmtpTransport extends AbstractTransport
             'subject',
             'returnPath',
         ]);
-        $message = $this->_prepareMessage($message);
+        $message = $this->prepareMessage($message);
 
-        $this->_smtpSend($headers . "\r\n\r\n" . $message . "\r\n\r\n\r\n.");
+        $this->smtpSend($headers . "\r\n\r\n" . $message . "\r\n\r\n\r\n.");
         $this->_content = ['headers' => $headers, 'message' => $message];
     }
 
@@ -565,9 +565,9 @@ class SmtpTransport extends AbstractTransport
      * @return void
      * @throws \Cake\Network\Exception\SocketException
      */
-    protected function _disconnect(): void
+    protected function doDisconnect(): void
     {
-        $this->_smtpSend('QUIT', false);
+        $this->smtpSend('QUIT', false);
         $this->_socket->disconnect();
         $this->authType = null;
     }
@@ -578,7 +578,7 @@ class SmtpTransport extends AbstractTransport
      * @return void
      * @throws \Cake\Network\Exception\SocketException
      */
-    protected function _generateSocket(): void
+    protected function generateSocket(): void
     {
         $this->_socket = new Socket($this->_config);
     }
@@ -591,7 +591,7 @@ class SmtpTransport extends AbstractTransport
      * @return string|null The matched code, or null if nothing matched
      * @throws \Cake\Network\Exception\SocketException
      */
-    protected function _smtpSend(?string $data, string|false $checkCode = '250'): ?string
+    protected function smtpSend(?string $data, string|false $checkCode = '250'): ?string
     {
         $this->_lastResponse = [];
 
@@ -619,7 +619,7 @@ class SmtpTransport extends AbstractTransport
             $responseLines = explode("\r\n", rtrim($response, "\r\n"));
             $response = end($responseLines);
 
-            $this->_bufferResponseLines($responseLines);
+            $this->bufferResponseLines($responseLines);
 
             if (preg_match('/^(' . $checkCode . ')(.)/', $response, $code)) {
                 if ($code[2] === '-') {

--- a/src/Mailer/TransportFactory.php
+++ b/src/Mailer/TransportFactory.php
@@ -75,7 +75,7 @@ class TransportFactory
      * @return void
      * @throws \InvalidArgumentException When a tranport cannot be created.
      */
-    protected static function _buildTransport(string $name): void
+    protected static function buildTransport(string $name): void
     {
         if (!isset(static::$_config[$name])) {
             throw new InvalidArgumentException(
@@ -106,7 +106,7 @@ class TransportFactory
             return $registry->{$name};
         }
 
-        static::_buildTransport($name);
+        static::buildTransport($name);
 
         return $registry->{$name};
     }

--- a/src/Mailer/TransportRegistry.php
+++ b/src/Mailer/TransportRegistry.php
@@ -35,7 +35,7 @@ class TransportRegistry extends ObjectRegistry
      * @param string $class Partial classname to resolve or transport instance.
      * @return class-string<\Cake\Mailer\AbstractTransport>|null Either the correct classname or null.
      */
-    protected function _resolveClassName(string $class): ?string
+    protected function resolveClassName(string $class): ?string
     {
         /** @var class-string<\Cake\Mailer\AbstractTransport>|null */
         return App::className($class, 'Mailer/Transport', 'Transport');
@@ -51,7 +51,7 @@ class TransportRegistry extends ObjectRegistry
      * @return void
      * @throws \BadMethodCallException
      */
-    protected function _throwMissingClassError(string $class, ?string $plugin): void
+    protected function throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new BadMethodCallException(sprintf('Mailer transport `%s` is not available.', $class));
     }
@@ -66,7 +66,7 @@ class TransportRegistry extends ObjectRegistry
      * @param array<string, mixed> $config An array of settings to use for the cache engine.
      * @return \Cake\Mailer\AbstractTransport The constructed transport class.
      */
-    protected function _create(object|string $class, string $alias, array $config): AbstractTransport
+    protected function create(object|string $class, string $alias, array $config): AbstractTransport
     {
         if (is_object($class)) {
             return $class;

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -131,7 +131,7 @@ class Socket
             $scheme = $this->_config['protocol'] . '://';
         }
 
-        $this->_setSslContext($this->_config['host']);
+        $this->setSslContext($this->_config['host']);
         if (!empty($this->_config['context'])) {
             $context = stream_context_create($this->_config['context']);
         } else {
@@ -147,7 +147,7 @@ class Socket
          * @psalm-suppress InvalidArgument
          * @phpstan-ignore-next-line
          */
-        set_error_handler($this->_connectionErrorHandler(...));
+        set_error_handler($this->connectionErrorHandler(...));
         $remoteSocketTarget = $scheme . $this->_config['host'];
         $port = (int)$this->_config['port'];
         if ($port > 0) {
@@ -156,7 +156,7 @@ class Socket
 
         $errNum = 0;
         $errStr = '';
-        $this->connection = $this->_getStreamSocketClient(
+        $this->connection = $this->getStreamSocketClient(
             $remoteSocketTarget,
             $errNum,
             $errStr,
@@ -207,7 +207,7 @@ class Socket
      * @param resource $context context
      * @return resource|null
      */
-    protected function _getStreamSocketClient(
+    protected function getStreamSocketClient(
         string $remoteSocketTarget,
         int &$errNum,
         string &$errStr,
@@ -237,7 +237,7 @@ class Socket
      * @param string $host The host name being connected to.
      * @return void
      */
-    protected function _setSslContext(string $host): void
+    protected function setSslContext(string $host): void
     {
         foreach ($this->_config as $key => $value) {
             if (!str_starts_with($key, 'ssl_')) {
@@ -274,7 +274,7 @@ class Socket
      * @param string $message Message.
      * @return void
      */
-    protected function _connectionErrorHandler(int $code, string $message): void
+    protected function connectionErrorHandler(int $code, string $message): void
     {
         $this->_connectionErrors[] = $message;
     }

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -235,7 +235,7 @@ abstract class Association
         [, $name] = pluginSplit($alias);
         $this->_name = $name;
 
-        $this->_options($options);
+        $this->options($options);
 
         if (!empty($options['strategy'])) {
             $this->setStrategy($options['strategy']);
@@ -566,7 +566,7 @@ abstract class Association
     public function getProperty(): string
     {
         if (!isset($this->_propertyName)) {
-            $this->_propertyName = $this->_propertyName();
+            $this->_propertyName = $this->propertyName();
             if (in_array($this->_propertyName, $this->_sourceTable->getSchema()->columns(), true)) {
                 $msg = 'Association property name `%s` clashes with field of same name of table `%s`.' .
                     ' You should explicitly specify the `propertyName` option.';
@@ -585,7 +585,7 @@ abstract class Association
      *
      * @return string
      */
-    protected function _propertyName(): string
+    protected function propertyName(): string
     {
         [, $name] = pluginSplit($this->_name);
 
@@ -657,7 +657,7 @@ abstract class Association
      * @param array<string, mixed> $options List of options used for initialization
      * @return void
      */
-    protected function _options(array $options): void
+    protected function options(array $options): void
     {
     }
 
@@ -709,13 +709,13 @@ abstract class Association
         }
 
         if ($options['foreignKey']) {
-            $joinCondition = $this->_joinCondition($options);
+            $joinCondition = $this->joinCondition($options);
             if ($joinCondition) {
                 $options['conditions'][] = $joinCondition;
             }
         }
 
-        [$finder, $opts] = $this->_extractFinder($options['finder']);
+        [$finder, $opts] = $this->extractFinder($options['finder']);
         $dummy = $this
             ->find($finder, ...$opts)
             ->eagerLoaded(true);
@@ -742,7 +742,7 @@ abstract class Association
         }
 
         $dummy->where($options['conditions']);
-        $this->_dispatchBeforeFind($dummy);
+        $this->dispatchBeforeFind($dummy);
 
         $query->join([$this->_name => [
             'table' => $options['table'],
@@ -750,10 +750,10 @@ abstract class Association
             'type' => $options['joinType'],
         ]]);
 
-        $this->_appendFields($query, $dummy, $options);
-        $this->_formatAssociationResults($query, $dummy, $options);
-        $this->_bindNewAssociations($query, $dummy, $options);
-        $this->_appendNotMatching($query, $options);
+        $this->appendFields($query, $dummy, $options);
+        $this->formatAssociationResults($query, $dummy, $options);
+        $this->bindNewAssociations($query, $dummy, $options);
+        $this->appendNotMatching($query, $options);
     }
 
     /**
@@ -764,7 +764,7 @@ abstract class Association
      * @param array<string, mixed> $options Options array containing the `negateMatch` key.
      * @return void
      */
-    protected function _appendNotMatching(SelectQuery $query, array $options): void
+    protected function appendNotMatching(SelectQuery $query, array $options): void
     {
         $target = $this->getTarget();
         if (!empty($options['negateMatch'])) {
@@ -839,7 +839,7 @@ abstract class Association
     public function find(array|string|null $type = null, mixed ...$args): SelectQuery
     {
         $type = $type ?: $this->getFinder();
-        [$type, $opts] = $this->_extractFinder($type);
+        [$type, $opts] = $this->extractFinder($type);
 
         $args += $opts;
 
@@ -923,7 +923,7 @@ abstract class Association
      * @param \Cake\ORM\Query\SelectQuery $query the query this association is attaching itself to
      * @return void
      */
-    protected function _dispatchBeforeFind(SelectQuery $query): void
+    protected function dispatchBeforeFind(SelectQuery $query): void
     {
         $query->triggerBeforeFind();
     }
@@ -937,7 +937,7 @@ abstract class Association
      * @param array<string, mixed> $options options passed to the method `attachTo`
      * @return void
      */
-    protected function _appendFields(SelectQuery $query, SelectQuery $surrogate, array $options): void
+    protected function appendFields(SelectQuery $query, SelectQuery $surrogate, array $options): void
     {
         if ($query->getEagerLoader()->isAutoFieldsEnabled() === false) {
             return;
@@ -969,7 +969,7 @@ abstract class Association
      * @param array<string, mixed> $options options passed to the method `attachTo`
      * @return void
      */
-    protected function _formatAssociationResults(SelectQuery $query, SelectQuery $surrogate, array $options): void
+    protected function formatAssociationResults(SelectQuery $query, SelectQuery $surrogate, array $options): void
     {
         $formatters = $surrogate->getResultFormatters();
 
@@ -1029,7 +1029,7 @@ abstract class Association
      * @param array<string, mixed> $options options passed to the method `attachTo`
      * @return void
      */
-    protected function _bindNewAssociations(SelectQuery $query, SelectQuery $surrogate, array $options): void
+    protected function bindNewAssociations(SelectQuery $query, SelectQuery $surrogate, array $options): void
     {
         $loader = $surrogate->getEagerLoader();
         $contain = $loader->getContain();
@@ -1067,7 +1067,7 @@ abstract class Association
      * @throws \Cake\Database\Exception\DatabaseException if the number of columns in the foreignKey do not
      * match the number of columns in the source table primaryKey
      */
-    protected function _joinCondition(array $options): array
+    protected function joinCondition(array $options): array
     {
         $conditions = [];
         $tAlias = $this->_name;
@@ -1119,7 +1119,7 @@ abstract class Association
      * and options as value.
      * @return array
      */
-    protected function _extractFinder(array|string $finderData): array
+    protected function extractFinder(array|string $finderData): array
     {
         $finderData = (array)$finderData;
 

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -53,7 +53,7 @@ class BelongsTo extends Association
     public function getForeignKey(): array|string|false
     {
         if (!isset($this->_foreignKey)) {
-            $this->_foreignKey = $this->_modelKey($this->getTarget()->getAlias());
+            $this->_foreignKey = $this->modelKey($this->getTarget()->getAlias());
         }
 
         return $this->_foreignKey;

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -92,7 +92,7 @@ class BelongsTo extends Association
      *
      * @return string
      */
-    protected function _propertyName(): string
+    protected function propertyName(): string
     {
         [, $name] = pluginSplit($this->_name);
 
@@ -167,7 +167,7 @@ class BelongsTo extends Association
      * @throws \Cake\Database\Exception\DatabaseException if the number of columns in the foreignKey do not
      * match the number of columns in the target table primaryKey
      */
-    protected function _joinCondition(array $options): array
+    protected function joinCondition(array $options): array
     {
         $conditions = [];
         $tAlias = $this->_name;

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -264,7 +264,7 @@ class BelongsToMany extends Association
         if ($table === null && $this->_through !== null) {
             $table = $this->_through;
         } elseif ($table === null) {
-            $tableName = $this->_junctionTableName();
+            $tableName = $this->junctionTableName();
             $tableAlias = Inflector::camelize($tableName);
 
             $config = [];
@@ -293,9 +293,9 @@ class BelongsToMany extends Association
             ));
         }
 
-        $this->_generateSourceAssociations($table, $source);
-        $this->_generateTargetAssociations($table, $source, $target);
-        $this->_generateJunctionAssociations($table, $source, $target);
+        $this->generateSourceAssociations($table, $source);
+        $this->generateTargetAssociations($table, $source, $target);
+        $this->generateJunctionAssociations($table, $source, $target);
 
         return $this->_junctionTable = $table;
     }
@@ -339,7 +339,7 @@ class BelongsToMany extends Association
      * @param \Cake\ORM\Table $target The target table.
      * @return void
      */
-    protected function _generateTargetAssociations(Table $junction, Table $source, Table $target): void
+    protected function generateTargetAssociations(Table $junction, Table $source, Table $target): void
     {
         $junctionAlias = $junction->getAlias();
         $sAlias = $source->getAlias();
@@ -385,7 +385,7 @@ class BelongsToMany extends Association
      * @param \Cake\ORM\Table $source The source table.
      * @return void
      */
-    protected function _generateSourceAssociations(Table $junction, Table $source): void
+    protected function generateSourceAssociations(Table $junction, Table $source): void
     {
         $junctionAlias = $junction->getAlias();
         $sAlias = $source->getAlias();
@@ -422,7 +422,7 @@ class BelongsToMany extends Association
      * @return void
      * @throws \InvalidArgumentException If the expected associations are incompatible with existing associations.
      */
-    protected function _generateJunctionAssociations(Table $junction, Table $source, Table $target): void
+    protected function generateJunctionAssociations(Table $junction, Table $source, Table $target): void
     {
         $tAlias = $target->getAlias();
         $sAlias = $source->getAlias();
@@ -474,14 +474,14 @@ class BelongsToMany extends Association
     public function attachTo(SelectQuery $query, array $options = []): void
     {
         if (!empty($options['negateMatch'])) {
-            $this->_appendNotMatching($query, $options);
+            $this->appendNotMatching($query, $options);
 
             return;
         }
 
         $junction = $this->junction();
         $belongsTo = $junction->getAssociation($this->getSource()->getAlias());
-        $cond = $belongsTo->_joinCondition(['foreignKey' => $belongsTo->getForeignKey()]);
+        $cond = $belongsTo->joinCondition(['foreignKey' => $belongsTo->getForeignKey()]);
         $cond += $this->junctionConditions();
 
         $includeFields = $options['includeFields'] ?? null;
@@ -503,13 +503,13 @@ class BelongsToMany extends Association
         $thisJoin = $query->clause('join')[$this->getName()];
         /** @var \Cake\Database\Expression\QueryExpression $conditions */
         $conditions = $thisJoin['conditions'];
-        $conditions->add($assoc->_joinCondition(['foreignKey' => $foreignKey]));
+        $conditions->add($assoc->joinCondition(['foreignKey' => $foreignKey]));
     }
 
     /**
      * @inheritDoc
      */
-    protected function _appendNotMatching(SelectQuery $query, array $options): void
+    protected function appendNotMatching(SelectQuery $query, array $options): void
     {
         if (empty($options['negateMatch'])) {
             return;
@@ -517,7 +517,7 @@ class BelongsToMany extends Association
         $options['conditions'] ??= [];
         $junction = $this->junction();
         $belongsTo = $junction->getAssociation($this->getSource()->getAlias());
-        $conds = $belongsTo->_joinCondition(['foreignKey' => $belongsTo->getForeignKey()]);
+        $conds = $belongsTo->joinCondition(['foreignKey' => $belongsTo->getForeignKey()]);
 
         $subquery = $this->find()
             ->select(array_values($conds))
@@ -527,7 +527,7 @@ class BelongsToMany extends Association
             $subquery = $options['queryBuilder']($subquery);
         }
 
-        $subquery = $this->_appendJunctionJoin($subquery);
+        $subquery = $this->appendJunctionJoin($subquery);
 
         $query
             ->andWhere(function (QueryExpression $exp) use ($subquery, $conds) {
@@ -562,7 +562,7 @@ class BelongsToMany extends Association
      * @param array<string, mixed> $options list of options passed to attachTo method
      * @return array
      */
-    protected function _joinCondition(array $options): array
+    protected function joinCondition(array $options): array
     {
         return [];
     }
@@ -572,7 +572,7 @@ class BelongsToMany extends Association
      */
     public function eagerLoader(array $options): Closure
     {
-        $name = $this->_junctionAssociationName();
+        $name = $this->junctionAssociationName();
         $loader = new SelectWithPivotLoader([
             'alias' => $this->getAlias(),
             'sourceAlias' => $this->getSource()->getAlias(),
@@ -587,7 +587,7 @@ class BelongsToMany extends Association
             'junctionAssoc' => $this->getTarget()->getAssociation($name),
             'junctionConditions' => $this->junctionConditions(),
             'finder' => function () {
-                return $this->_appendJunctionJoin($this->find(), []);
+                return $this->appendJunctionJoin($this->find(), []);
             },
         ]);
 
@@ -720,7 +720,7 @@ class BelongsToMany extends Association
         }
 
         if ($strategy === self::SAVE_APPEND) {
-            return $this->_saveTarget($entity, $targetEntity, $options);
+            return $this->saveTarget($entity, $targetEntity, $options);
         }
 
         if ($this->replaceLinks($entity, $targetEntity, $options)) {
@@ -744,7 +744,7 @@ class BelongsToMany extends Association
      * @return \Cake\Datasource\EntityInterface|false The parent entity after all links have been
      * created if no errors happened, false otherwise
      */
-    protected function _saveTarget(
+    protected function saveTarget(
         EntityInterface $parentEntity,
         array $entities,
         array $options,
@@ -789,7 +789,7 @@ class BelongsToMany extends Association
         }
 
         $options['associated'] = $joinAssociations;
-        $success = $this->_saveLinks($parentEntity, $persisted, $options);
+        $success = $this->saveLinks($parentEntity, $persisted, $options);
         if (!$success && !empty($options['atomic'])) {
             $parentEntity->set($this->getProperty(), $original);
 
@@ -811,7 +811,7 @@ class BelongsToMany extends Association
      * @param array<string, mixed> $options list of options accepted by `Table::save()`
      * @return bool success
      */
-    protected function _saveLinks(EntityInterface $sourceEntity, array $targetEntities, array $options): bool
+    protected function saveLinks(EntityInterface $sourceEntity, array $targetEntities, array $options): bool
     {
         $target = $this->getTarget();
         $junction = $this->junction();
@@ -890,7 +890,7 @@ class BelongsToMany extends Association
      */
     public function link(EntityInterface $sourceEntity, array $targetEntities, array $options = []): bool
     {
-        $this->_checkPersistenceStatus($sourceEntity, $targetEntities);
+        $this->checkPersistenceStatus($sourceEntity, $targetEntities);
         $property = $this->getProperty();
         $links = $sourceEntity->get($property) ?: [];
         $links = array_merge($links, $targetEntities);
@@ -898,7 +898,7 @@ class BelongsToMany extends Association
 
         return $this->junction()->getConnection()->transactional(
             function () use ($sourceEntity, $targetEntities, $options) {
-                return $this->_saveLinks($sourceEntity, $targetEntities, $options);
+                return $this->saveLinks($sourceEntity, $targetEntities, $options);
             },
         );
     }
@@ -949,12 +949,12 @@ class BelongsToMany extends Association
             $options += ['cleanProperty' => true];
         }
 
-        $this->_checkPersistenceStatus($sourceEntity, $targetEntities);
+        $this->checkPersistenceStatus($sourceEntity, $targetEntities);
         $property = $this->getProperty();
 
         $this->junction()->getConnection()->transactional(
             function () use ($sourceEntity, $targetEntities, $options): void {
-                $links = $this->_collectJointEntities($sourceEntity, $targetEntities);
+                $links = $this->collectJointEntities($sourceEntity, $targetEntities);
                 foreach ($links as $entity) {
                     $this->_junctionTable->delete($entity, $options);
                 }
@@ -1069,7 +1069,7 @@ class BelongsToMany extends Association
         if (!is_array($conditions)) {
             return $matching;
         }
-        $alias = $this->_junctionAssociationName() . '.';
+        $alias = $this->junctionAssociationName() . '.';
         foreach ($conditions as $field => $value) {
             $isString = is_string($field);
             if ($isString && str_starts_with($field, $alias)) {
@@ -1102,7 +1102,7 @@ class BelongsToMany extends Association
     public function find(array|string|null $type = null, mixed ...$args): SelectQuery
     {
         $type = $type ?: $this->getFinder();
-        [$type, $opts] = $this->_extractFinder($type);
+        [$type, $opts] = $this->extractFinder($type);
 
         $args += $opts;
 
@@ -1112,7 +1112,7 @@ class BelongsToMany extends Association
             ->addDefaultTypes($this->getTarget());
 
         if ($this->junctionConditions()) {
-            return $this->_appendJunctionJoin($query);
+            return $this->appendJunctionJoin($query);
         }
 
         return $query;
@@ -1125,18 +1125,18 @@ class BelongsToMany extends Association
      * @param array|null $conditions The query conditions to use.
      * @return \Cake\ORM\Query\SelectQuery The modified query.
      */
-    protected function _appendJunctionJoin(SelectQuery $query, ?array $conditions = null): SelectQuery
+    protected function appendJunctionJoin(SelectQuery $query, ?array $conditions = null): SelectQuery
     {
         $junctionTable = $this->junction();
         if ($conditions === null) {
             $belongsTo = $junctionTable->getAssociation($this->getTarget()->getAlias());
-            $conditions = $belongsTo->_joinCondition([
+            $conditions = $belongsTo->joinCondition([
                 'foreignKey' => $this->getTargetForeignKey(),
             ]);
             $conditions += $this->junctionConditions();
         }
 
-        $name = $this->_junctionAssociationName();
+        $name = $this->junctionAssociationName();
         $joins = $query->clause('join');
         assert(is_array($joins));
         $matching = [
@@ -1236,7 +1236,7 @@ class BelongsToMany extends Association
 
                 // Use association to create row selection
                 // with finders & association conditions.
-                $matches = $this->_appendJunctionJoin($this->find())
+                $matches = $this->appendJunctionJoin($this->find())
                     ->select($keys)
                     ->where(array_combine($prefixedForeignKey, $primaryValue));
 
@@ -1249,13 +1249,13 @@ class BelongsToMany extends Association
                         $matchesConditions,
                     );
 
-                $jointEntities = $this->_collectJointEntities($sourceEntity, $targetEntities);
-                $inserts = $this->_diffLinks($existing, $jointEntities, $targetEntities, $options);
+                $jointEntities = $this->collectJointEntities($sourceEntity, $targetEntities);
+                $inserts = $this->diffLinks($existing, $jointEntities, $targetEntities, $options);
                 if ($inserts === false) {
                     return false;
                 }
 
-                if ($inserts && !$this->_saveTarget($sourceEntity, $inserts, $options)) {
+                if ($inserts && !$this->saveTarget($sourceEntity, $inserts, $options)) {
                     return false;
                 }
 
@@ -1291,7 +1291,7 @@ class BelongsToMany extends Association
      * @param array<string, mixed> $options list of options accepted by `Table::delete()`
      * @return array|false Array of entities not deleted or false in case of deletion failure for atomic saves.
      */
-    protected function _diffLinks(
+    protected function diffLinks(
         SelectQuery $existing,
         array $jointEntities,
         array $targetEntities,
@@ -1382,7 +1382,7 @@ class BelongsToMany extends Association
      * @return bool
      * @throws \InvalidArgumentException
      */
-    protected function _checkPersistenceStatus(EntityInterface $sourceEntity, array $targetEntities): bool
+    protected function checkPersistenceStatus(EntityInterface $sourceEntity, array $targetEntities): bool
     {
         if ($sourceEntity->isNew()) {
             $error = 'Source entity needs to be persisted before links can be created or removed.';
@@ -1411,7 +1411,7 @@ class BelongsToMany extends Association
      *   key value
      * @return array<\Cake\Datasource\EntityInterface>
      */
-    protected function _collectJointEntities(EntityInterface $sourceEntity, array $targetEntities): array
+    protected function collectJointEntities(EntityInterface $sourceEntity, array $targetEntities): array
     {
         $target = $this->getTarget();
         $source = $this->getSource();
@@ -1475,7 +1475,7 @@ class BelongsToMany extends Association
      *
      * @return string
      */
-    protected function _junctionAssociationName(): string
+    protected function junctionAssociationName(): string
     {
         if (!isset($this->_junctionAssociationName)) {
             $this->_junctionAssociationName = $this->getTarget()
@@ -1494,7 +1494,7 @@ class BelongsToMany extends Association
      * @param string|null $name The name of the junction table.
      * @return string
      */
-    protected function _junctionTableName(?string $name = null): string
+    protected function junctionTableName(?string $name = null): string
     {
         if ($name === null) {
             if (empty($this->_junctionTableName)) {
@@ -1518,13 +1518,13 @@ class BelongsToMany extends Association
      * @param array<string, mixed> $options original list of options passed in constructor
      * @return void
      */
-    protected function _options(array $options): void
+    protected function options(array $options): void
     {
         if (!empty($options['targetForeignKey'])) {
             $this->setTargetForeignKey($options['targetForeignKey']);
         }
         if (!empty($options['joinTable'])) {
-            $this->_junctionTableName($options['joinTable']);
+            $this->junctionTableName($options['joinTable']);
         }
         if (!empty($options['through'])) {
             $this->setThrough($options['through']);

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -183,7 +183,7 @@ class BelongsToMany extends Association
      */
     public function getTargetForeignKey(): array|string
     {
-        return $this->_targetForeignKey ??= $this->_modelKey($this->getTarget()->getAlias());
+        return $this->_targetForeignKey ??= $this->modelKey($this->getTarget()->getAlias());
     }
 
     /**
@@ -204,7 +204,7 @@ class BelongsToMany extends Association
     public function getForeignKey(): array|string|false
     {
         if (!isset($this->_foreignKey)) {
-            $this->_foreignKey = $this->_modelKey($this->getSource()->getTable());
+            $this->_foreignKey = $this->modelKey($this->getSource()->getTable());
         }
 
         return $this->_foreignKey;

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -180,7 +180,7 @@ class HasMany extends Association
 
         if (
             $this->_saveStrategy === self::SAVE_REPLACE &&
-            !$this->_unlinkAssociated($foreignKeyReference, $entity, $this->getTarget(), $targetEntities, $options)
+            !$this->unlinkAssociated($foreignKeyReference, $entity, $this->getTarget(), $targetEntities, $options)
         ) {
             return false;
         }
@@ -188,7 +188,7 @@ class HasMany extends Association
         if (!is_array($targetEntities)) {
             $targetEntities = iterator_to_array($targetEntities);
         }
-        if (!$this->_saveTarget($foreignKeyReference, $entity, $targetEntities, $options)) {
+        if (!$this->saveTarget($foreignKeyReference, $entity, $targetEntities, $options)) {
             return false;
         }
 
@@ -208,7 +208,7 @@ class HasMany extends Association
      * @param array<string, mixed> $options list of options accepted by `Table::save()`.
      * @return bool `true` on success, `false` otherwise.
      */
-    protected function _saveTarget(
+    protected function saveTarget(
         array $foreignKeyReference,
         EntityInterface $parentEntity,
         array $entities,
@@ -393,7 +393,7 @@ class HasMany extends Association
                 ->toList(),
         ];
 
-        $this->_unlink($foreignKey, $target, $conditions, $options);
+        $this->doUnlink($foreignKey, $target, $conditions, $options);
 
         $result = $sourceEntity->get($property);
         if ($options['cleanProperty'] && $result !== null) {
@@ -485,7 +485,7 @@ class HasMany extends Association
      * @param array<string, mixed> $options list of options accepted by `Table::delete()`
      * @return bool success
      */
-    protected function _unlinkAssociated(
+    protected function unlinkAssociated(
         array $foreignKeyReference,
         EntityInterface $entity,
         Table $target,
@@ -517,7 +517,7 @@ class HasMany extends Association
             ];
         }
 
-        return $this->_unlink(array_keys($foreignKeyReference), $target, $conditions, $options);
+        return $this->doUnlink(array_keys($foreignKeyReference), $target, $conditions, $options);
     }
 
     /**
@@ -532,9 +532,9 @@ class HasMany extends Association
      * @param array<string, mixed> $options list of options accepted by `Table::delete()`
      * @return bool success
      */
-    protected function _unlink(array $foreignKey, Table $target, array $conditions = [], array $options = []): bool
+    protected function doUnlink(array $foreignKey, Table $target, array $conditions = [], array $options = []): bool
     {
-        $mustBeDependent = (!$this->_foreignKeyAcceptsNull($target, $foreignKey) || $this->getDependent());
+        $mustBeDependent = (!$this->foreignKeyAcceptsNull($target, $foreignKey) || $this->getDependent());
 
         if ($mustBeDependent) {
             if ($this->_cascadeCallbacks) {
@@ -574,7 +574,7 @@ class HasMany extends Association
      * @param array $properties the list of fields that compose the foreign key
      * @return bool
      */
-    protected function _foreignKeyAcceptsNull(Table $table, array $properties): bool
+    protected function foreignKeyAcceptsNull(Table $table, array $properties): bool
     {
         return !in_array(
             false,
@@ -663,7 +663,7 @@ class HasMany extends Association
      * @param array<string, mixed> $options original list of options passed in constructor
      * @return void
      */
-    protected function _options(array $options): void
+    protected function options(array $options): void
     {
         if (!empty($options['saveStrategy'])) {
             $this->setSaveStrategy($options['saveStrategy']);

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -615,7 +615,7 @@ class HasMany extends Association
     public function getForeignKey(): array|string|false
     {
         if (!isset($this->_foreignKey)) {
-            $this->_foreignKey = $this->_modelKey($this->getSource()->getTable());
+            $this->_foreignKey = $this->modelKey($this->getSource()->getTable());
         }
 
         return $this->_foreignKey;

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -51,7 +51,7 @@ class HasOne extends Association
     public function getForeignKey(): array|string|false
     {
         if (!isset($this->_foreignKey)) {
-            $this->_foreignKey = $this->_modelKey($this->getSource()->getAlias());
+            $this->_foreignKey = $this->modelKey($this->getSource()->getAlias());
         }
 
         return $this->_foreignKey;

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -76,7 +76,7 @@ class HasOne extends Association
      *
      * @return string
      */
-    protected function _propertyName(): string
+    protected function propertyName(): string
     {
         [, $name] = pluginSplit($this->_name);
 

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -124,11 +124,11 @@ class SelectLoader
      */
     public function buildEagerLoader(array $options): Closure
     {
-        $options += $this->_defaultOptions();
-        $fetchQuery = $this->_buildQuery($options);
-        $resultMap = $this->_buildResultMap($fetchQuery, $options);
+        $options += $this->defaultOptions();
+        $fetchQuery = $this->buildQuery($options);
+        $resultMap = $this->buildResultMap($fetchQuery, $options);
 
-        return $this->_resultInjector($fetchQuery, $resultMap, $options);
+        return $this->resultInjector($fetchQuery, $resultMap, $options);
     }
 
     /**
@@ -136,7 +136,7 @@ class SelectLoader
      *
      * @return array<string, mixed>
      */
-    protected function _defaultOptions(): array
+    protected function defaultOptions(): array
     {
         return [
             'foreignKey' => $this->foreignKey,
@@ -156,9 +156,9 @@ class SelectLoader
      * @return \Cake\ORM\Query\SelectQuery
      * @throws \InvalidArgumentException When a key is required for associations but not selected.
      */
-    protected function _buildQuery(array $options): SelectQuery
+    protected function buildQuery(array $options): SelectQuery
     {
-        $key = $this->_linkField($options);
+        $key = $this->linkField($options);
         $filter = $options['keys'];
         $useSubquery = $options['strategy'] === Association::STRATEGY_SUBQUERY;
         $finder = $this->finder;
@@ -167,7 +167,7 @@ class SelectLoader
         $query = $finder();
         assert($query instanceof SelectQuery);
         if (isset($options['finder'])) {
-            [$finderName, $opts] = $this->_extractFinder($options['finder']);
+            [$finderName, $opts] = $this->extractFinder($options['finder']);
             $query = $query->find($finderName, ...$opts);
         }
 
@@ -187,10 +187,10 @@ class SelectLoader
         }
 
         if ($useSubquery) {
-            $filter = $this->_buildSubquery($selectQuery);
-            $fetchQuery = $this->_addFilteringJoin($fetchQuery, $key, $filter);
+            $filter = $this->buildSubquery($selectQuery);
+            $fetchQuery = $this->addFilteringJoin($fetchQuery, $key, $filter);
         } else {
-            $fetchQuery = $this->_addFilteringCondition($fetchQuery, $key, $filter);
+            $fetchQuery = $this->addFilteringCondition($fetchQuery, $key, $filter);
         }
 
         if (!empty($options['sort'])) {
@@ -205,7 +205,7 @@ class SelectLoader
             $fetchQuery = $options['queryBuilder']($fetchQuery);
         }
 
-        $this->_assertFieldsPresent($fetchQuery, (array)$key);
+        $this->assertFieldsPresent($fetchQuery, (array)$key);
 
         return $fetchQuery;
     }
@@ -226,7 +226,7 @@ class SelectLoader
      * and options as value.
      * @return array
      */
-    protected function _extractFinder(array|string $finderData): array
+    protected function extractFinder(array|string $finderData): array
     {
         $finderData = (array)$finderData;
 
@@ -247,7 +247,7 @@ class SelectLoader
      * @return void
      * @throws \InvalidArgumentException
      */
-    protected function _assertFieldsPresent(SelectQuery $fetchQuery, array $key): void
+    protected function assertFieldsPresent(SelectQuery $fetchQuery, array $key): void
     {
         if ($fetchQuery->isAutoFieldsEnabled()) {
             return;
@@ -294,7 +294,7 @@ class SelectLoader
      * @param \Cake\ORM\Query\SelectQuery $subquery The Subquery to use for filtering
      * @return \Cake\ORM\Query\SelectQuery
      */
-    protected function _addFilteringJoin(SelectQuery $query, array|string $key, SelectQuery $subquery): SelectQuery
+    protected function addFilteringJoin(SelectQuery $query, array|string $key, SelectQuery $subquery): SelectQuery
     {
         $filter = [];
         $aliasedTable = $this->sourceAlias;
@@ -309,7 +309,7 @@ class SelectLoader
         $subquery->select($filter, true);
 
         if (is_array($key)) {
-            $conditions = $this->_createTupleCondition($query, $key, $filter, '=');
+            $conditions = $this->createTupleCondition($query, $key, $filter, '=');
         } else {
             $filter = current($filter);
             $conditions = $query->newExpr([$key => $filter]);
@@ -330,10 +330,10 @@ class SelectLoader
      * @param mixed $filter The value that should be used to match for $key
      * @return \Cake\ORM\Query\SelectQuery
      */
-    protected function _addFilteringCondition(SelectQuery $query, array|string $key, mixed $filter): SelectQuery
+    protected function addFilteringCondition(SelectQuery $query, array|string $key, mixed $filter): SelectQuery
     {
         if (is_array($key)) {
-            $conditions = $this->_createTupleCondition($query, $key, $filter, 'IN');
+            $conditions = $this->createTupleCondition($query, $key, $filter, 'IN');
         } else {
             $conditions = [$key . ' IN' => $filter];
         }
@@ -351,7 +351,7 @@ class SelectLoader
      * @param string $operator The operator for comparing the tuples
      * @return \Cake\Database\Expression\TupleComparison
      */
-    protected function _createTupleCondition(
+    protected function createTupleCondition(
         SelectQuery $query,
         array $keys,
         mixed $filter,
@@ -376,7 +376,7 @@ class SelectLoader
      * @return array<string>|string
      * @throws \Cake\Database\Exception\DatabaseException
      */
-    protected function _linkField(array $options): array|string
+    protected function linkField(array $options): array|string
     {
         $links = [];
         $name = $this->alias;
@@ -410,7 +410,7 @@ class SelectLoader
      * @param \Cake\ORM\Query\SelectQuery $query the original query used to load source records
      * @return \Cake\ORM\Query\SelectQuery
      */
-    protected function _buildSubquery(SelectQuery $query): SelectQuery
+    protected function buildSubquery(SelectQuery $query): SelectQuery
     {
         $filterQuery = clone $query;
         $filterQuery->disableAutoFields();
@@ -426,7 +426,7 @@ class SelectLoader
             $filterQuery->offset(null);
         }
 
-        $fields = $this->_subqueryFields($query);
+        $fields = $this->subqueryFields($query);
         $filterQuery->select($fields['select'], true)->groupBy($fields['group']);
 
         return $filterQuery;
@@ -442,7 +442,7 @@ class SelectLoader
      * @param \Cake\ORM\Query\SelectQuery $query The query to get fields from.
      * @return array<string, array> The list of fields for the subquery.
      */
-    protected function _subqueryFields(SelectQuery $query): array
+    protected function subqueryFields(SelectQuery $query): array
     {
         $keys = (array)$this->bindingKey;
 
@@ -476,7 +476,7 @@ class SelectLoader
      * @param array<string, mixed> $options The options passed to the eager loader
      * @return array<string, mixed>
      */
-    protected function _buildResultMap(SelectQuery $fetchQuery, array $options): array
+    protected function buildResultMap(SelectQuery $fetchQuery, array $options): array
     {
         $resultMap = [];
         $singleResult = in_array($this->associationType, [Association::MANY_TO_ONE, Association::ONE_TO_ONE], true);
@@ -519,7 +519,7 @@ class SelectLoader
      * @param array<string, mixed> $options The options passed to the eagerLoader method
      * @return \Closure
      */
-    protected function _resultInjector(SelectQuery $fetchQuery, array $resultMap, array $options): Closure
+    protected function resultInjector(SelectQuery $fetchQuery, array $resultMap, array $options): Closure
     {
         $keys = $this->associationType === Association::MANY_TO_ONE ?
             $this->foreignKey :
@@ -533,7 +533,7 @@ class SelectLoader
 
         $nestKey = $options['nestKey'];
         if (count($sourceKeys) > 1) {
-            return $this->_multiKeysInjector($resultMap, $sourceKeys, $nestKey);
+            return $this->multiKeysInjector($resultMap, $sourceKeys, $nestKey);
         }
 
         $sourceKey = $sourceKeys[0];
@@ -557,7 +557,7 @@ class SelectLoader
      * @param string $nestKey The key under which results should be nested
      * @return \Closure
      */
-    protected function _multiKeysInjector(array $resultMap, array $sourceKeys, string $nestKey): Closure
+    protected function multiKeysInjector(array $resultMap, array $sourceKeys, string $nestKey): Closure
     {
         return function ($row) use ($resultMap, $sourceKeys, $nestKey) {
             $values = [];

--- a/src/ORM/Association/Loader/SelectWithPivotLoader.php
+++ b/src/ORM/Association/Loader/SelectWithPivotLoader.php
@@ -80,7 +80,7 @@ class SelectWithPivotLoader extends SelectLoader
      * @return \Cake\ORM\Query\SelectQuery
      * @throws \InvalidArgumentException When a key is required for associations but not selected.
      */
-    protected function _buildQuery(array $options): SelectQuery
+    protected function buildQuery(array $options): SelectQuery
     {
         $name = $this->junctionAssociationName;
         $assoc = $this->junctionAssoc;
@@ -91,7 +91,7 @@ class SelectWithPivotLoader extends SelectLoader
             unset($options['queryBuilder']);
         }
 
-        $query = parent::_buildQuery($options);
+        $query = parent::buildQuery($options);
 
         if ($queryBuilder) {
             /** @var \Cake\ORM\Query\SelectQuery $query */
@@ -137,9 +137,9 @@ class SelectWithPivotLoader extends SelectLoader
     /**
      * @inheritDoc
      */
-    protected function _assertFieldsPresent(SelectQuery $fetchQuery, array $key): void
+    protected function assertFieldsPresent(SelectQuery $fetchQuery, array $key): void
     {
-        // _buildQuery() manually adds in required fields from junction table
+        // buildQuery() manually adds in required fields from junction table
     }
 
     /**
@@ -149,7 +149,7 @@ class SelectWithPivotLoader extends SelectLoader
      * @param array<string, mixed> $options the options to use for getting the link field.
      * @return array<string>|string
      */
-    protected function _linkField(array $options): array|string
+    protected function linkField(array $options): array|string
     {
         $links = [];
         $name = $this->junctionAssociationName;
@@ -174,7 +174,7 @@ class SelectWithPivotLoader extends SelectLoader
      * @return array<string, mixed>
      * @throws \Cake\Database\Exception\DatabaseException when the association property is not part of the results set.
      */
-    protected function _buildResultMap(SelectQuery $fetchQuery, array $options): array
+    protected function buildResultMap(SelectQuery $fetchQuery, array $options): array
     {
         $resultMap = [];
         $key = (array)$options['foreignKey'];

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -226,7 +226,7 @@ class AssociationCollection implements IteratorAggregate
             return true;
         }
 
-        return $this->_saveAssociations($table, $entity, $associations, $options, false);
+        return $this->saveAssociations($table, $entity, $associations, $options, false);
     }
 
     /**
@@ -248,7 +248,7 @@ class AssociationCollection implements IteratorAggregate
             return true;
         }
 
-        return $this->_saveAssociations($table, $entity, $associations, $options, true);
+        return $this->saveAssociations($table, $entity, $associations, $options, true);
     }
 
     /**
@@ -263,7 +263,7 @@ class AssociationCollection implements IteratorAggregate
      * @return bool Success
      * @throws \InvalidArgumentException When an unknown alias is used.
      */
-    protected function _saveAssociations(
+    protected function saveAssociations(
         Table $table,
         EntityInterface $entity,
         array $associations,
@@ -288,7 +288,7 @@ class AssociationCollection implements IteratorAggregate
             if ($relation->isOwningSide($table) !== $owningSide) {
                 continue;
             }
-            if (!$this->_save($relation, $entity, $nested, $options)) {
+            if (!$this->save($relation, $entity, $nested, $options)) {
                 return false;
             }
         }
@@ -305,7 +305,7 @@ class AssociationCollection implements IteratorAggregate
      * @param array<string, mixed> $options Original options
      * @return bool Success
      */
-    protected function _save(
+    protected function save(
         Association $association,
         EntityInterface $entity,
         array $nested,
@@ -371,7 +371,7 @@ class AssociationCollection implements IteratorAggregate
             return [];
         }
 
-        return $this->_normalizeAssociations($keys);
+        return $this->normalizeAssociations($keys);
     }
 
     /**

--- a/src/ORM/AssociationsNormalizerTrait.php
+++ b/src/ORM/AssociationsNormalizerTrait.php
@@ -29,7 +29,7 @@ trait AssociationsNormalizerTrait
      * @param array|string $associations The array of included associations.
      * @return array An array having dot notation transformed into nested arrays
      */
-    protected function _normalizeAssociations(array|string $associations): array
+    protected function normalizeAssociations(array|string $associations): array
     {
         $result = [];
         foreach ((array)$associations as $table => $options) {

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -152,12 +152,12 @@ class Behavior implements EventListenerInterface
      */
     public function __construct(Table $table, array $config = [])
     {
-        $config = $this->_resolveMethodAliases(
+        $config = $this->resolveMethodAliases(
             'implementedFinders',
             $this->_defaultConfig,
             $config,
         );
-        $config = $this->_resolveMethodAliases(
+        $config = $this->resolveMethodAliases(
             'implementedMethods',
             $this->_defaultConfig,
             $config,
@@ -198,7 +198,7 @@ class Behavior implements EventListenerInterface
      * @param array<string, mixed> $config The customized method mappings.
      * @return array A de-duped list of config data.
      */
-    protected function _resolveMethodAliases(string $key, array $defaults, array $config): array
+    protected function resolveMethodAliases(string $key, array $defaults, array $config): array
     {
         if (!isset($defaults[$key], $config[$key])) {
             return $config;
@@ -329,7 +329,7 @@ class Behavior implements EventListenerInterface
             return $methods;
         }
 
-        return $this->_reflectionCache()['finders'];
+        return $this->reflectionCache()['finders'];
     }
 
     /**
@@ -361,7 +361,7 @@ class Behavior implements EventListenerInterface
             return $methods;
         }
 
-        return $this->_reflectionCache()['methods'];
+        return $this->reflectionCache()['methods'];
     }
 
     /**
@@ -374,7 +374,7 @@ class Behavior implements EventListenerInterface
      * @return array
      * @throws \ReflectionException
      */
-    protected function _reflectionCache(): array
+    protected function reflectionCache(): array
     {
         $class = static::class;
         if (isset(self::$_reflectionCache[$class])) {

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -169,7 +169,7 @@ class CounterCacheBehavior extends Behavior
             return;
         }
 
-        $this->_processAssociations($event, $entity);
+        $this->processAssociations($event, $entity);
         $this->_ignoreDirty = [];
     }
 
@@ -189,7 +189,7 @@ class CounterCacheBehavior extends Behavior
             return;
         }
 
-        $this->_processAssociations($event, $entity);
+        $this->processAssociations($event, $entity);
     }
 
     /**
@@ -282,7 +282,7 @@ class CounterCacheBehavior extends Behavior
 
                 $countConditions = array_combine($foreignKeys, $updateConditions);
 
-                $count = $this->_getCount($config, $countConditions);
+                $count = $this->getCount($config, $countConditions);
                 $assoc->getTarget()->updateAll([$field => $count], $updateConditions);
             }
         } while (!$singlePage && $results->count() === $limit);
@@ -295,11 +295,11 @@ class CounterCacheBehavior extends Behavior
      * @param \Cake\Datasource\EntityInterface $entity Entity.
      * @return void
      */
-    protected function _processAssociations(EventInterface $event, EntityInterface $entity): void
+    protected function processAssociations(EventInterface $event, EntityInterface $entity): void
     {
         foreach ($this->_config as $assoc => $settings) {
             $assoc = $this->_table->getAssociation($assoc);
-            $this->_processAssociation($event, $entity, $assoc, $settings);
+            $this->processAssociation($event, $entity, $assoc, $settings);
         }
     }
 
@@ -313,7 +313,7 @@ class CounterCacheBehavior extends Behavior
      * @return void
      * @throws \RuntimeException If invalid callable is passed.
      */
-    protected function _processAssociation(
+    protected function processAssociation(
         EventInterface $event,
         EntityInterface $entity,
         Association $assoc,
@@ -352,22 +352,22 @@ class CounterCacheBehavior extends Behavior
                 continue;
             }
 
-            if ($this->_shouldUpdateCount($updateConditions)) {
+            if ($this->shouldUpdateCount($updateConditions)) {
                 if ($config instanceof Closure) {
                     $count = $config($event, $entity, $this->_table, false);
                 } else {
-                    $count = $this->_getCount($config, $countConditions);
+                    $count = $this->getCount($config, $countConditions);
                 }
                 if ($count !== false) {
                     $assoc->getTarget()->updateAll([$field => $count], $updateConditions);
                 }
             }
 
-            if ($updateOriginalConditions && $this->_shouldUpdateCount($updateOriginalConditions)) {
+            if ($updateOriginalConditions && $this->shouldUpdateCount($updateOriginalConditions)) {
                 if ($config instanceof Closure) {
                     $count = $config($event, $entity, $this->_table, true);
                 } else {
-                    $count = $this->_getCount($config, $countOriginalConditions);
+                    $count = $this->getCount($config, $countOriginalConditions);
                 }
                 if ($count !== false) {
                     $assoc->getTarget()->updateAll([$field => $count], $updateOriginalConditions);
@@ -382,7 +382,7 @@ class CounterCacheBehavior extends Behavior
      * @param array $conditions Conditions to update count.
      * @return bool True if the count update should happen, false otherwise.
      */
-    protected function _shouldUpdateCount(array $conditions): bool
+    protected function shouldUpdateCount(array $conditions): bool
     {
         return !empty(array_filter($conditions, function ($value) {
             return $value !== null;
@@ -397,7 +397,7 @@ class CounterCacheBehavior extends Behavior
      * @return \Cake\ORM\Query\SelectQuery|int The query to fetch the number of
      *   relations matching the given config and conditions or the number itself.
      */
-    protected function _getCount(array $config, array $conditions): SelectQuery|int
+    protected function getCount(array $config, array $conditions): SelectQuery|int
     {
         $finder = 'all';
         if (!empty($config['finder'])) {

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -118,7 +118,7 @@ class TimestampBehavior extends Behavior
                     !$new
                 )
             ) {
-                $this->_updateField($entity, $field, $refresh);
+                $this->updateField($entity, $field, $refresh);
             }
         }
     }
@@ -186,7 +186,7 @@ class TimestampBehavior extends Behavior
             if (in_array($when, ['always', 'existing'], true)) {
                 $return = true;
                 $entity->setDirty($field, false);
-                $this->_updateField($entity, $field, $refresh);
+                $this->updateField($entity, $field, $refresh);
             }
         }
 
@@ -201,7 +201,7 @@ class TimestampBehavior extends Behavior
      * @param bool $refreshTimestamp Whether to refresh timestamp.
      * @return void
      */
-    protected function _updateField(EntityInterface $entity, string $field, bool $refreshTimestamp): void
+    protected function updateField(EntityInterface $entity, string $field, bool $refreshTimestamp): void
     {
         if ($entity->isDirty($field)) {
             return;

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -106,7 +106,7 @@ class TreeBehavior extends Behavior
         $isNew = $entity->isNew();
         $config = $this->getConfig();
         $parent = $entity->get($config['parent']);
-        $primaryKey = $this->_getPrimaryKey();
+        $primaryKey = $this->getPrimaryKey();
         $dirty = $entity->isDirty($config['parent']);
         $level = $config['level'];
 
@@ -116,11 +116,11 @@ class TreeBehavior extends Behavior
 
         if ($isNew) {
             if ($parent) {
-                $parentNode = $this->_getNode($parent);
+                $parentNode = $this->getNode($parent);
                 $edge = $parentNode->get($config['right']);
                 $entity->set($config['left'], $edge);
                 $entity->set($config['right'], $edge + 1);
-                $this->_sync(2, '+', ">= {$edge}");
+                $this->sync(2, '+', ">= {$edge}");
 
                 if ($level) {
                     $entity->set($level, $parentNode[$level] + 1);
@@ -129,7 +129,7 @@ class TreeBehavior extends Behavior
                 return;
             }
 
-            $edge = $this->_getMax();
+            $edge = $this->getMax();
             $entity->set($config['left'], $edge + 1);
             $entity->set($config['right'], $edge + 2);
 
@@ -142,17 +142,17 @@ class TreeBehavior extends Behavior
 
         if ($dirty) {
             if ($parent) {
-                $this->_setParent($entity, $parent);
+                $this->setParent($entity, $parent);
 
                 if ($level) {
-                    $parentNode = $this->_getNode($parent);
+                    $parentNode = $this->getNode($parent);
                     $entity->set($level, $parentNode[$level] + 1);
                 }
 
                 return;
             }
 
-            $this->_setAsRoot($entity);
+            $this->setAsRoot($entity);
 
             if ($level) {
                 $entity->set($level, 0);
@@ -175,7 +175,7 @@ class TreeBehavior extends Behavior
             return;
         }
 
-        $this->_setChildrenLevel($entity);
+        $this->setChildrenLevel($entity);
     }
 
     /**
@@ -184,7 +184,7 @@ class TreeBehavior extends Behavior
      * @param \Cake\Datasource\EntityInterface $entity The entity whose descendants need to be updated.
      * @return void
      */
-    protected function _setChildrenLevel(EntityInterface $entity): void
+    protected function setChildrenLevel(EntityInterface $entity): void
     {
         $config = $this->getConfig();
 
@@ -192,7 +192,7 @@ class TreeBehavior extends Behavior
             return;
         }
 
-        $primaryKey = $this->_getPrimaryKey();
+        $primaryKey = $this->getPrimaryKey();
         $primaryKeyValue = $entity->get($primaryKey);
         $depths = [$primaryKeyValue => $entity->get($config['level'])];
 
@@ -200,7 +200,7 @@ class TreeBehavior extends Behavior
         $children = $this->_table->find(
             'children',
             for: $primaryKeyValue,
-            fields: [$this->_getPrimaryKey(), $config['parent'], $config['level']],
+            fields: [$this->getPrimaryKey(), $config['parent'], $config['level']],
             order: $config['left'],
         )
         ->all();
@@ -227,14 +227,14 @@ class TreeBehavior extends Behavior
     public function beforeDelete(EventInterface $event, EntityInterface $entity): void
     {
         $config = $this->getConfig();
-        $this->_ensureFields($entity);
+        $this->ensureFields($entity);
         $left = $entity->get($config['left']);
         $right = $entity->get($config['right']);
         $diff = (int)($right - $left + 1);
 
         if ($diff > 2) {
             if ($this->getConfig('cascadeCallbacks')) {
-                $query = $this->_scope($this->_table->query())
+                $query = $this->scope($this->_table->query())
                     ->where(
                         fn(QueryExpression $exp) => $exp
                             ->gte($config['leftField'], $left + 1)
@@ -246,7 +246,7 @@ class TreeBehavior extends Behavior
                     $this->_table->delete($entityToDelete, ['atomic' => false]);
                 }
             } else {
-                $this->_scope($this->_table->deleteQuery())
+                $this->scope($this->_table->deleteQuery())
                     ->where(
                         fn(QueryExpression $exp) => $exp
                             ->gte($config['leftField'], $left + 1)
@@ -256,7 +256,7 @@ class TreeBehavior extends Behavior
             }
         }
 
-        $this->_sync($diff, '-', "> {$right}");
+        $this->sync($diff, '-', "> {$right}");
     }
 
     /**
@@ -269,11 +269,11 @@ class TreeBehavior extends Behavior
      * @return void
      * @throws \Cake\Database\Exception\DatabaseException if the parent to set to the entity is not valid
      */
-    protected function _setParent(EntityInterface $entity, mixed $parent): void
+    protected function setParent(EntityInterface $entity, mixed $parent): void
     {
         $config = $this->getConfig();
-        $parentNode = $this->_getNode($parent);
-        $this->_ensureFields($entity);
+        $parentNode = $this->getNode($parent);
+        $this->ensureFields($entity);
         $parentLeft = $parentNode->get($config['left']);
         $parentRight = $parentNode->get($config['right']);
         $right = $entity->get($config['right']);
@@ -283,7 +283,7 @@ class TreeBehavior extends Behavior
             throw new DatabaseException(sprintf(
                 'Cannot use node `%s` as parent for entity `%s`.',
                 $parent,
-                $entity->get($this->_getPrimaryKey()),
+                $entity->get($this->getPrimaryKey()),
             ));
         }
 
@@ -307,13 +307,13 @@ class TreeBehavior extends Behavior
             // Correcting internal subtree
             $internalLeft = $left + 1;
             $internalRight = $right - 1;
-            $this->_sync($targetLeft - $left, '+', "BETWEEN {$internalLeft} AND {$internalRight}", true);
+            $this->sync($targetLeft - $left, '+', "BETWEEN {$internalLeft} AND {$internalRight}", true);
         }
 
-        $this->_sync($diff, '+', "BETWEEN {$min} AND {$max}");
+        $this->sync($diff, '+', "BETWEEN {$min} AND {$max}");
 
         if ($right - $left > 1) {
-            $this->_unmarkInternalTree();
+            $this->unmarkInternalTree();
         }
 
         // Allocating new position
@@ -329,11 +329,11 @@ class TreeBehavior extends Behavior
      * @param \Cake\Datasource\EntityInterface $entity The entity to set as a new root
      * @return void
      */
-    protected function _setAsRoot(EntityInterface $entity): void
+    protected function setAsRoot(EntityInterface $entity): void
     {
         $config = $this->getConfig();
-        $edge = $this->_getMax();
-        $this->_ensureFields($entity);
+        $edge = $this->getMax();
+        $this->ensureFields($entity);
         $right = $entity->get($config['right']);
         $left = $entity->get($config['left']);
         $diff = $right - $left;
@@ -342,13 +342,13 @@ class TreeBehavior extends Behavior
             //Correcting internal subtree
             $internalLeft = $left + 1;
             $internalRight = $right - 1;
-            $this->_sync($edge - $diff - $left, '+', "BETWEEN {$internalLeft} AND {$internalRight}", true);
+            $this->sync($edge - $diff - $left, '+', "BETWEEN {$internalLeft} AND {$internalRight}", true);
         }
 
-        $this->_sync($diff + 1, '-', "BETWEEN {$right} AND {$edge}");
+        $this->sync($diff + 1, '-', "BETWEEN {$right} AND {$edge}");
 
         if ($right - $left > 1) {
-            $this->_unmarkInternalTree();
+            $this->unmarkInternalTree();
         }
 
         $entity->set($config['left'], $edge - $diff);
@@ -362,7 +362,7 @@ class TreeBehavior extends Behavior
      *
      * @return void
      */
-    protected function _unmarkInternalTree(): void
+    protected function unmarkInternalTree(): void
     {
         $config = $this->getConfig();
         $this->_table->updateAll(
@@ -401,7 +401,7 @@ class TreeBehavior extends Behavior
 
         $node = $this->_table->get($for, select: [$left, $right]);
 
-        return $this->_scope($query)
+        return $this->scope($query)
             ->where([
                 "{$left} <=" => $node->get($config['left']),
                 "{$right} >=" => $node->get($config['right']),
@@ -423,12 +423,12 @@ class TreeBehavior extends Behavior
         $parent = $this->_table->aliasField($config['parent']);
 
         if ($direct) {
-            return $this->_scope($this->_table->find())
-                ->where([$parent => $node->get($this->_getPrimaryKey())])
+            return $this->scope($this->_table->find())
+                ->where([$parent => $node->get($this->getPrimaryKey())])
                 ->count();
         }
 
-        $this->_ensureFields($node);
+        $this->ensureFields($node);
 
         return ($node->get($config['right']) - $node->get($config['left']) - 1) / 2;
     }
@@ -460,12 +460,12 @@ class TreeBehavior extends Behavior
         }
 
         if ($direct) {
-            return $this->_scope($query)->where([$parent => $for]);
+            return $this->scope($query)->where([$parent => $for]);
         }
 
-        $node = $this->_getNode($for);
+        $node = $this->getNode($for);
 
-        return $this->_scope($query)
+        return $this->scope($query)
             ->where([
                 "{$right} <" => $node->get($config['right']),
                 "{$left} >" => $node->get($config['left']),
@@ -493,7 +493,7 @@ class TreeBehavior extends Behavior
     ): SelectQuery {
         $left = $this->_table->aliasField($this->getConfig('left'));
 
-        $results = $this->_scope($query)
+        $results = $this->scope($query)
             ->find('threaded', parentField: $this->getConfig('parent'), order: [$left => 'ASC']);
 
         return $this->formatTreeList($results, $keyPath, $valuePath, $spacer);
@@ -520,7 +520,7 @@ class TreeBehavior extends Behavior
     ): SelectQuery {
         return $query->formatResults(
             function (CollectionInterface $results) use ($keyPath, $valuePath, $spacer) {
-                $keyPath ??= $this->_getPrimaryKey();
+                $keyPath ??= $this->getPrimaryKey();
                 $valuePath ??= $this->_table->getDisplayField();
                 $spacer ??= '_';
 
@@ -547,9 +547,9 @@ class TreeBehavior extends Behavior
     public function removeFromTree(EntityInterface $node): EntityInterface|false
     {
         return $this->_table->getConnection()->transactional(function () use ($node) {
-            $this->_ensureFields($node);
+            $this->ensureFields($node);
 
-            return $this->_removeFromTree($node);
+            return $this->doRemoveFromTree($node);
         });
     }
 
@@ -560,7 +560,7 @@ class TreeBehavior extends Behavior
      * @return \Cake\Datasource\EntityInterface|false the node after being removed from the tree or
      * false on error
      */
-    protected function _removeFromTree(EntityInterface $node): EntityInterface|false
+    protected function doRemoveFromTree(EntityInterface $node): EntityInterface|false
     {
         $config = $this->getConfig();
         $left = $node->get($config['left']);
@@ -573,14 +573,14 @@ class TreeBehavior extends Behavior
             return $this->_table->save($node);
         }
 
-        $primary = $this->_getPrimaryKey();
+        $primary = $this->getPrimaryKey();
         $this->_table->updateAll(
             [$config['parent'] => $parent],
             [$config['parent'] => $node->get($primary)],
         );
-        $this->_sync(1, '-', 'BETWEEN ' . ($left + 1) . ' AND ' . ($right - 1));
-        $this->_sync(2, '-', "> {$right}");
-        $edge = $this->_getMax();
+        $this->sync(1, '-', 'BETWEEN ' . ($left + 1) . ' AND ' . ($right - 1));
+        $this->sync(2, '-', "> {$right}");
+        $edge = $this->getMax();
         $node->set($config['left'], $edge + 1);
         $node->set($config['right'], $edge + 2);
         $fields = [$config['parent'], $config['left'], $config['right']];
@@ -612,9 +612,9 @@ class TreeBehavior extends Behavior
         }
 
         return $this->_table->getConnection()->transactional(function () use ($node, $number) {
-            $this->_ensureFields($node);
+            $this->ensureFields($node);
 
-            return $this->_moveUp($node, $number);
+            return $this->doMoveUp($node, $number);
         });
     }
 
@@ -626,7 +626,7 @@ class TreeBehavior extends Behavior
      * @return \Cake\Datasource\EntityInterface $node The node after being moved
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When node was not found
      */
-    protected function _moveUp(EntityInterface $node, int|bool $number): EntityInterface
+    protected function doMoveUp(EntityInterface $node, int|bool $number): EntityInterface
     {
         $config = $this->getConfig();
         [$parent, $left, $right] = [$config['parent'], $config['left'], $config['right']];
@@ -635,7 +635,7 @@ class TreeBehavior extends Behavior
         $targetNode = null;
         if ($number !== true) {
             /** @var \Cake\Datasource\EntityInterface|null $targetNode */
-            $targetNode = $this->_scope($this->_table->find())
+            $targetNode = $this->scope($this->_table->find())
                 ->select([$left, $right])
                 ->where(["{$parent} IS" => $nodeParent])
                 ->where(fn(QueryExpression $exp) => $exp->lt($config['rightField'], $nodeLeft))
@@ -646,7 +646,7 @@ class TreeBehavior extends Behavior
         }
         if (!$targetNode) {
             /** @var \Cake\Datasource\EntityInterface|null $targetNode */
-            $targetNode = $this->_scope($this->_table->find())
+            $targetNode = $this->scope($this->_table->find())
                 ->select([$left, $right])
                 ->where(["{$parent} IS" => $nodeParent])
                 ->where(fn(QueryExpression $exp) => $exp->lt($config['rightField'], $nodeLeft))
@@ -660,16 +660,16 @@ class TreeBehavior extends Behavior
         }
 
         [$targetLeft] = array_values($targetNode->extract([$left, $right]));
-        $edge = $this->_getMax();
+        $edge = $this->getMax();
         $leftBoundary = $targetLeft;
         $rightBoundary = $nodeLeft - 1;
 
         $nodeToEdge = $edge - $nodeLeft + 1;
         $shift = $nodeRight - $nodeLeft + 1;
         $nodeToHole = $edge - $leftBoundary + 1;
-        $this->_sync($nodeToEdge, '+', "BETWEEN {$nodeLeft} AND {$nodeRight}");
-        $this->_sync($shift, '+', "BETWEEN {$leftBoundary} AND {$rightBoundary}");
-        $this->_sync($nodeToHole, '-', "> {$edge}");
+        $this->sync($nodeToEdge, '+', "BETWEEN {$nodeLeft} AND {$nodeRight}");
+        $this->sync($shift, '+', "BETWEEN {$leftBoundary} AND {$rightBoundary}");
+        $this->sync($nodeToHole, '-', "> {$edge}");
 
         /** @var string $left */
         $node->set($left, $targetLeft);
@@ -700,9 +700,9 @@ class TreeBehavior extends Behavior
         }
 
         return $this->_table->getConnection()->transactional(function () use ($node, $number) {
-            $this->_ensureFields($node);
+            $this->ensureFields($node);
 
-            return $this->_moveDown($node, $number);
+            return $this->doMoveDown($node, $number);
         });
     }
 
@@ -714,7 +714,7 @@ class TreeBehavior extends Behavior
      * @return \Cake\Datasource\EntityInterface $node The node after being moved
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When node was not found
      */
-    protected function _moveDown(EntityInterface $node, int|bool $number): EntityInterface
+    protected function doMoveDown(EntityInterface $node, int|bool $number): EntityInterface
     {
         $config = $this->getConfig();
         [$parent, $left, $right] = [$config['parent'], $config['left'], $config['right']];
@@ -724,7 +724,7 @@ class TreeBehavior extends Behavior
         $targetNode = null;
         if ($number !== true) {
             /** @var \Cake\Datasource\EntityInterface|null $targetNode */
-            $targetNode = $this->_scope($this->_table->find())
+            $targetNode = $this->scope($this->_table->find())
                 ->select([$left, $right])
                 ->where(["{$parent} IS" => $nodeParent])
                 ->where(fn(QueryExpression $exp) => $exp->gt($config['leftField'], $nodeRight))
@@ -735,7 +735,7 @@ class TreeBehavior extends Behavior
         }
         if (!$targetNode) {
             /** @var \Cake\Datasource\EntityInterface|null $targetNode */
-            $targetNode = $this->_scope($this->_table->find())
+            $targetNode = $this->scope($this->_table->find())
                 ->select([$left, $right])
                 ->where(["{$parent} IS" => $nodeParent])
                 ->where(fn(QueryExpression $exp) => $exp->gt($config['leftField'], $nodeRight))
@@ -749,16 +749,16 @@ class TreeBehavior extends Behavior
         }
 
         [, $targetRight] = array_values($targetNode->extract([$left, $right]));
-        $edge = $this->_getMax();
+        $edge = $this->getMax();
         $leftBoundary = $nodeRight + 1;
         $rightBoundary = $targetRight;
 
         $nodeToEdge = $edge - $nodeLeft + 1;
         $shift = $nodeRight - $nodeLeft + 1;
         $nodeToHole = $edge - $rightBoundary + $shift;
-        $this->_sync($nodeToEdge, '+', "BETWEEN {$nodeLeft} AND {$nodeRight}");
-        $this->_sync($shift, '-', "BETWEEN {$leftBoundary} AND {$rightBoundary}");
-        $this->_sync($nodeToHole, '-', "> {$edge}");
+        $this->sync($nodeToEdge, '+', "BETWEEN {$nodeLeft} AND {$nodeRight}");
+        $this->sync($shift, '-', "BETWEEN {$leftBoundary} AND {$rightBoundary}");
+        $this->sync($nodeToHole, '-', "> {$edge}");
 
         $node->set($left, $targetRight - ($nodeRight - $nodeLeft));
         $node->set($right, $targetRight);
@@ -776,17 +776,17 @@ class TreeBehavior extends Behavior
      * @return \Cake\Datasource\EntityInterface
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When node was not found
      */
-    protected function _getNode(mixed $id): EntityInterface
+    protected function getNode(mixed $id): EntityInterface
     {
         $config = $this->getConfig();
         [$parent, $left, $right] = [$config['parent'], $config['left'], $config['right']];
-        $primaryKey = $this->_getPrimaryKey();
+        $primaryKey = $this->getPrimaryKey();
         $fields = [$parent, $left, $right];
         if ($config['level']) {
             $fields[] = $config['level'];
         }
 
-        $node = $this->_scope($this->_table->find())
+        $node = $this->scope($this->_table->find())
             ->select($fields)
             ->where([$this->_table->aliasField($primaryKey) => $id])
             ->first();
@@ -807,7 +807,7 @@ class TreeBehavior extends Behavior
     public function recover(): void
     {
         $this->_table->getConnection()->transactional(function (): void {
-            $this->_recoverTree();
+            $this->recoverTree();
         });
     }
 
@@ -819,14 +819,14 @@ class TreeBehavior extends Behavior
      * @param int $level Node level
      * @return int The next lftRght value
      */
-    protected function _recoverTree(int $lftRght = 1, mixed $parentId = null, int $level = 0): int
+    protected function recoverTree(int $lftRght = 1, mixed $parentId = null, int $level = 0): int
     {
         $config = $this->getConfig();
         [$parent, $left, $right] = [$config['parent'], $config['left'], $config['right']];
-        $primaryKey = $this->_getPrimaryKey();
+        $primaryKey = $this->getPrimaryKey();
         $order = $config['recoverOrder'] ?: $primaryKey;
 
-        $nodes = $this->_scope($this->_table->selectQuery())
+        $nodes = $this->scope($this->_table->selectQuery())
             ->select($primaryKey)
             ->where([$parent . ' IS' => $parentId])
             ->orderBy($order)
@@ -835,7 +835,7 @@ class TreeBehavior extends Behavior
 
         foreach ($nodes as $node) {
             $nodeLft = $lftRght++;
-            $lftRght = $this->_recoverTree($lftRght, $node[$primaryKey], $level + 1);
+            $lftRght = $this->recoverTree($lftRght, $node[$primaryKey], $level + 1);
 
             $fields = [$left => $nodeLft, $right => $lftRght++];
             if ($config['level']) {
@@ -856,11 +856,11 @@ class TreeBehavior extends Behavior
      *
      * @return int
      */
-    protected function _getMax(): int
+    protected function getMax(): int
     {
         $field = $this->_config['right'];
         $rightField = $this->_config['rightField'];
-        $edge = $this->_scope($this->_table->find())
+        $edge = $this->scope($this->_table->find())
             ->select([$field])
             ->orderByDesc($rightField)
             ->first();
@@ -884,13 +884,13 @@ class TreeBehavior extends Behavior
      * modified by future calls to this function.
      * @return void
      */
-    protected function _sync(int $shift, string $dir, string $conditions, bool $mark = false): void
+    protected function sync(int $shift, string $dir, string $conditions, bool $mark = false): void
     {
         $config = $this->_config;
 
         /** @var \Cake\Database\Expression\IdentifierExpression $field */
         foreach ([$config['leftField'], $config['rightField']] as $field) {
-            $query = $this->_scope($this->_table->updateQuery());
+            $query = $this->scope($this->_table->updateQuery());
             $exp = $query->newExpr();
 
             $movement = clone $exp;
@@ -921,7 +921,7 @@ class TreeBehavior extends Behavior
      * @psalm-param T $query
      * @psalm-return T
      */
-    protected function _scope(SelectQuery|UpdateQuery|DeleteQuery $query): SelectQuery|UpdateQuery|DeleteQuery
+    protected function scope(SelectQuery|UpdateQuery|DeleteQuery $query): SelectQuery|UpdateQuery|DeleteQuery
     {
         $scope = $this->getConfig('scope');
 
@@ -939,7 +939,7 @@ class TreeBehavior extends Behavior
      * @param \Cake\Datasource\EntityInterface $entity The entity to ensure fields for
      * @return void
      */
-    protected function _ensureFields(EntityInterface $entity): void
+    protected function ensureFields(EntityInterface $entity): void
     {
         $config = $this->getConfig();
         $fields = [$config['left'], $config['right']];
@@ -948,7 +948,7 @@ class TreeBehavior extends Behavior
             return;
         }
 
-        $fresh = $this->_table->get($entity->get($this->_getPrimaryKey()));
+        $fresh = $this->_table->get($entity->get($this->getPrimaryKey()));
         $entity->patch($fresh->extract($fields), ['guard' => false]);
 
         foreach ($fields as $field) {
@@ -961,7 +961,7 @@ class TreeBehavior extends Behavior
      *
      * @return string
      */
-    protected function _getPrimaryKey(): string
+    protected function getPrimaryKey(): string
     {
         if (!$this->_primaryKey) {
             $primaryKey = (array)$this->_table->getPrimaryKey();
@@ -979,7 +979,7 @@ class TreeBehavior extends Behavior
      */
     public function getLevel(EntityInterface|string|int $entity): int|false
     {
-        $primaryKey = $this->_getPrimaryKey();
+        $primaryKey = $this->getPrimaryKey();
         $id = $entity;
         if ($entity instanceof EntityInterface) {
             $id = $entity->get($primaryKey);
@@ -999,6 +999,6 @@ class TreeBehavior extends Behavior
             $config['right'] . ' >' => $entity[$config['right']],
         ]);
 
-        return $this->_scope($query)->count();
+        return $this->scope($query)->count();
     }
 }

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -107,7 +107,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @param string $class Partial classname to resolve.
      * @return class-string<\Cake\ORM\Behavior>|null Either the correct class name or null.
      */
-    protected function _resolveClassName(string $class): ?string
+    protected function resolveClassName(string $class): ?string
     {
         /** @var class-string<\Cake\ORM\Behavior>|null */
         return static::className($class);
@@ -124,7 +124,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @return void
      * @throws \Cake\ORM\Exception\MissingBehaviorException
      */
-    protected function _throwMissingClassError(string $class, ?string $plugin): void
+    protected function throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new MissingBehaviorException([
             'class' => $class . 'Behavior',
@@ -143,7 +143,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @param array<string, mixed> $config An array of config to use for the behavior.
      * @return \Cake\ORM\Behavior The constructed behavior class.
      */
-    protected function _create(object|string $class, string $alias, array $config): Behavior
+    protected function create(object|string $class, string $alias, array $config): Behavior
     {
         if (is_object($class)) {
             return $class;

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -155,7 +155,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
         if ($enable) {
             $this->getEventManager()->on($instance);
         }
-        $methods = $this->_getMethods($instance, $class, $alias);
+        $methods = $this->getMethods($instance, $class, $alias);
         $this->_methodMap += $methods['methods'];
         $this->_finderMap += $methods['finders'];
 
@@ -175,7 +175,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @return array A list of implemented finders and methods.
      * @throws \LogicException when duplicate methods are connected.
      */
-    protected function _getMethods(Behavior $instance, string $class, string $alias): array
+    protected function getMethods(Behavior $instance, string $class, string $alias): array
     {
         $finders = array_change_key_case($instance->implementedFinders());
         $methods = array_change_key_case($instance->implementedMethods());
@@ -222,7 +222,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
     {
         parent::set($name, $object);
 
-        $methods = $this->_getMethods($object, $object::class, $name);
+        $methods = $this->getMethods($object, $object::class, $name);
         $this->_methodMap += $methods['methods'];
         $this->_finderMap += $methods['finders'];
 

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -146,7 +146,7 @@ class EagerLoader
         }
 
         $associations = (array)$associations;
-        $associations = $this->_reformatContain($associations, $this->_containments);
+        $associations = $this->reformatContain($associations, $this->_containments);
         $this->_normalized = null;
         $this->_loadExternal = [];
         $this->_aliasList = [];
@@ -300,7 +300,7 @@ class EagerLoader
                 $contain = $this->_containments;
                 break;
             }
-            $contain[$alias] = $this->_normalizeContain(
+            $contain[$alias] = $this->normalizeContain(
                 $repository,
                 $alias,
                 $options,
@@ -321,7 +321,7 @@ class EagerLoader
      * with the new one.
      * @return array
      */
-    protected function _reformatContain(array $associations, array $original): array
+    protected function reformatContain(array $associations, array $original): array
     {
         $result = $original;
 
@@ -356,7 +356,7 @@ class EagerLoader
                 $options = isset($options['config']) ?
                     $options['config'] + $options['associations'] :
                     $options;
-                $options = $this->_reformatContain(
+                $options = $this->reformatContain(
                     $options,
                     $pointer[$table] ?? [],
                 );
@@ -435,10 +435,10 @@ class EagerLoader
     {
         $contain = $this->normalized($repository);
         $matching = $this->_matching ? $this->_matching->normalized($repository) : [];
-        $this->_fixStrategies();
+        $this->fixStrategies();
         $this->_loadExternal = [];
 
-        return $this->_resolveJoins($contain, $matching);
+        return $this->resolveJoins($contain, $matching);
     }
 
     /**
@@ -474,7 +474,7 @@ class EagerLoader
      * @return \Cake\ORM\EagerLoadable Object with normalized associations
      * @throws \InvalidArgumentException When containments refer to associations that do not exist.
      */
-    protected function _normalizeContain(Table $parent, string $alias, array $options, array $paths): EagerLoadable
+    protected function normalizeContain(Table $parent, string $alias, array $options, array $paths): EagerLoadable
     {
         $defaults = $this->_containOptions;
         $instance = $parent->getAssociation($alias);
@@ -514,7 +514,7 @@ class EagerLoader
         foreach ($extra as $t => $assoc) {
             $eagerLoadable->addAssociation(
                 $t,
-                $this->_normalizeContain($table, $t, $assoc, $paths),
+                $this->normalizeContain($table, $t, $assoc, $paths),
             );
         }
 
@@ -530,7 +530,7 @@ class EagerLoader
      *
      * @return void
      */
-    protected function _fixStrategies(): void
+    protected function fixStrategies(): void
     {
         foreach ($this->_aliasList as $aliases) {
             foreach ($aliases as $configs) {
@@ -540,7 +540,7 @@ class EagerLoader
                 foreach ($configs as $loadable) {
                     assert($loadable instanceof EagerLoadable);
                     if (str_contains($loadable->aliasPath(), '.')) {
-                        $this->_correctStrategy($loadable);
+                        $this->correctStrategy($loadable);
                     }
                 }
             }
@@ -554,7 +554,7 @@ class EagerLoader
      * @param \Cake\ORM\EagerLoadable $loadable The association config.
      * @return void
      */
-    protected function _correctStrategy(EagerLoadable $loadable): void
+    protected function correctStrategy(EagerLoadable $loadable): void
     {
         $config = $loadable->getConfig();
         $currentStrategy = $config['strategy'] ?? Association::STRATEGY_JOIN;
@@ -576,23 +576,23 @@ class EagerLoader
      * @param array<\Cake\ORM\EagerLoadable> $matching List of associations that should be forcibly joined.
      * @return array<\Cake\ORM\EagerLoadable>
      */
-    protected function _resolveJoins(array $associations, array $matching = []): array
+    protected function resolveJoins(array $associations, array $matching = []): array
     {
         $result = [];
         foreach ($matching as $table => $loadable) {
             $result[$table] = $loadable;
-            $result += $this->_resolveJoins($loadable->associations(), []);
+            $result += $this->resolveJoins($loadable->associations(), []);
         }
         foreach ($associations as $table => $loadable) {
             $inMatching = isset($matching[$table]);
             if (!$inMatching && $loadable->canBeJoined()) {
                 $result[$table] = $loadable;
-                $result += $this->_resolveJoins($loadable->associations(), []);
+                $result += $this->resolveJoins($loadable->associations(), []);
                 continue;
             }
 
             if ($inMatching) {
-                $this->_correctStrategy($loadable);
+                $this->correctStrategy($loadable);
             }
 
             $loadable->setCanBeJoined(false);
@@ -629,7 +629,7 @@ class EagerLoader
             return $results;
         }
 
-        $collected = $this->_collectKeys($external, $query, $results);
+        $collected = $this->collectKeys($external, $query, $results);
 
         foreach ($external as $meta) {
             $contain = $meta->associations();
@@ -698,10 +698,10 @@ class EagerLoader
 
         assert($this->_matching !== null, 'EagerLoader not available');
 
-        $map = $this->_buildAssociationsMap($map, $this->_matching->normalized($table), true);
-        $map = $this->_buildAssociationsMap($map, $this->normalized($table));
+        $map = $this->buildAssociationsMap($map, $this->_matching->normalized($table), true);
+        $map = $this->buildAssociationsMap($map, $this->normalized($table));
 
-        return $this->_buildAssociationsMap($map, $this->_joinsMap);
+        return $this->buildAssociationsMap($map, $this->_joinsMap);
     }
 
     /**
@@ -713,7 +713,7 @@ class EagerLoader
      * @param bool $matching Whether it is an association loaded through `matching()`.
      * @return array
      */
-    protected function _buildAssociationsMap(array $map, array $level, bool $matching = false): array
+    protected function buildAssociationsMap(array $map, array $level, bool $matching = false): array
     {
         foreach ($level as $assoc => $meta) {
             $canBeJoined = $meta->canBeJoined();
@@ -730,7 +730,7 @@ class EagerLoader
                 'targetProperty' => $meta->targetProperty(),
             ];
             if ($canBeJoined && $associations) {
-                $map = $this->_buildAssociationsMap($map, $associations, $matching);
+                $map = $this->buildAssociationsMap($map, $associations, $matching);
             }
         }
 
@@ -775,7 +775,7 @@ class EagerLoader
      * @param array $results Results array.
      * @return array
      */
-    protected function _collectKeys(array $external, SelectQuery $query, array $results): array
+    protected function collectKeys(array $external, SelectQuery $query, array $results): array
     {
         $collectKeys = [];
         foreach ($external as $meta) {
@@ -801,7 +801,7 @@ class EagerLoader
             return [];
         }
 
-        return $this->_groupKeys($results, $collectKeys);
+        return $this->groupKeys($results, $collectKeys);
     }
 
     /**
@@ -812,7 +812,7 @@ class EagerLoader
      * @param array<string, array> $collectKeys The keys to collect.
      * @return array
      */
-    protected function _groupKeys(array $results, array $collectKeys): array
+    protected function groupKeys(array $results, array $collectKeys): array
     {
         $keys = [];
         foreach ($results as $result) {

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -52,10 +52,10 @@ class LazyEagerLoader
             $returnSingle = true;
         }
 
-        $query = $this->_getQuery($entities, $contain, $source);
+        $query = $this->getQuery($entities, $contain, $source);
         $associations = array_keys($query->getContain());
 
-        $entities = $this->_injectResults($entities, $query, $associations, $source);
+        $entities = $this->injectResults($entities, $query, $associations, $source);
 
         /** @var \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface> */
         return $returnSingle ? array_shift($entities) : $entities;
@@ -70,7 +70,7 @@ class LazyEagerLoader
      * @param \Cake\ORM\Table $source The table to use for fetching the top level entities
      * @return \Cake\ORM\Query\SelectQuery
      */
-    protected function _getQuery(array $entities, array $contain, Table $source): SelectQuery
+    protected function getQuery(array $entities, array $contain, Table $source): SelectQuery
     {
         $primaryKey = $source->getPrimaryKey();
         $method = is_string($primaryKey) ? 'get' : 'extract';
@@ -114,7 +114,7 @@ class LazyEagerLoader
      * @param array<string> $associations The name of the top level associations
      * @return array<string, string>
      */
-    protected function _getPropertyMap(Table $source, array $associations): array
+    protected function getPropertyMap(Table $source, array $associations): array
     {
         $map = [];
         $container = $source->associations();
@@ -137,14 +137,14 @@ class LazyEagerLoader
      * @param \Cake\ORM\Table $source The table where the entities came from
      * @return array<\Cake\Datasource\EntityInterface>
      */
-    protected function _injectResults(
+    protected function injectResults(
         array $entities,
         SelectQuery $query,
         array $associations,
         Table $source,
     ): array {
         $injected = [];
-        $properties = $this->_getPropertyMap($source, $associations);
+        $properties = $this->getPropertyMap($source, $associations);
         $primaryKey = (array)$source->getPrimaryKey();
         /** @var array<\Cake\Datasource\EntityInterface> $results */
         $results = $query

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -229,7 +229,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
         }
 
         $allowFallbackClass = $options['allowFallbackClass'] ?? $this->allowFallbackClass;
-        $className = $this->_getClassName($alias, $options);
+        $className = $this->getClassName($alias, $options);
         if ($className) {
             $options['className'] = $className;
         } elseif ($allowFallbackClass) {
@@ -269,7 +269,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
         }
 
         $options['registryAlias'] = $alias;
-        $instance = $this->_create($options);
+        $instance = $this->create($options);
 
         if ($options['className'] === $this->fallbackClassName) {
             $this->_fallbacked[$alias] = $instance;
@@ -285,7 +285,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
      * @param array<string, mixed> $options Table options array.
      * @return string|null
      */
-    protected function _getClassName(string $alias, array $options = []): ?string
+    protected function getClassName(string $alias, array $options = []): ?string
     {
         if (empty($options['className'])) {
             $options['className'] = $alias;
@@ -311,7 +311,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
      * @param array<string, mixed> $options The alias to check for.
      * @return \Cake\ORM\Table
      */
-    protected function _create(array $options): Table
+    protected function create(array $options): Table
     {
         /** @var class-string<\Cake\ORM\Table> $class */
         $class = $options['className'];

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1040,7 +1040,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
     public function clearContain(): static
     {
         $this->getEagerLoader()->clearContain();
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -1127,7 +1127,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
     {
         $result = $this->getEagerLoader()->setMatching($assoc, $builder)->getMatching();
         $this->_addAssociationsToTypeMap($this->getRepository(), $this->getTypeMap(), $result);
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -1204,7 +1204,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
             ])
             ->getMatching();
         $this->_addAssociationsToTypeMap($this->getRepository(), $this->getTypeMap(), $result);
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -1253,7 +1253,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
             ])
             ->getMatching();
         $this->_addAssociationsToTypeMap($this->getRepository(), $this->getTypeMap(), $result);
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -1318,7 +1318,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
             ])
             ->getMatching();
         $this->_addAssociationsToTypeMap($this->getRepository(), $this->getTypeMap(), $result);
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -1364,7 +1364,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      */
     public function clearResult(): static
     {
-        $this->_dirty();
+        $this->dirty();
 
         return $this;
     }
@@ -1490,7 +1490,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      */
     public function enableHydration(bool $enable = true): static
     {
-        $this->_dirty();
+        $this->dirty();
         $this->_hydrate = $enable;
 
         return $this;
@@ -1506,7 +1506,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      */
     public function disableHydration(): static
     {
-        $this->_dirty();
+        $this->dirty();
         $this->_hydrate = false;
 
         return $this;
@@ -1701,11 +1701,11 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @return void
      */
-    protected function _dirty(): void
+    protected function dirty(): void
     {
         $this->_results = null;
         $this->_resultsCount = null;
-        parent::_dirty();
+        parent::dirty();
     }
 
     /**

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -371,7 +371,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
     {
         if ($this->_results !== null) {
             if (!($this->_results instanceof ResultSetInterface)) {
-                $this->_results = $this->_decorateResults($this->_results);
+                $this->_results = $this->doDecorateResults($this->_results);
             }
 
             return $this->_results;
@@ -379,7 +379,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
 
         $results = $this->_cache?->fetch($this);
         if ($results === null) {
-            $results = $this->_decorateResults($this->_execute());
+            $results = $this->doDecorateResults($this->doExecute());
             $this->_cache?->store($this, $results);
         }
         $this->_results = $results;
@@ -728,7 +728,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * @param iterable $result Original results
      * @return \Cake\Datasource\ResultSetInterface<\Cake\Datasource\EntityInterface|mixed>
      */
-    protected function _decorateResults(iterable $result): ResultSetInterface
+    protected function doDecorateResults(iterable $result): ResultSetInterface
     {
         $resultSetClass = $this->resultSetFactory()->getResultSetClass();
 
@@ -1015,7 +1015,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
         if ($associations) {
             $loader->contain($associations, $queryBuilder);
         }
-        $this->_addAssociationsToTypeMap(
+        $this->addAssociationsToTypeMap(
             $this->getRepository(),
             $this->getTypeMap(),
             $loader->getContain(),
@@ -1055,7 +1055,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * @param array<string, array> $associations The nested tree of associations to walk.
      * @return void
      */
-    protected function _addAssociationsToTypeMap(Table $table, TypeMap $typeMap, array $associations): void
+    protected function addAssociationsToTypeMap(Table $table, TypeMap $typeMap, array $associations): void
     {
         foreach ($associations as $name => $nested) {
             if (!$table->hasAssociation($name)) {
@@ -1068,7 +1068,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
                 $this->addDefaultTypes($target);
             }
             if ($nested) {
-                $this->_addAssociationsToTypeMap($target, $typeMap, $nested);
+                $this->addAssociationsToTypeMap($target, $typeMap, $nested);
             }
         }
     }
@@ -1126,7 +1126,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
     public function matching(string $assoc, ?Closure $builder = null): static
     {
         $result = $this->getEagerLoader()->setMatching($assoc, $builder)->getMatching();
-        $this->_addAssociationsToTypeMap($this->getRepository(), $this->getTypeMap(), $result);
+        $this->addAssociationsToTypeMap($this->getRepository(), $this->getTypeMap(), $result);
         $this->dirty();
 
         return $this;
@@ -1203,7 +1203,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
                 'fields' => false,
             ])
             ->getMatching();
-        $this->_addAssociationsToTypeMap($this->getRepository(), $this->getTypeMap(), $result);
+        $this->addAssociationsToTypeMap($this->getRepository(), $this->getTypeMap(), $result);
         $this->dirty();
 
         return $this;
@@ -1252,7 +1252,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
                 'fields' => false,
             ])
             ->getMatching();
-        $this->_addAssociationsToTypeMap($this->getRepository(), $this->getTypeMap(), $result);
+        $this->addAssociationsToTypeMap($this->getRepository(), $this->getTypeMap(), $result);
         $this->dirty();
 
         return $this;
@@ -1317,7 +1317,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
                 'negateMatch' => true,
             ])
             ->getMatching();
-        $this->_addAssociationsToTypeMap($this->getRepository(), $this->getTypeMap(), $result);
+        $this->addAssociationsToTypeMap($this->getRepository(), $this->getTypeMap(), $result);
         $this->dirty();
 
         return $this;
@@ -1393,7 +1393,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      */
     public function count(): int
     {
-        return $this->_resultsCount ??= $this->_performCount();
+        return $this->_resultsCount ??= $this->performCount();
     }
 
     /**
@@ -1401,7 +1401,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @return int
      */
-    protected function _performCount(): int
+    protected function performCount(): int
     {
         $query = $this->cleanCopy();
         $counter = $this->_counter;
@@ -1550,7 +1550,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
     {
         $this->triggerBeforeFind();
 
-        $this->_transformQuery();
+        $this->transformQuery();
 
         return parent::sql($binder);
     }
@@ -1560,7 +1560,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @return iterable
      */
-    protected function _execute(): iterable
+    protected function doExecute(): iterable
     {
         $this->triggerBeforeFind();
         if ($this->_results !== null) {
@@ -1599,7 +1599,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * @see \Cake\Database\Query::execute()
      * @return void
      */
-    protected function _transformQuery(): void
+    protected function transformQuery(): void
     {
         if (!$this->_dirty) {
             return;
@@ -1610,9 +1610,9 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
         if (empty($this->_parts['from'])) {
             $this->from([$repository->getAlias() => $repository->getTable()]);
         }
-        $this->_addDefaultFields();
+        $this->addDefaultFields();
         $this->getEagerLoader()->attachAssociations($this, $repository, !$this->_hasFields);
-        $this->_addDefaultSelectTypes();
+        $this->addDefaultSelectTypes();
     }
 
     /**
@@ -1621,7 +1621,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @return void
      */
-    protected function _addDefaultFields(): void
+    protected function addDefaultFields(): void
     {
         $select = $this->clause('select');
         $this->_hasFields = true;
@@ -1645,7 +1645,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @return void
      */
-    protected function _addDefaultSelectTypes(): void
+    protected function addDefaultSelectTypes(): void
     {
         $typeMap = $this->getTypeMap()->getDefaults();
         $select = $this->clause('select');

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -123,7 +123,7 @@ class ExistsIn
             return true;
         }
 
-        if ($this->_fieldsAreNull($entity, $source)) {
+        if ($this->fieldsAreNull($entity, $source)) {
             return true;
         }
 
@@ -156,7 +156,7 @@ class ExistsIn
      * @param \Cake\ORM\Table $source The table to use schema from.
      * @return bool
      */
-    protected function _fieldsAreNull(EntityInterface $entity, Table $source): bool
+    protected function fieldsAreNull(EntityInterface $entity, Table $source): bool
     {
         $nulls = 0;
         $schema = $source->getSchema();

--- a/src/ORM/Rule/IsUnique.php
+++ b/src/ORM/Rule/IsUnique.php
@@ -79,10 +79,10 @@ class IsUnique
         $repository = $options['repository'];
 
         $alias = $repository->getAlias();
-        $conditions = $this->_alias($alias, $fields);
+        $conditions = $this->alias($alias, $fields);
         if ($entity->isNew() === false) {
             $keys = (array)$repository->getPrimaryKey();
-            $keys = $this->_alias($alias, $entity->extract($keys));
+            $keys = $this->alias($alias, $entity->extract($keys));
             if (Hash::filter($keys)) {
                 $conditions['NOT'] = $keys;
             }
@@ -98,7 +98,7 @@ class IsUnique
      * @param array $conditions The conditions to alias.
      * @return array<string, mixed>
      */
-    protected function _alias(string $alias, array $conditions): array
+    protected function alias(string $alias, array $conditions): array
     {
         $aliased = [];
         foreach ($conditions as $key => $value) {

--- a/src/ORM/Rule/LinkConstraint.php
+++ b/src/ORM/Rule/LinkConstraint.php
@@ -97,7 +97,7 @@ class LinkConstraint
             $association = $table->getAssociation($association);
         }
 
-        $count = $this->_countLinks($association, $entity);
+        $count = $this->countLinks($association, $entity);
 
         if (
             (
@@ -122,7 +122,7 @@ class LinkConstraint
      * @param \Cake\ORM\Table $source The object to use for aliasing.
      * @return array<string> The aliased fields
      */
-    protected function _aliasFields(array $fields, Table $source): array
+    protected function aliasFields(array $fields, Table $source): array
     {
         foreach ($fields as $key => $value) {
             $fields[$key] = $source->aliasField($value);
@@ -138,7 +138,7 @@ class LinkConstraint
      * @param array $values The condition values.
      * @return array<string, string> A conditions array combined from the passed fields and values.
      */
-    protected function _buildConditions(array $fields, array $values): array
+    protected function buildConditions(array $fields, array $values): array
     {
         if (count($fields) !== count($values)) {
             throw new InvalidArgumentException(sprintf(
@@ -158,7 +158,7 @@ class LinkConstraint
      * @param \Cake\Datasource\EntityInterface $entity The entity involved in the operation.
      * @return int The number of links.
      */
-    protected function _countLinks(Association $association, EntityInterface $entity): int
+    protected function countLinks(Association $association, EntityInterface $entity): int
     {
         $source = $association->getSource();
 
@@ -174,8 +174,8 @@ class LinkConstraint
             ));
         }
 
-        $aliasedPrimaryKey = $this->_aliasFields($primaryKey, $source);
-        $conditions = $this->_buildConditions(
+        $aliasedPrimaryKey = $this->aliasFields($primaryKey, $source);
+        $conditions = $this->buildConditions(
             $aliasedPrimaryKey,
             $entity->extract($primaryKey),
         );

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -146,7 +146,7 @@ class RulesChecker extends BaseRulesChecker
         ?string $field = null,
         ?string $message = null,
     ): RuleInvoker {
-        return $this->_addLinkConstraintRule(
+        return $this->addLinkConstraintRule(
             $association,
             $field,
             $message,
@@ -179,7 +179,7 @@ class RulesChecker extends BaseRulesChecker
         ?string $field = null,
         ?string $message = null,
     ): RuleInvoker {
-        return $this->_addLinkConstraintRule(
+        return $this->addLinkConstraintRule(
             $association,
             $field,
             $message,
@@ -205,7 +205,7 @@ class RulesChecker extends BaseRulesChecker
      * @see \Cake\ORM\Rule\LinkConstraint::STATUS_LINKED
      * @see \Cake\ORM\Rule\LinkConstraint::STATUS_NOT_LINKED
      */
-    protected function _addLinkConstraintRule(
+    protected function addLinkConstraintRule(
         Association|string $association,
         ?string $errorField,
         ?string $message,

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -69,7 +69,7 @@ class RulesChecker extends BaseRulesChecker
 
         $errorField = current($fields);
 
-        return $this->_addError(new IsUnique($fields, $options), '_isUnique', compact('errorField', 'message'));
+        return $this->addError(new IsUnique($fields, $options), '_isUnique', compact('errorField', 'message'));
     }
 
     /**
@@ -119,7 +119,7 @@ class RulesChecker extends BaseRulesChecker
 
         $errorField = is_string($field) ? $field : current($field);
 
-        return $this->_addError(new ExistsIn($field, $table, $options), '_existsIn', compact('errorField', 'message'));
+        return $this->addError(new ExistsIn($field, $table, $options), '_existsIn', compact('errorField', 'message'));
     }
 
     /**
@@ -249,7 +249,7 @@ class RulesChecker extends BaseRulesChecker
             $linkStatus,
         );
 
-        return $this->_addError($rule, $ruleName, compact('errorField', 'message'));
+        return $this->addError($rule, $ruleName, compact('errorField', 'message'));
     }
 
     /**
@@ -277,7 +277,7 @@ class RulesChecker extends BaseRulesChecker
 
         $errorField = $field;
 
-        return $this->_addError(
+        return $this->addError(
             new ValidCount($field),
             '_validCount',
             compact('count', 'operator', 'errorField', 'message'),

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1381,7 +1381,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             }
         }
 
-        $options = $this->_setFieldMatchers(
+        $options = $this->setFieldMatchers(
             compact('keyField', 'valueField', 'groupField', 'valueSeparator'),
             ['keyField', 'valueField', 'groupField'],
         );
@@ -1423,7 +1423,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     ): SelectQuery {
         $keyField ??= $this->getPrimaryKey();
 
-        $options = $this->_setFieldMatchers(compact('keyField', 'parentField'), ['keyField', 'parentField']);
+        $options = $this->setFieldMatchers(compact('keyField', 'parentField'), ['keyField', 'parentField']);
 
         return $query->formatResults(fn(CollectionInterface $results) => $results->nest(
             $options['keyField'],
@@ -1445,7 +1445,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * the associated value
      * @return array<string, mixed>
      */
-    protected function _setFieldMatchers(array $options, array $keys): array
+    protected function setFieldMatchers(array $options, array $keys): array
     {
         foreach ($keys as $field) {
             if (!is_array($options[$field])) {
@@ -1557,7 +1557,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param bool $atomic Whether to execute the worker inside a database transaction.
      * @return mixed
      */
-    protected function _executeTransaction(callable $worker, bool $atomic = true): mixed
+    protected function executeTransaction(callable $worker, bool $atomic = true): mixed
     {
         if ($atomic) {
             return $this->getConnection()->transactional(fn() => $worker());
@@ -1573,7 +1573,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param bool $primary True if a primary was used.
      * @return bool Returns true if a transaction was committed.
      */
-    protected function _transactionCommitted(bool $atomic, bool $primary): bool
+    protected function transactionCommitted(bool $atomic, bool $primary): bool
     {
         return !$this->getConnection()->inTransaction() && ($atomic || $primary);
     }
@@ -1622,12 +1622,12 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             'defaults' => true,
         ]);
 
-        $entity = $this->_executeTransaction(
-            fn() => $this->_processFindOrCreate($search, $callback, $options->getArrayCopy()),
+        $entity = $this->executeTransaction(
+            fn() => $this->processFindOrCreate($search, $callback, $options->getArrayCopy()),
             $options['atomic'],
         );
 
-        if ($entity && $this->_transactionCommitted($options['atomic'], true)) {
+        if ($entity && $this->transactionCommitted($options['atomic'], true)) {
             $this->dispatchEvent('Model.afterSaveCommit', compact('entity', 'options'));
         }
 
@@ -1647,12 +1647,12 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \Cake\ORM\Exception\PersistenceFailedException When the entity couldn't be saved
      * @throws \InvalidArgumentException
      */
-    protected function _processFindOrCreate(
+    protected function processFindOrCreate(
         SelectQuery|callable|array $search,
         callable|array|null $callback = null,
         array $options = [],
     ): EntityInterface|array {
-        $query = $this->_getFindOrCreateQuery($search);
+        $query = $this->getFindOrCreateQuery($search);
 
         $row = $query->first();
         if ($row !== null) {
@@ -1690,7 +1690,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param \Cake\ORM\Query\SelectQuery|callable|array $search The criteria to find existing records by.
      * @return \Cake\ORM\Query\SelectQuery
      */
-    protected function _getFindOrCreateQuery(SelectQuery|callable|array $search): SelectQuery
+    protected function getFindOrCreateQuery(SelectQuery|callable|array $search): SelectQuery
     {
         if (is_callable($search)) {
             $query = $this->find();
@@ -1934,13 +1934,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             return $entity;
         }
 
-        $success = $this->_executeTransaction(
-            fn() => $this->_processSave($entity, $options),
+        $success = $this->executeTransaction(
+            fn() => $this->processSave($entity, $options),
             $options['atomic'],
         );
 
         if ($success) {
-            if ($this->_transactionCommitted($options['atomic'], $options['_primary'])) {
+            if ($this->transactionCommitted($options['atomic'], $options['_primary'])) {
                 $this->dispatchEvent('Model.afterSaveCommit', compact('entity', 'options'));
             }
             if ($options['atomic'] || $options['_primary']) {
@@ -1985,7 +1985,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \Cake\ORM\Exception\RolledbackTransactionException If the transaction
      *   is aborted in the afterSave event.
      */
-    protected function _processSave(EntityInterface $entity, ArrayObject $options): EntityInterface|false
+    protected function processSave(EntityInterface $entity, ArrayObject $options): EntityInterface|false
     {
         $primaryColumns = (array)$this->getPrimaryKey();
 
@@ -2041,13 +2041,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $isNew = $entity->isNew();
 
         if ($isNew) {
-            $success = $this->_insert($entity, $data);
+            $success = $this->insert($entity, $data);
         } else {
-            $success = $this->_update($entity, $data);
+            $success = $this->update($entity, $data);
         }
 
         if ($success) {
-            $success = $this->_onSaveSuccess($entity, $options);
+            $success = $this->onSaveSuccess($entity, $options);
         }
 
         if (!$success && $isNew) {
@@ -2068,7 +2068,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \Cake\ORM\Exception\RolledbackTransactionException If the transaction
      *   is aborted in the afterSave event.
      */
-    protected function _onSaveSuccess(EntityInterface $entity, ArrayObject $options): bool
+    protected function onSaveSuccess(EntityInterface $entity, ArrayObject $options): bool
     {
         $success = $this->_associations->saveChildren(
             $this,
@@ -2105,7 +2105,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \Cake\Database\Exception\DatabaseException if not all the primary keys where supplied or could
      * be generated when the table has composite primary keys. Or when the table has no primary key.
      */
-    protected function _insert(EntityInterface $entity, array $data): EntityInterface|false
+    protected function insert(EntityInterface $entity, array $data): EntityInterface|false
     {
         $primary = (array)$this->getPrimaryKey();
         if (!$primary) {
@@ -2116,7 +2116,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             throw new DatabaseException($msg);
         }
         $keys = array_fill(0, count($primary), null);
-        $id = (array)$this->_newId($primary) + $keys;
+        $id = (array)$this->newId($primary) + $keys;
 
         // Generate primary keys preferring values in $data.
         $primary = array_combine($primary, $id);
@@ -2183,7 +2183,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array<string> $primary The primary key columns to get a new ID for.
      * @return string|null Either null or the primary key value or a list of primary key values.
      */
-    protected function _newId(array $primary): ?string
+    protected function newId(array $primary): ?string
     {
         if (!$primary || count($primary) > 1) {
             return null;
@@ -2203,7 +2203,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @return \Cake\Datasource\EntityInterface|false
      * @throws \InvalidArgumentException When primary key data is missing.
      */
-    protected function _update(EntityInterface $entity, array $data): EntityInterface|false
+    protected function update(EntityInterface $entity, array $data): EntityInterface|false
     {
         $primaryColumns = (array)$this->getPrimaryKey();
         $primaryKey = $entity->extract($primaryColumns);
@@ -2251,7 +2251,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         array $options = [],
     ): iterable|false {
         try {
-            return $this->_saveMany($entities, $options);
+            return $this->doSaveMany($entities, $options);
         } catch (PersistenceFailedException) {
             return false;
         }
@@ -2272,7 +2272,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function saveManyOrFail(iterable $entities, array $options = []): iterable
     {
-        return $this->_saveMany($entities, $options);
+        return $this->doSaveMany($entities, $options);
     }
 
     /**
@@ -2282,7 +2282,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \Exception If an entity couldn't be saved.
      * @return iterable<\Cake\Datasource\EntityInterface> Entities list.
      */
-    protected function _saveMany(
+    protected function doSaveMany(
         iterable $entities,
         array $options = [],
     ): iterable {
@@ -2352,7 +2352,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             }
         };
 
-        if ($this->_transactionCommitted($options['atomic'], $options['_primary'])) {
+        if ($this->transactionCommitted($options['atomic'], $options['_primary'])) {
             foreach ($entities as $entity) {
                 $this->dispatchEvent('Model.afterSaveCommit', compact('entity', 'options'));
                 if ($options['atomic'] || $options['_primary']) {
@@ -2402,12 +2402,12 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             '_primary' => true,
         ]);
 
-        $success = $this->_executeTransaction(
-            fn() => $this->_processDelete($entity, $options),
+        $success = $this->executeTransaction(
+            fn() => $this->processDelete($entity, $options),
             $options['atomic'],
         );
 
-        if ($success && $this->_transactionCommitted($options['atomic'], $options['_primary'])) {
+        if ($success && $this->transactionCommitted($options['atomic'], $options['_primary'])) {
             $this->dispatchEvent('Model.afterDeleteCommit', [
                 'entity' => $entity,
                 'options' => $options,
@@ -2432,7 +2432,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function deleteMany(iterable $entities, array $options = []): iterable|false
     {
-        $failed = $this->_deleteMany($entities, $options);
+        $failed = $this->doDeleteMany($entities, $options);
 
         if ($failed !== null) {
             return false;
@@ -2456,7 +2456,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function deleteManyOrFail(iterable $entities, array $options = []): iterable
     {
-        $failed = $this->_deleteMany($entities, $options);
+        $failed = $this->doDeleteMany($entities, $options);
 
         if ($failed !== null) {
             throw new PersistenceFailedException($failed, ['deleteMany']);
@@ -2470,7 +2470,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array<string, mixed> $options Options used.
      * @return \Cake\Datasource\EntityInterface|null
      */
-    protected function _deleteMany(iterable $entities, array $options = []): ?EntityInterface
+    protected function doDeleteMany(iterable $entities, array $options = []): ?EntityInterface
     {
         $options = new ArrayObject($options + [
                 'atomic' => true,
@@ -2478,9 +2478,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 '_primary' => true,
             ]);
 
-        $failed = $this->_executeTransaction(function () use ($entities, $options) {
+        $failed = $this->executeTransaction(function () use ($entities, $options) {
             foreach ($entities as $entity) {
-                if (!$this->_processDelete($entity, $options)) {
+                if (!$this->processDelete($entity, $options)) {
                     return $entity;
                 }
             }
@@ -2488,7 +2488,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             return null;
         }, $options['atomic']);
 
-        if ($failed === null && $this->_transactionCommitted($options['atomic'], $options['_primary'])) {
+        if ($failed === null && $this->transactionCommitted($options['atomic'], $options['_primary'])) {
             foreach ($entities as $entity) {
                 $this->dispatchEvent('Model.afterDeleteCommit', [
                     'entity' => $entity,
@@ -2532,7 +2532,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * passed entity
      * @return bool success
      */
-    protected function _processDelete(EntityInterface $entity, ArrayObject $options): bool
+    protected function processDelete(EntityInterface $entity, ArrayObject $options): bool
     {
         if ($entity->isNew()) {
             return false;
@@ -2674,7 +2674,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \BadMethodCallException when there are missing arguments, or when
      *  and & or are combined.
      */
-    protected function _dynamicFinder(string $method, array $args): SelectQuery
+    protected function dynamicFinder(string $method, array $args): SelectQuery
     {
         $method = Inflector::underscore($method);
         preg_match('/^find_([\w]+)_by_/', $method, $matches);
@@ -2743,7 +2743,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             return $this->_behaviors->call($method, $args);
         }
         if (preg_match('/^find(?:\w+)?By/', $method) > 0) {
-            return $this->_dynamicFinder($method, $args);
+            return $this->dynamicFinder($method, $args);
         }
 
         throw new BadMethodCallException(

--- a/src/Routing/Middleware/AssetMiddleware.php
+++ b/src/Routing/Middleware/AssetMiddleware.php
@@ -74,7 +74,7 @@ class AssetMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        $assetFile = $this->_getAssetFile($url);
+        $assetFile = $this->getAssetFile($url);
         if ($assetFile === null || !is_file($assetFile)) {
             return $handler->handle($request);
         }
@@ -117,7 +117,7 @@ class AssetMiddleware implements MiddlewareInterface
      * @param string $url Asset URL
      * @return string|null Absolute path for asset file, null on failure
      */
-    protected function _getAssetFile(string $url): ?string
+    protected function getAssetFile(string $url): ?string
     {
         $parts = explode('/', ltrim($url, '/'), 3);
         $pluginPart = [];

--- a/src/Routing/Route/DashedRoute.php
+++ b/src/Routing/Route/DashedRoute.php
@@ -41,7 +41,7 @@ class DashedRoute extends Route
      * @param string $plugin Plugin name
      * @return string
      */
-    protected function _camelizePlugin(string $plugin): string
+    protected function camelizePlugin(string $plugin): string
     {
         $plugin = str_replace('-', '_', $plugin);
         if (!str_contains($plugin, '/')) {
@@ -71,7 +71,7 @@ class DashedRoute extends Route
             $params['controller'] = Inflector::camelize($params['controller'], '-');
         }
         if (!empty($params['plugin'])) {
-            $params['plugin'] = $this->_camelizePlugin($params['plugin']);
+            $params['plugin'] = $this->camelizePlugin($params['plugin']);
         }
         if (!empty($params['action'])) {
             $params['action'] = Inflector::variable(str_replace(
@@ -96,10 +96,10 @@ class DashedRoute extends Route
      */
     public function match(array $url, array $context = []): ?string
     {
-        $url = $this->_dasherize($url);
+        $url = $this->dasherize($url);
         if ($this->_inflectedDefaults === null) {
             $this->compile();
-            $this->_inflectedDefaults = $this->_dasherize($this->defaults);
+            $this->_inflectedDefaults = $this->dasherize($this->defaults);
         }
         $restore = $this->defaults;
         try {
@@ -117,7 +117,7 @@ class DashedRoute extends Route
      * @param array $url An array of URL keys.
      * @return array
      */
-    protected function _dasherize(array $url): array
+    protected function dasherize(array $url): array
     {
         foreach (['controller', 'plugin', 'action'] as $element) {
             if (!empty($url[$element])) {

--- a/src/Routing/Route/EntityRoute.php
+++ b/src/Routing/Route/EntityRoute.php
@@ -49,7 +49,7 @@ class EntityRoute extends Route
 
         if (isset($url['_entity'])) {
             $entity = $url['_entity'];
-            $this->_checkEntity($entity);
+            $this->checkEntity($entity);
 
             foreach ($this->keys as $field) {
                 if (!isset($url[$field]) && isset($entity[$field])) {
@@ -68,7 +68,7 @@ class EntityRoute extends Route
      * @param mixed $entity Entity value from the URL options
      * @return void
      */
-    protected function _checkEntity(mixed $entity): void
+    protected function checkEntity(mixed $entity): void
     {
         if (!$entity instanceof ArrayAccess && !is_array($entity)) {
             throw new CakeException(sprintf(

--- a/src/Routing/Route/InflectedRoute.php
+++ b/src/Routing/Route/InflectedRoute.php
@@ -75,10 +75,10 @@ class InflectedRoute extends Route
      */
     public function match(array $url, array $context = []): ?string
     {
-        $url = $this->_underscore($url);
+        $url = $this->underscore($url);
         if ($this->_inflectedDefaults === null) {
             $this->compile();
-            $this->_inflectedDefaults = $this->_underscore($this->defaults);
+            $this->_inflectedDefaults = $this->underscore($this->defaults);
         }
         $restore = $this->defaults;
         try {
@@ -96,7 +96,7 @@ class InflectedRoute extends Route
      * @param array $url An array of URL keys.
      * @return array
      */
-    protected function _underscore(array $url): array
+    protected function underscore(array $url): array
     {
         if (!empty($url['controller'])) {
             $url['controller'] = Inflector::underscore($url['controller']);

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -308,7 +308,7 @@ class Route
     public function compile(): string
     {
         if ($this->_compiledRoute === null) {
-            $this->_writeRoute();
+            $this->writeRoute();
         }
         assert($this->_compiledRoute !== null);
 
@@ -323,7 +323,7 @@ class Route
      *
      * @return void
      */
-    protected function _writeRoute(): void
+    protected function writeRoute(): void
     {
         if (empty($this->template) || ($this->template === '/')) {
             $this->_compiledRoute = '#^/*$#';
@@ -463,7 +463,7 @@ class Route
         }
 
         $compiledRoute = $this->compile();
-        [$url, $ext] = $this->_parseExtension($url);
+        [$url, $ext] = $this->parseExtension($url);
 
         $urldecode = $this->options['_urldecode'] ?? true;
         if ($urldecode) {
@@ -502,7 +502,7 @@ class Route
 
         if (isset($route['_args_'])) {
             /** @psalm-suppress PossiblyInvalidArgument */
-            $pass = $this->_parseArgs($route['_args_'], $route);
+            $pass = $this->parseArgs($route['_args_'], $route);
             $route['pass'] = array_merge($route['pass'], $pass);
             unset($route['_args_']);
         }
@@ -561,7 +561,7 @@ class Route
      * @param string $url The url to parse.
      * @return array containing url, extension
      */
-    protected function _parseExtension(string $url): array
+    protected function parseExtension(string $url): array
     {
         if (count($this->_extensions) && str_contains($url, '.')) {
             foreach ($this->_extensions as $ext) {
@@ -585,7 +585,7 @@ class Route
      * @param array $context The current route context, which should contain controller/action keys.
      * @return array<string> Array of passed args.
      */
-    protected function _parseArgs(string $args, array $context): array
+    protected function parseArgs(string $args, array $context): array
     {
         $pass = [];
         $args = explode('/', $args);
@@ -610,7 +610,7 @@ class Route
      * @param array $params An array of persistent values to replace persistent ones.
      * @return array An array with persistent parameters applied.
      */
-    protected function _persistParams(array $url, array $params): array
+    protected function persistParams(array $url, array $params): array
     {
         foreach ($this->options['persist'] as $persistKey) {
             if (array_key_exists($persistKey, $params) && !isset($url[$persistKey])) {
@@ -646,7 +646,7 @@ class Route
             !empty($this->options['persist']) &&
             is_array($this->options['persist'])
         ) {
-            $url = $this->_persistParams($url, $context['params']);
+            $url = $this->persistParams($url, $context['params']);
         }
         unset($context['params']);
         $hostOptions = array_intersect_key($url, $context);
@@ -697,7 +697,7 @@ class Route
         }
 
         // Check the method first as it is special.
-        if (!$this->_matchMethod($url)) {
+        if (!$this->matchMethod($url)) {
             return null;
         }
         unset($url['_method'], $url['[method]'], $defaults['_method']);
@@ -763,7 +763,7 @@ class Route
             return null;
         }
 
-        return $this->_writeUrl($url, $pass, $query);
+        return $this->writeUrl($url, $pass, $query);
     }
 
     /**
@@ -772,7 +772,7 @@ class Route
      * @param array $url The array for the URL being generated.
      * @return bool
      */
-    protected function _matchMethod(array $url): bool
+    protected function matchMethod(array $url): bool
     {
         if (empty($this->defaults['_method'])) {
             return true;
@@ -802,7 +802,7 @@ class Route
      * @param array $query An array of parameters
      * @return string Composed route string.
      */
-    protected function _writeUrl(array $params, array $pass = [], array $query = []): string
+    protected function writeUrl(array $params, array $pass = [], array $query = []): string
     {
         $pass = array_map(function ($value) {
             return rawurlencode((string)$value);

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -442,7 +442,7 @@ class RouteBuilder
      */
     public function get(string $template, array|string $target, ?string $name = null): Route
     {
-        return $this->_methodRoute('GET', $template, $target, $name);
+        return $this->methodRoute('GET', $template, $target, $name);
     }
 
     /**
@@ -456,7 +456,7 @@ class RouteBuilder
      */
     public function post(string $template, array|string $target, ?string $name = null): Route
     {
-        return $this->_methodRoute('POST', $template, $target, $name);
+        return $this->methodRoute('POST', $template, $target, $name);
     }
 
     /**
@@ -470,7 +470,7 @@ class RouteBuilder
      */
     public function put(string $template, array|string $target, ?string $name = null): Route
     {
-        return $this->_methodRoute('PUT', $template, $target, $name);
+        return $this->methodRoute('PUT', $template, $target, $name);
     }
 
     /**
@@ -484,7 +484,7 @@ class RouteBuilder
      */
     public function patch(string $template, array|string $target, ?string $name = null): Route
     {
-        return $this->_methodRoute('PATCH', $template, $target, $name);
+        return $this->methodRoute('PATCH', $template, $target, $name);
     }
 
     /**
@@ -498,7 +498,7 @@ class RouteBuilder
      */
     public function delete(string $template, array|string $target, ?string $name = null): Route
     {
-        return $this->_methodRoute('DELETE', $template, $target, $name);
+        return $this->methodRoute('DELETE', $template, $target, $name);
     }
 
     /**
@@ -512,7 +512,7 @@ class RouteBuilder
      */
     public function head(string $template, array|string $target, ?string $name = null): Route
     {
-        return $this->_methodRoute('HEAD', $template, $target, $name);
+        return $this->methodRoute('HEAD', $template, $target, $name);
     }
 
     /**
@@ -526,7 +526,7 @@ class RouteBuilder
      */
     public function options(string $template, array|string $target, ?string $name = null): Route
     {
-        return $this->_methodRoute('OPTIONS', $template, $target, $name);
+        return $this->methodRoute('OPTIONS', $template, $target, $name);
     }
 
     /**
@@ -539,7 +539,7 @@ class RouteBuilder
      * @param string|null $name The name of the route.
      * @return \Cake\Routing\Route\Route
      */
-    protected function _methodRoute(string $method, string $template, array|string $target, ?string $name): Route
+    protected function methodRoute(string $method, string $template, array|string $target, ?string $name): Route
     {
         if ($name !== null) {
             $name = $this->_namePrefix . $name;
@@ -554,7 +554,7 @@ class RouteBuilder
         $target = $this->parseDefaults($target);
         $target['_method'] = $method;
 
-        $route = $this->_makeRoute($template, $target, $options);
+        $route = $this->makeRoute($template, $target, $options);
         $this->_collection->add($route, $options);
 
         return $route;
@@ -684,7 +684,7 @@ class RouteBuilder
             $options['_middleware'] = $this->middleware;
         }
 
-        $route = $this->_makeRoute($route, $defaults, $options);
+        $route = $this->makeRoute($route, $defaults, $options);
         $this->_collection->add($route, $options);
 
         return $route;
@@ -715,7 +715,7 @@ class RouteBuilder
      * @throws \InvalidArgumentException when route class or route object is invalid.
      * @throws \BadMethodCallException when the route to make conflicts with the current scope
      */
-    protected function _makeRoute(Route|string $route, array $defaults, array $options): Route
+    protected function makeRoute(Route|string $route, array $defaults, array $options): Route
     {
         if (is_string($route)) {
             /** @var class-string<\Cake\Routing\Route\Route>|null $routeClass */

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -195,7 +195,7 @@ class RouteCollection
      * @param array $url The url to match.
      * @return array<string> The set of names of the url
      */
-    protected function _getNames(array $url): array
+    protected function getNames(array $url): array
     {
         $plugin = false;
         if (isset($url['plugin']) && $url['plugin'] !== false) {
@@ -303,7 +303,7 @@ class RouteCollection
             throw new MissingRouteException(['url' => $name, 'context' => $context]);
         }
 
-        foreach ($this->_getNames($url) as $name) {
+        foreach ($this->getNames($url) as $name) {
             if (empty($this->_routeTable[$name])) {
                 continue;
             }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -313,7 +313,7 @@ class Router
      * @see \Cake\Routing\Router::url()
      * @see \Cake\Routing\Router::addUrlFilter()
      */
-    protected static function _applyUrlFilters(array $url): array
+    protected static function applyUrlFilters(array $url): array
     {
         $request = static::getRequest();
         foreach (static::$_urlFilters as $filter) {
@@ -416,7 +416,7 @@ class Router
             }
             unset($url['_https'], $url['_full'], $url['#']);
 
-            $url = static::_applyUrlFilters($url);
+            $url = static::applyUrlFilters($url);
 
             if (!isset($url['_name'])) {
                 // Copy the current action if the controller is the current one.

--- a/src/TestSuite/Constraint/Response/BodyContains.php
+++ b/src/TestSuite/Constraint/Response/BodyContains.php
@@ -55,7 +55,7 @@ class BodyContains extends ResponseBase
             $method = 'mb_stripos';
         }
 
-        return $method($this->_getBodyAsString(), $other) !== false;
+        return $method($this->getBodyAsString(), $other) !== false;
     }
 
     /**

--- a/src/TestSuite/Constraint/Response/BodyEmpty.php
+++ b/src/TestSuite/Constraint/Response/BodyEmpty.php
@@ -30,7 +30,7 @@ class BodyEmpty extends ResponseBase
      */
     public function matches(mixed $other): bool
     {
-        return empty($this->_getBodyAsString());
+        return empty($this->getBodyAsString());
     }
 
     /**

--- a/src/TestSuite/Constraint/Response/BodyEquals.php
+++ b/src/TestSuite/Constraint/Response/BodyEquals.php
@@ -30,7 +30,7 @@ class BodyEquals extends ResponseBase
      */
     public function matches(mixed $other): bool
     {
-        return $this->_getBodyAsString() === $other;
+        return $this->getBodyAsString() === $other;
     }
 
     /**

--- a/src/TestSuite/Constraint/Response/BodyRegExp.php
+++ b/src/TestSuite/Constraint/Response/BodyRegExp.php
@@ -30,7 +30,7 @@ class BodyRegExp extends ResponseBase
      */
     public function matches(mixed $other): bool
     {
-        return preg_match($other, $this->_getBodyAsString()) > 0;
+        return preg_match($other, $this->getBodyAsString()) > 0;
     }
 
     /**

--- a/src/TestSuite/Constraint/Response/CookieEncryptedEquals.php
+++ b/src/TestSuite/Constraint/Response/CookieEncryptedEquals.php
@@ -69,7 +69,7 @@ class CookieEncryptedEquals extends CookieEquals
     {
         $cookie = $this->response->getCookie($this->cookieName);
 
-        return $cookie !== null && $this->_decrypt($cookie['value'], $this->mode) === $other;
+        return $cookie !== null && $this->decrypt($cookie['value'], $this->mode) === $other;
     }
 
     /**

--- a/src/TestSuite/Constraint/Response/CookieEncryptedEquals.php
+++ b/src/TestSuite/Constraint/Response/CookieEncryptedEquals.php
@@ -87,7 +87,7 @@ class CookieEncryptedEquals extends CookieEquals
      *
      * @return string
      */
-    protected function _getCookieEncryptionKey(): string
+    protected function getCookieEncryptionKey(): string
     {
         return $this->key;
     }

--- a/src/TestSuite/Constraint/Response/ResponseBase.php
+++ b/src/TestSuite/Constraint/Response/ResponseBase.php
@@ -51,7 +51,7 @@ abstract class ResponseBase extends Constraint
      *
      * @return string The response body.
      */
-    protected function _getBodyAsString(): string
+    protected function getBodyAsString(): string
     {
         return (string)$this->response->getBody();
     }

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -116,10 +116,10 @@ class TestFixture implements FixtureInterface
     public function init(): void
     {
         if (!$this->table) {
-            $this->table = $this->_tableFromClass();
+            $this->table = $this->tableFromClass();
         }
 
-        $this->_schemaFromReflection();
+        $this->schemaFromReflection();
     }
 
     /**
@@ -127,7 +127,7 @@ class TestFixture implements FixtureInterface
      *
      * @return string
      */
-    protected function _tableFromClass(): string
+    protected function tableFromClass(): string
     {
         [, $class] = namespaceSplit(static::class);
         preg_match('/^(.*)Fixture$/', $class, $matches);
@@ -142,7 +142,7 @@ class TestFixture implements FixtureInterface
      * @return void
      * @throws \Cake\Core\Exception\CakeException when trying to reflect a table that does not exist
      */
-    protected function _schemaFromReflection(): void
+    protected function schemaFromReflection(): void
     {
         $db = ConnectionManager::get($this->connection());
         assert($db instanceof Connection);
@@ -176,7 +176,7 @@ class TestFixture implements FixtureInterface
     {
         assert($connection instanceof Connection);
         if ($this->records) {
-            [$fields, $values, $types] = $this->_getRecords();
+            [$fields, $values, $types] = $this->getRecords();
             $query = $connection->insertQuery()
                 ->insert($fields, $types)
                 ->into($this->sourceName());
@@ -195,7 +195,7 @@ class TestFixture implements FixtureInterface
      *
      * @return array
      */
-    protected function _getRecords(): array
+    protected function getRecords(): array
     {
         $fields = [];
         $values = [];

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -372,7 +372,7 @@ trait IntegrationTestTrait
      * @param string|null $key Encryption key used. Defaults
      *   to Security.salt.
      * @return void
-     * @see \Cake\Utility\CookieCryptTrait::_encrypt()
+     * @see \Cake\Utility\CookieCryptTrait::encrypt()
      */
     public function cookieEncrypted(
         string $name,
@@ -381,7 +381,7 @@ trait IntegrationTestTrait
         ?string $key = null,
     ): void {
         $this->_cookieEncryptionKey = $key;
-        $this->_cookie[$name] = $this->_encrypt($value, $encrypt);
+        $this->_cookie[$name] = $this->encrypt($value, $encrypt);
     }
 
     /**
@@ -1416,7 +1416,7 @@ trait IntegrationTestTrait
      *   to Security.salt.
      * @param string $message The failure message that will be appended to the generated message.
      * @return void
-     * @see \Cake\Utility\CookieCryptTrait::_encrypt()
+     * @see \Cake\Utility\CookieCryptTrait::encrypt()
      */
     public function assertCookieEncrypted(
         mixed $expected,

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -396,7 +396,7 @@ trait IntegrationTestTrait
      */
     public function get(array|string $url): void
     {
-        $this->_sendRequest($url, 'GET');
+        $this->sendRequest($url, 'GET');
     }
 
     /**
@@ -412,7 +412,7 @@ trait IntegrationTestTrait
      */
     public function post(array|string $url, array|string $data = []): void
     {
-        $this->_sendRequest($url, 'POST', $data);
+        $this->sendRequest($url, 'POST', $data);
     }
 
     /**
@@ -428,7 +428,7 @@ trait IntegrationTestTrait
      */
     public function patch(array|string $url, array|string $data = []): void
     {
-        $this->_sendRequest($url, 'PATCH', $data);
+        $this->sendRequest($url, 'PATCH', $data);
     }
 
     /**
@@ -444,7 +444,7 @@ trait IntegrationTestTrait
      */
     public function put(array|string $url, array|string $data = []): void
     {
-        $this->_sendRequest($url, 'PUT', $data);
+        $this->sendRequest($url, 'PUT', $data);
     }
 
     /**
@@ -459,7 +459,7 @@ trait IntegrationTestTrait
      */
     public function delete(array|string $url): void
     {
-        $this->_sendRequest($url, 'DELETE');
+        $this->sendRequest($url, 'DELETE');
     }
 
     /**
@@ -474,7 +474,7 @@ trait IntegrationTestTrait
      */
     public function head(array|string $url): void
     {
-        $this->_sendRequest($url, 'HEAD');
+        $this->sendRequest($url, 'HEAD');
     }
 
     /**
@@ -489,7 +489,7 @@ trait IntegrationTestTrait
      */
     public function options(array|string $url): void
     {
-        $this->_sendRequest($url, 'OPTIONS');
+        $this->sendRequest($url, 'OPTIONS');
     }
 
     /**
@@ -503,13 +503,13 @@ trait IntegrationTestTrait
      * @return void
      * @throws \PHPUnit\Exception|\Throwable
      */
-    protected function _sendRequest(array|string $url, string $method, array|string $data = []): void
+    protected function sendRequest(array|string $url, string $method, array|string $data = []): void
     {
         $url = $this->resolveUrl($url);
-        $dispatcher = $this->_makeDispatcher();
+        $dispatcher = $this->makeDispatcher();
 
         try {
-            $request = $this->_buildRequest($url, $method, $data);
+            $request = $this->buildRequest($url, $method, $data);
             $response = $dispatcher->execute($request);
             $this->_requestSession = $request['session'];
             if ($this->_retainFlashMessages && $this->_flashMessages) {
@@ -521,7 +521,7 @@ trait IntegrationTestTrait
         } catch (Throwable $e) {
             $this->_exception = $e;
             // Simulate the global exception handler being invoked.
-            $this->_handleError($e);
+            $this->handleError($e);
         }
     }
 
@@ -579,7 +579,7 @@ trait IntegrationTestTrait
      *
      * @return \Cake\TestSuite\MiddlewareDispatcher A dispatcher instance
      */
-    protected function _makeDispatcher(): MiddlewareDispatcher
+    protected function makeDispatcher(): MiddlewareDispatcher
     {
         EventManager::instance()->on('Controller.initialize', $this->controllerSpy(...));
         $app = $this->createApp();
@@ -634,7 +634,7 @@ trait IntegrationTestTrait
      * @param \Throwable $exception Exception to handle.
      * @return void
      */
-    protected function _handleError(Throwable $exception): void
+    protected function handleError(Throwable $exception): void
     {
         $class = Configure::read('Error.exceptionRenderer');
         if (!$class || !class_exists($class)) {
@@ -653,13 +653,13 @@ trait IntegrationTestTrait
      * @param array|string $data The request data.
      * @return array The request context
      */
-    protected function _buildRequest(string $url, string $method, array|string $data = []): array
+    protected function buildRequest(string $url, string $method, array|string $data = []): array
     {
         $sessionConfig = (array)Configure::read('Session') + [
             'defaults' => 'php',
         ];
         $session = Session::create($sessionConfig);
-        [$url, $query, $hostInfo] = $this->_url($url);
+        [$url, $query, $hostInfo] = $this->url($url);
         $tokenUrl = $url;
 
         if ($query) {
@@ -707,9 +707,9 @@ trait IntegrationTestTrait
             $props['input'] = http_build_query($data);
         } else {
             if ($method !== 'GET' || $data !== []) {
-                $data = $this->_addTokens($tokenUrl, $data, $method);
+                $data = $this->addTokens($tokenUrl, $data, $method);
             }
-            $props['post'] = $this->_castToString($data);
+            $props['post'] = $this->castToString($data);
         }
 
         $props['cookies'] = $this->_cookie;
@@ -726,7 +726,7 @@ trait IntegrationTestTrait
      * @param string $method The request method.
      * @return array The request body with tokens added.
      */
-    protected function _addTokens(string $url, array $data, string $method): array
+    protected function addTokens(string $url, array $data, string $method): array
     {
         if ($this->_securityToken === true) {
             $fields = array_diff_key($data, array_flip($this->_unlockedFields));
@@ -776,7 +776,7 @@ trait IntegrationTestTrait
      * @param array $data POST data
      * @return array
      */
-    protected function _castToString(array $data): array
+    protected function castToString(array $data): array
     {
         foreach ($data as $key => $value) {
             if (is_scalar($value)) {
@@ -791,7 +791,7 @@ trait IntegrationTestTrait
                     continue;
                 }
 
-                $data[$key] = $this->_castToString($value);
+                $data[$key] = $this->castToString($value);
             }
         }
 
@@ -804,7 +804,7 @@ trait IntegrationTestTrait
      * @param string $url The URL
      * @return array Qualified URL, the query parameters, and host data
      */
-    protected function _url(string $url): array
+    protected function url(string $url): array
     {
         $uri = new Uri($url);
         $path = $uri->getPath();
@@ -826,7 +826,7 @@ trait IntegrationTestTrait
      *
      * @return string The response body.
      */
-    protected function _getBodyAsString(): string
+    protected function getBodyAsString(): string
     {
         if (!$this->_response) {
             $this->fail('No response set, cannot assert content.');

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -355,7 +355,7 @@ trait IntegrationTestTrait
      *
      * @return string
      */
-    protected function _getCookieEncryptionKey(): string
+    protected function getCookieEncryptionKey(): string
     {
         return $this->_cookieEncryptionKey ?? Security::getSalt();
     }
@@ -1431,7 +1431,7 @@ trait IntegrationTestTrait
         $this->_cookieEncryptionKey = $key;
         $this->assertThat(
             $expected,
-            new CookieEncryptedEquals($this->_response, $name, $encrypt, $this->_getCookieEncryptionKey()),
+            new CookieEncryptedEquals($this->_response, $name, $encrypt, $this->getCookieEncryptionKey()),
         );
     }
 

--- a/src/TestSuite/LogTestTrait.php
+++ b/src/TestSuite/LogTestTrait.php
@@ -97,7 +97,7 @@ trait LogTestTrait
         ?string $scope = null,
         string $failMsg = '',
     ): void {
-        $this->_expectLogMessage($level, $expectedMessage, $scope, $failMsg);
+        $this->expectLogMessage($level, $expectedMessage, $scope, $failMsg);
     }
 
     /**
@@ -114,7 +114,7 @@ trait LogTestTrait
         ?string $scope = null,
         string $failMsg = '',
     ): void {
-        $this->_expectLogMessage($level, $expectedMessage, $scope, $failMsg, true);
+        $this->expectLogMessage($level, $expectedMessage, $scope, $failMsg, true);
     }
 
     /**
@@ -126,7 +126,7 @@ trait LogTestTrait
      * @param bool $contains Flag to decide if the expectedMessage can only be part of the logged message
      * @return void
      */
-    protected function _expectLogMessage(
+    protected function expectLogMessage(
         string $level,
         string $expectedMessage,
         ?string $scope,

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -53,7 +53,7 @@ class MiddlewareDispatcher
      * @param array<string, mixed> $spec The request spec.
      * @return \Cake\Http\ServerRequest
      */
-    protected function _createRequest(array $spec): ServerRequest
+    protected function createRequest(array $spec): ServerRequest
     {
         if (isset($spec['input'])) {
             $spec['post'] = [];
@@ -90,6 +90,6 @@ class MiddlewareDispatcher
     {
         $server = new Server($this->app);
 
-        return $server->run($this->_createRequest($requestSpec));
+        return $server->run($this->createRequest($requestSpec));
     }
 }

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -758,7 +758,7 @@ abstract class TestCase extends BaseTestCase
                  * @var array<string, mixed> $assertion
                  * @var string $string
                  */
-                $string = $this->_assertAttributes($assertion, $string, $fullDebug, $regex);
+                $string = $this->assertAttributes($assertion, $string, $fullDebug, $regex);
                 if ($fullDebug && $string === false) {
                     debug($string, true);
                     debug($regex, true);
@@ -809,7 +809,7 @@ abstract class TestCase extends BaseTestCase
      * @param array|string $regex Full regexp from `assertHtml`
      * @return string|false
      */
-    protected function _assertAttributes(
+    protected function assertAttributes(
         array $assertions,
         string $string,
         bool $fullDebug = false,
@@ -848,7 +848,7 @@ abstract class TestCase extends BaseTestCase
      * @param string $path Path separated by "/" slash.
      * @return string Normalized path separated by DIRECTORY_SEPARATOR.
      */
-    protected function _normalizePath(string $path): string
+    protected function normalizePath(string $path): string
     {
         return str_replace('/', DIRECTORY_SEPARATOR, $path);
     }
@@ -931,7 +931,7 @@ abstract class TestCase extends BaseTestCase
      */
     public function getMockForModel(string $alias, array $methods = [], array $options = []): Table&MockObject
     {
-        $className = $this->_getTableClassName($alias, $options);
+        $className = $this->getTableClassName($alias, $options);
         $connectionName = $className::defaultConnectionName();
         $connection = ConnectionManager::get($connectionName);
 
@@ -975,7 +975,7 @@ abstract class TestCase extends BaseTestCase
      * @return class-string<\Cake\ORM\Table>
      * @throws \Cake\ORM\Exception\MissingTableClassException
      */
-    protected function _getTableClassName(string $alias, array $options): string
+    protected function getTableClassName(string $alias, array $options): string
     {
         if (empty($options['className'])) {
             $class = Inflector::camelize($alias);

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -39,7 +39,7 @@ trait CookieCryptTrait
      *
      * @return string
      */
-    abstract protected function _getCookieEncryptionKey(): string;
+    abstract protected function getCookieEncryptionKey(): string;
 
     /**
      * Encrypts $value using public $type method in Security class
@@ -61,7 +61,7 @@ trait CookieCryptTrait
         $this->_checkCipher($encrypt);
         $prefix = 'Q2FrZQ==.';
         $cipher = '';
-        $key ??= $this->_getCookieEncryptionKey();
+        $key ??= $this->getCookieEncryptionKey();
         if ($encrypt === 'aes') {
             $cipher = Security::encrypt($value, $key);
         }
@@ -136,7 +136,7 @@ trait CookieCryptTrait
             return '';
         }
 
-        $key ??= $this->_getCookieEncryptionKey();
+        $key ??= $this->getCookieEncryptionKey();
         if ($encrypt === 'aes') {
             $value = Security::decrypt($value, $key);
         }

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -50,15 +50,15 @@ trait CookieCryptTrait
      * @param string|null $key Used as the security salt if specified.
      * @return string Encoded values
      */
-    protected function _encrypt(array|string $value, string|false $encrypt, ?string $key = null): string
+    protected function encrypt(array|string $value, string|false $encrypt, ?string $key = null): string
     {
         if (is_array($value)) {
-            $value = $this->_implode($value);
+            $value = $this->implode($value);
         }
         if ($encrypt === false) {
             return $value;
         }
-        $this->_checkCipher($encrypt);
+        $this->checkCipher($encrypt);
         $prefix = 'Q2FrZQ==.';
         $cipher = '';
         $key ??= $this->getCookieEncryptionKey();
@@ -76,7 +76,7 @@ trait CookieCryptTrait
      * @return void
      * @throws \RuntimeException When an invalid cipher is provided.
      */
-    protected function _checkCipher(string $encrypt): void
+    protected function checkCipher(string $encrypt): void
     {
         if (!in_array($encrypt, $this->_validCiphers, true)) {
             $msg = sprintf(
@@ -95,15 +95,15 @@ trait CookieCryptTrait
      * @param string|null $key Used as the security salt if specified.
      * @return array|string Decrypted values
      */
-    protected function _decrypt(array|string $values, string|false $mode, ?string $key = null): array|string
+    protected function decrypt(array|string $values, string|false $mode, ?string $key = null): array|string
     {
         if (is_string($values)) {
-            return $this->_decode($values, $mode, $key);
+            return $this->decode($values, $mode, $key);
         }
 
         $decrypted = [];
         foreach ($values as $name => $value) {
-            $decrypted[$name] = $this->_decode($value, $mode, $key);
+            $decrypted[$name] = $this->decode($value, $mode, $key);
         }
 
         return $decrypted;
@@ -117,12 +117,12 @@ trait CookieCryptTrait
      * @param string|null $key Used as the security salt if specified.
      * @return array|string Decoded values.
      */
-    protected function _decode(string $value, string|false $encrypt, ?string $key): array|string
+    protected function decode(string $value, string|false $encrypt, ?string $key): array|string
     {
         if (!$encrypt) {
-            return $this->_explode($value);
+            return $this->explode($value);
         }
-        $this->_checkCipher($encrypt);
+        $this->checkCipher($encrypt);
         $prefix = 'Q2FrZQ==.';
         $prefixLength = strlen($prefix);
 
@@ -145,7 +145,7 @@ trait CookieCryptTrait
             return '';
         }
 
-        return $this->_explode($value);
+        return $this->explode($value);
     }
 
     /**
@@ -154,7 +154,7 @@ trait CookieCryptTrait
      * @param array $array Map of key and values
      * @return string A JSON encoded string.
      */
-    protected function _implode(array $array): string
+    protected function implode(array $array): string
     {
         return json_encode($array, JSON_THROW_ON_ERROR);
     }
@@ -166,7 +166,7 @@ trait CookieCryptTrait
      * @param string $string A string containing JSON encoded data, or a bare string.
      * @return array|string Map of key and values
      */
-    protected function _explode(string $string): array|string
+    protected function explode(string $string): array|string
     {
         $first = substr($string, 0, 1);
         if ($first === '{' || $first === '[') {

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -146,7 +146,7 @@ class Hash
         foreach ($tokens as $token) {
             $next = [];
 
-            [$token, $conditions] = self::_splitConditions($token);
+            [$token, $conditions] = self::splitConditions($token);
 
             foreach ($context[$_key] as $item) {
                 if (is_object($item) && method_exists($item, 'toArray')) {
@@ -154,7 +154,7 @@ class Hash
                     $item = $item->toArray();
                 }
                 foreach ((array)$item as $k => $v) {
-                    if (static::_matchToken($k, $token)) {
+                    if (static::matchToken($k, $token)) {
                         $next[] = $v;
                     }
                 }
@@ -169,7 +169,7 @@ class Hash
                             is_array($item) ||
                             $item instanceof ArrayAccess
                         ) &&
-                        static::_matches($item, $conditions)
+                        static::matches($item, $conditions)
                     ) {
                         $filter[] = $item;
                     }
@@ -188,7 +188,7 @@ class Hash
      * @param string $token the token being split.
      * @return array [token, conditions] with token split
      */
-    protected static function _splitConditions(string $token): array
+    protected static function splitConditions(string $token): array
     {
         $conditions = false;
         $position = strpos($token, '[');
@@ -207,7 +207,7 @@ class Hash
      * @param string $token The token being matched.
      * @return bool
      */
-    protected static function _matchToken(mixed $key, string $token): bool
+    protected static function matchToken(mixed $key, string $token): bool
     {
         return match ($token) {
             '{n}' => is_numeric($key),
@@ -224,7 +224,7 @@ class Hash
      * @param string $selector The patterns to match.
      * @return bool Fitness of expression.
      */
-    protected static function _matches(ArrayAccess|array $data, string $selector): bool
+    protected static function matches(ArrayAccess|array $data, string $selector): bool
     {
         preg_match_all(
             '/(\[ (?P<attr>[^=><!]+?) (\s* (?P<op>[><!]?[=]|[><]) \s* (?P<val>(?:\/.*?\/ | [^\]]+)) )? \])/x',
@@ -313,7 +313,7 @@ class Hash
         }
 
         if ($noTokens && !str_contains($path, '{')) {
-            return static::_simpleOp('insert', $data, $tokens, $values);
+            return static::simpleOp('insert', $data, $tokens, $values);
         }
 
         if (!is_iterable($data)) {
@@ -324,12 +324,12 @@ class Hash
         $token = array_shift($tokens);
         $nextPath = implode('.', $tokens);
 
-        [$token, $conditions] = static::_splitConditions($token);
+        [$token, $conditions] = static::splitConditions($token);
 
         foreach ($data as $k => $v) {
             if (
-                static::_matchToken($k, $token) &&
-                (!$conditions || ((is_array($v) || $v instanceof ArrayAccess) && static::_matches($v, $conditions)))
+                static::matchToken($k, $token) &&
+                (!$conditions || ((is_array($v) || $v instanceof ArrayAccess) && static::matches($v, $conditions)))
             ) {
                 $data[$k] = $nextPath
                     ? static::insert($v, $nextPath, $values)
@@ -349,7 +349,7 @@ class Hash
      * @param mixed $values The values to insert when doing inserts.
      * @return \ArrayAccess|array
      */
-    protected static function _simpleOp(
+    protected static function simpleOp(
         string $op,
         ArrayAccess|array $data,
         array $path,
@@ -415,7 +415,7 @@ class Hash
         $tokens = $noTokens ? explode('.', $path) : Text::tokenize($path, '.', '[', ']');
 
         if ($noExpansion && $noTokens) {
-            return static::_simpleOp('remove', $data, $tokens);
+            return static::simpleOp('remove', $data, $tokens);
         }
 
         if (!is_iterable($data)) {
@@ -426,13 +426,13 @@ class Hash
         $token = array_shift($tokens);
         $nextPath = implode('.', $tokens);
 
-        [$token, $conditions] = self::_splitConditions($token);
+        [$token, $conditions] = self::splitConditions($token);
 
         foreach ($data as $k => $v) {
-            $match = static::_matchToken($k, $token);
+            $match = static::matchToken($k, $token);
             if ($match && (is_array($v) || $v instanceof ArrayAccess)) {
                 if ($conditions) {
-                    if (static::_matches($v, $conditions)) {
+                    if (static::matches($v, $conditions)) {
                         if ($nextPath !== '') {
                             $data[$k] = static::remove($v, $nextPath);
                         } else {
@@ -667,7 +667,7 @@ class Hash
             }
         }
 
-        return array_filter($data, $callback ?? static::_filter(...));
+        return array_filter($data, $callback ?? static::doFilter(...));
     }
 
     /**
@@ -676,7 +676,7 @@ class Hash
      * @param mixed $var Array to filter.
      * @return bool
      */
-    protected static function _filter(mixed $var): bool
+    protected static function doFilter(mixed $var): bool
     {
         return $var === 0 || $var === 0.0 || $var === '0' || !empty($var);
     }
@@ -786,7 +786,7 @@ class Hash
             $stack[] = [(array)$curArg, &$return];
         }
         unset($curArg);
-        static::_merge($stack, $return);
+        static::doMerge($stack, $return);
 
         return $return;
     }
@@ -798,7 +798,7 @@ class Hash
      * @param array $return The return value to operate on.
      * @return void
      */
-    protected static function _merge(array $stack, array &$return): void
+    protected static function doMerge(array $stack, array &$return): void
     {
         while ($stack !== []) {
             foreach ($stack as $curKey => &$curMerge) {
@@ -1022,7 +1022,7 @@ class Hash
         } elseif ($missingData) {
             $sortValues = array_pad($sortValues, $dataCount, null);
         }
-        $result = static::_squash($sortValues);
+        $result = static::squash($sortValues);
         $keys = static::extract($result, '{n}.id');
 
         $values = static::extract($result, '{n}.value');
@@ -1085,7 +1085,7 @@ class Hash
      * @param string|int|null $key The key for the data.
      * @return array
      */
-    protected static function _squash(array $data, string|int|null $key = null): array
+    protected static function squash(array $data, string|int|null $key = null): array
     {
         $stack = [];
         foreach ($data as $k => $r) {
@@ -1094,7 +1094,7 @@ class Hash
                 $id = $key;
             }
             if (is_array($r) && $r !== []) {
-                $stack = array_merge($stack, static::_squash($r, $id));
+                $stack = array_merge($stack, static::squash($r, $id));
             } else {
                 $stack[] = ['id' => $id, 'value' => $r];
             }

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -185,7 +185,7 @@ class Inflector
      * @param string|false $value Inflected value
      * @return string|false Inflected value on cache hit or false on cache miss.
      */
-    protected static function _cache(string $type, string $key, string|false $value = false): string|false
+    protected static function cache(string $type, string $key, string|false $value = false): string|false
     {
         $key = '_' . $key;
         $type = '_' . $type;
@@ -378,11 +378,11 @@ class Inflector
     {
         $cacheKey = __FUNCTION__ . $delimiter;
 
-        $result = static::_cache($cacheKey, $string);
+        $result = static::cache($cacheKey, $string);
 
         if ($result === false) {
             $result = str_replace(' ', '', static::humanize($string, $delimiter));
-            static::_cache($cacheKey, $string, $result);
+            static::cache($cacheKey, $string, $result);
         }
 
         return $result;
@@ -428,7 +428,7 @@ class Inflector
     {
         $cacheKey = __FUNCTION__ . $delimiter;
 
-        $result = static::_cache($cacheKey, $string);
+        $result = static::cache($cacheKey, $string);
 
         if ($result === false) {
             $result = explode(' ', str_replace($delimiter, ' ', $string));
@@ -436,7 +436,7 @@ class Inflector
                 $word = mb_strtoupper(mb_substr($word, 0, 1)) . mb_substr($word, 1);
             }
             $result = implode(' ', $result);
-            static::_cache($cacheKey, $string, $result);
+            static::cache($cacheKey, $string, $result);
         }
 
         return $result;
@@ -453,11 +453,11 @@ class Inflector
     {
         $cacheKey = __FUNCTION__ . $delimiter;
 
-        $result = static::_cache($cacheKey, $string);
+        $result = static::cache($cacheKey, $string);
 
         if ($result === false) {
             $result = mb_strtolower((string)preg_replace('/(?<=\\w)([A-Z])/', $delimiter . '\\1', $string));
-            static::_cache($cacheKey, $string, $result);
+            static::cache($cacheKey, $string, $result);
         }
 
         return $result;
@@ -472,11 +472,11 @@ class Inflector
      */
     public static function tableize(string $className): string
     {
-        $result = static::_cache(__FUNCTION__, $className);
+        $result = static::cache(__FUNCTION__, $className);
 
         if ($result === false) {
             $result = static::pluralize(static::underscore($className));
-            static::_cache(__FUNCTION__, $className, $result);
+            static::cache(__FUNCTION__, $className, $result);
         }
 
         return $result;
@@ -491,11 +491,11 @@ class Inflector
      */
     public static function classify(string $tableName): string
     {
-        $result = static::_cache(__FUNCTION__, $tableName);
+        $result = static::cache(__FUNCTION__, $tableName);
 
         if ($result === false) {
             $result = static::camelize(static::singularize($tableName));
-            static::_cache(__FUNCTION__, $tableName, $result);
+            static::cache(__FUNCTION__, $tableName, $result);
         }
 
         return $result;
@@ -510,13 +510,13 @@ class Inflector
      */
     public static function variable(string $string): string
     {
-        $result = static::_cache(__FUNCTION__, $string);
+        $result = static::cache(__FUNCTION__, $string);
 
         if ($result === false) {
             $camelized = static::camelize(static::underscore($string));
             $replace = strtolower(substr($camelized, 0, 1));
             $result = $replace . substr($camelized, 1);
-            static::_cache(__FUNCTION__, $string, $result);
+            static::cache(__FUNCTION__, $string, $result);
         }
 
         return $result;

--- a/src/Utility/MergeVariablesTrait.php
+++ b/src/Utility/MergeVariablesTrait.php
@@ -33,7 +33,7 @@ trait MergeVariablesTrait
      * @param array<string, mixed> $options The options to use when merging properties.
      * @return void
      */
-    protected function _mergeVars(array $properties, array $options = []): void
+    protected function mergeVars(array $properties, array $options = []): void
     {
         $class = static::class;
         $parents = [];
@@ -53,7 +53,7 @@ trait MergeVariablesTrait
             if ($thisValue === null || $thisValue === false) {
                 continue;
             }
-            $this->_mergeProperty($property, $parents, $options);
+            $this->mergeProperty($property, $parents, $options);
         }
     }
 
@@ -65,7 +65,7 @@ trait MergeVariablesTrait
      * @param array<string, mixed> $options Options for merging the property, see _mergeVars()
      * @return void
      */
-    protected function _mergeProperty(string $property, array $parentClasses, array $options): void
+    protected function mergeProperty(string $property, array $parentClasses, array $options): void
     {
         $thisValue = $this->{$property};
         $isAssoc = false;
@@ -88,7 +88,7 @@ trait MergeVariablesTrait
             if (!is_array($parentProperty)) {
                 continue;
             }
-            $thisValue = $this->_mergePropertyData($thisValue, $parentProperty, $isAssoc);
+            $thisValue = $this->mergePropertyData($thisValue, $parentProperty, $isAssoc);
         }
         $this->{$property} = $thisValue;
     }
@@ -101,7 +101,7 @@ trait MergeVariablesTrait
      * @param bool $isAssoc Whether the merging should be done in associative mode.
      * @return array The updated value.
      */
-    protected function _mergePropertyData(array $current, array $parent, bool $isAssoc): array
+    protected function mergePropertyData(array $current, array $parent, bool $isAssoc): array
     {
         if (!$isAssoc) {
             return array_merge($parent, $current);

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -197,7 +197,7 @@ class Security
      */
     public static function encrypt(string $plain, string $key, ?string $hmacSalt = null): string
     {
-        self::_checkKey($key, 'encrypt()');
+        self::checkKey($key, 'encrypt()');
 
         $hmacSalt ??= static::getSalt();
         // Generate the encryption and hmac key.
@@ -218,7 +218,7 @@ class Security
      * @return void
      * @throws \InvalidArgumentException When key length is not 256 bit/32 bytes
      */
-    protected static function _checkKey(string $key, string $method): void
+    protected static function checkKey(string $key, string $method): void
     {
         if (mb_strlen($key, '8bit') < 32) {
             throw new InvalidArgumentException(
@@ -239,7 +239,7 @@ class Security
      */
     public static function decrypt(string $cipher, string $key, ?string $hmacSalt = null): ?string
     {
-        self::_checkKey($key, 'decrypt()');
+        self::checkKey($key, 'decrypt()');
         if (!$cipher) {
             throw new InvalidArgumentException('The data to decrypt cannot be empty.');
         }

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -409,7 +409,7 @@ class Text
     {
         $paragraphs = explode($break, $text);
         foreach ($paragraphs as &$paragraph) {
-            $paragraph = static::_wordWrap($paragraph, $width, $break, $cut);
+            $paragraph = static::doWordWrap($paragraph, $width, $break, $cut);
         }
 
         return implode($break, $paragraphs);
@@ -424,7 +424,7 @@ class Text
      * @param bool $cut If the cut is set to true, the string is always wrapped at the specified width.
      * @return string Formatted text.
      */
-    protected static function _wordWrap(string $text, int $width = 72, string $break = "\n", bool $cut = false): string
+    protected static function doWordWrap(string $text, int $width = 72, string $break = "\n", bool $cut = false): string
     {
         $parts = [];
         if ($cut) {
@@ -592,7 +592,7 @@ class Text
         $suffix = $options['ellipsis'];
 
         if ($options['html']) {
-            $ellipsisLength = self::_strlen(strip_tags($options['ellipsis']), $options);
+            $ellipsisLength = self::strlen(strip_tags($options['ellipsis']), $options);
 
             $truncateLength = 0;
             $totalLength = 0;
@@ -603,7 +603,7 @@ class Text
             foreach ($tags as $tag) {
                 $contentLength = 0;
                 if (!in_array($tag[2], static::$_defaultHtmlNoCount, true)) {
-                    $contentLength = self::_strlen($tag[3], $options);
+                    $contentLength = self::strlen($tag[3], $options);
                 }
 
                 if ($truncate === '') {
@@ -650,22 +650,22 @@ class Text
                 $suffix .= '</' . $tag . '>';
             }
         } else {
-            if (self::_strlen($text, $options) <= $length) {
+            if (self::strlen($text, $options) <= $length) {
                 return $text;
             }
-            $ellipsisLength = self::_strlen($options['ellipsis'], $options);
+            $ellipsisLength = self::strlen($options['ellipsis'], $options);
         }
 
-        $result = self::_substr($text, 0, $length - $ellipsisLength, $options);
+        $result = self::substr($text, 0, $length - $ellipsisLength, $options);
 
         if (!$options['exact']) {
-            if (self::_substr($text, $length - $ellipsisLength, 1, $options) !== ' ') {
-                $result = self::_removeLastWord($result);
+            if (self::substr($text, $length - $ellipsisLength, 1, $options) !== ' ') {
+                $result = self::removeLastWord($result);
             }
 
             // If result is empty, then we don't need to count ellipsis in the cut.
             if ($result === '') {
-                $result = self::_substr($text, 0, $length, $options);
+                $result = self::substr($text, 0, $length, $options);
             }
         }
 
@@ -698,7 +698,7 @@ class Text
      * @param array<string, mixed> $options An array of options.
      * @return int
      */
-    protected static function _strlen(string $text, array $options): int
+    protected static function strlen(string $text, array $options): int
     {
         if (empty($options['trimWidth'])) {
             $strlen = 'mb_strlen';
@@ -738,7 +738,7 @@ class Text
      * @param array<string, mixed> $options An array of options.
      * @return string
      */
-    protected static function _substr(string $text, int $start, ?int $length, array $options): string
+    protected static function substr(string $text, int $start, ?int $length, array $options): string
     {
         if (empty($options['trimWidth'])) {
             $substr = 'mb_substr';
@@ -746,7 +746,7 @@ class Text
             $substr = 'mb_strimwidth';
         }
 
-        $maxPosition = self::_strlen($text, ['trimWidth' => false] + $options);
+        $maxPosition = self::strlen($text, ['trimWidth' => false] + $options);
         if ($start < 0) {
             $start += $maxPosition;
             if ($start < 0) {
@@ -757,12 +757,12 @@ class Text
             return '';
         }
 
-        $length ??= self::_strlen($text, $options);
+        $length ??= self::strlen($text, $options);
 
         if ($length < 0) {
-            $text = self::_substr($text, $start, null, $options);
+            $text = self::substr($text, $start, null, $options);
             $start = 0;
-            $length += self::_strlen($text, $options);
+            $length += self::strlen($text, $options);
         }
 
         if ($length <= 0) {
@@ -783,7 +783,7 @@ class Text
             $offset = 0;
 
             if ($totalOffset < $start) {
-                $len = self::_strlen($part, ['trimWidth' => false] + $options);
+                $len = self::strlen($part, ['trimWidth' => false] + $options);
                 if ($totalOffset + $len <= $start) {
                     $totalOffset += $len;
                     continue;
@@ -793,7 +793,7 @@ class Text
                 $totalOffset = $start;
             }
 
-            $len = self::_strlen($part, $options);
+            $len = self::strlen($part, $options);
             if ($offset !== 0 || $totalLength + $len > $length) {
                 if (
                     str_starts_with($part, '&')
@@ -805,7 +805,7 @@ class Text
                 }
 
                 $part = $substr($part, $offset, $length - $totalLength);
-                $len = self::_strlen($part, $options);
+                $len = self::strlen($part, $options);
             }
 
             $result .= $part;
@@ -824,7 +824,7 @@ class Text
      * @param string $text The input text
      * @return string
      */
-    protected static function _removeLastWord(string $text): string
+    protected static function removeLastWord(string $text): string
     {
         $spacepos = mb_strrpos($text, ' ');
 

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -126,11 +126,11 @@ class Xml
                 throw new CakeException(sprintf('Cannot read file content of `%s`', $input));
             }
 
-            return static::_loadXml($content, $options);
+            return static::loadXml($content, $options);
         }
 
         if (str_contains($input, '<')) {
-            return static::_loadXml($input, $options);
+            return static::loadXml($input, $options);
         }
 
         throw new XmlException('XML cannot be read.');
@@ -144,7 +144,7 @@ class Xml
      * @return \SimpleXMLElement|\DOMDocument
      * @throws \Cake\Utility\Exception\XmlException
      */
-    protected static function _loadXml(string $input, array $options): SimpleXMLElement|DOMDocument
+    protected static function loadXml(string $input, array $options): SimpleXMLElement|DOMDocument
     {
         return static::load(
             $input,
@@ -291,7 +291,7 @@ class Xml
         if ($options['pretty']) {
             $dom->formatOutput = true;
         }
-        self::_fromArray($dom, $dom, $input, $options['format']);
+        self::doFromArray($dom, $dom, $input, $options['format']);
 
         $options['return'] = strtolower($options['return']);
         if ($options['return'] === 'simplexml' || $options['return'] === 'simplexmlelement') {
@@ -311,7 +311,7 @@ class Xml
      * @return void
      * @throws \Cake\Utility\Exception\XmlException
      */
-    protected static function _fromArray(
+    protected static function doFromArray(
         DOMDocument $dom,
         DOMDocument|DOMElement $node,
         mixed $data,
@@ -372,11 +372,11 @@ class Xml
                         foreach ($value as $item) {
                             $itemData = compact('dom', 'node', 'key', 'format');
                             $itemData['value'] = $item;
-                            static::_createChild($itemData);
+                            static::createChild($itemData);
                         }
                     } else {
 // Struct
-                        static::_createChild(compact('dom', 'node', 'key', 'value', 'format'));
+                        static::createChild(compact('dom', 'node', 'key', 'value', 'format'));
                     }
                 }
             } else {
@@ -392,7 +392,7 @@ class Xml
      * @return void
      * @psalm-param {dom: \DOMDocument, node: \DOMDocument|\DOMElement, key: string, format: string, ?value: mixed} $data
      */
-    protected static function _createChild(array $data): void
+    protected static function createChild(array $data): void
     {
         $data += [
             'value' => null,
@@ -431,7 +431,7 @@ class Xml
             $child->setAttribute('xmlns', $childNS);
         }
 
-        static::_fromArray($dom, $child, $value, $format);
+        static::doFromArray($dom, $child, $value, $format);
         $node->appendChild($child);
     }
 
@@ -454,7 +454,7 @@ class Xml
 
         $result = [];
         $namespaces = array_merge(['' => ''], $obj->getNamespaces(true));
-        static::_toArray($obj, $result, '', array_keys($namespaces));
+        static::doToArray($obj, $result, '', array_keys($namespaces));
 
         return $result;
     }
@@ -468,7 +468,7 @@ class Xml
      * @param array<string> $namespaces List of namespaces in XML
      * @return void
      */
-    protected static function _toArray(SimpleXMLElement $xml, array &$parentData, string $ns, array $namespaces): void
+    protected static function doToArray(SimpleXMLElement $xml, array &$parentData, string $ns, array $namespaces): void
     {
         $data = [];
 
@@ -482,7 +482,7 @@ class Xml
             }
 
             foreach ($xml->children($namespace, true) as $child) {
-                static::_toArray($child, $data, $namespace, $namespaces);
+                static::doToArray($child, $data, $namespace, $namespaces);
             }
         }
 

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -644,7 +644,7 @@ class Validation
      * @throws \InvalidArgumentException when unsupported $type given
      * @see \Cake\I18n\Time::parseDate()
      * @see \Cake\I18n\Time::parseTime()
-     * @see \Cake\I18n\Time::parseDateTime()
+     * @see \Cake\I18n\Time::doParseDateTime()
      */
     public static function localizedTime(mixed $check, string $type = 'datetime', string|int|null $format = null): bool
     {

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -152,7 +152,7 @@ class Validation
             return false;
         }
 
-        return static::_check($check, '/[^\s]+/m');
+        return static::check($check, '/[^\s]+/m');
     }
 
     /**
@@ -170,7 +170,7 @@ class Validation
             return false;
         }
 
-        return self::_check($check, '/^[\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}]+$/Du');
+        return self::check($check, '/^[\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}]+$/Du');
     }
 
     /**
@@ -199,7 +199,7 @@ class Validation
             return false;
         }
 
-        return self::_check($check, '/^[[:alnum:]]+$/');
+        return self::check($check, '/^[[:alnum:]]+$/');
     }
 
     /**
@@ -261,7 +261,7 @@ class Validation
             return false;
         }
 
-        if ($regex !== null && static::_check($check, $regex)) {
+        if ($regex !== null && static::check($check, $regex)) {
             return !$deep || static::luhn($check);
         }
         $cards = [
@@ -289,7 +289,7 @@ class Validation
             foreach ($type as $value) {
                 $regex = $cards['all'][strtolower($value)];
 
-                if (static::_check($check, $regex)) {
+                if (static::check($check, $regex)) {
                     return static::luhn($check);
                 }
             }
@@ -297,14 +297,14 @@ class Validation
             foreach ($cards['all'] as $value) {
                 $regex = $value;
 
-                if (static::_check($check, $regex)) {
+                if (static::check($check, $regex)) {
                     return static::luhn($check);
                 }
             }
         } else {
             $regex = $cards['fast'];
 
-            if (static::_check($check, $regex)) {
+            if (static::check($check, $regex)) {
                 return static::luhn($check);
             }
         }
@@ -422,7 +422,7 @@ class Validation
             return false;
         }
 
-        return static::_check($check, $regex);
+        return static::check($check, $regex);
     }
 
     /**
@@ -458,12 +458,12 @@ class Validation
             return false;
         }
         if (is_array($check)) {
-            $check = static::_getDateString($check);
+            $check = static::getDateString($check);
             $format = 'ymd';
         }
 
         if ($regex !== null) {
-            return static::_check($check, $regex);
+            return static::check($check, $regex);
         }
         $month = '(0[123456789]|10|11|12)';
         $separator = '([- /.])';
@@ -505,7 +505,7 @@ class Validation
 
         $format = (array)$format;
         foreach ($format as $key) {
-            if (static::_check($check, $regex[$key])) {
+            if (static::check($check, $regex[$key])) {
                 return true;
             }
         }
@@ -563,7 +563,7 @@ class Validation
 
         $valid = false;
         if (is_array($check)) {
-            $check = static::_getDateString($check);
+            $check = static::getDateString($check);
             $dateFormat = 'ymd';
         }
         $parts = preg_split('/[\sT]+/', $check);
@@ -601,7 +601,7 @@ class Validation
         // phpcs:ignore Generic.Files.LineLength
         $regex = '/^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/';
 
-        return static::_check($check, $regex);
+        return static::check($check, $regex);
     }
 
     /**
@@ -620,7 +620,7 @@ class Validation
             return true;
         }
         if (is_array($check)) {
-            $check = static::_getDateString($check);
+            $check = static::getDateString($check);
         }
 
         if (!is_scalar($check)) {
@@ -630,7 +630,7 @@ class Validation
         $meridianClockRegex = '^((0?[1-9]|1[012])(:[0-5]\d){0,2} ?([AP]M|[ap]m))$';
         $standardClockRegex = '^([01]\d|2[0-3])((:[0-5]\d){1,2}|(:[0-5]\d){2}\.\d{0,6})$';
 
-        return static::_check($check, '%' . $meridianClockRegex . '|' . $standardClockRegex . '%');
+        return static::check($check, '%' . $meridianClockRegex . '|' . $standardClockRegex . '%');
     }
 
     /**
@@ -733,7 +733,7 @@ class Validation
             [$check, $regex] = static::getDecimalRegex($check, $places);
         }
 
-        return static::_check($check, $regex);
+        return static::check($check, $regex);
     }
 
     /**
@@ -780,7 +780,7 @@ class Validation
 
         $check = str_replace([$groupingSep, $decimalPoint], ['', '.'], $check);
 
-        return static::_check($check, $regex);
+        return static::check($check, $regex);
     }
 
     /**
@@ -833,7 +833,7 @@ class Validation
         // phpcs:ignore Generic.Files.LineLength
         $regex ??= '/^[\p{L}0-9!#$%&\'*+\/=?^_`{|}~-]+(?:\.[\p{L}0-9!#$%&\'*+\/=?^_`{|}~-]+)*@' . self::$_pattern['hostname'] . '$/ui';
 
-        $return = static::_check($check, $regex);
+        $return = static::check($check, $regex);
         if ($deep === false || $deep === null) {
             return $return;
         }
@@ -1162,7 +1162,7 @@ class Validation
             $regex = '/^(?!\x{00a2})\p{Sc}?' . $money . '$/u';
         }
 
-        return static::_check($check, $regex);
+        return static::check($check, $regex);
     }
 
     /**
@@ -1237,7 +1237,7 @@ class Validation
     {
         $regex = $allowZero ? '/^(?:0|[1-9][0-9]*)$/' : '/^[1-9][0-9]*$/';
 
-        return static::_check($check, $regex);
+        return static::check($check, $regex);
     }
 
     /**
@@ -1291,7 +1291,7 @@ class Validation
             return false;
         }
 
-        static::_populateIp();
+        static::populateIp();
 
         $emoji = '\x{1F190}-\x{1F9EF}';
         $alpha = '0-9\p{L}\p{N}' . $emoji;
@@ -1307,7 +1307,7 @@ class Validation
             '(?:#' . $fragmentAndQuery . '*)?$/iu';
         // phpcs:enable Generic.Files.LineLength
 
-        return static::_check($check, $regex);
+        return static::check($check, $regex);
     }
 
     /**
@@ -1343,7 +1343,7 @@ class Validation
     {
         $regex = '/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[0-5][a-fA-F0-9]{3}-[089aAbB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$/';
 
-        return self::_check($check, $regex);
+        return self::check($check, $regex);
     }
 
     /**
@@ -1353,7 +1353,7 @@ class Validation
      * @param string $regex Regular expression
      * @return bool Success of match
      */
-    protected static function _check(mixed $check, string $regex): bool
+    protected static function check(mixed $check, string $regex): bool
     {
         return is_scalar($check) && preg_match($regex, (string)$check);
     }
@@ -1421,7 +1421,7 @@ class Validation
         }
 
         if (is_string($mimeTypes)) {
-            return self::_check($mime, $mimeTypes);
+            return self::check($mime, $mimeTypes);
         }
 
         foreach ($mimeTypes as $key => $val) {
@@ -1840,7 +1840,7 @@ class Validation
      */
     public static function hexColor(mixed $check): bool
     {
-        return static::_check($check, '/^#[0-9a-f]{6}$/iD');
+        return static::check($check, '/^#[0-9a-f]{6}$/iD');
     }
 
     /**
@@ -1888,7 +1888,7 @@ class Validation
      * @param array<string, mixed> $value The array representing a date or datetime.
      * @return string
      */
-    protected static function _getDateString(array $value): string
+    protected static function getDateString(array $value): string
     {
         $formatted = '';
         if (
@@ -1934,7 +1934,7 @@ class Validation
      *
      * @return void
      */
-    protected static function _populateIp(): void
+    protected static function populateIp(): void
     {
         // phpcs:disable Generic.Files.LineLength
         if (!isset(static::$_pattern['IPv6'])) {
@@ -1967,7 +1967,7 @@ class Validation
      *
      * @return void
      */
-    protected static function _reset(): void
+    protected static function reset(): void
     {
         static::$errors = [];
     }

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -80,7 +80,7 @@ class ValidationRule
      */
     public function __construct(array $validator)
     {
-        $this->_addValidatorProps($validator);
+        $this->addValidatorProps($validator);
     }
 
     /**
@@ -116,7 +116,7 @@ class ValidationRule
     {
         $context += ['data' => [], 'newRecord' => true, 'providers' => $providers];
 
-        if ($this->_skip($context)) {
+        if ($this->skip($context)) {
             return true;
         }
 
@@ -178,7 +178,7 @@ class ValidationRule
      *   be passed as the last argument for the validation method
      * @return bool True if the ValidationRule should be skipped
      */
-    protected function _skip(array $context): bool
+    protected function skip(array $context): bool
     {
         if (is_string($this->_on)) {
             $newRecord = $context['newRecord'];
@@ -202,7 +202,7 @@ class ValidationRule
      * @param array<string, mixed> $validator [optional]
      * @return void
      */
-    protected function _addValidatorProps(array $validator = []): void
+    protected function addValidatorProps(array $validator = []): void
     {
         foreach ($validator as $key => $value) {
             if (!$value) {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -233,7 +233,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             $providers = $this->_providers;
             $context = compact('data', 'newRecord', 'field', 'providers');
 
-            if (!$keyPresent && !$this->_checkPresence($field, $context)) {
+            if (!$keyPresent && !$this->checkPresence($field, $context)) {
                 $errors[$name]['_required'] = $this->getRequiredMessage($name);
                 continue;
             }
@@ -241,7 +241,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 continue;
             }
 
-            $canBeEmpty = $this->_canBeEmpty($field, $context);
+            $canBeEmpty = $this->canBeEmpty($field, $context);
 
             $flags = static::EMPTY_NULL;
             if (isset($this->_allowEmptyFlags[$name])) {
@@ -259,7 +259,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 continue;
             }
 
-            $result = $this->_processRules($name, $field, $data, $newRecord);
+            $result = $this->processRules($name, $field, $data, $newRecord);
             if ($result) {
                 $errors[$name] = $result;
             }
@@ -656,11 +656,11 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ];
 
         if (!is_array($field)) {
-            $field = $this->_convertValidatorToArray((string)$field, $defaults);
+            $field = $this->convertValidatorToArray((string)$field, $defaults);
         }
 
         foreach ($field as $fieldName => $setting) {
-            $settings = $this->_convertValidatorToArray((string)$fieldName, $defaults, $setting);
+            $settings = $this->convertValidatorToArray((string)$fieldName, $defaults, $setting);
             /** @var string $fieldName */
             $fieldName = current(array_keys($settings));
 
@@ -1020,7 +1020,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @return array<string, array<string|int, mixed>>
      * @throws \InvalidArgumentException
      */
-    protected function _convertValidatorToArray(
+    protected function convertValidatorToArray(
         string $fieldName,
         array $defaults = [],
         array|string|int $settings = [],
@@ -3032,7 +3032,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $data = [];
         $context = compact('data', 'newRecord', 'field', 'providers');
 
-        return $this->_canBeEmpty($this->field($field), $context);
+        return $this->canBeEmpty($this->field($field), $context);
     }
 
     /**
@@ -3049,7 +3049,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $data = [];
         $context = compact('data', 'newRecord', 'field', 'providers');
 
-        return !$this->_checkPresence($this->field($field), $context);
+        return !$this->checkPresence($this->field($field), $context);
     }
 
     /**
@@ -3143,7 +3143,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param array<string, mixed> $context A key value list of data containing the validation context.
      * @return bool
      */
-    protected function _checkPresence(ValidationSet $field, array $context): bool
+    protected function checkPresence(ValidationSet $field, array $context): bool
     {
         $required = $field->isPresenceRequired();
 
@@ -3167,7 +3167,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param array<string, mixed> $context a key value list of data containing the validation context.
      * @return bool
      */
-    protected function _canBeEmpty(ValidationSet $field, array $context): bool
+    protected function canBeEmpty(ValidationSet $field, array $context): bool
     {
         $allowed = $field->isEmptyAllowed();
 
@@ -3247,7 +3247,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param bool $newRecord whether is it a new record or an existing one
      * @return array<string, mixed>
      */
-    protected function _processRules(string $field, ValidationSet $rules, array $data, bool $newRecord): array
+    protected function processRules(string $field, ValidationSet $rules, array $data, bool $newRecord): array
     {
         $errors = [];
 

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -165,7 +165,7 @@ abstract class Cell implements EventDispatcherInterface, Stringable
     {
         $cache = [];
         if ($this->_cache) {
-            $cache = $this->_cacheConfig($this->action, $template);
+            $cache = $this->cacheConfig($this->action, $template);
         }
 
         $render = function () use ($template): string {
@@ -231,7 +231,7 @@ abstract class Cell implements EventDispatcherInterface, Stringable
      * @param string|null $template The name of the template to be rendered.
      * @return array The cache configuration.
      */
-    protected function _cacheConfig(string $action, ?string $template = null): array
+    protected function cacheConfig(string $action, ?string $template = null): array
     {
         if (!$this->_cache) {
             return [];

--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -75,7 +75,7 @@ trait CellTrait
 
         $options = ['action' => $action, 'args' => $data] + $options;
 
-        return $this->_createCell($className, $action, $plugin, $options);
+        return $this->createCell($className, $action, $plugin, $options);
     }
 
     /**
@@ -87,7 +87,7 @@ trait CellTrait
      * @param array<string, mixed> $options The constructor options for the cell.
      * @return \Cake\View\Cell
      */
-    protected function _createCell(string $className, string $action, ?string $plugin, array $options): Cell
+    protected function createCell(string $className, string $action, ?string $plugin, array $options): Cell
     {
         /** @var \Cake\View\Cell $instance */
         $instance = new $className($this->request, $this->response, $this->getEventManager(), $options);

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -104,7 +104,7 @@ class EntityContext implements ContextInterface
             'validator' => [],
         ];
         $this->_context = $context;
-        $this->_prepare();
+        $this->prepare();
     }
 
     /**
@@ -122,7 +122,7 @@ class EntityContext implements ContextInterface
      * @return void
      * @throws \Cake\Core\Exception\CakeException When a table object cannot be located/inferred.
      */
-    protected function _prepare(): void
+    protected function prepare(): void
     {
         $table = $this->_context['table'];
 
@@ -177,7 +177,7 @@ class EntityContext implements ContextInterface
     public function isPrimaryKey(string $field): bool
     {
         $parts = explode('.', $field);
-        $table = $this->_getTable($parts);
+        $table = $this->getTable($parts);
         if (!$table) {
             return false;
         }
@@ -241,7 +241,7 @@ class EntityContext implements ContextInterface
         $entity = $this->entity($parts);
 
         if ($entity && end($parts) === '_ids') {
-            return $this->_extractMultiple($entity, $parts);
+            return $this->extractMultiple($entity, $parts);
         }
 
         if ($entity instanceof EntityInterface) {
@@ -266,7 +266,7 @@ class EntityContext implements ContextInterface
                 return $options['default'];
             }
 
-            return $this->_schemaDefault($parts);
+            return $this->schemaDefault($parts);
         }
         if (is_array($entity) || $entity instanceof ArrayAccess) {
             $key = array_pop($parts);
@@ -283,9 +283,9 @@ class EntityContext implements ContextInterface
      * @param array<string> $parts Each one of the parts in a path for a field name
      * @return mixed
      */
-    protected function _schemaDefault(array $parts): mixed
+    protected function schemaDefault(array $parts): mixed
     {
-        $table = $this->_getTable($parts);
+        $table = $this->getTable($parts);
         if ($table === null) {
             return null;
         }
@@ -306,12 +306,12 @@ class EntityContext implements ContextInterface
      * @param array<string> $path Each one of the parts in a path for a field name
      * @return array|null
      */
-    protected function _extractMultiple(mixed $values, array $path): ?array
+    protected function extractMultiple(mixed $values, array $path): ?array
     {
         if (!is_iterable($values)) {
             return null;
         }
-        $table = $this->_getTable($path, false);
+        $table = $this->getTable($path, false);
         $primary = $table ? (array)$table->getPrimaryKey() : ['id'];
 
         return (new Collection($values))->extract($primary[0])->toArray();
@@ -353,10 +353,10 @@ class EntityContext implements ContextInterface
         $last = $len - 1;
         for ($i = 0; $i < $len; $i++) {
             $prop = $path[$i];
-            $next = $this->_getProp($entity, $prop);
+            $next = $this->getProp($entity, $prop);
             $isLast = ($i === $last);
             if (!$isLast && $next === null && $prop !== '_ids') {
-                $table = $this->_getTable($path);
+                $table = $this->getTable($path);
                 if ($table) {
                     return $table->newEmptyEntity();
                 }
@@ -415,7 +415,7 @@ class EntityContext implements ContextInterface
         $leafEntity = $entity;
         for ($i = 0; $i < $len; $i++) {
             $prop = $path[$i];
-            $next = $this->_getProp($entity, $prop);
+            $next = $this->getProp($entity, $prop);
 
             // Did not dig into an entity, return the current one.
             if (is_array($entity) && (!$next instanceof EntityInterface && !$next instanceof Traversable)) {
@@ -450,7 +450,7 @@ class EntityContext implements ContextInterface
      * @param string $field The next field to fetch.
      * @return mixed
      */
-    protected function _getProp(mixed $target, string $field): mixed
+    protected function getProp(mixed $target, string $field): mixed
     {
         if (is_array($target) && isset($target[$field])) {
             return $target[$field];
@@ -487,7 +487,7 @@ class EntityContext implements ContextInterface
             $isNew = $entity->isNew();
         }
 
-        $validator = $this->_getValidator($parts);
+        $validator = $this->getValidator($parts);
         $fieldName = array_pop($parts);
         if (!$validator->hasField($fieldName)) {
             return null;
@@ -506,7 +506,7 @@ class EntityContext implements ContextInterface
     {
         $parts = explode('.', $field);
 
-        $validator = $this->_getValidator($parts);
+        $validator = $this->getValidator($parts);
         $fieldName = array_pop($parts);
         if (!$validator->hasField($fieldName)) {
             return null;
@@ -529,7 +529,7 @@ class EntityContext implements ContextInterface
     public function getMaxLength(string $field): ?int
     {
         $parts = explode('.', $field);
-        $validator = $this->_getValidator($parts);
+        $validator = $this->getValidator($parts);
         $fieldName = array_pop($parts);
 
         if ($validator->hasField($fieldName)) {
@@ -557,7 +557,7 @@ class EntityContext implements ContextInterface
      */
     public function fieldNames(): array
     {
-        $table = $this->_getTable('0');
+        $table = $this->getTable('0');
         if (!$table) {
             return [];
         }
@@ -573,7 +573,7 @@ class EntityContext implements ContextInterface
      * @return \Cake\Validation\Validator
      * @throws \Cake\Core\Exception\CakeException If validator cannot be retrieved based on the parts.
      */
-    protected function _getValidator(array $parts): Validator
+    protected function getValidator(array $parts): Validator
     {
         $keyParts = array_filter(array_slice($parts, 0, -1), function ($part) {
             return !is_numeric($part);
@@ -589,7 +589,7 @@ class EntityContext implements ContextInterface
             return $this->_validator[$key];
         }
 
-        $table = $this->_getTable($parts);
+        $table = $this->getTable($parts);
         if (!$table) {
             throw new InvalidArgumentException(sprintf('Validator not found: `%s`.', $key));
         }
@@ -619,7 +619,7 @@ class EntityContext implements ContextInterface
      *  when a nonexistent field/property is being encountered.
      * @return \Cake\ORM\Table|null Table instance or null
      */
-    protected function _getTable(EntityInterface|array|string $parts, bool $fallback = true): ?Table
+    protected function getTable(EntityInterface|array|string $parts, bool $fallback = true): ?Table
     {
         if (!is_array($parts) || count($parts) === 1) {
             return $this->_tables[$this->_rootName];
@@ -674,7 +674,7 @@ class EntityContext implements ContextInterface
     public function type(string $field): ?string
     {
         $parts = explode('.', $field);
-        $table = $this->_getTable($parts);
+        $table = $this->getTable($parts);
 
         return $table?->getSchema()->baseColumnType(array_pop($parts));
     }
@@ -688,7 +688,7 @@ class EntityContext implements ContextInterface
     public function attributes(string $field): array
     {
         $parts = explode('.', $field);
-        $table = $this->_getTable($parts);
+        $table = $this->getTable($parts);
         if (!$table) {
             return [];
         }

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -105,7 +105,7 @@ class FormContext implements ContextInterface
             return $options['default'];
         }
 
-        return $this->_schemaDefault($field);
+        return $this->schemaDefault($field);
     }
 
     /**
@@ -114,7 +114,7 @@ class FormContext implements ContextInterface
      * @param string $field Field name.
      * @return mixed
      */
-    protected function _schemaDefault(string $field): mixed
+    protected function schemaDefault(string $field): mixed
     {
         $field = $this->_form->getSchema()->field($field);
         if (!$field) {

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -128,7 +128,7 @@ class Helper implements EventListenerInterface
      * @param string $cancelCode Code to be executed after user chose 'Cancel'
      * @return string "onclick" JS code
      */
-    protected function _confirm(string $okCode, string $cancelCode): string
+    protected function confirm(string $okCode, string $cancelCode): string
     {
         return "if (confirm(this.dataset.confirmMessage)) { {$okCode} } {$cancelCode}";
     }

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -388,7 +388,7 @@ class FormHelper extends Helper
                 $options['context'] = [];
             }
             $options['context']['entity'] = $context;
-            $context = $this->_getContext((array)$options['context']);
+            $context = $this->getContext((array)$options['context']);
             unset($options['context']);
         }
 
@@ -428,11 +428,11 @@ class FormHelper extends Helper
             $url = $this->_View->getRequest()->getRequestTarget();
             $action = null;
         } else {
-            $url = $this->_formUrl($context, $options);
+            $url = $this->formUrl($context, $options);
             $action = $this->Url->build($url);
         }
 
-        $this->_lastAction($url);
+        $this->lastAction($url);
         unset($options['url'], $options['idPrefix']);
 
         $htmlAttributes = [];
@@ -478,7 +478,7 @@ class FormHelper extends Helper
                 $this->formProtector = $this->createFormProtector($formTokenData);
             }
 
-            $append .= $this->_csrfField();
+            $append .= $this->csrfField();
         }
 
         if ($append) {
@@ -500,7 +500,7 @@ class FormHelper extends Helper
      * @param array<string, mixed> $options An array of options from create()
      * @return array|string The action attribute for the form.
      */
-    protected function _formUrl(ContextInterface $context, array $options): array|string
+    protected function formUrl(ContextInterface $context, array $options): array|string
     {
         $request = $this->_View->getRequest();
 
@@ -533,7 +533,7 @@ class FormHelper extends Helper
      * @param array|string|null $url The URL of the last form.
      * @return void
      */
-    protected function _lastAction(array|string|null $url = null): void
+    protected function lastAction(array|string|null $url = null): void
     {
         $action = Router::url($url, true);
         $query = parse_url($action, PHP_URL_QUERY);
@@ -549,7 +549,7 @@ class FormHelper extends Helper
      *
      * @return string
      */
-    protected function _csrfField(): string
+    protected function csrfField(): string
     {
         $request = $this->_View->getRequest();
 
@@ -632,7 +632,7 @@ class FormHelper extends Helper
 
         $tokenData = $this->formProtector->buildTokenData(
             $this->_lastAction,
-            $this->_getFormProtectorSessionId(),
+            $this->getFormProtectorSessionId(),
         );
         $tokenFields = array_merge($secureAttributes, [
             'value' => $tokenData['fields'],
@@ -677,7 +677,7 @@ class FormHelper extends Helper
      *
      * @return string
      */
-    protected function _getFormProtectorSessionId(): string
+    protected function getFormProtectorSessionId(): string
     {
         return $this->_View->getRequest()->getSession()->id();
     }
@@ -733,7 +733,7 @@ class FormHelper extends Helper
      */
     public function isFieldError(string $field): bool
     {
-        return $this->_getContext()->hasError($field);
+        return $this->getContext()->hasError($field);
     }
 
     /**
@@ -760,7 +760,7 @@ class FormHelper extends Helper
         }
         $options += ['escape' => true];
 
-        $context = $this->_getContext();
+        $context = $this->getContext();
         if (!$context->hasError($field)) {
             return '';
         }
@@ -805,7 +805,7 @@ class FormHelper extends Helper
 
         return $this->formatTemplate('error', [
             'content' => $error,
-            'id' => $this->_domId($field) . '-error',
+            'id' => $this->domId($field) . '-error',
         ]);
     }
 
@@ -888,7 +888,7 @@ class FormHelper extends Helper
             $labelFor = $options['for'];
             unset($options['for']);
         } else {
-            $labelFor = $this->_domId($fieldName);
+            $labelFor = $this->domId($fieldName);
         }
         $attrs = $options + [
             'for' => $labelFor,
@@ -938,7 +938,7 @@ class FormHelper extends Helper
      */
     public function allControls(array $fields = [], array $options = []): string
     {
-        $context = $this->_getContext();
+        $context = $this->getContext();
 
         $modelFields = $context->fieldNames();
 
@@ -1006,7 +1006,7 @@ class FormHelper extends Helper
     {
         $legend = $options['legend'] ?? true;
         $fieldset = $options['fieldset'] ?? true;
-        $context = $this->_getContext();
+        $context = $this->getContext();
         $out = $fields;
 
         if ($legend === true) {
@@ -1080,8 +1080,8 @@ class FormHelper extends Helper
             'templateVars' => [],
             'labelOptions' => true,
         ];
-        $options = $this->_parseOptions($fieldName, $options);
-        $options += ['id' => $this->_domId($fieldName)];
+        $options = $this->parseOptions($fieldName, $options);
+        $options += ['id' => $this->domId($fieldName)];
 
         $templater = $this->templater();
         $newTemplates = $options['templates'];
@@ -1114,7 +1114,7 @@ class FormHelper extends Helper
                 str_contains($inputContainer, '{{error}}')
             ) {
                 $options += [
-                   'aria-describedby' => $isFieldError ? $this->_domId($fieldName) . '-error' : null,
+                   'aria-describedby' => $isFieldError ? $this->domId($fieldName) . '-error' : null,
                 ];
             }
             if (isset($options['placeholder']) && $options['label'] === false) {
@@ -1159,7 +1159,7 @@ class FormHelper extends Helper
         }
 
         /** @var string $input */
-        $input = $this->_getInput($fieldName, $options + ['labelOptions' => $labelOptions]);
+        $input = $this->getInput($fieldName, $options + ['labelOptions' => $labelOptions]);
         if ($options['type'] === 'hidden' || $options['type'] === 'submit') {
             if ($newTemplates) {
                 $templater->pop();
@@ -1168,13 +1168,13 @@ class FormHelper extends Helper
             return $input;
         }
 
-        $label = $this->_getLabel($fieldName, compact('input', 'label', 'error', 'nestedInput') + $options);
+        $label = $this->getLabel($fieldName, compact('input', 'label', 'error', 'nestedInput') + $options);
         if ($nestedInput) {
-            $result = $this->_groupTemplate(compact('label', 'error', 'options'));
+            $result = $this->groupTemplate(compact('label', 'error', 'options'));
         } else {
-            $result = $this->_groupTemplate(compact('input', 'label', 'error', 'options'));
+            $result = $this->groupTemplate(compact('input', 'label', 'error', 'options'));
         }
-        $result = $this->_inputContainerTemplate([
+        $result = $this->inputContainerTemplate([
             'content' => $result,
             'error' => $error,
             'errorSuffix' => $errorSuffix,
@@ -1195,7 +1195,7 @@ class FormHelper extends Helper
      * @param array<string, mixed> $options The options for group template
      * @return string The generated group template
      */
-    protected function _groupTemplate(array $options): string
+    protected function groupTemplate(array $options): string
     {
         $groupTemplate = $options['options']['type'] . 'FormGroup';
         if (!$this->templater()->get($groupTemplate)) {
@@ -1216,7 +1216,7 @@ class FormHelper extends Helper
      * @param array<string, mixed> $options The options for input container template
      * @return string The generated input container template
      */
-    protected function _inputContainerTemplate(array $options): string
+    protected function inputContainerTemplate(array $options): string
     {
         $inputContainerTemplate = 'inputContainer';
         $checkTemplates = [
@@ -1254,7 +1254,7 @@ class FormHelper extends Helper
      * @return array|string The generated input element string
      *  or array if checkbox() is called with option 'hiddenField' set to '_split'.
      */
-    protected function _getInput(string $fieldName, array $options): array|string
+    protected function getInput(string $fieldName, array $options): array|string
     {
         $label = $options['labelOptions'];
         unset($options['labelOptions']);
@@ -1287,15 +1287,15 @@ class FormHelper extends Helper
      * @param array<string, mixed> $options Options list.
      * @return array<string, mixed> Options
      */
-    protected function _parseOptions(string $fieldName, array $options): array
+    protected function parseOptions(string $fieldName, array $options): array
     {
         $needsMagicType = false;
         if (empty($options['type'])) {
             $needsMagicType = true;
-            $options['type'] = $this->_inputType($fieldName, $options);
+            $options['type'] = $this->inputType($fieldName, $options);
         }
 
-        return $this->_magicOptions($fieldName, $options, $needsMagicType);
+        return $this->magicOptions($fieldName, $options, $needsMagicType);
     }
 
     /**
@@ -1307,9 +1307,9 @@ class FormHelper extends Helper
      * @param array<string, mixed> $options the options passed to the input method
      * @return string
      */
-    protected function _inputType(string $fieldName, array $options): string
+    protected function inputType(string $fieldName, array $options): string
     {
-        $context = $this->_getContext();
+        $context = $this->getContext();
 
         if ($context->isPrimaryKey($fieldName)) {
             return 'hidden';
@@ -1347,13 +1347,13 @@ class FormHelper extends Helper
      * @param array<string, mixed> $options Options list.
      * @return array<string, mixed>
      */
-    protected function _optionsOptions(string $fieldName, array $options): array
+    protected function optionsOptions(string $fieldName, array $options): array
     {
         if (isset($options['options'])) {
             return $options;
         }
 
-        $internalType = $this->_getContext()->type($fieldName);
+        $internalType = $this->getContext()->type($fieldName);
         if ($internalType && str_starts_with($internalType, 'enum-')) {
             $dbType = TypeFactory::build($internalType);
             if ($dbType instanceof EnumType) {
@@ -1425,7 +1425,7 @@ class FormHelper extends Helper
      * overwrite the 'type' key in options.
      * @return array<string, mixed>
      */
-    protected function _magicOptions(string $fieldName, array $options, bool $allowOverride): array
+    protected function magicOptions(string $fieldName, array $options, bool $allowOverride): array
     {
         $options += [
             'templateVars' => [],
@@ -1436,7 +1436,7 @@ class FormHelper extends Helper
         $typesWithOptions = ['text', 'number', 'radio', 'select'];
         $magicOptions = (in_array($options['type'], ['radio', 'select'], true) || $allowOverride);
         if ($magicOptions && in_array($options['type'], $typesWithOptions, true)) {
-            $options = $this->_optionsOptions($fieldName, $options);
+            $options = $this->optionsOptions($fieldName, $options);
         }
 
         if ($allowOverride && str_ends_with($fieldName, '._ids')) {
@@ -1458,7 +1458,7 @@ class FormHelper extends Helper
      */
     protected function setRequiredAndCustomValidity(string $fieldName, array $options): array
     {
-        $context = $this->_getContext();
+        $context = $this->getContext();
 
         if (!isset($options['required']) && $options['type'] !== 'hidden') {
             $options['required'] = $context->isRequired($fieldName);
@@ -1492,7 +1492,7 @@ class FormHelper extends Helper
      * @param array<string, mixed> $options Options list.
      * @return string|false Generated label element or false.
      */
-    protected function _getLabel(string $fieldName, array $options): string|false
+    protected function getLabel(string $fieldName, array $options): string|false
     {
         if ($options['type'] === 'hidden') {
             return false;
@@ -1507,7 +1507,7 @@ class FormHelper extends Helper
             return false;
         }
 
-        return $this->_inputLabel($fieldName, $label, $options);
+        return $this->inputLabel($fieldName, $label, $options);
     }
 
     /**
@@ -1518,7 +1518,7 @@ class FormHelper extends Helper
      * @param mixed $default The default option value
      * @return mixed the contents of the option or default
      */
-    protected function _extractOption(string $name, array $options, mixed $default = null): mixed
+    protected function extractOption(string $name, array $options, mixed $default = null): mixed
     {
         if (array_key_exists($name, $options)) {
             return $options[$name];
@@ -1538,7 +1538,7 @@ class FormHelper extends Helper
      * @param array<string, mixed> $options Options for the label element.
      * @return string Generated label element
      */
-    protected function _inputLabel(string $fieldName, array|string|null $label = null, array $options = []): string
+    protected function inputLabel(string $fieldName, array|string|null $label = null, array $options = []): string
     {
         $options += ['id' => null, 'input' => null, 'nestedInput' => false, 'templateVars' => []];
         $labelAttributes = ['templateVars' => $options['templateVars']];
@@ -1593,7 +1593,7 @@ class FormHelper extends Helper
         // Work around value=>val translations.
         $value = $options['value'];
         unset($options['value']);
-        $options = $this->_initInputField($fieldName, $options);
+        $options = $this->initInputField($fieldName, $options);
         $options['value'] = $value;
 
         $output = '';
@@ -1655,7 +1655,7 @@ class FormHelper extends Helper
             $attributes['id'] = true;
             $generatedHiddenId = true;
         }
-        $attributes = $this->_initInputField($fieldName, $attributes);
+        $attributes = $this->initInputField($fieldName, $attributes);
 
         $hiddenField = $attributes['hiddenField'] ?? true;
         unset($attributes['hiddenField']);
@@ -1707,7 +1707,7 @@ class FormHelper extends Helper
         }
         $options = $params[1] ?? [];
         $options['type'] ??= $method;
-        $options = $this->_initInputField($params[0], $options);
+        $options = $this->initInputField($params[0], $options);
 
         return $this->widget($options['type'], $options);
     }
@@ -1726,7 +1726,7 @@ class FormHelper extends Helper
      */
     public function textarea(string $fieldName, array $options = []): string
     {
-        $options = $this->_initInputField($fieldName, $options);
+        $options = $this->initInputField($fieldName, $options);
         unset($options['type']);
 
         return $this->widget('textarea', $options);
@@ -1747,7 +1747,7 @@ class FormHelper extends Helper
         $secure = $options['secure'];
         unset($options['secure']);
 
-        $options = $this->_initInputField($fieldName, array_merge(
+        $options = $this->initInputField($fieldName, array_merge(
             $options,
             ['secure' => static::SECURE_SKIP],
         ));
@@ -1776,7 +1776,7 @@ class FormHelper extends Helper
     public function file(string $fieldName, array $options = []): string
     {
         $options += ['secure' => true];
-        $options = $this->_initInputField($fieldName, $options);
+        $options = $this->initInputField($fieldName, $options);
 
         unset($options['val']);
         $options['type'] = 'file';
@@ -1813,7 +1813,7 @@ class FormHelper extends Helper
         $confirmMessage = $options['confirm'];
         unset($options['confirm']);
         if ($confirmMessage) {
-            $confirm = $this->_confirm('return true;', 'return false;');
+            $confirm = $this->confirm('return true;', 'return false;');
             $options['data-confirm-message'] = $confirmMessage;
             $options['onclick'] = $this->templater()->format('confirmJs', [
                 'confirmMessage' => h($confirmMessage),
@@ -1929,7 +1929,7 @@ class FormHelper extends Helper
         $templater = $this->templater();
 
         $restoreAction = $this->_lastAction;
-        $this->_lastAction($url);
+        $this->lastAction($url);
         $restoreFormProtector = $this->formProtector;
 
         $action = $templater->formatAttributes([
@@ -1944,7 +1944,7 @@ class FormHelper extends Helper
             'value' => $requestMethod,
             'secure' => static::SECURE_SKIP,
         ]);
-        $out .= $this->_csrfField();
+        $out .= $this->csrfField();
 
         $formTokenData = $this->_View->getRequest()->getAttribute('formTokenData');
         if ($formTokenData !== null) {
@@ -1976,7 +1976,7 @@ class FormHelper extends Helper
         $url = '#';
         $onClick = 'document.' . $formName . '.requestSubmit();';
         if ($confirmMessage) {
-            $onClick = $this->_confirm($onClick, '');
+            $onClick = $this->confirm($onClick, '');
             $onClick .= 'event.returnValue = false; return false;';
             $onClick = $this->templater()->format('confirmJs', [
                 'confirmMessage' => h($confirmMessage),
@@ -1990,7 +1990,7 @@ class FormHelper extends Helper
 
         $script = null;
         if ($this->_View->getRequest()->getAttribute('cspScriptNonce')) {
-            $options['id'] ??= $this->_domId('link-' . $formName);
+            $options['id'] ??= $this->domId('link-' . $formName);
             $script = $this->templater()->format('postLinkJs', [
                 'linkId' => $options['id'],
                 'content' => $onClick,
@@ -2177,7 +2177,7 @@ class FormHelper extends Helper
         ];
 
         if ($attributes['empty'] === null && $attributes['multiple'] !== 'checkbox') {
-            $required = $this->_getContext()->isRequired($fieldName);
+            $required = $this->getContext()->isRequired($fieldName);
             $attributes['empty'] = $required === null ? false : !$required;
         }
 
@@ -2200,7 +2200,7 @@ class FormHelper extends Helper
             $attributes['secure'] = false;
         }
 
-        $attributes = $this->_initInputField($fieldName, $attributes);
+        $attributes = $this->initInputField($fieldName, $attributes);
         $attributes['options'] = $options;
 
         $hidden = '';
@@ -2258,7 +2258,7 @@ class FormHelper extends Helper
             $generatedHiddenId = true;
         }
 
-        $attributes = $this->_initInputField($fieldName, $attributes);
+        $attributes = $this->initInputField($fieldName, $attributes);
         $attributes['options'] = $options;
         $attributes['idPrefix'] = $this->_idPrefix;
 
@@ -2305,7 +2305,7 @@ class FormHelper extends Helper
         $options += [
             'empty' => true,
         ];
-        $options = $this->_initInputField($fieldName, $options);
+        $options = $this->initInputField($fieldName, $options);
         unset($options['type']);
 
         return $this->widget('year', $options);
@@ -2328,7 +2328,7 @@ class FormHelper extends Helper
             'value' => null,
         ];
 
-        $options = $this->_initInputField($fieldName, $options);
+        $options = $this->initInputField($fieldName, $options);
         $options['type'] = 'month';
 
         return $this->widget('datetime', $options);
@@ -2351,7 +2351,7 @@ class FormHelper extends Helper
         $options += [
             'value' => null,
         ];
-        $options = $this->_initInputField($fieldName, $options);
+        $options = $this->initInputField($fieldName, $options);
         $options['type'] = 'datetime-local';
         $options['fieldName'] = $fieldName;
 
@@ -2374,7 +2374,7 @@ class FormHelper extends Helper
         $options += [
             'value' => null,
         ];
-        $options = $this->_initInputField($fieldName, $options);
+        $options = $this->initInputField($fieldName, $options);
         $options['type'] = 'time';
 
         return $this->widget('datetime', $options);
@@ -2397,7 +2397,7 @@ class FormHelper extends Helper
             'value' => null,
         ];
 
-        $options = $this->_initInputField($fieldName, $options);
+        $options = $this->initInputField($fieldName, $options);
         $options['type'] = 'date';
 
         return $this->widget('datetime', $options);
@@ -2427,17 +2427,17 @@ class FormHelper extends Helper
      * @param array<string, mixed> $options Array of options to append options into.
      * @return array<string, mixed> Array of options for the input.
      */
-    protected function _initInputField(string $field, array $options = []): array
+    protected function initInputField(string $field, array $options = []): array
     {
         $options += ['fieldName' => $field];
 
         if (!isset($options['secure'])) {
             $options['secure'] = $this->_View->getRequest()->getAttribute('formTokenData') !== null;
         }
-        $context = $this->_getContext();
+        $context = $this->getContext();
 
         if (isset($options['id']) && $options['id'] === true) {
-            $options['id'] = $this->_domId($field);
+            $options['id'] = $this->domId($field);
         }
 
         if (!isset($options['name'])) {
@@ -2474,7 +2474,7 @@ class FormHelper extends Helper
         if ($context->hasError($field)) {
             $options = $this->addClass($options, $this->templater()->get('errorClass'));
         }
-        $isDisabled = $this->_isDisabled($options);
+        $isDisabled = $this->isDisabled($options);
         if ($isDisabled) {
             $options['secure'] = self::SECURE_SKIP;
         }
@@ -2488,7 +2488,7 @@ class FormHelper extends Helper
      * @param array<string, mixed> $options The option set.
      * @return bool Whether the field is disabled.
      */
-    protected function _isDisabled(array $options): bool
+    protected function isDisabled(array $options): bool
     {
         if (!isset($options['disabled'])) {
             return false;
@@ -2553,7 +2553,7 @@ class FormHelper extends Helper
             $this->_context = $context;
         }
 
-        return $this->_getContext();
+        return $this->getContext();
     }
 
     /**
@@ -2566,7 +2566,7 @@ class FormHelper extends Helper
      * @throws \RuntimeException when the context class does not implement the
      *   ContextInterface.
      */
-    protected function _getContext(array $data = []): ContextInterface
+    protected function getContext(array $data = []): ContextInterface
     {
         if ($this->_context !== null && !$data) {
             return $this->_context;
@@ -2719,7 +2719,7 @@ class FormHelper extends Helper
         ];
         foreach ($this->getValueSources() as $valuesSource) {
             if ($valuesSource === 'context') {
-                $val = $this->_getContext()->val($fieldname, $options);
+                $val = $this->getContext()->val($fieldname, $options);
                 if ($val !== null) {
                     return $val;
                 }

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -294,7 +294,7 @@ class HtmlHelper extends Helper
             unset($options['confirm']);
         }
         if ($confirmMessage) {
-            $confirm = $this->_confirm('return true;', 'return false;');
+            $confirm = $this->confirm('return true;', 'return false;');
             $options['data-confirm-message'] = $confirmMessage;
             $options['onclick'] = $templater->format('confirmJs', [
                 'confirmMessage' => h($confirmMessage),
@@ -839,7 +839,7 @@ class HtmlHelper extends Helper
         $out = [];
         foreach ($data as $line) {
             $count++;
-            $cellsOut = $this->_renderCells($line, $useCount);
+            $cellsOut = $this->renderCells($line, $useCount);
             $opts = $count % 2 ? $oddTrOptions : $evenTrOptions;
             /** @var array<string, mixed> $options */
             $options = (array)$opts;
@@ -859,7 +859,7 @@ class HtmlHelper extends Helper
      * @param bool $useCount Renders the count into the row. Default is false.
      * @return array<string>
      */
-    protected function _renderCells(array $line, bool $useCount = false): array
+    protected function renderCells(array $line, bool $useCount = false): array
     {
         $i = 0;
         $cellsOut = [];
@@ -1155,7 +1155,7 @@ class HtmlHelper extends Helper
     public function nestedList(array $list, array $options = [], array $itemOptions = []): string
     {
         $options += ['tag' => 'ul'];
-        $items = $this->_nestedListItem($list, $options, $itemOptions);
+        $items = $this->nestedListItem($list, $options, $itemOptions);
 
         return $this->formatTemplate($options['tag'], [
             'attrs' => $this->templater()->formatAttributes($options, ['tag']),
@@ -1172,7 +1172,7 @@ class HtmlHelper extends Helper
      * @return string The nested list element
      * @see \Cake\View\Helper\HtmlHelper::nestedList()
      */
-    protected function _nestedListItem(array $items, array $options, array $itemOptions): string
+    protected function nestedListItem(array $items, array $options, array $itemOptions): string
     {
         $out = '';
 

--- a/src/View/Helper/IdGeneratorTrait.php
+++ b/src/View/Helper/IdGeneratorTrait.php
@@ -43,7 +43,7 @@ trait IdGeneratorTrait
      *
      * @return void
      */
-    protected function _clearIds(): void
+    protected function clearIds(): void
     {
         $this->_idSuffixes = [];
     }
@@ -57,10 +57,10 @@ trait IdGeneratorTrait
      * @param string $val The ID attribute value.
      * @return string Generated id.
      */
-    protected function _id(string $name, string $val): string
+    protected function id(string $name, string $val): string
     {
-        $name = $this->_domId($name);
-        $suffix = $this->_idSuffix($val);
+        $name = $this->domId($name);
+        $suffix = $this->idSuffix($val);
 
         return trim($name . '-' . $suffix, '-');
     }
@@ -73,7 +73,7 @@ trait IdGeneratorTrait
      * @param string $val The ID attribute value.
      * @return string Generated id suffix.
      */
-    protected function _idSuffix(string $val): string
+    protected function idSuffix(string $val): string
     {
         $idSuffix = mb_strtolower(str_replace(['/', '@', '<', '>', ' ', '"', "'"], '-', $val));
         $count = 1;
@@ -92,7 +92,7 @@ trait IdGeneratorTrait
      * @param string $value The value to convert into an ID.
      * @return string The generated id.
      */
-    protected function _domId(string $value): string
+    protected function domId(string $value): string
     {
         $domId = mb_strtolower(Text::slug($value, '-'));
         if ($this->_idPrefix) {

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -241,7 +241,7 @@ class PaginatorHelper extends Helper
      * @param array<string, mixed> $templates An array of templates with the 'active' and 'disabled' keys.
      * @return string Generated HTML
      */
-    protected function _toggledLink(string|false $text, bool $enabled, array $options, array $templates): string
+    protected function toggledLink(string|false $text, bool $enabled, array $options, array $templates): string
     {
         $template = $templates['active'];
         if (!$enabled) {
@@ -325,7 +325,7 @@ class PaginatorHelper extends Helper
             'disabled' => 'prevDisabled',
         ];
 
-        return $this->_toggledLink($title, $this->hasPrev(), $options, $templates);
+        return $this->toggledLink($title, $this->hasPrev(), $options, $templates);
     }
 
     /**
@@ -362,7 +362,7 @@ class PaginatorHelper extends Helper
             'disabled' => 'nextDisabled',
         ];
 
-        return $this->_toggledLink($title, $this->hasNext(), $options, $templates);
+        return $this->toggledLink($title, $this->hasNext(), $options, $templates);
     }
 
     /**
@@ -491,14 +491,14 @@ class PaginatorHelper extends Helper
             && !empty($options['sort'])
             && !str_contains($options['sort'], '.')
         ) {
-            $paging['sort'] = $this->_removeAlias($paging['sort']);
+            $paging['sort'] = $this->removeAlias($paging['sort']);
         }
         if (
             !empty($paging['sortDefault'])
             && !empty($options['sort'])
             && !str_contains($options['sort'], '.')
         ) {
-            $paging['sortDefault'] = $this->_removeAlias($paging['sortDefault'], $this->param('alias'));
+            $paging['sortDefault'] = $this->removeAlias($paging['sortDefault'], $this->param('alias'));
         }
 
         $options += array_intersect_key(
@@ -552,7 +552,7 @@ class PaginatorHelper extends Helper
      * @param string $field Current field
      * @return string Unaliased field if applicable
      */
-    protected function _removeAlias(string $field, ?string $alias = null): string
+    protected function removeAlias(string $field, ?string $alias = null): string
     {
         $currentModel = $alias ?: $this->param('alias');
 
@@ -707,9 +707,9 @@ class PaginatorHelper extends Helper
         }
 
         if ($options['modulus'] !== false && $params['pageCount'] > $options['modulus']) {
-            $out = $this->_modulusNumbers($templater, $params, $options);
+            $out = $this->modulusNumbers($templater, $params, $options);
         } else {
-            $out = $this->_numbers($templater, $params, $options);
+            $out = $this->doNumbers($templater, $params, $options);
         }
 
         if (isset($options['templates'])) {
@@ -727,7 +727,7 @@ class PaginatorHelper extends Helper
      * @return array An array with the start and end numbers.
      * @psalm-return array{0: int, 1: int}
      */
-    protected function _getNumbersStartAndEnd(array $params, array $options): array
+    protected function getNumbersStartAndEnd(array $params, array $options): array
     {
         $half = (int)($options['modulus'] / 2);
         $end = max(1 + $options['modulus'], $params['currentPage'] + $half);
@@ -765,7 +765,7 @@ class PaginatorHelper extends Helper
      * @param array<string, mixed> $options Options from the numbers() method.
      * @return string
      */
-    protected function _formatNumber(StringTemplate $templater, array $options): string
+    protected function formatNumber(StringTemplate $templater, array $options): string
     {
         $vars = [
             'text' => $options['text'],
@@ -783,18 +783,18 @@ class PaginatorHelper extends Helper
      * @param array<string, mixed> $options Options from the numbers() method.
      * @return string Markup output.
      */
-    protected function _modulusNumbers(StringTemplate $templater, array $params, array $options): string
+    protected function modulusNumbers(StringTemplate $templater, array $params, array $options): string
     {
         $out = '';
         $ellipsis = $templater->format('ellipsis', []);
 
-        [$start, $end] = $this->_getNumbersStartAndEnd($params, $options);
+        [$start, $end] = $this->getNumbersStartAndEnd($params, $options);
 
-        $out .= $this->_firstNumber($ellipsis, $params, $start, $options);
+        $out .= $this->firstNumber($ellipsis, $params, $start, $options);
         $out .= $options['before'];
 
         for ($i = $start; $i < $params['currentPage']; $i++) {
-            $out .= $this->_formatNumber($templater, [
+            $out .= $this->formatNumber($templater, [
                 'text' => $this->Number->format($i),
                 'page' => $i,
                 'url' => $options['url'],
@@ -809,7 +809,7 @@ class PaginatorHelper extends Helper
         $start = (int)$params['currentPage'] + 1;
         $i = $start;
         while ($i < $end) {
-            $out .= $this->_formatNumber($templater, [
+            $out .= $this->formatNumber($templater, [
                 'text' => $this->Number->format($i),
                 'page' => $i,
                 'url' => $options['url'],
@@ -818,7 +818,7 @@ class PaginatorHelper extends Helper
         }
 
         if ($end !== $params['currentPage']) {
-            $out .= $this->_formatNumber($templater, [
+            $out .= $this->formatNumber($templater, [
                 'text' => $this->Number->format($i),
                 'page' => $end,
                 'url' => $options['url'],
@@ -826,7 +826,7 @@ class PaginatorHelper extends Helper
         }
 
         $out .= $options['after'];
-        $out .= $this->_lastNumber($ellipsis, $params, $end, $options);
+        $out .= $this->lastNumber($ellipsis, $params, $end, $options);
 
         return $out;
     }
@@ -840,7 +840,7 @@ class PaginatorHelper extends Helper
      * @param array<string, mixed> $options Options from the numbers() method.
      * @return string Markup output.
      */
-    protected function _firstNumber(string $ellipsis, array $params, int $start, array $options): string
+    protected function firstNumber(string $ellipsis, array $params, int $start, array $options): string
     {
         $out = '';
         $first = is_int($options['first']) ? $options['first'] : 0;
@@ -864,7 +864,7 @@ class PaginatorHelper extends Helper
      * @param array<string, mixed> $options Options from the numbers() method.
      * @return string Markup output.
      */
-    protected function _lastNumber(string $ellipsis, array $params, int $end, array $options): string
+    protected function lastNumber(string $ellipsis, array $params, int $end, array $options): string
     {
         $out = '';
         $last = is_int($options['last']) ? $options['last'] : 0;
@@ -887,7 +887,7 @@ class PaginatorHelper extends Helper
      * @param array<string, mixed> $options Options from the numbers() method.
      * @return string Markup output.
      */
-    protected function _numbers(StringTemplate $templater, array $params, array $options): string
+    protected function doNumbers(StringTemplate $templater, array $params, array $options): string
     {
         $out = '';
         $out .= $options['before'];

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -105,13 +105,13 @@ class TextHelper extends Helper
 
         $text = (string)preg_replace_callback(
             $pattern,
-            [&$this, '_insertPlaceHolder'],
+            [&$this, 'insertPlaceHolder'],
             $text,
         );
         // phpcs:disable Generic.Files.LineLength
         $text = preg_replace_callback(
             '#(?<!href="|">)(?<!\b[[:punct:]])(?<!http://|https://|ftp://|nntp://)www\.[^\s\n\%\ <]+[^\s<\n\%\,\.\ ](?<!\))#i',
-            [&$this, '_insertPlaceHolder'],
+            [&$this, 'insertPlaceHolder'],
             $text,
         );
         // phpcs:enable Generic.Files.LineLength
@@ -119,7 +119,7 @@ class TextHelper extends Helper
             $text = h($text);
         }
 
-        return $this->_linkUrls($text, $options);
+        return $this->linkUrls($text, $options);
     }
 
     /**
@@ -129,7 +129,7 @@ class TextHelper extends Helper
      * @param array $matches An array of regexp matches.
      * @return string Replaced values.
      */
-    protected function _insertPlaceHolder(array $matches): string
+    protected function insertPlaceHolder(array $matches): string
     {
         $match = $matches[0];
         $envelope = ['', ''];
@@ -156,7 +156,7 @@ class TextHelper extends Helper
      * @param array<string, mixed> $htmlOptions The options for the generated links.
      * @return string The text with links inserted.
      */
-    protected function _linkUrls(string $text, array $htmlOptions): string
+    protected function linkUrls(string $text, array $htmlOptions): string
     {
         $replace = [];
         foreach ($this->_placeholders as $hash => $content) {
@@ -169,7 +169,7 @@ class TextHelper extends Helper
 
             $linkOptions = $htmlOptions;
             unset($htmlOptions['maxLength'], $htmlOptions['stripProtocol'], $htmlOptions['ellipsis']);
-            $link = $this->_prepareLinkLabel($link, $linkOptions);
+            $link = $this->prepareLinkLabel($link, $linkOptions);
 
             $replace[$hash] = $envelope[0] . $this->Html->link($link, $url, $htmlOptions) . $envelope[1];
         }
@@ -184,7 +184,7 @@ class TextHelper extends Helper
      * @param array $options<string, mixed> $htmlOptions The options for the generated link label.
      * @return string Modified link label.
      */
-    protected function _prepareLinkLabel(string $name, array $options): string
+    protected function prepareLinkLabel(string $name, array $options): string
     {
         if (isset($options['stripProtocol']) && $options['stripProtocol'] === true) {
             $name = (string)preg_replace('(^https?://)', '', $name);
@@ -209,7 +209,7 @@ class TextHelper extends Helper
      * @return string
      * @see \Cake\View\Helper\TextHelper::autoLinkEmails()
      */
-    protected function _linkEmails(string $text, array $options): string
+    protected function linkEmails(string $text, array $options): string
     {
         $replace = [];
         foreach ($this->_placeholders as $hash => $content) {
@@ -241,14 +241,14 @@ class TextHelper extends Helper
         $atom = '[\p{L}0-9!#$%&\'*+\/=?^_`{|}~-]';
         $text = preg_replace_callback(
             '/(?<=\s|^|\(|\>|\;)(' . $atom . '*(?:\.' . $atom . '+)*@[\p{L}0-9-]+(?:\.[\p{L}0-9-]+)+)/ui',
-            [&$this, '_insertPlaceholder'],
+            [&$this, 'insertPlaceHolder'],
             $text,
         );
         if ($options['escape']) {
             $text = h($text);
         }
 
-        return $this->_linkEmails($text, $options);
+        return $this->linkEmails($text, $options);
     }
 
     /**

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -53,7 +53,7 @@ class TimeHelper extends Helper
      * @param \DateTimeZone|string|null $timezone The override timezone if applicable.
      * @return \DateTimeZone|string|null The chosen timezone or null.
      */
-    protected function _getTimezone(DateTimeZone|string|null $timezone): DateTimeZone|string|null
+    protected function getTimezone(DateTimeZone|string|null $timezone): DateTimeZone|string|null
     {
         if ($timezone) {
             return $timezone;
@@ -94,7 +94,7 @@ class TimeHelper extends Helper
         DateTimeZone|string|null $timezone = null,
         ?string $locale = null,
     ): string {
-        $timezone = $this->_getTimezone($timezone);
+        $timezone = $this->getTimezone($timezone);
 
         return (new DateTime($dateString))->nice($timezone, $locale);
     }
@@ -253,7 +253,7 @@ class TimeHelper extends Helper
         ChronosDate|DateTimeInterface|string|int $dateString,
         DateTimeZone|string|null $timezone = null,
     ): string {
-        $timezone = $this->_getTimezone($timezone) ?: date_default_timezone_get();
+        $timezone = $this->getTimezone($timezone) ?: date_default_timezone_get();
 
         return (new DateTime($dateString))->setTimezone($timezone)->toAtomString();
     }
@@ -269,7 +269,7 @@ class TimeHelper extends Helper
         ChronosDate|DateTimeInterface|string|int $dateString,
         DateTimeZone|string|null $timezone = null,
     ): string {
-        $timezone = $this->_getTimezone($timezone) ?: date_default_timezone_get();
+        $timezone = $this->getTimezone($timezone) ?: date_default_timezone_get();
 
         return (new DateTime($dateString))->setTimezone($timezone)->toRssString();
     }
@@ -300,7 +300,7 @@ class TimeHelper extends Helper
             'element' => null,
             'timezone' => null,
         ];
-        $options['timezone'] = $this->_getTimezone($options['timezone']);
+        $options['timezone'] = $this->getTimezone($options['timezone']);
         if ($options['timezone'] && $dateTime instanceof DateTimeInterface) {
             if ($dateTime instanceof DateTime) {
                 $dateTime = clone $dateTime;
@@ -432,7 +432,7 @@ class TimeHelper extends Helper
         if ($date === null) {
             return $invalid;
         }
-        $timezone = $this->_getTimezone($timezone);
+        $timezone = $this->getTimezone($timezone);
 
         try {
             if ($date instanceof DateTime) {

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -112,7 +112,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
      * @param string $class Partial classname to resolve.
      * @return class-string<\Cake\View\Helper>|null Either the correct class name or null.
      */
-    protected function _resolveClassName(string $class): ?string
+    protected function resolveClassName(string $class): ?string
     {
         /** @var class-string<\Cake\View\Helper>|null */
         return App::className($class, 'View/Helper', 'Helper');
@@ -129,7 +129,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
      * @return void
      * @throws \Cake\View\Exception\MissingHelperException
      */
-    protected function _throwMissingClassError(string $class, ?string $plugin): void
+    protected function throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new MissingHelperException([
             'class' => $class . 'Helper',
@@ -148,7 +148,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
      * @param array<string, mixed> $config An array of settings to use for the helper.
      * @return \Cake\View\Helper The constructed helper class.
      */
-    protected function _create(object|string $class, string $alias, array $config): Helper
+    protected function create(object|string $class, string $alias, array $config): Helper
     {
         if (is_object($class)) {
             return $class;

--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -133,9 +133,9 @@ class JsonView extends SerializedView
     /**
      * @inheritDoc
      */
-    protected function _serialize(array|string $serialize): string
+    protected function serialize(array|string $serialize): string
     {
-        $data = $this->_dataToSerialize($serialize);
+        $data = $this->dataToSerialize($serialize);
 
         $jsonOptions = $this->getConfig('jsonOptions')
             ?? JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_PARTIAL_OUTPUT_ON_ERROR;
@@ -157,7 +157,7 @@ class JsonView extends SerializedView
      * @param array|string $serialize The name(s) of the view variable(s) that need(s) to be serialized.
      * @return mixed The data to serialize.
      */
-    protected function _dataToSerialize(array|string $serialize): mixed
+    protected function dataToSerialize(array|string $serialize): mixed
     {
         if (is_array($serialize)) {
             $data = [];

--- a/src/View/SerializedView.php
+++ b/src/View/SerializedView.php
@@ -62,7 +62,7 @@ abstract class SerializedView extends View
      *   need(s) to be serialized
      * @return string The serialized data.
      */
-    abstract protected function _serialize(array|string $serialize): string;
+    abstract protected function serialize(array|string $serialize): string;
 
     /**
      * Render view template or return serialized data.
@@ -77,7 +77,7 @@ abstract class SerializedView extends View
         $serialize = $this->serializeKeys();
         if ($serialize !== false) {
             try {
-                return $this->_serialize($serialize);
+                return $this->serialize($serialize);
             } catch (Exception | TypeError $e) {
                 throw new SerializationFailureException(
                     'Serialization of View data failed.',

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -161,7 +161,7 @@ class StringTemplate
     public function add(array $templates): static
     {
         $this->setConfig($templates);
-        $this->_compileTemplates(array_keys($templates));
+        $this->compileTemplates(array_keys($templates));
 
         return $this;
     }
@@ -172,7 +172,7 @@ class StringTemplate
      * @param array<string> $templates The template names to compile. If empty all templates will be compiled.
      * @return void
      */
-    protected function _compileTemplates(array $templates = []): void
+    protected function compileTemplates(array $templates = []): void
     {
         if (!$templates) {
             $templates = array_keys($this->_config);
@@ -303,7 +303,7 @@ class StringTemplate
 
         foreach ($options as $key => $value) {
             if (!isset($exclude[$key]) && $value !== false && $value !== null) {
-                $attributes[] = $this->_formatAttribute((string)$key, $value, $escape);
+                $attributes[] = $this->formatAttribute((string)$key, $value, $escape);
             }
         }
         $out = trim(implode(' ', $attributes));
@@ -320,7 +320,7 @@ class StringTemplate
      * @param bool $escape Define if the value must be escaped
      * @return string The composed attribute.
      */
-    protected function _formatAttribute(string $key, mixed $value, bool $escape = true): string
+    protected function formatAttribute(string $key, mixed $value, bool $escape = true): string
     {
         if (is_array($value)) {
             $value = implode(' ', $value);

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -658,7 +658,7 @@ class View implements EventDispatcherInterface
     {
         $options += ['callbacks' => false, 'cache' => null, 'plugin' => null, 'ignoreMissing' => false];
         if (isset($options['cache'])) {
-            $options['cache'] = $this->_elementCache(
+            $options['cache'] = $this->elementCache(
                 $name,
                 $data,
                 array_diff_key($options, ['callbacks' => false, 'plugin' => null, 'ignoreMissing' => null]),
@@ -666,14 +666,14 @@ class View implements EventDispatcherInterface
         }
 
         $pluginCheck = $options['plugin'] !== false;
-        $file = $this->_getElementFileName($name, $pluginCheck);
+        $file = $this->getElementFileName($name, $pluginCheck);
         if ($file && $options['cache']) {
             return $this->cache(function () use ($file, $data, $options): void {
-                echo $this->_renderElement($file, $data, $options);
+                echo $this->renderElement($file, $data, $options);
             }, $options['cache']);
         }
         if ($file) {
-            return $this->_renderElement($file, $data, $options);
+            return $this->renderElement($file, $data, $options);
         }
 
         if ($options['ignoreMissing']) {
@@ -740,7 +740,7 @@ class View implements EventDispatcherInterface
      */
     public function elementExists(string $name): bool
     {
-        return (bool)$this->_getElementFileName($name);
+        return (bool)$this->getElementFileName($name);
     }
 
     /**
@@ -779,10 +779,10 @@ class View implements EventDispatcherInterface
             $this->layout = $layout;
         }
 
-        $templateFileName = $this->_getTemplateFileName($template);
+        $templateFileName = $this->getTemplateFileName($template);
         $this->_currentType = static::TYPE_TEMPLATE;
         $this->dispatchEvent('View.beforeRender', [$templateFileName]);
-        $this->Blocks->set('content', $this->_render($templateFileName));
+        $this->Blocks->set('content', $this->doRender($templateFileName));
         $this->dispatchEvent('View.afterRender', [$templateFileName]);
 
         if ($this->autoLayout) {
@@ -819,7 +819,7 @@ class View implements EventDispatcherInterface
      */
     public function renderLayout(string $content, ?string $layout = null): string
     {
-        $layoutFileName = $this->_getLayoutFileName($layout);
+        $layoutFileName = $this->getLayoutFileName($layout);
 
         if ($content) {
             $this->Blocks->set('content', $content);
@@ -834,7 +834,7 @@ class View implements EventDispatcherInterface
         }
 
         $this->_currentType = static::TYPE_LAYOUT;
-        $this->Blocks->set('content', $this->_render($layoutFileName));
+        $this->Blocks->set('content', $this->doRender($layoutFileName));
 
         $this->dispatchEvent('View.afterLayout', [$layoutFileName]);
 
@@ -1055,10 +1055,10 @@ class View implements EventDispatcherInterface
         $type = str_starts_with($name, '/') ? static::TYPE_TEMPLATE : $this->_currentType;
         switch ($type) {
             case static::TYPE_ELEMENT:
-                $parent = $this->_getElementFileName($name);
+                $parent = $this->getElementFileName($name);
                 if (!$parent) {
                     [$plugin, $name] = $this->pluginSplit($name);
-                    $paths = $this->_paths($plugin);
+                    $paths = $this->paths($plugin);
                     $defaultPath = $paths[0] . static::TYPE_ELEMENT . DIRECTORY_SEPARATOR;
                     throw new LogicException(sprintf(
                         'You cannot extend an element which does not exist (%s).',
@@ -1067,10 +1067,10 @@ class View implements EventDispatcherInterface
                 }
                 break;
             case static::TYPE_LAYOUT:
-                $parent = $this->_getLayoutFileName($name);
+                $parent = $this->getLayoutFileName($name);
                 break;
             default:
-                $parent = $this->_getTemplateFileName($name);
+                $parent = $this->getTemplateFileName($name);
         }
 
         if ($parent === $this->_current) {
@@ -1131,7 +1131,7 @@ class View implements EventDispatcherInterface
      * @triggers View.beforeRenderFile $this, [$templateFile]
      * @triggers View.afterRenderFile $this, [$templateFile, $content]
      */
-    protected function _render(string $templateFile, array $data = []): string
+    protected function doRender(string $templateFile, array $data = []): string
     {
         if (!$data) {
             $data = $this->viewVars;
@@ -1141,7 +1141,7 @@ class View implements EventDispatcherInterface
 
         $this->dispatchEvent('View.beforeRenderFile', [$templateFile]);
 
-        $content = $this->_evaluate($templateFile, $data);
+        $content = $this->evaluate($templateFile, $data);
 
         $afterEvent = $this->dispatchEvent('View.afterRenderFile', [$templateFile, $content]);
         if ($afterEvent->getResult() !== null) {
@@ -1152,7 +1152,7 @@ class View implements EventDispatcherInterface
             $this->_stack[] = $this->fetch('content');
             $this->assign('content', $content);
 
-            $content = $this->_render($this->_parents[$templateFile]);
+            $content = $this->doRender($this->_parents[$templateFile]);
             $this->assign('content', array_pop($this->_stack));
         }
 
@@ -1175,7 +1175,7 @@ class View implements EventDispatcherInterface
      * @param array $dataForView Data to include in rendered view.
      * @return string Rendered output
      */
-    protected function _evaluate(string $templateFile, array $dataForView): string
+    protected function evaluate(string $templateFile, array $dataForView): string
     {
         extract($dataForView);
 
@@ -1329,7 +1329,7 @@ class View implements EventDispatcherInterface
      * @throws \Cake\View\Exception\MissingTemplateException when a template file could not be found.
      * @throws \Cake\Core\Exception\CakeException When template name not provided.
      */
-    protected function _getTemplateFileName(?string $name = null): string
+    protected function getTemplateFileName(?string $name = null): string
     {
         $templatePath = '';
         $subDir = '';
@@ -1354,7 +1354,7 @@ class View implements EventDispatcherInterface
         $name = str_replace('/', DIRECTORY_SEPARATOR, $name);
 
         if (!str_contains($name, DIRECTORY_SEPARATOR) && $name !== '' && !str_starts_with($name, '.')) {
-            $name = $templatePath . $subDir . $this->_inflectTemplateFileName($name);
+            $name = $templatePath . $subDir . $this->inflectTemplateFileName($name);
         } elseif (str_contains($name, DIRECTORY_SEPARATOR)) {
             if (str_starts_with($name, DIRECTORY_SEPARATOR) || $name[1] === ':') {
                 $name = trim($name, DIRECTORY_SEPARATOR);
@@ -1366,10 +1366,10 @@ class View implements EventDispatcherInterface
         }
 
         $name .= $this->_ext;
-        $paths = $this->_paths($plugin);
+        $paths = $this->paths($plugin);
         foreach ($paths as $path) {
             if (is_file($path . $name)) {
-                return $this->_checkFilePath($path . $name, $path);
+                return $this->checkFilePath($path . $name, $path);
             }
         }
 
@@ -1382,7 +1382,7 @@ class View implements EventDispatcherInterface
      * @param string $name Name of file which should be inflected.
      * @return string File name after conversion
      */
-    protected function _inflectTemplateFileName(string $name): string
+    protected function inflectTemplateFileName(string $name): string
     {
         return Inflector::underscore($name);
     }
@@ -1398,7 +1398,7 @@ class View implements EventDispatcherInterface
      * @return string The file path
      * @throws \InvalidArgumentException
      */
-    protected function _checkFilePath(string $file, string $path): string
+    protected function checkFilePath(string $file, string $path): string
     {
         if (!str_contains($file, '..')) {
             return $file;
@@ -1447,7 +1447,7 @@ class View implements EventDispatcherInterface
      * @throws \Cake\View\Exception\MissingLayoutException when a layout cannot be located
      * @throws \Cake\Core\Exception\CakeException
      */
-    protected function _getLayoutFileName(?string $name = null): string
+    protected function getLayoutFileName(?string $name = null): string
     {
         if ($name === null) {
             if (!$this->layout) {
@@ -1463,7 +1463,7 @@ class View implements EventDispatcherInterface
 
         foreach ($this->getLayoutPaths($plugin) as $path) {
             if (is_file($path . $name)) {
-                return $this->_checkFilePath($path . $name, $path);
+                return $this->checkFilePath($path . $name, $path);
             }
         }
 
@@ -1483,9 +1483,9 @@ class View implements EventDispatcherInterface
         if ($this->layoutPath) {
             $subDir = $this->layoutPath . DIRECTORY_SEPARATOR;
         }
-        $layoutPaths = $this->_getSubPaths(static::TYPE_LAYOUT . DIRECTORY_SEPARATOR . $subDir);
+        $layoutPaths = $this->getSubPaths(static::TYPE_LAYOUT . DIRECTORY_SEPARATOR . $subDir);
 
-        foreach ($this->_paths($plugin) as $path) {
+        foreach ($this->paths($plugin) as $path) {
             foreach ($layoutPaths as $layoutPath) {
                 yield $path . $layoutPath;
             }
@@ -1499,7 +1499,7 @@ class View implements EventDispatcherInterface
      * @param bool $pluginCheck - if false will ignore the request's plugin if parsed plugin is not loaded
      * @return string|false Either a string to the element filename or false when one can't be found.
      */
-    protected function _getElementFileName(string $name, bool $pluginCheck = true): string|false
+    protected function getElementFileName(string $name, bool $pluginCheck = true): string|false
     {
         [$plugin, $name] = $this->pluginSplit($name, $pluginCheck);
 
@@ -1521,8 +1521,8 @@ class View implements EventDispatcherInterface
      */
     protected function getElementPaths(?string $plugin): Generator
     {
-        $elementPaths = $this->_getSubPaths(static::TYPE_ELEMENT);
-        foreach ($this->_paths($plugin) as $path) {
+        $elementPaths = $this->getSubPaths(static::TYPE_ELEMENT);
+        foreach ($this->paths($plugin) as $path) {
             foreach ($elementPaths as $subDir) {
                 yield $path . $subDir . DIRECTORY_SEPARATOR;
             }
@@ -1540,7 +1540,7 @@ class View implements EventDispatcherInterface
      * @param string $basePath Base path on which to get the prefixed one.
      * @return array<string> Array with all the templates paths.
      */
-    protected function _getSubPaths(string $basePath): array
+    protected function getSubPaths(string $basePath): array
     {
         $paths = [$basePath];
         if ($this->request->getParam('prefix')) {
@@ -1566,7 +1566,7 @@ class View implements EventDispatcherInterface
      * @param bool $cached Set to false to force a refresh of view paths. Default true.
      * @return array<string> paths
      */
-    protected function _paths(?string $plugin = null, bool $cached = true): array
+    protected function paths(?string $plugin = null, bool $cached = true): array
     {
         if ($cached) {
             if ($plugin === null && $this->_paths !== []) {
@@ -1627,7 +1627,7 @@ class View implements EventDispatcherInterface
      * @return array<string, mixed> Element Cache configuration.
      * @psalm-return array{key:string, config:string}
      */
-    protected function _elementCache(string $name, array $data, array $options): array
+    protected function elementCache(string $name, array $data, array $options): array
     {
         if (isset($options['cache']['key'], $options['cache']['config'])) {
             /** @psalm-var array{key:string, config:string} $cache */
@@ -1676,7 +1676,7 @@ class View implements EventDispatcherInterface
      * @triggers View.beforeRender $this, [$file]
      * @triggers View.afterRender $this, [$file, $element]
      */
-    protected function _renderElement(string $file, array $data, array $options): string
+    protected function renderElement(string $file, array $data, array $options): string
     {
         $current = $this->_current;
         $restore = $this->_currentType;
@@ -1686,7 +1686,7 @@ class View implements EventDispatcherInterface
             $this->dispatchEvent('View.beforeRender', [$file]);
         }
 
-        $element = $this->_render($file, array_merge($this->viewVars, $data));
+        $element = $this->doRender($file, array_merge($this->viewVars, $data));
 
         if ($options['callbacks']) {
             $this->dispatchEvent('View.afterRender', [$file, $element]);

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -621,7 +621,7 @@ class ViewBuilder implements JsonSerializable
             $array[$property] = $this->{$property};
         }
 
-        array_walk_recursive($array['_vars'], $this->_checkViewVars(...));
+        array_walk_recursive($array['_vars'], $this->checkViewVars(...));
 
         return array_filter($array, function ($i) {
             return !is_array($i) && strlen((string)$i) || !empty($i);
@@ -636,7 +636,7 @@ class ViewBuilder implements JsonSerializable
      * @return void
      * @throws \InvalidArgumentException
      */
-    protected function _checkViewVars(mixed &$item, string $key): void
+    protected function checkViewVars(mixed &$item, string $key): void
     {
         if ($item instanceof Exception) {
             $item = (string)$item;

--- a/src/View/Widget/CheckboxWidget.php
+++ b/src/View/Widget/CheckboxWidget.php
@@ -60,7 +60,7 @@ class CheckboxWidget extends BasicWidget
     {
         $data += $this->mergeDefaults($data, $context);
 
-        if ($this->_isChecked($data)) {
+        if ($this->isChecked($data)) {
             $data['checked'] = true;
         }
         unset($data['val']);
@@ -84,7 +84,7 @@ class CheckboxWidget extends BasicWidget
      * @param array<string, mixed> $data Data to look at and determine checked state.
      * @return bool
      */
-    protected function _isChecked(array $data): bool
+    protected function isChecked(array $data): bool
     {
         if (array_key_exists('checked', $data)) {
             return (bool)$data['checked'];

--- a/src/View/Widget/MultiCheckboxWidget.php
+++ b/src/View/Widget/MultiCheckboxWidget.php
@@ -124,9 +124,9 @@ class MultiCheckboxWidget extends BasicWidget
         $data += $this->mergeDefaults($data, $context);
 
         $this->_idPrefix = $data['idPrefix'];
-        $this->_clearIds();
+        $this->clearIds();
 
-        return implode('', $this->_renderInputs($data, $context));
+        return implode('', $this->renderInputs($data, $context));
     }
 
     /**
@@ -136,13 +136,13 @@ class MultiCheckboxWidget extends BasicWidget
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return array<string> An array of rendered inputs.
      */
-    protected function _renderInputs(array $data, ContextInterface $context): array
+    protected function renderInputs(array $data, ContextInterface $context): array
     {
         $out = [];
         foreach ($data['options'] as $key => $val) {
             // Grouped inputs in a fieldset.
             if (is_string($key) && is_array($val) && !isset($val['text'], $val['value'])) {
-                $inputs = $this->_renderInputs(['options' => $val] + $data, $context);
+                $inputs = $this->renderInputs(['options' => $val] + $data, $context);
                 $title = $this->_templates->format('multicheckboxTitle', ['text' => $key]);
                 $out[] = $this->_templates->format('multicheckboxWrapper', [
                     'content' => $title . implode('', $inputs),
@@ -169,19 +169,19 @@ class MultiCheckboxWidget extends BasicWidget
             }
             $checkbox['name'] = $data['name'];
             $checkbox['escape'] = $data['escape'];
-            $checkbox['checked'] = $this->_isSelected((string)$checkbox['value'], $data['val']);
-            $checkbox['disabled'] = $this->_isDisabled((string)$checkbox['value'], $data['disabled']);
+            $checkbox['checked'] = $this->isSelected((string)$checkbox['value'], $data['val']);
+            $checkbox['disabled'] = $this->isDisabled((string)$checkbox['value'], $data['disabled']);
             if (empty($checkbox['id'])) {
                 if (isset($data['id'])) {
                     $checkbox['id'] = $data['id'] . '-' . trim(
-                        $this->_idSuffix((string)$checkbox['value']),
+                        $this->idSuffix((string)$checkbox['value']),
                         '-',
                     );
                 } else {
-                    $checkbox['id'] = $this->_id($checkbox['name'], (string)$checkbox['value']);
+                    $checkbox['id'] = $this->id($checkbox['name'], (string)$checkbox['value']);
                 }
             }
-            $out[] = $this->_renderInput($checkbox + $data, $context);
+            $out[] = $this->renderInput($checkbox + $data, $context);
         }
 
         return $out;
@@ -194,7 +194,7 @@ class MultiCheckboxWidget extends BasicWidget
      * @param \Cake\View\Form\ContextInterface $context Context object.
      * @return string
      */
-    protected function _renderInput(array $checkbox, ContextInterface $context): string
+    protected function renderInput(array $checkbox, ContextInterface $context): string
     {
         $input = $this->_templates->format('checkbox', [
             'name' => $checkbox['name'] . '[]',
@@ -240,7 +240,7 @@ class MultiCheckboxWidget extends BasicWidget
      * @param array<string>|string|int|false|null $selected The selected values.
      * @return bool
      */
-    protected function _isSelected(string $key, array|string|int|false|null $selected): bool
+    protected function isSelected(string $key, array|string|int|false|null $selected): bool
     {
         if ($selected === null) {
             return false;
@@ -260,7 +260,7 @@ class MultiCheckboxWidget extends BasicWidget
      * @param mixed $disabled The disabled values.
      * @return bool
      */
-    protected function _isDisabled(string $key, mixed $disabled): bool
+    protected function isDisabled(string $key, mixed $disabled): bool
     {
         if ($disabled === null || $disabled === false) {
             return false;

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -114,10 +114,10 @@ class RadioWidget extends BasicWidget
         unset($data['empty']);
 
         $this->_idPrefix = $data['idPrefix'];
-        $this->_clearIds();
+        $this->clearIds();
         $opts = [];
         foreach ($options as $val => $text) {
-            $opts[] = $this->_renderInput($val, $text, $data, $context);
+            $opts[] = $this->renderInput($val, $text, $data, $context);
         }
 
         return implode('', $opts);
@@ -130,7 +130,7 @@ class RadioWidget extends BasicWidget
      * @param array|string|true|null $disabled The disabled values.
      * @return bool
      */
-    protected function _isDisabled(array $radio, array|string|bool|null $disabled): bool
+    protected function isDisabled(array $radio, array|string|bool|null $disabled): bool
     {
         if (!$disabled) {
             return false;
@@ -152,7 +152,7 @@ class RadioWidget extends BasicWidget
      * @param \Cake\View\Form\ContextInterface $context The form context
      * @return string
      */
-    protected function _renderInput(
+    protected function renderInput(
         string|int $val,
         array|string|int $text,
         array $data,
@@ -174,11 +174,11 @@ class RadioWidget extends BasicWidget
         if (empty($radio['id'])) {
             if (isset($data['id'])) {
                 $radio['id'] = $data['id'] . '-' . rtrim(
-                    $this->_idSuffix((string)$radio['value']),
+                    $this->idSuffix((string)$radio['value']),
                     '-',
                 );
             } else {
-                $radio['id'] = $this->_id((string)$radio['name'], (string)$radio['value']);
+                $radio['id'] = $this->id((string)$radio['name'], (string)$radio['value']);
             }
         }
         if (isset($data['val']) && is_bool($data['val'])) {
@@ -194,7 +194,7 @@ class RadioWidget extends BasicWidget
             $data['label'] = $this->_templates->addClass($data['label'], $selectedClass);
         }
 
-        $radio['disabled'] = $this->_isDisabled($radio, $data['disabled']);
+        $radio['disabled'] = $this->isDisabled($radio, $data['disabled']);
         if (!empty($data['required'])) {
             $radio['required'] = true;
         }
@@ -212,7 +212,7 @@ class RadioWidget extends BasicWidget
             ),
         ]);
 
-        $label = $this->_renderLabel(
+        $label = $this->renderLabel(
             $radio,
             $data['label'],
             $input,
@@ -247,7 +247,7 @@ class RadioWidget extends BasicWidget
      * @param bool $escape Whether to HTML escape the label.
      * @return string|false Generated label.
      */
-    protected function _renderLabel(
+    protected function renderLabel(
         array $radio,
         array|string|bool|null $label,
         string $input,

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -123,7 +123,7 @@ class SelectBoxWidget extends BasicWidget
     {
         $data += $this->mergeDefaults($data, $context);
 
-        $options = $this->_renderContent($data);
+        $options = $this->renderContent($data);
         $name = $data['name'];
         unset($data['name'], $data['options'], $data['empty'], $data['val'], $data['escape']);
         if (isset($data['disabled']) && is_array($data['disabled'])) {
@@ -151,7 +151,7 @@ class SelectBoxWidget extends BasicWidget
      * @param array<string, mixed> $data The context for rendering a select.
      * @return array<string>
      */
-    protected function _renderContent(array $data): array
+    protected function renderContent(array $data): array
     {
         $options = $data['options'];
 
@@ -160,7 +160,7 @@ class SelectBoxWidget extends BasicWidget
         }
 
         if (!empty($data['empty'])) {
-            $options = $this->_emptyValue($data['empty']) + (array)$options;
+            $options = $this->emptyValue($data['empty']) + (array)$options;
         }
         if (!$options) {
             return [];
@@ -173,7 +173,7 @@ class SelectBoxWidget extends BasicWidget
         }
         $templateVars = $data['templateVars'];
 
-        return $this->_renderOptions($options, $disabled, $selected, $templateVars, $data['escape']);
+        return $this->renderOptions($options, $disabled, $selected, $templateVars, $data['escape']);
     }
 
     /**
@@ -182,7 +182,7 @@ class SelectBoxWidget extends BasicWidget
      * @param array|string|bool $value The provided empty value.
      * @return array The generated option key/value.
      */
-    protected function _emptyValue(array|string|bool $value): array
+    protected function emptyValue(array|string|bool $value): array
     {
         if ($value === true) {
             return ['' => ''];
@@ -205,7 +205,7 @@ class SelectBoxWidget extends BasicWidget
      * @param bool $escape Toggle HTML escaping
      * @return string Formatted template string
      */
-    protected function _renderOptgroup(
+    protected function renderOptgroup(
         string $label,
         ArrayAccess|array $optgroup,
         ?array $disabled,
@@ -220,7 +220,7 @@ class SelectBoxWidget extends BasicWidget
             $label = $optgroup['text'];
             $attrs = (array)$optgroup;
         }
-        $groupOptions = $this->_renderOptions($opts, $disabled, $selected, $templateVars, $escape);
+        $groupOptions = $this->renderOptions($opts, $disabled, $selected, $templateVars, $escape);
 
         return $this->_templates->format('optgroup', [
             'label' => $escape ? h($label) : $label,
@@ -242,7 +242,7 @@ class SelectBoxWidget extends BasicWidget
      * @param bool $escape Toggle HTML escaping.
      * @return array<string> Option elements.
      */
-    protected function _renderOptions(
+    protected function renderOptions(
         iterable $options,
         ?array $disabled,
         mixed $selected,
@@ -269,7 +269,7 @@ class SelectBoxWidget extends BasicWidget
                 )
             ) {
                 /** @var \ArrayAccess<string, mixed>|array<string, mixed> $val */
-                $out[] = $this->_renderOptgroup((string)$key, $val, $disabled, $selected, $templateVars, $escape);
+                $out[] = $this->renderOptgroup((string)$key, $val, $disabled, $selected, $templateVars, $escape);
                 continue;
             }
 
@@ -285,10 +285,10 @@ class SelectBoxWidget extends BasicWidget
                 $key = $optAttrs['value'];
             }
             $optAttrs['templateVars'] ??= [];
-            if ($this->_isSelected((string)$key, $selected)) {
+            if ($this->isSelected((string)$key, $selected)) {
                 $optAttrs['selected'] = true;
             }
-            if ($this->_isDisabled((string)$key, $disabled)) {
+            if ($this->isDisabled((string)$key, $disabled)) {
                 $optAttrs['disabled'] = true;
             }
             if ($templateVars) {
@@ -314,7 +314,7 @@ class SelectBoxWidget extends BasicWidget
      * @param mixed $selected The selected values.
      * @return bool
      */
-    protected function _isSelected(string $key, mixed $selected): bool
+    protected function isSelected(string $key, mixed $selected): bool
     {
         if ($selected === null) {
             return false;
@@ -336,7 +336,7 @@ class SelectBoxWidget extends BasicWidget
      * @param array<string>|null $disabled The disabled values.
      * @return bool
      */
-    protected function _isDisabled(string $key, ?array $disabled): bool
+    protected function isDisabled(string $key, ?array $disabled): bool
     {
         if ($disabled === null) {
             return false;

--- a/src/View/Widget/WidgetLocator.php
+++ b/src/View/Widget/WidgetLocator.php
@@ -167,7 +167,7 @@ class WidgetLocator
             return $this->_widgets[$name];
         }
 
-        return $this->_widgets[$name] = $this->_resolveWidget($this->_widgets[$name]);
+        return $this->_widgets[$name] = $this->resolveWidget($this->_widgets[$name]);
     }
 
     /**
@@ -187,7 +187,7 @@ class WidgetLocator
      * @return \Cake\View\Widget\WidgetInterface Widget instance.
      * @throws \InvalidArgumentException
      */
-    protected function _resolveWidget(array|string $config): WidgetInterface
+    protected function resolveWidget(array|string $config): WidgetInterface
     {
         if (is_string($config)) {
             $config = [$config];

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -109,7 +109,7 @@ class XmlView extends SerializedView
     /**
      * @inheritDoc
      */
-    protected function _serialize(array|string $serialize): string
+    protected function serialize(array|string $serialize): string
     {
         /** @var string $rootNode */
         $rootNode = $this->getConfig('rootNode', 'response');

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -188,7 +188,7 @@ class RedisEngineTest extends TestCase
      */
     public function testConnectTransient(): void
     {
-        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $Redis = $this->createPartialMock(RedisEngine::class, ['createRedisInstance']);
         $phpredis = $this->createMock(Redis::class);
 
         $phpredis->expects($this->once())
@@ -206,7 +206,7 @@ class RedisEngineTest extends TestCase
             ->willReturn(true);
 
         $Redis->expects($this->once())
-            ->method('_createRedisInstance')
+            ->method('createRedisInstance')
             ->willReturn($phpredis);
 
         $config = [
@@ -215,7 +215,7 @@ class RedisEngineTest extends TestCase
         ];
         $this->assertTrue($Redis->init($config + Cache::pool('redis')->getConfig()));
 
-        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $Redis = $this->createPartialMock(RedisEngine::class, ['createRedisInstance']);
         $phpredis = $this->createMock(Redis::class);
 
         $phpredis->expects($this->once())
@@ -233,7 +233,7 @@ class RedisEngineTest extends TestCase
             ->willReturn(true);
 
         $Redis->expects($this->once())
-            ->method('_createRedisInstance')
+            ->method('createRedisInstance')
             ->willReturn($phpredis);
 
         $config = [
@@ -249,7 +249,7 @@ class RedisEngineTest extends TestCase
      */
     public function testConnectTransientContext(): void
     {
-        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $Redis = $this->createPartialMock(RedisEngine::class, ['createRedisInstance']);
         $phpredis = $this->createMock(Redis::class);
 
         $cafile = ROOT . DS . 'vendor' . DS . 'composer' . DS . 'ca-bundle' . DS . 'res' . DS . 'cacert.pem';
@@ -279,7 +279,7 @@ class RedisEngineTest extends TestCase
             ->willReturn(true);
 
         $Redis->expects($this->once())
-            ->method('_createRedisInstance')
+            ->method('createRedisInstance')
             ->willReturn($phpredis);
 
         $config = [
@@ -296,7 +296,7 @@ class RedisEngineTest extends TestCase
      */
     public function testConnectPersistent(): void
     {
-        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $Redis = $this->createPartialMock(RedisEngine::class, ['createRedisInstance']);
         $phpredis = $this->createMock(Redis::class);
 
         $expectedPersistentId = $this->port . $Redis->getConfig('timeout') . $Redis->getConfig('database');
@@ -317,7 +317,7 @@ class RedisEngineTest extends TestCase
             ->willReturn(true);
 
         $Redis->expects($this->once())
-            ->method('_createRedisInstance')
+            ->method('createRedisInstance')
             ->willReturn($phpredis);
 
         $config = [
@@ -325,7 +325,7 @@ class RedisEngineTest extends TestCase
         ];
         $this->assertTrue($Redis->init($config + Cache::pool('redis')->getConfig()));
 
-        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $Redis = $this->createPartialMock(RedisEngine::class, ['createRedisInstance']);
         $phpredis = $this->createMock(Redis::class);
 
         $phpredis->expects($this->once())
@@ -344,7 +344,7 @@ class RedisEngineTest extends TestCase
             ->willReturn(true);
 
         $Redis->expects($this->once())
-            ->method('_createRedisInstance')
+            ->method('createRedisInstance')
             ->willReturn($phpredis);
 
         $config = [
@@ -359,7 +359,7 @@ class RedisEngineTest extends TestCase
      */
     public function testConnectPersistentContext(): void
     {
-        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $Redis = $this->createPartialMock(RedisEngine::class, ['createRedisInstance']);
         $phpredis = $this->createMock(Redis::class);
 
         $expectedPersistentId = $this->port . $Redis->getConfig('timeout') . $Redis->getConfig('database');
@@ -391,7 +391,7 @@ class RedisEngineTest extends TestCase
             ->willReturn(true);
 
         $Redis->expects($this->once())
-            ->method('_createRedisInstance')
+            ->method('createRedisInstance')
             ->willReturn($phpredis);
 
         $config = [

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -119,14 +119,14 @@ class PluginAssetsCommandsTest extends TestCase
         $parser->addOption('overwrite', ['default' => false, 'boolean' => true]);
 
         $command = $this->getMockBuilder(PluginAssetsSymlinkCommand::class)
-            ->onlyMethods(['getOptionParser', '_createSymlink', '_copyDirectory'])
+            ->onlyMethods(['getOptionParser', 'createSymlink', 'copyDirectory'])
             ->getMock();
         $command->method('getOptionParser')->willReturn($parser);
 
         $this->assertDirectoryExists($this->wwwRoot . 'test_theme');
 
-        $command->expects($this->never())->method('_createSymlink');
-        $command->expects($this->never())->method('_copyDirectory');
+        $command->expects($this->never())->method('createSymlink');
+        $command->expects($this->never())->method('copyDirectory');
         $command->run([], $io);
     }
 

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -39,7 +39,7 @@ class ConsoleOutputTest extends TestCase
     {
         parent::setUp();
         $this->output = $this->getMockBuilder(ConsoleOutput::class)
-            ->onlyMethods(['_write'])
+            ->onlyMethods(['writeMessage'])
             ->getMock();
         $this->output->setOutputAs(ConsoleOutput::COLOR);
     }
@@ -67,7 +67,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testWriteNoNewLine(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeMessage')
             ->with('Some output');
 
         $this->output->write('Some output', 0);
@@ -78,7 +78,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testWriteNewLine(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeMessage')
             ->with('Some output' . PHP_EOL);
 
         $this->output->write('Some output');
@@ -89,7 +89,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testWriteMultipleNewLines(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeMessage')
             ->with('Some output' . PHP_EOL . PHP_EOL . PHP_EOL . PHP_EOL);
 
         $this->output->write('Some output', 4);
@@ -100,7 +100,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testWriteArray(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeMessage')
             ->with('Line' . PHP_EOL . 'Line' . PHP_EOL . 'Line' . PHP_EOL);
 
         $this->output->write(['Line', 'Line', 'Line']);
@@ -141,7 +141,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testFormattingSimple(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeMessage')
             ->with("\033[31mError:\033[0m Something bad");
 
         $this->output->write('<error>Error:</error> Something bad', 0);
@@ -152,7 +152,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testFormattingNotEatingTags(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeMessage')
             ->with('<red> Something bad');
 
         $this->output->write('<red> Something bad', 0);
@@ -170,7 +170,7 @@ class ConsoleOutputTest extends TestCase
             'underline' => true,
         ]);
 
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeMessage')
             ->with("\033[35;46;5;4mAnnoy:\033[0m Something bad");
 
         $this->output->write('<annoying>Annoy:</annoying> Something bad', 0);
@@ -181,7 +181,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testFormattingMissingStyleName(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeMessage')
             ->with('<not_there>Error:</not_there> Something bad');
 
         $this->output->write('<not_there>Error:</not_there> Something bad', 0);
@@ -192,7 +192,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testFormattingMultipleStylesName(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeMessage')
             ->with("\033[31mBad\033[0m \033[33mWarning\033[0m Regular");
 
         $this->output->write('<error>Bad</error> <warning>Warning</warning> Regular', 0);
@@ -203,7 +203,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testFormattingMultipleSameTags(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeMessage')
             ->with("\033[31mBad\033[0m \033[31mWarning\033[0m Regular");
 
         $this->output->write('<error>Bad</error> <error>Warning</error> Regular', 0);
@@ -215,7 +215,7 @@ class ConsoleOutputTest extends TestCase
     public function testSetOutputAsRaw(): void
     {
         $this->output->setOutputAs(ConsoleOutput::RAW);
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeMessage')
             ->with('<error>Bad</error> Regular');
 
         $this->output->write('<error>Bad</error> Regular', 0);
@@ -228,7 +228,7 @@ class ConsoleOutputTest extends TestCase
     {
         $this->output->setOutputAs(ConsoleOutput::PLAIN);
         $this->assertSame(ConsoleOutput::PLAIN, $this->output->getOutputAs());
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeMessage')
             ->with('Bad Regular');
 
         $this->output->write('<error>Bad</error> Regular', 0);
@@ -241,7 +241,7 @@ class ConsoleOutputTest extends TestCase
     {
         $this->output->setOutputAs(ConsoleOutput::PLAIN);
         $this->output->expects($this->once())
-            ->method('_write')
+            ->method('writeMessage')
             ->with('Bad Regular <b>Left</b> <i>behind</i> <name>');
 
         $this->output->write('<error>Bad</error> Regular <b>Left</b> <i>behind</i> <name>', 0);

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -3033,9 +3033,9 @@ class SelectQueryTest extends TestCase
      * Tests that the values in tuple comparison expression are being bound correctly,
      * specifically for dialects that translate tuple comparisons.
      *
-     * @see \Cake\Database\Driver\TupleComparisonTranslatorTrait::_transformTupleComparison()
-     * @see \Cake\Database\Driver\Sqlite::_expressionTranslators()
-     * @see \Cake\Database\Driver\Sqlserver::_expressionTranslators()
+     * @see \Cake\Database\Driver\TupleComparisonTranslatorTrait::transformTupleComparison()
+     * @see \Cake\Database\Driver\Sqlite::expressionTranslators()
+     * @see \Cake\Database\Driver\Sqlserver::expressionTranslators()
      */
     public function testTupleComparisonValuesAreBeingBoundCorrectly(): void
     {
@@ -3073,9 +3073,9 @@ class SelectQueryTest extends TestCase
      * Tests that the values in tuple comparison expressions are being bound as expected
      * when types are omitted, specifically for dialects that translate tuple comparisons.
      *
-     * @see \Cake\Database\Driver\TupleComparisonTranslatorTrait::_transformTupleComparison()
-     * @see \Cake\Database\Driver\Sqlite::_expressionTranslators()
-     * @see \Cake\Database\Driver\Sqlserver::_expressionTranslators()
+     * @see \Cake\Database\Driver\TupleComparisonTranslatorTrait::transformTupleComparison()
+     * @see \Cake\Database\Driver\Sqlite::expressionTranslators()
+     * @see \Cake\Database\Driver\Sqlserver::expressionTranslators()
      */
     public function testTupleComparisonTypesCanBeOmitted(): void
     {
@@ -4155,7 +4155,7 @@ class SelectQueryTest extends TestCase
      * This replicates what the SQL Server driver would do for <= SQL Server 2008
      * when ordering on fields that are expressions.
      *
-     * @see \Cake\Database\Driver\Sqlserver::_pagingSubquery()
+     * @see \Cake\Database\Driver\Sqlserver::pagingSubquery()
      */
     public function testReusingExpressions(): void
     {

--- a/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
@@ -37,7 +37,7 @@ use PDOException;
  * Sqlserver, for which the tuple comparison will be transformed when
  * composite fields are used.
  *
- * @see \Cake\Database\Driver\TupleComparisonTranslatorTrait::_transformTupleComparison()
+ * @see \Cake\Database\Driver\TupleComparisonTranslatorTrait::transformTupleComparison()
  */
 class TupleComparisonQueryTest extends TestCase
 {

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -167,7 +167,7 @@ class FormTest extends TestCase
     {
         $form = new class extends Form {
             // phpcs:ignore CakePHP.NamingConventions.ValidFunctionName.PublicWithUnderscore
-            public function _execute(array $data): bool
+            public function doExecute(array $data): bool
             {
                 throw new Exception('Should not be called');
             }

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -38,7 +38,7 @@ class StreamTest extends TestCase
     {
         parent::setUp();
         $this->stream = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['_send'])
+            ->onlyMethods(['sendRequest'])
             ->getMock();
         stream_wrapper_unregister('http');
         stream_wrapper_register('http', CakeStreamWrapper::class);

--- a/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
@@ -37,7 +37,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
 
     protected static string $encryptedString = '';
 
-    protected function _getCookieEncryptionKey(): string
+    protected function getCookieEncryptionKey(): string
     {
         return 'super secret key that no one can guess';
     }
@@ -53,7 +53,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
 
         $this->middleware = new EncryptedCookieMiddleware(
             ['secret', 'ninja'],
-            $this->_getCookieEncryptionKey(),
+            $this->getCookieEncryptionKey(),
             'aes',
         );
     }
@@ -98,7 +98,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
         });
         $middleware = new EncryptedCookieMiddleware(
             ['secret'],
-            $this->_getCookieEncryptionKey(),
+            $this->getCookieEncryptionKey(),
             'aes',
         );
         $middleware->process($request, $handler);

--- a/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
@@ -49,7 +49,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
     {
         parent::setup();
 
-        static::$encryptedString = $this->_encrypt('secret data', 'aes');
+        static::$encryptedString = $this->encrypt('secret data', 'aes');
 
         $this->middleware = new EncryptedCookieMiddleware(
             ['secret', 'ninja'],
@@ -66,7 +66,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
         $request = new ServerRequest(['url' => '/cookies/nom']);
         $request = $request->withCookieParams([
             'plain' => 'always plain',
-            'secret' => $this->_encrypt('decoded', 'aes'),
+            'secret' => $this->encrypt('decoded', 'aes'),
         ]);
         $this->assertNotEquals('decoded', $request->getCookie('decoded'));
 
@@ -138,7 +138,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
         $this->assertTrue($cookies->has('ninja'));
         $this->assertSame(
             'shuriken',
-            $this->_decrypt($cookies->get('ninja')->getValue(), 'aes'),
+            $this->decrypt($cookies->get('ninja')->getValue(), 'aes'),
         );
     }
 
@@ -157,7 +157,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
         $this->assertNotSame('shuriken', $response->getCookie('ninja'));
         $this->assertSame(
             'shuriken',
-            $this->_decrypt($response->getCookie('ninja')['value'], 'aes'),
+            $this->decrypt($response->getCookie('ninja')['value'], 'aes'),
         );
     }
 }

--- a/tests/TestCase/Log/Engine/SyslogLogTest.php
+++ b/tests/TestCase/Log/Engine/SyslogLogTest.php
@@ -32,20 +32,20 @@ class SyslogLogTest extends TestCase
     {
         /** @var \Cake\Log\Engine\SyslogLog|\PHPUnit\Framework\MockObject\MockObject $log */
         $log = $this->getMockBuilder(SyslogLog::class)
-            ->onlyMethods(['_open', '_write'])
+            ->onlyMethods(['open', 'write'])
             ->getMock();
-        $log->expects($this->once())->method('_open')->with('', LOG_ODELAY, LOG_USER);
+        $log->expects($this->once())->method('open')->with('', LOG_ODELAY, LOG_USER);
         $log->log('debug', 'message');
 
         $log = $this->getMockBuilder(SyslogLog::class)
-            ->onlyMethods(['_open', '_write'])
+            ->onlyMethods(['open', 'write'])
             ->getMock();
         $log->setConfig([
             'prefix' => 'thing',
             'flag' => LOG_NDELAY,
             'facility' => LOG_MAIL,
         ]);
-        $log->expects($this->once())->method('_open')
+        $log->expects($this->once())->method('open')
             ->with('thing', LOG_NDELAY, LOG_MAIL);
         $log->log('debug', 'message');
     }
@@ -58,9 +58,9 @@ class SyslogLogTest extends TestCase
     {
         /** @var \Cake\Log\Engine\SyslogLog|\PHPUnit\Framework\MockObject\MockObject $log */
         $log = $this->getMockBuilder(SyslogLog::class)
-            ->onlyMethods(['_open', '_write'])
+            ->onlyMethods(['open', 'write'])
             ->getMock();
-        $log->expects($this->once())->method('_write')->with($expected, $type . ': Foo');
+        $log->expects($this->once())->method('write')->with($expected, $type . ': Foo');
         $log->log($type, 'Foo');
     }
 
@@ -71,10 +71,10 @@ class SyslogLogTest extends TestCase
     {
         /** @var \Cake\Log\Engine\SyslogLog|\PHPUnit\Framework\MockObject\MockObject $log */
         $log = $this->getMockBuilder(SyslogLog::class)
-            ->onlyMethods(['_open', '_write'])
+            ->onlyMethods(['open', 'write'])
             ->getMock();
         $log->expects($this->exactly(2))
-            ->method('_write')
+            ->method('write')
             ->with(
                 ...self::withConsecutive(
                     [LOG_DEBUG, 'debug: Foo'],

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -40,7 +40,7 @@ class MailTransportTest extends TestCase
     {
         parent::setUp();
         $this->MailTransport = $this->getMockBuilder(MailTransport::class)
-            ->onlyMethods(['_mail'])
+            ->onlyMethods(['mail'])
             ->getMock();
         $this->MailTransport->setConfig(['additionalParameters' => '-f']);
     }
@@ -98,7 +98,7 @@ class MailTransportTest extends TestCase
         $data .= "Content-Type: text/plain; charset=UTF-8{$eol}";
         $data .= 'Content-Transfer-Encoding: 8bit';
 
-        $this->MailTransport->expects($this->once())->method('_mail')
+        $this->MailTransport->expects($this->once())->method('mail')
             ->with(
                 'CakePHP <cake@cakephp.org>',
                 $encoded,

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -477,10 +477,10 @@ class SocketTest extends TestCase
     {
         $socketName = 'unix:///tmp/test.socket';
         $socket = $this->getMockBuilder(Socket::class)
-            ->onlyMethods(['_getStreamSocketClient'])
+            ->onlyMethods(['getStreamSocketClient'])
             ->getMock();
         $socket->expects($this->once())
-            ->method('_getStreamSocketClient')
+            ->method('getStreamSocketClient')
             ->with('unix:///tmp/test.socket', null, null, 1)
             ->willReturn(false);
         $socket->setConfig([

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1211,7 +1211,7 @@ class BelongsToManyTest extends TestCase
         $table->setSchema([]);
         /** @var \Cake\ORM\Association\BelongsToMany|\PHPUnit\Framework\MockObject\MockObject $assoc */
         $assoc = $this->getMockBuilder(BelongsToMany::class)
-            ->onlyMethods(['_saveTarget', 'replaceLinks'])
+            ->onlyMethods(['saveTarget', 'replaceLinks'])
             ->setConstructorArgs(['tags', ['sourceTable' => $table]])
             ->getMock();
         $entity = new Entity([
@@ -1223,7 +1223,7 @@ class BelongsToManyTest extends TestCase
         $assoc->expects($this->never())
             ->method('replaceLinks');
         $assoc->expects($this->never())
-            ->method('_saveTarget');
+            ->method('saveTarget');
         $this->assertSame($entity, $assoc->saveAssociated($entity));
     }
 
@@ -1241,7 +1241,7 @@ class BelongsToManyTest extends TestCase
         $table->setSchema([]);
         /** @var \Cake\ORM\Association\BelongsToMany|\PHPUnit\Framework\MockObject\MockObject $assoc */
         $assoc = $this->getMockBuilder(BelongsToMany::class)
-            ->onlyMethods(['_saveTarget', 'replaceLinks'])
+            ->onlyMethods(['saveTarget', 'replaceLinks'])
             ->setConstructorArgs(['tags', ['sourceTable' => $table]])
             ->getMock();
         $entity = new Entity([
@@ -1256,7 +1256,7 @@ class BelongsToManyTest extends TestCase
             ->willReturn(true);
 
         $assoc->expects($this->never())
-            ->method('_saveTarget');
+            ->method('saveTarget');
 
         $this->assertSame($entity, $assoc->saveAssociated($entity));
     }

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -59,7 +59,7 @@ class AssociationTest extends TestCase
         ];
         $this->association = $this->getMockBuilder(Association::class)
             ->onlyMethods([
-                '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
+                'options', 'attachTo', 'joinCondition', 'cascadeDelete', 'isOwningSide',
                 'saveAssociated', 'eagerLoader', 'type', 'requiresKeys',
             ])
             ->setConstructorArgs(['Foo', $config])
@@ -73,7 +73,7 @@ class AssociationTest extends TestCase
     public function testOptionsIsCalled(): void
     {
         $options = ['foo' => 'bar'];
-        $this->association->expects($this->once())->method('_options')->with($options);
+        $this->association->expects($this->once())->method('options')->with($options);
         $this->association->__construct('Name', $options);
     }
 
@@ -157,7 +157,7 @@ class AssociationTest extends TestCase
         ];
         $this->association = $this->getMockBuilder(Association::class)
             ->onlyMethods([
-                '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
+                'options', 'attachTo', 'joinCondition', 'cascadeDelete', 'isOwningSide',
                 'saveAssociated', 'eagerLoader', 'type', 'requiresKeys',
             ])
             ->setConstructorArgs(['Foo', $config])
@@ -179,7 +179,7 @@ class AssociationTest extends TestCase
         ];
         $this->association = $this->getMockBuilder(Association::class)
             ->onlyMethods([
-                '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
+                'options', 'attachTo', 'joinCondition', 'cascadeDelete', 'isOwningSide',
                 'saveAssociated', 'eagerLoader', 'type', 'requiresKeys',
             ])
             ->setConstructorArgs(['Test', $config])
@@ -204,7 +204,7 @@ class AssociationTest extends TestCase
         ];
         $this->association = $this->getMockBuilder(Association::class)
             ->onlyMethods([
-                '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
+                'options', 'attachTo', 'joinCondition', 'cascadeDelete', 'isOwningSide',
                 'saveAssociated', 'eagerLoader', 'type', 'requiresKeys',
             ])
             ->setConstructorArgs(['Test', $config])
@@ -411,7 +411,7 @@ class AssociationTest extends TestCase
         ];
         $association = $this->getMockBuilder(Association::class)
             ->onlyMethods([
-                '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
+                'options', 'attachTo', 'joinCondition', 'cascadeDelete', 'isOwningSide',
                 'saveAssociated', 'eagerLoader', 'type', 'requiresKeys',
             ])
             ->setConstructorArgs(['Foo', $config])

--- a/tests/TestCase/ORM/Query/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/Query/CompositeKeysTest.php
@@ -555,7 +555,7 @@ class CompositeKeysTest extends TestCase
     {
         $table = $this->getTableLocator()->get('SiteAuthors');
         $query = $this->getMockBuilder(SelectQuery::class)
-            ->onlyMethods(['_addDefaultFields', 'execute'])
+            ->onlyMethods(['addDefaultFields', 'execute'])
             ->setConstructorArgs([$table])
             ->getMock();
 

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -2354,11 +2354,11 @@ class SelectQueryTest extends TestCase
     {
         $query = $this->getMockBuilder(SelectQuery::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['_performCount'])
+            ->onlyMethods(['performCount'])
             ->getMock();
 
         $query->expects($this->once())
-            ->method('_performCount')
+            ->method('performCount')
             ->willReturn(1);
 
         $result = $query->count();
@@ -2376,11 +2376,11 @@ class SelectQueryTest extends TestCase
     {
         $query = $this->getMockBuilder(SelectQuery::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['_performCount'])
+            ->onlyMethods(['performCount'])
             ->getMock();
 
         $query->expects($this->exactly(2))
-            ->method('_performCount')
+            ->method('performCount')
             ->willReturn(1, 2);
 
         $result = $query->count();

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -153,11 +153,11 @@ class LinkConstraintTest extends TestCase
         $ruleMock = $this
             ->getMockBuilder(LinkConstraint::class)
             ->setConstructorArgs(['Comments', LinkConstraint::STATUS_NOT_LINKED])
-            ->onlyMethods(['_aliasFields'])
+            ->onlyMethods(['aliasFields'])
             ->getMock();
         $ruleMock
             ->expects($this->once())
-            ->method('_aliasFields')
+            ->method('aliasFields')
             ->willReturn([]);
 
         $rulesChecker = $Articles->rulesChecker();

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3984,13 +3984,13 @@ class TableTest extends TestCase
     public function testSaveCleanEntity(): void
     {
         $table = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['_processSave'])
+            ->onlyMethods(['processSave'])
             ->getMock();
         $entity = new Entity(
             ['id' => 'foo'],
             ['markNew' => false, 'markClean' => true],
         );
-        $table->expects($this->never())->method('_processSave');
+        $table->expects($this->never())->method('processSave');
         $this->assertSame($entity, $table->save($entity));
     }
 
@@ -4021,15 +4021,15 @@ class TableTest extends TestCase
     public function testSaveDeepAssociationOptions(): void
     {
         $articles = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['_insert'])
+            ->onlyMethods(['insert'])
             ->setConstructorArgs([['table' => 'articles', 'connection' => $this->connection]])
             ->getMock();
         $authors = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['_insert'])
+            ->onlyMethods(['insert'])
             ->setConstructorArgs([['table' => 'authors', 'connection' => $this->connection]])
             ->getMock();
         $supervisors = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['_insert'])
+            ->onlyMethods(['insert'])
             ->setConstructorArgs([[
                 'table' => 'authors',
                 'alias' => 'supervisors',
@@ -4037,7 +4037,7 @@ class TableTest extends TestCase
             ]])
             ->getMock();
         $tags = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['_insert'])
+            ->onlyMethods(['insert'])
             ->setConstructorArgs([['table' => 'tags', 'connection' => $this->connection]])
             ->getMock();
 
@@ -4061,21 +4061,21 @@ class TableTest extends TestCase
         $entity->author->tags[0]->setNew(true);
 
         $articles->expects($this->once())
-            ->method('_insert')
+            ->method('insert')
             ->with($entity, ['title' => 'bar'])
             ->willReturn($entity);
 
         $authors->expects($this->once())
-            ->method('_insert')
+            ->method('insert')
             ->with($entity->author, ['name' => 'Juan'])
             ->willReturn($entity->author);
 
         $supervisors->expects($this->once())
-            ->method('_insert')
+            ->method('insert')
             ->with($entity->author->supervisor, ['name' => 'Marc'])
             ->willReturn($entity->author->supervisor);
 
-        $tags->expects($this->never())->method('_insert');
+        $tags->expects($this->never())->method('insert');
 
         $this->assertSame($entity, $articles->save($entity, [
             'associated' => [
@@ -4092,11 +4092,11 @@ class TableTest extends TestCase
     {
         /** @var \TestApp\Model\Table\ArticlesTable $articles */
         $articles = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['_insert'])
+            ->onlyMethods(['insert'])
             ->setConstructorArgs([['table' => 'articles', 'connection' => $this->connection]])
             ->getMock();
         $authors = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['_insert'])
+            ->onlyMethods(['insert'])
             ->setConstructorArgs([['table' => 'authors', 'connection' => $this->connection]])
             ->getMock();
 
@@ -4119,7 +4119,7 @@ class TableTest extends TestCase
     {
         /** @var \TestApp\Model\Table\AuthorsTable $authors */
         $authors = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['_insert'])
+            ->onlyMethods(['insert'])
             ->setConstructorArgs([['table' => 'authors', 'connection' => $this->connection]])
             ->getMock();
 
@@ -4144,7 +4144,7 @@ class TableTest extends TestCase
     {
         /** @var \TestApp\Model\Table\AuthorsTable $authors */
         $authors = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['_insert'])
+            ->onlyMethods(['insert'])
             ->setConstructorArgs([['table' => 'authors', 'connection' => $this->connection]])
             ->getMock();
 
@@ -4171,7 +4171,7 @@ class TableTest extends TestCase
     {
         /** @var \TestApp\Model\Table\AuthorsTable $authors */
         $authors = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['_insert'])
+            ->onlyMethods(['insert'])
             ->setConstructorArgs([['table' => 'authors', 'connection' => $this->connection]])
             ->getMock();
         try {

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -299,7 +299,7 @@ class RouteTest extends TestCase
     public function testMatchParseExtension($url, array $expected, array $ext): void
     {
         $route = new ProtectedRoute('/{controller}/{action}/*', [], ['_ext' => $ext]);
-        $result = $route->parseExtension($url);
+        $result = $route->doParseExtension($url);
         $this->assertEquals($expected, $result);
     }
 
@@ -328,7 +328,7 @@ class RouteTest extends TestCase
     public function testNoMatchParseExtension($url, array $ext): void
     {
         $route = new ProtectedRoute('/{controller}/{action}/*', [], ['_ext' => $ext]);
-        [$outUrl, $outExt] = $route->parseExtension($url);
+        [$outUrl, $outExt] = $route->doParseExtension($url);
         $this->assertSame($url, $outUrl);
         $this->assertNull($outExt);
     }

--- a/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
@@ -114,7 +114,7 @@ class FixtureHelperTest extends TestCase
                 return 'test1';
             }
 
-            protected function _schemaFromReflection(): void
+            protected function schemaFromReflection(): void
             {
             }
         };
@@ -124,7 +124,7 @@ class FixtureHelperTest extends TestCase
                 return 'test2';
             }
 
-            protected function _schemaFromReflection(): void
+            protected function schemaFromReflection(): void
             {
             }
         };
@@ -171,7 +171,7 @@ class FixtureHelperTest extends TestCase
                 return 'test';
             }
 
-            protected function _schemaFromReflection(): void
+            protected function schemaFromReflection(): void
             {
             }
 
@@ -190,7 +190,7 @@ class FixtureHelperTest extends TestCase
                         return 'test';
                     }
 
-                    protected function _schemaFromReflection(): void
+                    protected function schemaFromReflection(): void
                     {
                     }
 
@@ -238,7 +238,7 @@ class FixtureHelperTest extends TestCase
                 return 'test';
             }
 
-            protected function _schemaFromReflection(): void
+            protected function schemaFromReflection(): void
             {
             }
 
@@ -257,7 +257,7 @@ class FixtureHelperTest extends TestCase
                         return 'test';
                     }
 
-                    protected function _schemaFromReflection(): void
+                    protected function schemaFromReflection(): void
                     {
                     }
 

--- a/tests/TestCase/TestSuite/Fixture/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TestFixtureTest.php
@@ -40,7 +40,7 @@ class TestFixtureTest extends TestCase
                 ];
             }
 
-            protected function _schemaFromReflection(): void
+            protected function schemaFromReflection(): void
             {
                 $this->_schema = new TableSchema(
                     'my_table',

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -139,7 +139,7 @@ class IntegrationTestTraitTest extends TestCase
             ],
             'upload' => new UploadedFile(__FILE__, 42, 0),
         ];
-        $request = $this->_buildRequest('/posts/add', 'POST', $data);
+        $request = $this->buildRequest('/posts/add', 'POST', $data);
         $this->assertIsString($request['post']['status']);
         $this->assertIsString($request['post']['published']);
         $this->assertSame('0', $request['post']['not_published']);
@@ -172,7 +172,7 @@ class IntegrationTestTraitTest extends TestCase
         ]);
         $this->cookie('split_token', 'def345');
         $this->session(['User' => ['id' => '1', 'username' => 'mark']]);
-        $request = $this->_buildRequest('/tasks/add', 'POST', ['title' => 'First post']);
+        $request = $this->buildRequest('/tasks/add', 'POST', ['title' => 'First post']);
 
         $this->assertSame('abc123', $request['environment']['HTTP_X_CSRF_TOKEN']);
         $this->assertSame('application/json', $request['environment']['CONTENT_TYPE']);
@@ -198,7 +198,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testRequestBuildingCsrfTokens(): void
     {
         $this->enableCsrfToken();
-        $request = $this->_buildRequest('/tasks/add', 'POST', ['title' => 'First post']);
+        $request = $this->buildRequest('/tasks/add', 'POST', ['title' => 'First post']);
 
         $this->assertArrayHasKey('csrfToken', $request['cookies']);
         $this->assertArrayHasKey('_csrfToken', $request['post']);
@@ -206,7 +206,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->assertSame($request['session']->read('csrfToken'), $request['post']['_csrfToken']);
 
         $this->cookie('csrfToken', '');
-        $request = $this->_buildRequest('/tasks/add', 'POST', [
+        $request = $this->buildRequest('/tasks/add', 'POST', [
             '_csrfToken' => 'fale',
             'title' => 'First post',
         ]);
@@ -221,8 +221,8 @@ class IntegrationTestTraitTest extends TestCase
     public function testEnableCsrfMultipleRequests(): void
     {
         $this->enableCsrfToken();
-        $first = $this->_buildRequest('/tasks/add', 'POST', ['title' => 'First post']);
-        $second = $this->_buildRequest('/tasks/add', 'POST', ['title' => 'Second post']);
+        $first = $this->buildRequest('/tasks/add', 'POST', ['title' => 'First post']);
+        $second = $this->buildRequest('/tasks/add', 'POST', ['title' => 'Second post']);
         $this->assertSame(
             $first['cookies']['csrfToken'],
             $second['post']['_csrfToken'],
@@ -247,7 +247,7 @@ class IntegrationTestTraitTest extends TestCase
     {
         $this->enableCsrfToken();
         $this->enableSecurityToken();
-        $requestWithoutTokens = $this->_buildRequest('tasks/view', 'GET');
+        $requestWithoutTokens = $this->buildRequest('tasks/view', 'GET');
 
         $this->assertArrayNotHasKey('_Token', $requestWithoutTokens['post']);
         $this->assertArrayNotHasKey('_csrfToken', $requestWithoutTokens['post']);
@@ -255,7 +255,7 @@ class IntegrationTestTraitTest extends TestCase
 
         $this->enableCsrfToken();
         $this->enableSecurityToken();
-        $requestWithTokens = $this->_buildRequest('tasks/view', 'GET', ['lorem' => 'ipsum']);
+        $requestWithTokens = $this->buildRequest('tasks/view', 'GET', ['lorem' => 'ipsum']);
 
         $this->assertArrayHasKey('_Token', $requestWithTokens['post']);
         $this->assertArrayHasKey('csrfToken', $requestWithTokens['cookies']);
@@ -267,7 +267,7 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testRequestBuildingQueryParameters(): void
     {
-        $request = $this->_buildRequest('/tasks/view?archived=yes', 'GET', []);
+        $request = $this->buildRequest('/tasks/view?archived=yes', 'GET', []);
 
         $this->assertSame('/tasks/view', $request['url']);
         $this->assertSame('archived=yes', $request['environment']['QUERY_STRING']);
@@ -283,7 +283,7 @@ class IntegrationTestTraitTest extends TestCase
     {
         Security::setSalt($this->key);
         $this->cookieEncrypted('KeyOfCookie', 'Encrypted with aes by default');
-        $request = $this->_buildRequest('/tasks/view', 'GET', []);
+        $request = $this->buildRequest('/tasks/view', 'GET', []);
         $this->assertStringStartsWith('Q2FrZQ==.', $request['cookies']['KeyOfCookie']);
     }
 
@@ -314,7 +314,7 @@ class IntegrationTestTraitTest extends TestCase
 
         $this->get('/some_alias');
         $this->assertResponseOk();
-        $this->assertSame('5', $this->_getBodyAsString());
+        $this->assertSame('5', $this->getBodyAsString());
     }
 
     public function testExceptionsInMiddlewareJsonView(): void

--- a/tests/TestCase/Utility/MergeVariablesTraitTest.php
+++ b/tests/TestCase/Utility/MergeVariablesTraitTest.php
@@ -31,7 +31,7 @@ class MergeVariablesTraitTest extends TestCase
     public function testMergeVarsAsList(): void
     {
         $object = new Grandchild();
-        $object->mergeVars(['listProperty']);
+        $object->doMergeVars(['listProperty']);
 
         $expected = ['One', 'Two', 'Three', 'Four', 'Five'];
         $this->assertSame($expected, $object->listProperty);
@@ -43,7 +43,7 @@ class MergeVariablesTraitTest extends TestCase
     public function testMergeVarsAsAssoc(): void
     {
         $object = new Grandchild();
-        $object->mergeVars(['assocProperty'], ['associative' => ['assocProperty']]);
+        $object->doMergeVars(['assocProperty'], ['associative' => ['assocProperty']]);
         $expected = [
             'Red' => null,
             'Orange' => null,
@@ -60,7 +60,7 @@ class MergeVariablesTraitTest extends TestCase
     public function testMergeVarsAsAssocWithKeyValues(): void
     {
         $object = new Grandchild();
-        $object->mergeVars(['nestedProperty'], ['associative' => ['nestedProperty']]);
+        $object->doMergeVars(['nestedProperty'], ['associative' => ['nestedProperty']]);
 
         $expected = [
             'Red' => [
@@ -79,7 +79,7 @@ class MergeVariablesTraitTest extends TestCase
     public function testMergeVarsMixedModes(): void
     {
         $object = new Grandchild();
-        $object->mergeVars(['assocProperty', 'listProperty'], ['associative' => ['assocProperty']]);
+        $object->doMergeVars(['assocProperty', 'listProperty'], ['associative' => ['assocProperty']]);
         $expected = [
             'Red' => null,
             'Orange' => null,
@@ -99,7 +99,7 @@ class MergeVariablesTraitTest extends TestCase
     public function testMergeVarsWithBoolean(): void
     {
         $object = new Child();
-        $object->mergeVars(['hasBoolean']);
+        $object->doMergeVars(['hasBoolean']);
         $this->assertSame(['test'], $object->hasBoolean);
     }
 }

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1853,11 +1853,11 @@ HTML;
     }
 
     /**
-     * Test _strlen method
+     * Test strlen method
      */
     public function testStrlen(): void
     {
-        $method = new ReflectionMethod(Text::class, '_strlen');
+        $method = new ReflectionMethod(Text::class, 'strlen');
         $strlen = function () use ($method) {
             return $method->invokeArgs(null, func_get_args());
         };
@@ -1876,11 +1876,11 @@ HTML;
     }
 
     /**
-     * Test _substr method
+     * Test substr method
      */
     public function testSubstr(): void
     {
-        $method = new ReflectionMethod(Text::class, '_substr');
+        $method = new ReflectionMethod(Text::class, 'substr');
         $substr = function () use ($method) {
             return $method->invokeArgs(null, func_get_args());
         };

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -132,32 +132,32 @@ class ViewTest extends TestCase
         $ThemeView = new TestView(null, null, null, $viewOptions);
         $ThemeView->setTheme('TestTheme');
         $expected = TEST_APP . 'templates' . DS . 'Pages' . DS . 'home.php';
-        $result = $ThemeView->getTemplateFileName('home');
+        $result = $ThemeView->doGetTemplateFileName('home');
         $this->assertPathEquals($expected, $result);
 
         $expected = Plugin::path('TestTheme') . 'templates' . DS . 'Posts' . DS . 'index.php';
-        $result = $ThemeView->getTemplateFileName('/Posts/index');
+        $result = $ThemeView->doGetTemplateFileName('/Posts/index');
         $this->assertPathEquals($expected, $result);
 
         $expected = Plugin::path('TestTheme') . 'templates' . DS . 'layout' . DS . 'default.php';
-        $result = $ThemeView->getLayoutFileName();
+        $result = $ThemeView->doGetLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
         $ThemeView->setLayoutPath('rss');
         $expected = TEST_APP . 'templates' . DS . 'layout' . DS . 'rss' . DS . 'default.php';
-        $result = $ThemeView->getLayoutFileName();
+        $result = $ThemeView->doGetLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
         $ThemeView->setLayoutPath('email' . DS . 'html');
         $expected = TEST_APP . 'templates' . DS . 'layout' . DS . 'email' . DS . 'html' . DS . 'default.php';
-        $result = $ThemeView->getLayoutFileName();
+        $result = $ThemeView->doGetLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
         $ThemeView = new TestView(null, null, null, $viewOptions);
 
         $ThemeView->setTheme('Company/TestPluginThree');
         $expected = Plugin::path('Company/TestPluginThree') . 'templates' . DS . 'layout' . DS . 'default.php';
-        $result = $ThemeView->getLayoutFileName();
+        $result = $ThemeView->doGetLayoutFileName();
         $this->assertPathEquals($expected, $result);
     }
 
@@ -176,11 +176,11 @@ class ViewTest extends TestCase
         $View = new TestView(null, null, null, $viewOptions);
 
         $expected = Plugin::path('TestPlugin') . 'templates' . DS . 'Tests' . DS . 'index.php';
-        $result = $View->getTemplateFileName('index');
+        $result = $View->doGetTemplateFileName('index');
         $this->assertSame($expected, $result);
 
         $expected = Plugin::path('TestPlugin') . 'templates' . DS . 'layout' . DS . 'default.php';
-        $result = $View->getLayoutFileName();
+        $result = $View->doGetLayoutFileName();
         $this->assertSame($expected, $result);
     }
 
@@ -199,10 +199,10 @@ class ViewTest extends TestCase
 
         $view = new TestView(null, null, null, $viewOptions);
         $expected = TEST_APP . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'templates' . DS . 'Pages' . DS . 'index.php';
-        $result = $view->getTemplateFileName('Company/TestPluginThree./Pages/index');
+        $result = $view->doGetTemplateFileName('Company/TestPluginThree./Pages/index');
         $this->assertPathEquals($expected, $result);
 
-        $view->getTemplateFileName('Company/TestPluginThree./etc/passwd');
+        $view->doGetTemplateFileName('Company/TestPluginThree./etc/passwd');
     }
 
     /**
@@ -222,15 +222,15 @@ class ViewTest extends TestCase
         $themePath = Plugin::path('TestTheme') . 'templates' . DS;
 
         $expected = $themePath . 'plugin' . DS . 'TestPlugin' . DS . 'Tests' . DS . 'index.php';
-        $result = $ThemeView->getTemplateFileName('index');
+        $result = $ThemeView->doGetTemplateFileName('index');
         $this->assertPathEquals($expected, $result);
 
         $expected = $themePath . 'plugin' . DS . 'TestPlugin' . DS . 'layout' . DS . 'plugin_default.php';
-        $result = $ThemeView->getLayoutFileName('plugin_default');
+        $result = $ThemeView->doGetLayoutFileName('plugin_default');
         $this->assertPathEquals($expected, $result);
 
         $expected = $themePath . 'layout' . DS . 'default.php';
-        $result = $ThemeView->getLayoutFileName('default');
+        $result = $ThemeView->doGetLayoutFileName('default');
         $this->assertPathEquals($expected, $result);
     }
 
@@ -247,11 +247,11 @@ class ViewTest extends TestCase
         ];
 
         $View = new TestView(null, null, null, $viewOptions);
-        $paths = $View->paths();
+        $paths = $View->doPaths();
         $expected = array_merge(App::path('templates'), App::core('templates'));
         $this->assertEquals($expected, $paths);
 
-        $paths = $View->paths('TestPlugin');
+        $paths = $View->doPaths('TestPlugin');
         $pluginPath = Plugin::path('TestPlugin');
         $expected = [
             TEST_APP . 'templates' . DS . 'plugin' . DS . 'TestPlugin' . DS,
@@ -276,7 +276,7 @@ class ViewTest extends TestCase
         ];
 
         $View = new TestView(null, null, null, $viewOptions);
-        $paths = $View->paths('TestPlugin');
+        $paths = $View->doPaths('TestPlugin');
         $pluginPath = Plugin::path('TestPlugin');
         $themePath = Plugin::path('TestTheme');
         $expected = [
@@ -308,7 +308,7 @@ class ViewTest extends TestCase
         Configure::write('App.paths.templates', $paths);
 
         $View = new TestView(null, null, null, $viewOptions);
-        $paths = $View->paths('TestPlugin');
+        $paths = $View->doPaths('TestPlugin');
         $pluginPath = Plugin::path('TestPlugin');
         $themePath = Plugin::path('TestTheme');
         $expected = [
@@ -341,11 +341,11 @@ class ViewTest extends TestCase
         $pluginPath = Plugin::path('TestPlugin');
         $expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'templates' . DS .
             'Tests' . DS . 'index.php';
-        $result = $View->getTemplateFileName('index');
+        $result = $View->doGetTemplateFileName('index');
         $this->assertPathEquals($expected, $result);
 
         $expected = $pluginPath . 'templates' . DS . 'layout' . DS . 'default.php';
-        $result = $View->getLayoutFileName();
+        $result = $View->doGetLayoutFileName();
         $this->assertPathEquals($expected, $result);
     }
 
@@ -362,29 +362,29 @@ class ViewTest extends TestCase
         $View = new TestView(null, null, null, $viewOptions);
 
         $expected = TEST_APP . 'templates' . DS . 'Pages' . DS . 'home.php';
-        $result = $View->getTemplateFileName('home');
+        $result = $View->doGetTemplateFileName('home');
         $this->assertPathEquals($expected, $result);
 
         $expected = TEST_APP . 'templates' . DS . 'Posts' . DS . 'index.php';
-        $result = $View->getTemplateFileName('/Posts/index');
+        $result = $View->doGetTemplateFileName('/Posts/index');
         $this->assertPathEquals($expected, $result);
 
         $expected = TEST_APP . 'templates' . DS . 'Posts' . DS . 'index.php';
-        $result = $View->getTemplateFileName('../Posts/index');
+        $result = $View->doGetTemplateFileName('../Posts/index');
         $this->assertPathEquals($expected, $result);
 
         $expected = TEST_APP . 'templates' . DS . 'Pages' . DS . 'page.home.php';
-        $result = $View->getTemplateFileName('page.home');
+        $result = $View->doGetTemplateFileName('page.home');
         $this->assertPathEquals($expected, $result, 'Should not ruin files with dots.');
 
         $expected = TEST_APP . 'templates' . DS . 'Pages' . DS . 'home.php';
-        $result = $View->getTemplateFileName('TestPlugin.home');
+        $result = $View->doGetTemplateFileName('TestPlugin.home');
         $this->assertPathEquals($expected, $result, 'Plugin is missing the view, cascade to app.');
 
         $View->setTemplatePath('Tests');
         $expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'templates' . DS .
             'Tests' . DS . 'index.php';
-        $result = $View->getTemplateFileName('TestPlugin.index');
+        $result = $View->doGetTemplateFileName('TestPlugin.index');
         $this->assertPathEquals($expected, $result);
     }
 
@@ -402,7 +402,7 @@ class ViewTest extends TestCase
 
         $view = new TestView(null, null, null, $viewOptions);
         $view->ext('.php');
-        $view->getTemplateFileName('../../../bootstrap');
+        $view->doGetTemplateFileName('../../../bootstrap');
     }
 
     /**
@@ -419,11 +419,11 @@ class ViewTest extends TestCase
         $view = new TestView(null, null, null, $viewOptions);
 
         $expected = TEST_APP . 'templates' . DS . 'Posts' . DS . 'json' . DS . 'index.php';
-        $result = $view->getTemplateFileName('index');
+        $result = $view->doGetTemplateFileName('index');
         $this->assertPathEquals($expected, $result);
 
         $view->setSubDir('json');
-        $result = $view->getTemplateFileName('index');
+        $result = $view->doGetTemplateFileName('index');
         $expected = TEST_APP . 'templates' . DS . 'Posts' . DS . 'json' . DS . 'index.php';
         $this->assertPathEquals($expected, $result);
     }
@@ -442,7 +442,7 @@ class ViewTest extends TestCase
         $view = new TestView(null, null, null, $viewOptions);
 
         $view->setSubDir('json');
-        $result = $view->getTemplateFileName('index');
+        $result = $view->doGetTemplateFileName('index');
         $expected = TEST_APP . 'templates' . DS . 'Jobs' . DS . 'json' . DS . 'index.php';
         $this->assertPathEquals($expected, $result);
     }
@@ -462,17 +462,17 @@ class ViewTest extends TestCase
         $View = new TestView(null, null, null, $viewOptions);
 
         $expected = TEST_APP . 'templates' . DS . 'layout' . DS . 'default.php';
-        $result = $View->getLayoutFileName();
+        $result = $View->doGetLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
         $View->setLayoutPath('rss');
         $expected = TEST_APP . 'templates' . DS . 'layout' . DS . 'rss' . DS . 'default.php';
-        $result = $View->getLayoutFileName();
+        $result = $View->doGetLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
         $View->setLayoutPath('email' . DS . 'html');
         $expected = TEST_APP . 'templates' . DS . 'layout' . DS . 'email' . DS . 'html' . DS . 'default.php';
-        $result = $View->getLayoutFileName();
+        $result = $View->doGetLayoutFileName();
         $this->assertPathEquals($expected, $result);
     }
 
@@ -492,13 +492,13 @@ class ViewTest extends TestCase
 
         $expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'templates' . DS .
             'layout' . DS . 'default.php';
-        $result = $View->getLayoutFileName('TestPlugin.default');
+        $result = $View->doGetLayoutFileName('TestPlugin.default');
         $this->assertPathEquals($expected, $result);
 
         $View->setRequest($View->getRequest()->withParam('plugin', 'TestPlugin'));
         $expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'templates' . DS .
             'layout' . DS . 'default.php';
-        $result = $View->getLayoutFileName('default');
+        $result = $View->doGetLayoutFileName('default');
         $this->assertPathEquals($expected, $result);
     }
 
@@ -513,30 +513,30 @@ class ViewTest extends TestCase
         $View->setRequest($View->getRequest()->withParam('prefix', 'foo_prefix'));
         $expected = TEST_APP . 'templates' . DS .
             'FooPrefix' . DS . 'layout' . DS . 'default.php';
-        $result = $View->getLayoutFileName();
+        $result = $View->doGetLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
         $View->setRequest($View->getRequest()->withParam('prefix', 'FooPrefix'));
-        $result = $View->getLayoutFileName();
+        $result = $View->doGetLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
         // Nested prefix layout
         $View->setRequest($View->getRequest()->withParam('prefix', 'foo_prefix/bar_prefix'));
         $expected = TEST_APP . 'templates' . DS .
             'FooPrefix' . DS . 'BarPrefix' . DS . 'layout' . DS . 'default.php';
-        $result = $View->getLayoutFileName();
+        $result = $View->doGetLayoutFileName();
         $this->assertPathEquals($expected, $result);
 
         $expected = TEST_APP . 'templates' . DS .
             'FooPrefix' . DS . 'layout' . DS . 'nested_prefix_cascade.php';
-        $result = $View->getLayoutFileName('nested_prefix_cascade');
+        $result = $View->doGetLayoutFileName('nested_prefix_cascade');
         $this->assertPathEquals($expected, $result);
 
         // Fallback to app's layout
         $View->setRequest($View->getRequest()->withParam('prefix', 'Admin'));
         $expected = TEST_APP . 'templates' . DS .
             'layout' . DS . 'default.php';
-        $result = $View->getLayoutFileName();
+        $result = $View->doGetLayoutFileName();
         $this->assertPathEquals($expected, $result);
     }
 
@@ -554,7 +554,7 @@ class ViewTest extends TestCase
 
         $view = new TestView(null, null, null, $viewOptions);
         $view->ext('.php');
-        $view->getLayoutFileName('../../../bootstrap');
+        $view->doGetLayoutFileName('../../../bootstrap');
     }
 
     /**
@@ -575,7 +575,7 @@ class ViewTest extends TestCase
         $response = new Response();
 
         $View = new TestView($request, $response, null, $viewOptions);
-        $View->getTemplateFileName('does_not_exist');
+        $View->doGetTemplateFileName('does_not_exist');
     }
 
     /**
@@ -594,7 +594,7 @@ class ViewTest extends TestCase
             'layout' => 'whatever',
         ];
         $View = new TestView(null, null, null, $viewOptions);
-        $View->getLayoutFileName();
+        $View->doGetLayoutFileName();
     }
 
     /**
@@ -1132,7 +1132,7 @@ class ViewTest extends TestCase
         $View->setTemplatePath('element');
 
         $pluginPath = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS;
-        $result = $View->getTemplateFileName('sub_dir/sub_element');
+        $result = $View->doGetTemplateFileName('sub_dir/sub_element');
         $expected = $pluginPath . 'templates' . DS . 'element' . DS . 'sub_dir' . DS . 'sub_element.php';
         $this->assertPathEquals($expected, $result);
     }
@@ -1170,20 +1170,20 @@ class ViewTest extends TestCase
         $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath('Posts');
 
-        $result = $View->getTemplateFileName('index');
+        $result = $View->doGetTemplateFileName('index');
         $this->assertMatchesRegularExpression('/Posts(\/|\\\)index.php/', $result);
 
-        $result = $View->getTemplateFileName('TestPlugin.index');
+        $result = $View->doGetTemplateFileName('TestPlugin.index');
         $this->assertMatchesRegularExpression('/Posts(\/|\\\)index.php/', $result);
 
-        $result = $View->getTemplateFileName('/Pages/home');
+        $result = $View->doGetTemplateFileName('/Pages/home');
         $this->assertMatchesRegularExpression('/Pages(\/|\\\)home.php/', $result);
 
-        $result = $View->getTemplateFileName('../element/test_element');
+        $result = $View->doGetTemplateFileName('../element/test_element');
         $this->assertMatchesRegularExpression('/element(\/|\\\)test_element.php/', $result);
 
         $expected = TEST_APP . 'templates' . DS . 'Posts' . DS . 'index.php';
-        $result = $View->getTemplateFileName('../Posts/index');
+        $result = $View->doGetTemplateFileName('../Posts/index');
         $this->assertPathEquals($expected, $result);
     }
 

--- a/tests/test_app/TestApp/Config/ReadOnlyTestInstanceConfig.php
+++ b/tests/test_app/TestApp/Config/ReadOnlyTestInstanceConfig.php
@@ -31,7 +31,7 @@ class ReadOnlyTestInstanceConfig
      * @param array|string $key
      * @param mixed $value
      */
-    protected function _configWrite($key, $value): void
+    protected function configWrite($key, $value): void
     {
         throw new Exception('This Instance is readonly');
     }

--- a/tests/test_app/TestApp/Core/TestApp.php
+++ b/tests/test_app/TestApp/Core/TestApp.php
@@ -9,7 +9,7 @@ class TestApp extends App
 {
     public static $existsInBaseCallback;
 
-    protected static function _classExistsInBase(string $name, string $namespace): bool
+    protected static function classExistsInBase(string $name, string $namespace): bool
     {
         $callback = static::$existsInBaseCallback;
 

--- a/tests/test_app/TestApp/Database/Schema/CompatDialect.php
+++ b/tests/test_app/TestApp/Database/Schema/CompatDialect.php
@@ -68,7 +68,7 @@ class CompatDialect extends SchemaDialect
             $precision = (int)$precision;
         }
 
-        $type = $this->_applyTypeSpecificColumnConversion(
+        $type = $this->applyTypeSpecificColumnConversion(
             $col,
             compact('length', 'precision', 'scale'),
         );
@@ -473,8 +473,8 @@ class CompatDialect extends SchemaDialect
         } else {
             $data['references'] = [$foreignKey['table'], $data['references']];
         }
-        $data['update'] = $this->_convertOnClause($foreignKey['on_update'] ?? '');
-        $data['delete'] = $this->_convertOnClause($foreignKey['on_delete'] ?? '');
+        $data['update'] = $this->convertOnClause($foreignKey['on_update'] ?? '');
+        $data['delete'] = $this->convertOnClause($foreignKey['on_delete'] ?? '');
 
         $name = implode('_', $data['columns']) . '_' . $row['id'] . '_fk';
 

--- a/tests/test_app/TestApp/Error/Renderer/TestAppsExceptionRenderer.php
+++ b/tests/test_app/TestApp/Error/Renderer/TestAppsExceptionRenderer.php
@@ -15,7 +15,7 @@ class TestAppsExceptionRenderer extends WebExceptionRenderer
     /**
      * @inheritDoc
      */
-    protected function _getController(): Controller
+    protected function getController(): Controller
     {
         $request = $this->request ?: Router::getRequest();
         if ($request === null) {

--- a/tests/test_app/TestApp/Http/Session/TestWebSession.php
+++ b/tests/test_app/TestApp/Http/Session/TestWebSession.php
@@ -10,12 +10,12 @@ use Cake\Http\Session;
  */
 class TestWebSession extends Session
 {
-    protected function _hasSession(): bool
+    protected function hasSession(): bool
     {
         $isCLI = $this->_isCLI;
         $this->_isCLI = false;
 
-        $result = parent::_hasSession();
+        $result = parent::hasSession();
 
         $this->_isCLI = $isCLI;
 

--- a/tests/test_app/TestApp/Mailer/Transport/SmtpTestTransport.php
+++ b/tests/test_app/TestApp/Mailer/Transport/SmtpTestTransport.php
@@ -22,7 +22,7 @@ class SmtpTestTransport extends SmtpTransport
     /**
      * Disabled the socket change
      */
-    protected function _generateSocket(): void
+    protected function generateSocket(): void
     {
     }
 
@@ -35,8 +35,6 @@ class SmtpTestTransport extends SmtpTransport
      */
     public function __call($method, $args)
     {
-        $method = '_' . $method;
-
         return call_user_func_array($this->$method(...), $args);
     }
 

--- a/tests/test_app/TestApp/Model/Behavior/Test3Behavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/Test3Behavior.php
@@ -71,6 +71,6 @@ class Test3Behavior extends Behavior
      */
     public function testReflectionCache(): array
     {
-        return $this->_reflectionCache();
+        return $this->reflectionCache();
     }
 }

--- a/tests/test_app/TestApp/Routing/Route/DashedRoute.php
+++ b/tests/test_app/TestApp/Routing/Route/DashedRoute.php
@@ -7,9 +7,9 @@ use Cake\Routing\Route\InflectedRoute;
 
 class DashedRoute extends InflectedRoute
 {
-    protected function _underscore(array $url): array
+    protected function underscore(array $url): array
     {
-        $url = parent::_underscore($url);
+        $url = parent::underscore($url);
 
         if (!empty($url['controller'])) {
             $url['controller'] = str_replace('_', '-', $url['controller']);

--- a/tests/test_app/TestApp/Routing/Route/ProtectedRoute.php
+++ b/tests/test_app/TestApp/Routing/Route/ProtectedRoute.php
@@ -14,8 +14,8 @@ class ProtectedRoute extends Route
      * @param string $url
      * @return array
      */
-    public function parseExtension($url): array
+    public function doParseExtension($url): array
     {
-        return $this->_parseExtension($url);
+        return $this->parseExtension($url);
     }
 }

--- a/tests/test_app/TestApp/Stub/Stub.php
+++ b/tests/test_app/TestApp/Stub/Stub.php
@@ -20,7 +20,7 @@ class Stub
 
     public function setProps(string $name): void
     {
-        $this->_setModelClass($name);
+        $this->setModelClass($name);
     }
 
     public function getModelClass(): ?string

--- a/tests/test_app/TestApp/Utility/Base.php
+++ b/tests/test_app/TestApp/Utility/Base.php
@@ -19,8 +19,8 @@ class Base
      * @param string[] $properties An array of properties and the merge strategy for them.
      * @param array<string, mixed> $options The options to use when merging properties.
      */
-    public function mergeVars(array $properties, array $options = []): void
+    public function doMergeVars(array $properties, array $options = []): void
     {
-        $this->_mergeVars($properties, $options);
+        $this->mergeVars($properties, $options);
     }
 }

--- a/tests/test_app/TestApp/View/TestView.php
+++ b/tests/test_app/TestApp/View/TestView.php
@@ -16,9 +16,9 @@ class TestView extends AppView
      * @param string|null $name Controller action to find template filename for
      * @return string Template filename
      */
-    public function getTemplateFileName(?string $name = null): string
+    public function doGetTemplateFileName(?string $name = null): string
     {
-        return $this->_getTemplateFileName($name);
+        return $this->getTemplateFileName($name);
     }
 
     /**
@@ -27,9 +27,9 @@ class TestView extends AppView
      * @param string|null $name The name of the layout to find.
      * @return string Filename for layout file (.php).
      */
-    public function getLayoutFileName(?string $name = null): string
+    public function doGetLayoutFileName(?string $name = null): string
     {
-        return $this->_getLayoutFileName($name);
+        return $this->getLayoutFileName($name);
     }
 
     /**
@@ -39,9 +39,9 @@ class TestView extends AppView
      * @param bool $cached Set to true to force a refresh of view paths.
      * @return string[] paths
      */
-    public function paths(?string $plugin = null, bool $cached = true): array
+    public function doPaths(?string $plugin = null, bool $cached = true): array
     {
-        return $this->_paths($plugin, $cached);
+        return $this->paths($plugin, $cached);
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/17862

Yes, this is a huge PR, because we have a 💩 load of methods which contain the `_` prefix (and I haven't even touched all the properties, but that will be a separate PR - if we wanna go this way)

If someone wants to review this I'd recommend going from commit to commit because I tried to split it up per package.

In general some methods could not just be renamed from e.g. `_execute` to `execute`, because that method already existed. In such scenarios I used the `doX` naming schema we already have in the HTTP packge, so in this example it would be `doExecute`