### PR TITLE
Add ValidatorAwareInterface::DEFAULT_VALIDATOR constant.

### DIFF
--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -49,13 +49,6 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
     use ValidatorAwareTrait;
 
     /**
-     * Name of default validation set.
-     *
-     * @var string
-     */
-    public const string DEFAULT_VALIDATOR = 'default';
-
-    /**
      * The alias this object is assigned to validators as.
      *
      * @var string

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -165,13 +165,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     use ValidatorAwareTrait;
 
     /**
-     * Name of default validation set.
-     *
-     * @var string
-     */
-    public const string DEFAULT_VALIDATOR = 'default';
-
-    /**
      * The alias this object is assigned to validators as.
      *
      * @var string

--- a/src/Validation/ValidatorAwareInterface.php
+++ b/src/Validation/ValidatorAwareInterface.php
@@ -22,6 +22,13 @@ namespace Cake\Validation;
 interface ValidatorAwareInterface
 {
     /**
+     * Name of default validation set.
+     *
+     * @var string
+     */
+    public const string DEFAULT_VALIDATOR = 'default';
+
+    /**
      * Returns the validation rules tagged with $name.
      *
      * If a $name argument has not been provided, the default validator will be returned.

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -27,9 +27,8 @@ use InvalidArgumentException;
  * the implementing class wants to build and customize a variety
  * of validator instances.
  *
- * This trait expects that classes including it define three constants:
+ * Classes using this trait can declare these constants:
  *
- * - `DEFAULT_VALIDATOR` - The default validator name.
  * - `VALIDATOR_PROVIDER_NAME ` - The provider name the including class is assigned
  *   in validators.
  * - `BUILD_VALIDATOR_EVENT` - The name of the event to be triggered when validators
@@ -159,7 +158,10 @@ trait ValidatorAwareTrait
      */
     public function setValidator(string $name, Validator $validator): static
     {
-        $validator->setProvider(static::VALIDATOR_PROVIDER_NAME, $this);
+        if (defined(static::class . '::VALIDATOR_PROVIDER_NAME')) {
+            $validator->setProvider(static::VALIDATOR_PROVIDER_NAME, $this);
+        }
+
         $this->_validators[$name] = $validator;
 
         return $this;


### PR DESCRIPTION
This avoids having to declare the constant in each implementing class.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
