### PR TITLE
Drop Number::DEFAULT_LOCALE.

### DIFF
--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -28,13 +28,6 @@ use NumberFormatter;
 class Number
 {
     /**
-     * Default locale
-     *
-     * @var string
-     */
-    public const string DEFAULT_LOCALE = 'en_US';
-
-    /**
      * Format type to format as currency
      *
      * @var string
@@ -262,7 +255,7 @@ class Number
     public static function getDefaultCurrency(): string
     {
         if (static::$_defaultCurrency === null) {
-            $locale = ini_get('intl.default_locale') ?: static::DEFAULT_LOCALE;
+            $locale = I18n::getLocale();
             $formatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
             static::$_defaultCurrency = $formatter->getTextAttribute(NumberFormatter::CURRENCY_CODE);
         }
@@ -331,11 +324,7 @@ class Number
     public static function formatter(array $options = []): NumberFormatter
     {
         /** @var string $locale */
-        $locale = $options['locale'] ?? ini_get('intl.default_locale');
-
-        if (!$locale) {
-            $locale = static::DEFAULT_LOCALE;
-        }
+        $locale = $options['locale'] ?? I18n::getLocale();
 
         $type = NumberFormatter::DECIMAL;
         if (!empty($options['type'])) {


### PR DESCRIPTION
Use I18n::DEFAULT_LOCALE instead. Having two constants in the same package, for the same value is unnecessary.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
