### PR TITLE
Refactor the validation process.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -309,6 +309,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 $this->{'set' . $cfg}($config[$cfg]);
             }
         }
+
         if (isset($config['validator'])) {
             if (is_array($config['validator'])) {
                 foreach ($config['validator'] as $name => $validator) {
@@ -318,6 +319,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 $this->setValidator(static::DEFAULT_VALIDATOR, $config['validator']);
             }
         }
+
         $this->_eventManager = $config['eventManager'] ?? new EventManager();
         $this->_behaviors = $config['behaviors'] ?? new BehaviorRegistry();
         $this->_behaviors->setTable($this);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -309,7 +309,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 $this->{'set' . $cfg}($config[$cfg]);
             }
         }
-
         if (isset($config['validator'])) {
             if (is_array($config['validator'])) {
                 foreach ($config['validator'] as $name => $validator) {
@@ -319,7 +318,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 $this->setValidator(static::DEFAULT_VALIDATOR, $config['validator']);
             }
         }
-
         $this->_eventManager = $config['eventManager'] ?? new EventManager();
         $this->_behaviors = $config['behaviors'] ?? new BehaviorRegistry();
         $this->_behaviors->setTable($this);

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -33,12 +33,12 @@ class ValidationRule
      * Constructor
      */
     public function __construct(
-        public protected(set) Closure $callable,
-        public protected(set) ?string $name = null,
-        public protected(set) ?string $message = null,
-        public protected(set) Closure|string|null $on = null,
-        public protected(set) bool $last = false,
-        public protected(set) array $pass = [],
+        public readonly Closure $callable,
+        public readonly ?string $name = null,
+        public readonly ?string $message = null,
+        public readonly Closure|string|null $on = null,
+        public readonly bool $last = false,
+        public readonly array $pass = [],
     ) {
     }
 

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -31,6 +31,13 @@ use ReflectionFunction;
 class ValidationRule
 {
     /**
+     * The rule name
+     *
+     * @var string|null
+     */
+    protected ?string $_name = null;
+
+    /**
      * The rule callable
      *
      * @var callable
@@ -180,7 +187,7 @@ class ValidationRule
             if (!$value) {
                 continue;
             }
-            if (in_array($key, ['callable', 'on', 'message', 'last', 'pass'], true)) {
+            if (in_array($key, ['name', 'callable', 'on', 'message', 'last', 'pass'], true)) {
                 $this->{"_{$key}"} = $value;
             }
         }

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -72,8 +72,8 @@ class ValidationRule
         }
 
         $params = (new ReflectionFunction($this->callable))->getParameters();
-        $lastParm = array_pop($params);
-        if ($lastParm && $lastParm->getName() === 'context') {
+        $lastParam = array_pop($params);
+        if ($lastParam && $lastParam->getName() === 'context') {
             $args['context'] = $context;
         }
 

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -43,7 +43,6 @@ class ValidationRule
         callable $callable,
         public protected(set) ?string $name = null,
         public protected(set) ?string $message = null,
-        /** @var \Closure|string|null */
         public protected(set) Closure|string|null $on = null,
         public protected(set) bool $last = false,
         public protected(set) array $pass = [],

--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -155,6 +155,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     public function add(string $name, ValidationRule|array $rule): static
     {
         if (!($rule instanceof ValidationRule)) {
+            $rule += ['name' => $name];
             $rule = new ValidationRule($rule);
         }
         if (array_key_exists($name, $this->_rules)) {

--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -156,7 +156,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     {
         if (!($rule instanceof ValidationRule)) {
             $rule += ['name' => $name];
-            $rule = new ValidationRule($rule);
+            $rule = new ValidationRule(...$rule);
         }
         if (array_key_exists($name, $this->_rules)) {
             throw new CakeException("A validation rule with the name `{$name}` already exists");

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -3147,8 +3147,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         }
 
         foreach ($this->_fields[$field] as $rule) {
-            if ($rule->get('name') === 'notBlank' && $rule->get('message')) {
-                return $rule->get('message');
+            if ($rule->name === 'notBlank' && $rule->message) {
+                return $rule->message;
             }
         }
 
@@ -3299,7 +3299,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 $errors[$name] = $result;
             }
 
-            if ($rule->isLast()) {
+            if ($rule->last) {
                 break;
             }
         }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -3147,8 +3147,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         }
 
         foreach ($this->_fields[$field] as $rule) {
-            $callable = $rule->get('callable');
-            if (is_array($callable) && $callable[1] === 'notBlank' && $rule->get('message')) {
+            if ($rule->get('name') === 'notBlank' && $rule->get('message')) {
                 return $rule->get('message');
             }
         }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -515,12 +515,12 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
 
         $method = $rule['rule'];
         if (is_string($method)) {
-            $rule['callable'] = Closure::fromCallable([$this->_providers[$rule['provider']], $method]);
+            $rule['callable'] = [$this->_providers[$rule['provider']], $method](...);
         } elseif (is_array($method) && !is_callable($method)) {
             $rule['pass'] = array_slice($method, 1);
-            $rule['callable'] = Closure::fromCallable([$this->_providers[$rule['provider']], array_shift($method)]);
+            $rule['callable'] = [$this->_providers[$rule['provider']], array_shift($method)](...);
         } else {
-            $rule['callable'] = $method instanceof Closure ? $method : Closure::fromCallable($method);
+            $rule['callable'] = $method(...);
         }
 
         unset($rule['provider'], $rule['rule']);

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -230,8 +230,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             $name = (string)$name;
             $keyPresent = array_key_exists($name, $data);
 
-            $providers = $this->_providers;
-            $context = compact('data', 'newRecord', 'field', 'providers');
+            $context = compact('data', 'newRecord', 'field');
 
             if (!$keyPresent && !$this->_checkPresence($field, $context)) {
                 $errors[$name]['_required'] = $this->getRequiredMessage($name);
@@ -405,6 +404,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         if (!$value instanceof ValidationSet) {
             $set = new ValidationSet();
             foreach ($value as $name => $rule) {
+                if (is_array($rule)) {
+                    $rule = $this->normalizeRuleArray($name, $rule);
+                }
+
                 $set->add($name, $rule);
             }
             $value = $set;
@@ -478,22 +481,50 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         }
 
         foreach ($rules as $name => $rule) {
-            if (is_array($rule)) {
-                $rule += [
-                    'rule' => $name,
-                    'last' => $this->_stopOnFailure,
-                ];
-            }
-            if (!is_string($name)) {
+            if (is_numeric($name)) {
                 throw new InvalidArgumentException(
-                    'You cannot add validation rules without a `name` key. Update rules array to have string keys.',
+                    'You cannot add validation rules without a name. Update your rules array to have string keys.',
                 );
+            }
+
+            if (is_array($rule)) {
+                $rule = $this->normalizeRuleArray($name, $rule);
             }
 
             $validationSet->add($name, $rule);
         }
 
         return $this;
+    }
+
+    /**
+     * Normalizes the rule array to ensure it has the correct keys and values.
+     *
+     * @param string $name The name of the rule.
+     * @param array $rule The rule array to normalize.
+     * @return array
+     */
+    protected function normalizeRuleArray(string $name, array $rule): array
+    {
+        $rule += [
+            'rule' => $name,
+            'last' => $this->_stopOnFailure,
+            'provider' => 'default',
+            'pass' => [],
+        ];
+
+        if (is_string($rule['rule'])) {
+            $rule['callable'] = [$this->_providers[$rule['provider']], $rule['rule']];
+        } elseif (is_array($rule['rule']) && !is_callable($rule['rule'])) {
+            $rule['pass'] = array_slice($rule['rule'], 1);
+            $rule['callable'] = [$this->_providers[$rule['provider']], array_shift($rule['rule'])];
+        } else {
+            $rule['callable'] = $rule['rule'];
+        }
+
+        unset($rule['provider'], $rule['rule']);
+
+        return $rule;
     }
 
     /**
@@ -525,21 +556,19 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['message' => $message, 'on' => $when]);
 
         $validationSet = $this->field($field);
-        $validationSet->add(static::NESTED, $extra + ['rule' => function ($value, $context) use ($validator, $message) {
-            if (!is_array($value)) {
-                return false;
-            }
-            foreach ($this->providers() as $name) {
-                /** @var object|class-string $provider */
-                $provider = $this->getProvider($name);
-                $validator->setProvider($name, $provider);
-            }
-            $errors = $validator->validate($value, $context['newRecord']);
+        $validationSet->add(
+            static::NESTED,
+            $extra + ['callable' => function ($value, $context) use ($validator, $message) {
+                if (!is_array($value)) {
+                    return false;
+                }
 
-            $message = $message ? [static::NESTED => $message] : [];
+                $errors = $validator->validate($value, $context['newRecord']);
+                $message = $message ? [static::NESTED => $message] : [];
 
-            return $errors === [] ? true : $errors + $message;
-        }]);
+                return $errors === [] ? true : $errors + $message;
+            }],
+        );
 
         return $this;
     }
@@ -573,30 +602,29 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['message' => $message, 'on' => $when]);
 
         $validationSet = $this->field($field);
-        $validationSet->add(static::NESTED, $extra + ['rule' => function ($value, $context) use ($validator, $message) {
-            if (!is_array($value)) {
-                return false;
-            }
-            foreach ($this->providers() as $name) {
-                /** @var object|class-string $provider */
-                $provider = $this->getProvider($name);
-                $validator->setProvider($name, $provider);
-            }
-            $errors = [];
-            foreach ($value as $i => $row) {
-                if (!is_array($row)) {
+        $validationSet->add(
+            static::NESTED,
+            $extra + ['callable' => function ($value, $context) use ($validator, $message) {
+                if (!is_array($value)) {
                     return false;
                 }
-                $check = $validator->validate($row, $context['newRecord']);
-                if ($check) {
-                    $errors[$i] = $check;
+
+                $errors = [];
+                foreach ($value as $i => $row) {
+                    if (!is_array($row)) {
+                        return false;
+                    }
+                    $check = $validator->validate($row, $context['newRecord']);
+                    if ($check) {
+                        $errors[$i] = $check;
+                    }
                 }
-            }
 
-            $message = $message ? [static::NESTED => $message] : [];
+                $message = $message ? [static::NESTED => $message] : [];
 
-            return $errors === [] ? true : $errors + $message;
-        }]);
+                return $errors === [] ? true : $errors + $message;
+            }],
+        );
 
         return $this;
     }
@@ -3119,7 +3147,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         }
 
         foreach ($this->_fields[$field] as $rule) {
-            if ($rule->get('rule') === 'notBlank' && $rule->get('message')) {
+            $callable = $rule->get('callable');
+            if (is_array($callable) && $callable[1] === 'notBlank' && $rule->get('message')) {
                 return $rule->get('message');
             }
         }
@@ -3258,7 +3287,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         }
 
         foreach ($rules as $name => $rule) {
-            $result = $rule->process($data[$field], $this->_providers, compact('newRecord', 'data', 'field'));
+            $result = $rule->process($data[$field], compact('newRecord', 'data', 'field'));
             if ($result === true) {
                 continue;
             }

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -534,7 +534,8 @@ class EntityContext implements ContextInterface
 
         if ($validator->hasField($fieldName)) {
             foreach ($validator->field($fieldName)->rules() as $rule) {
-                if ($rule->get('rule') === 'maxLength') {
+                $callable = $rule->get('callable');
+                if (is_array($callable) && $callable[1] === 'maxLength') {
                     return $rule->get('pass')[0];
                 }
             }

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -534,8 +534,8 @@ class EntityContext implements ContextInterface
 
         if ($validator->hasField($fieldName)) {
             foreach ($validator->field($fieldName)->rules() as $rule) {
-                if ($rule->get('name') === 'maxLength') {
-                    return $rule->get('pass')[0];
+                if ($rule->name === 'maxLength' && isset($rule->pass[0])) {
+                    return $rule->pass[0];
                 }
             }
         }

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -534,8 +534,7 @@ class EntityContext implements ContextInterface
 
         if ($validator->hasField($fieldName)) {
             foreach ($validator->field($fieldName)->rules() as $rule) {
-                $callable = $rule->get('callable');
-                if (is_array($callable) && $callable[1] === 'maxLength') {
+                if ($rule->get('name') === 'maxLength') {
                     return $rule->get('pass')[0];
                 }
             }

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -171,8 +171,7 @@ class FormContext implements ContextInterface
             return null;
         }
         foreach ($validator->field($field)->rules() as $rule) {
-            $callable = $rule->get('callable');
-            if (is_array($callable) && $callable[1] === 'maxLength') {
+            if ($rule->get('name') === 'maxLength') {
                 return $rule->get('pass')[0];
             }
         }

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -171,8 +171,8 @@ class FormContext implements ContextInterface
             return null;
         }
         foreach ($validator->field($field)->rules() as $rule) {
-            if ($rule->get('name') === 'maxLength') {
-                return $rule->get('pass')[0];
+            if ($rule->name === 'maxLength' && isset($rule->pass[0])) {
+                return $rule->pass[0];
             }
         }
 

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -171,7 +171,8 @@ class FormContext implements ContextInterface
             return null;
         }
         foreach ($validator->field($field)->rules() as $rule) {
-            if ($rule->get('rule') === 'maxLength') {
+            $callable = $rule->get('callable');
+            if (is_array($callable) && $callable[1] === 'maxLength') {
                 return $rule->get('pass')[0];
             }
         }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3355,6 +3355,17 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests that a InvalidArgumentException is thrown if the custom validator method does not exist.
+     */
+    public function testValidatorWithMissingMethod(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The `Cake\ORM\Table::validationMissing()` validation method does not exists.');
+        $table = new Table();
+        $table->getValidator('missing');
+    }
+
+    /**
      * Tests that it is possible to set a custom validator under a name
      */
     public function testValidatorSetter(): void
@@ -5729,8 +5740,8 @@ class TableTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Users');
         $validator = new Validator();
-        $validator->add('username', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
         $validator->setProvider('table', $table);
+        $validator->add('username', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
 
         $data = ['username' => ['larry', 'notthere']];
         $this->assertNotEmpty($validator->validate($data));
@@ -5758,11 +5769,11 @@ class TableTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Users');
         $validator = new Validator();
+        $validator->setProvider('table', $table);
         $validator->add('username', 'unique', [
             'rule' => ['validateUnique', ['derp' => 'erp', 'scope' => 'id']],
             'provider' => 'table',
         ]);
-        $validator->setProvider('table', $table);
         $data = ['username' => 'larry', 'id' => 3];
         $this->assertNotEmpty($validator->validate($data));
 
@@ -5789,6 +5800,7 @@ class TableTest extends TestCase
         $table->save($entity);
 
         $validator = new Validator();
+        $validator->setProvider('table', $table);
         $validator->add('site_id', 'unique', [
             'rule' => [
                 'validateUnique',
@@ -5800,7 +5812,6 @@ class TableTest extends TestCase
             'provider' => 'table',
             'message' => 'Must be unique.',
         ]);
-        $validator->setProvider('table', $table);
 
         $data = ['site_id' => 1, 'author_id' => null, 'title' => 'Null dupe'];
         $expected = ['site_id' => ['unique' => 'Must be unique.']];

--- a/tests/TestCase/Validation/ValidationRuleTest.php
+++ b/tests/TestCase/Validation/ValidationRuleTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Validation;
 
 use Cake\TestSuite\TestCase;
 use Cake\Validation\ValidationRule;
+use Closure;
 
 /**
  * ValidationRuleTest
@@ -56,16 +57,16 @@ class ValidationRuleTest extends TestCase
         $data = 'some data';
 
         $context = ['newRecord' => true];
-        $Rule = new ValidationRule([$this, 'willFail']);
+        $Rule = new ValidationRule(Closure::fromCallable([$this, 'willFail']));
         $this->assertFalse($Rule->process($data, $context));
 
-        $Rule = new ValidationRule([$this, 'willPass'], pass: ['key' => 'value']);
+        $Rule = new ValidationRule(Closure::fromCallable([$this, 'willPass']), pass: ['key' => 'value']);
         $this->assertTrue($Rule->process($data, $context));
 
-        $Rule = new ValidationRule([$this, 'willFail3']);
+        $Rule = new ValidationRule(Closure::fromCallable([$this, 'willFail3']));
         $this->assertSame('string', $Rule->process($data, $context));
 
-        $Rule = new ValidationRule([$this, 'willFail'], message: 'foo');
+        $Rule = new ValidationRule(Closure::fromCallable([$this, 'willFail']), message: 'foo');
         $this->assertSame('foo', $Rule->process($data, $context));
     }
 
@@ -88,13 +89,13 @@ class ValidationRuleTest extends TestCase
     {
         $data = 'some data';
 
-        $Rule = new ValidationRule([$this, 'willFail'], on: 'create');
+        $Rule = new ValidationRule(Closure::fromCallable([$this, 'willFail']), on: 'create');
         $this->assertFalse($Rule->process($data, ['newRecord' => true]));
 
-        $Rule = new ValidationRule([$this, 'willFail'], on: 'update');
+        $Rule = new ValidationRule(Closure::fromCallable([$this, 'willFail']), on: 'update');
         $this->assertTrue($Rule->process($data, ['newRecord' => true]));
 
-        $Rule = new ValidationRule([$this, 'willFail'], on: 'update');
+        $Rule = new ValidationRule(Closure::fromCallable([$this, 'willFail']), on: 'update');
         $this->assertFalse($Rule->process($data, ['newRecord' => false]));
     }
 
@@ -106,7 +107,7 @@ class ValidationRuleTest extends TestCase
         $data = 'some data';
 
         $Rule = new ValidationRule(
-            callable: [$this, 'willFail'],
+            callable: Closure::fromCallable(Closure::fromCallable([$this, 'willFail'])),
             on: function ($context) {
                 $expected = ['newRecord' => true, 'data' => []];
                 $this->assertEquals($expected, $context);
@@ -117,7 +118,7 @@ class ValidationRuleTest extends TestCase
         $this->assertFalse($Rule->process($data, ['newRecord' => true]));
 
         $Rule = new ValidationRule(
-            [$this, 'willFail'],
+            Closure::fromCallable(Closure::fromCallable([$this, 'willFail'])),
             on: function ($context) {
                 $expected = ['newRecord' => true, 'data' => []];
                 $this->assertEquals($expected, $context);

--- a/tests/TestCase/Validation/ValidationSetTest.php
+++ b/tests/TestCase/Validation/ValidationSetTest.php
@@ -23,6 +23,7 @@ use Cake\TestSuite\TestCase;
 use Cake\Validation\Validation;
 use Cake\Validation\ValidationRule;
 use Cake\Validation\ValidationSet;
+use Closure;
 
 /**
  * ValidationSetTest
@@ -35,11 +36,11 @@ class ValidationSetTest extends TestCase
     public function testGetRule(): void
     {
         $field = new ValidationSet();
-        $field->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank', 'message' => 'Can not be empty']);
+        $field->add('notBlank', ['callable' => Closure::fromCallable(Validation::class . '::' . 'notBlank'), 'message' => 'Can not be empty']);
         $result = $field->rule('notBlank');
         $this->assertInstanceOf(ValidationRule::class, $result);
         $this->assertEquals(
-            new ValidationRule(name: 'notBlank', callable: Validation::class . '::' . 'notBlank', message: 'Can not be empty'),
+            new ValidationRule(name: 'notBlank', callable: Closure::fromCallable(Validation::class . '::' . 'notBlank'), message: 'Can not be empty'),
             $result,
         );
     }
@@ -50,7 +51,7 @@ class ValidationSetTest extends TestCase
     public function testGetRules(): void
     {
         $field = new ValidationSet();
-        $field->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank', 'message' => 'Can not be empty']);
+        $field->add('notBlank', ['callable' => Closure::fromCallable(Validation::class . '::' . 'notBlank'), 'message' => 'Can not be empty']);
 
         $result = $field->rules();
         $this->assertEquals(['notBlank'], array_keys($result));
@@ -63,28 +64,28 @@ class ValidationSetTest extends TestCase
     public function testArrayAccessGet(): void
     {
         $set = (new ValidationSet())
-            ->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank'])
-            ->add('numeric', ['callable' => Validation::class . '::' . 'numeric'])
-            ->add('other', ['callable' => Validation::class . '::' . 'email']);
+            ->add('notBlank', ['callable' => Closure::fromCallable(Validation::class . '::' . 'notBlank')])
+            ->add('numeric', ['callable' => Closure::fromCallable(Validation::class . '::' . 'numeric')])
+            ->add('other', ['callable' => Closure::fromCallable(Validation::class . '::' . 'email')]);
 
         $rule = $set['notBlank'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
         $this->assertEquals(
-            new ValidationRule(name: 'notBlank', callable: Validation::class . '::' . 'notBlank'),
+            new ValidationRule(name: 'notBlank', callable: Closure::fromCallable(Validation::class . '::' . 'notBlank')),
             $rule,
         );
 
         $rule = $set['numeric'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
         $this->assertEquals(
-            new ValidationRule(name: 'numeric', callable: Validation::class . '::' . 'numeric'),
+            new ValidationRule(name: 'numeric', callable: Closure::fromCallable(Validation::class . '::' . 'numeric')),
             $rule,
         );
 
         $rule = $set['other'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
         $this->assertEquals(
-            new ValidationRule(name: 'other', callable: Validation::class . '::' . 'email'),
+            new ValidationRule(name: 'other', callable: Closure::fromCallable(Validation::class . '::' . 'email')),
             $rule,
         );
     }
@@ -95,9 +96,9 @@ class ValidationSetTest extends TestCase
     public function testArrayAccessExists(): void
     {
         $set = (new ValidationSet())
-            ->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank'])
-            ->add('numeric', ['callable' => Validation::class . '::' . 'numeric'])
-            ->add('other', ['callable' => Validation::class . '::' . 'email']);
+            ->add('notBlank', ['callable' => Closure::fromCallable(Validation::class . '::' . 'notBlank')])
+            ->add('numeric', ['callable' => Closure::fromCallable(Validation::class . '::' . 'numeric')])
+            ->add('other', ['callable' => Closure::fromCallable(Validation::class . '::' . 'email')]);
 
         $this->assertArrayHasKey('notBlank', $set);
         $this->assertArrayHasKey('numeric', $set);
@@ -111,14 +112,14 @@ class ValidationSetTest extends TestCase
     public function testArrayAccessSet(): void
     {
         $set = (new ValidationSet())
-            ->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank']);
+            ->add('notBlank', ['callable' => Closure::fromCallable(Validation::class . '::' . 'notBlank')]);
 
         $this->assertArrayNotHasKey('other', $set);
-        $set['other'] = ['callable' => Validation::class . '::' . 'email'];
+        $set['other'] = ['callable' => Closure::fromCallable(Validation::class . '::' . 'email')];
         $rule = $set['other'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
         $this->assertEquals(
-            new ValidationRule(name: 'other', callable: Validation::class . '::' . 'email'),
+            new ValidationRule(name: 'other', callable: Closure::fromCallable(Validation::class . '::' . 'email')),
             $rule,
         );
     }
@@ -129,9 +130,9 @@ class ValidationSetTest extends TestCase
     public function testArrayAccessUnset(): void
     {
         $set = (new ValidationSet())
-            ->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank'])
-            ->add('numeric', ['callable' => Validation::class . '::' . 'numeric'])
-            ->add('other', ['callable' => Validation::class . '::' . 'email']);
+            ->add('notBlank', ['callable' => Closure::fromCallable(Validation::class . '::' . 'notBlank')])
+            ->add('numeric', ['callable' => Closure::fromCallable(Validation::class . '::' . 'numeric')])
+            ->add('other', ['callable' => Closure::fromCallable(Validation::class . '::' . 'email')]);
 
         unset($set['notBlank']);
         $this->assertArrayNotHasKey('notBlank', $set);
@@ -149,9 +150,9 @@ class ValidationSetTest extends TestCase
     public function testIterator(): void
     {
         $set = (new ValidationSet())
-            ->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank'])
-            ->add('numeric', ['callable' => Validation::class . '::' . 'numeric'])
-            ->add('other', ['callable' => Validation::class . '::' . 'email']);
+            ->add('notBlank', ['callable' => Closure::fromCallable(Validation::class . '::' . 'notBlank')])
+            ->add('numeric', ['callable' => Closure::fromCallable(Validation::class . '::' . 'numeric')])
+            ->add('other', ['callable' => Closure::fromCallable(Validation::class . '::' . 'email')]);
 
         $i = 0;
         foreach ($set as $name => $rule) {
@@ -176,9 +177,9 @@ class ValidationSetTest extends TestCase
     public function testCount(): void
     {
         $set = (new ValidationSet())
-            ->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank'])
-            ->add('numeric', ['callable' => Validation::class . '::' . 'numeric'])
-            ->add('other', ['callable' => Validation::class . '::' . 'email']);
+            ->add('notBlank', ['callable' => Closure::fromCallable(Validation::class . '::' . 'notBlank')])
+            ->add('numeric', ['callable' => Closure::fromCallable(Validation::class . '::' . 'numeric')])
+            ->add('other', ['callable' => Closure::fromCallable(Validation::class . '::' . 'email')]);
         $this->assertCount(3, $set);
 
         unset($set['other']);
@@ -191,9 +192,9 @@ class ValidationSetTest extends TestCase
     public function testRemoveRule(): void
     {
         $set = (new ValidationSet())
-            ->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank'])
-            ->add('numeric', ['callable' => Validation::class . '::' . 'numeric'])
-            ->add('other', ['callable' => Validation::class . '::' . 'email']);
+            ->add('notBlank', ['callable' => Closure::fromCallable(Validation::class . '::' . 'notBlank')])
+            ->add('numeric', ['callable' => Closure::fromCallable(Validation::class . '::' . 'numeric')])
+            ->add('other', ['callable' => Closure::fromCallable(Validation::class . '::' . 'email')]);
 
         $this->assertArrayHasKey('notBlank', $set);
         $set->remove('notBlank');

--- a/tests/TestCase/Validation/ValidationSetTest.php
+++ b/tests/TestCase/Validation/ValidationSetTest.php
@@ -37,8 +37,10 @@ class ValidationSetTest extends TestCase
         $field->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank', 'message' => 'Can not be empty']);
         $result = $field->rule('notBlank');
         $this->assertInstanceOf(ValidationRule::class, $result);
-        $expected = new ValidationRule(['callable' => Validation::class . '::' . 'notBlank', 'message' => 'Can not be empty']);
-        $this->assertEquals($expected, $result);
+        $this->assertEquals(
+            new ValidationRule(['name' => 'notBlank', 'callable' => Validation::class . '::' . 'notBlank', 'message' => 'Can not be empty']),
+            $result,
+        );
     }
 
     /**
@@ -66,15 +68,24 @@ class ValidationSetTest extends TestCase
 
         $rule = $set['notBlank'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
-        $this->assertEquals(new ValidationRule(['callable' => Validation::class . '::' . 'notBlank']), $rule);
+        $this->assertEquals(
+            new ValidationRule(['name' => 'notBlank', 'callable' => Validation::class . '::' . 'notBlank']),
+            $rule,
+        );
 
         $rule = $set['numeric'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
-        $this->assertEquals(new ValidationRule(['callable' => Validation::class . '::' . 'numeric']), $rule);
+        $this->assertEquals(
+            new ValidationRule(['name' => 'numeric', 'callable' => Validation::class . '::' . 'numeric']),
+            $rule,
+        );
 
         $rule = $set['other'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
-        $this->assertEquals(new ValidationRule(['callable' => Validation::class . '::' . 'email']), $rule);
+        $this->assertEquals(
+            new ValidationRule(['name' => 'other', 'callable' => Validation::class . '::' . 'email']),
+            $rule,
+        );
     }
 
     /**
@@ -105,7 +116,10 @@ class ValidationSetTest extends TestCase
         $set['other'] = ['callable' => Validation::class . '::' . 'email'];
         $rule = $set['other'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
-        $this->assertEquals(new ValidationRule(['callable' => Validation::class . '::' . 'email']), $rule);
+        $this->assertEquals(
+            new ValidationRule(['name' => 'other', 'callable' => Validation::class . '::' . 'email']),
+            $rule,
+        );
     }
 
     /**

--- a/tests/TestCase/Validation/ValidationSetTest.php
+++ b/tests/TestCase/Validation/ValidationSetTest.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Validation;
 
 use Cake\TestSuite\TestCase;
+use Cake\Validation\Validation;
 use Cake\Validation\ValidationRule;
 use Cake\Validation\ValidationSet;
 
@@ -33,10 +34,10 @@ class ValidationSetTest extends TestCase
     public function testGetRule(): void
     {
         $field = new ValidationSet();
-        $field->add('notBlank', ['rule' => 'notBlank', 'message' => 'Can not be empty']);
+        $field->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank', 'message' => 'Can not be empty']);
         $result = $field->rule('notBlank');
         $this->assertInstanceOf(ValidationRule::class, $result);
-        $expected = new ValidationRule(['rule' => 'notBlank', 'message' => 'Can not be empty']);
+        $expected = new ValidationRule(['callable' => Validation::class . '::' . 'notBlank', 'message' => 'Can not be empty']);
         $this->assertEquals($expected, $result);
     }
 
@@ -46,7 +47,7 @@ class ValidationSetTest extends TestCase
     public function testGetRules(): void
     {
         $field = new ValidationSet();
-        $field->add('notBlank', ['rule' => 'notBlank', 'message' => 'Can not be empty']);
+        $field->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank', 'message' => 'Can not be empty']);
 
         $result = $field->rules();
         $this->assertEquals(['notBlank'], array_keys($result));
@@ -59,21 +60,21 @@ class ValidationSetTest extends TestCase
     public function testArrayAccessGet(): void
     {
         $set = (new ValidationSet())
-            ->add('notBlank', ['rule' => 'notBlank'])
-            ->add('numeric', ['rule' => 'numeric'])
-            ->add('other', ['rule' => 'email']);
+            ->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank'])
+            ->add('numeric', ['callable' => Validation::class . '::' . 'numeric'])
+            ->add('other', ['callable' => Validation::class . '::' . 'email']);
 
         $rule = $set['notBlank'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
-        $this->assertEquals(new ValidationRule(['rule' => 'notBlank']), $rule);
+        $this->assertEquals(new ValidationRule(['callable' => Validation::class . '::' . 'notBlank']), $rule);
 
         $rule = $set['numeric'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
-        $this->assertEquals(new ValidationRule(['rule' => 'numeric']), $rule);
+        $this->assertEquals(new ValidationRule(['callable' => Validation::class . '::' . 'numeric']), $rule);
 
         $rule = $set['other'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
-        $this->assertEquals(new ValidationRule(['rule' => 'email']), $rule);
+        $this->assertEquals(new ValidationRule(['callable' => Validation::class . '::' . 'email']), $rule);
     }
 
     /**
@@ -82,9 +83,9 @@ class ValidationSetTest extends TestCase
     public function testArrayAccessExists(): void
     {
         $set = (new ValidationSet())
-            ->add('notBlank', ['rule' => 'notBlank'])
-            ->add('numeric', ['rule' => 'numeric'])
-            ->add('other', ['rule' => 'email']);
+            ->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank'])
+            ->add('numeric', ['callable' => Validation::class . '::' . 'numeric'])
+            ->add('other', ['callable' => Validation::class . '::' . 'email']);
 
         $this->assertArrayHasKey('notBlank', $set);
         $this->assertArrayHasKey('numeric', $set);
@@ -98,13 +99,13 @@ class ValidationSetTest extends TestCase
     public function testArrayAccessSet(): void
     {
         $set = (new ValidationSet())
-            ->add('notBlank', ['rule' => 'notBlank']);
+            ->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank']);
 
         $this->assertArrayNotHasKey('other', $set);
-        $set['other'] = ['rule' => 'email'];
+        $set['other'] = ['callable' => Validation::class . '::' . 'email'];
         $rule = $set['other'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
-        $this->assertEquals(new ValidationRule(['rule' => 'email']), $rule);
+        $this->assertEquals(new ValidationRule(['callable' => Validation::class . '::' . 'email']), $rule);
     }
 
     /**
@@ -113,9 +114,9 @@ class ValidationSetTest extends TestCase
     public function testArrayAccessUnset(): void
     {
         $set = (new ValidationSet())
-            ->add('notBlank', ['rule' => 'notBlank'])
-            ->add('numeric', ['rule' => 'numeric'])
-            ->add('other', ['rule' => 'email']);
+            ->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank'])
+            ->add('numeric', ['callable' => Validation::class . '::' . 'numeric'])
+            ->add('other', ['callable' => Validation::class . '::' . 'email']);
 
         unset($set['notBlank']);
         $this->assertArrayNotHasKey('notBlank', $set);
@@ -133,9 +134,9 @@ class ValidationSetTest extends TestCase
     public function testIterator(): void
     {
         $set = (new ValidationSet())
-            ->add('notBlank', ['rule' => 'notBlank'])
-            ->add('numeric', ['rule' => 'numeric'])
-            ->add('other', ['rule' => 'email']);
+            ->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank'])
+            ->add('numeric', ['callable' => Validation::class . '::' . 'numeric'])
+            ->add('other', ['callable' => Validation::class . '::' . 'email']);
 
         $i = 0;
         foreach ($set as $name => $rule) {
@@ -160,9 +161,9 @@ class ValidationSetTest extends TestCase
     public function testCount(): void
     {
         $set = (new ValidationSet())
-            ->add('notBlank', ['rule' => 'notBlank'])
-            ->add('numeric', ['rule' => 'numeric'])
-            ->add('other', ['rule' => 'email']);
+            ->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank'])
+            ->add('numeric', ['callable' => Validation::class . '::' . 'numeric'])
+            ->add('other', ['callable' => Validation::class . '::' . 'email']);
         $this->assertCount(3, $set);
 
         unset($set['other']);
@@ -175,9 +176,9 @@ class ValidationSetTest extends TestCase
     public function testRemoveRule(): void
     {
         $set = (new ValidationSet())
-            ->add('notBlank', ['rule' => 'notBlank'])
-            ->add('numeric', ['rule' => 'numeric'])
-            ->add('other', ['rule' => 'email']);
+            ->add('notBlank', ['callable' => Validation::class . '::' . 'notBlank'])
+            ->add('numeric', ['callable' => Validation::class . '::' . 'numeric'])
+            ->add('other', ['callable' => Validation::class . '::' . 'email']);
 
         $this->assertArrayHasKey('notBlank', $set);
         $set->remove('notBlank');

--- a/tests/TestCase/Validation/ValidationSetTest.php
+++ b/tests/TestCase/Validation/ValidationSetTest.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Validation;
 
+use Cake\Core\Exception\CakeException;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validation;
 use Cake\Validation\ValidationRule;
@@ -38,7 +39,7 @@ class ValidationSetTest extends TestCase
         $result = $field->rule('notBlank');
         $this->assertInstanceOf(ValidationRule::class, $result);
         $this->assertEquals(
-            new ValidationRule(['name' => 'notBlank', 'callable' => Validation::class . '::' . 'notBlank', 'message' => 'Can not be empty']),
+            new ValidationRule(name: 'notBlank', callable: Validation::class . '::' . 'notBlank', message: 'Can not be empty'),
             $result,
         );
     }
@@ -69,21 +70,21 @@ class ValidationSetTest extends TestCase
         $rule = $set['notBlank'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
         $this->assertEquals(
-            new ValidationRule(['name' => 'notBlank', 'callable' => Validation::class . '::' . 'notBlank']),
+            new ValidationRule(name: 'notBlank', callable: Validation::class . '::' . 'notBlank'),
             $rule,
         );
 
         $rule = $set['numeric'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
         $this->assertEquals(
-            new ValidationRule(['name' => 'numeric', 'callable' => Validation::class . '::' . 'numeric']),
+            new ValidationRule(name: 'numeric', callable: Validation::class . '::' . 'numeric'),
             $rule,
         );
 
         $rule = $set['other'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
         $this->assertEquals(
-            new ValidationRule(['name' => 'other', 'callable' => Validation::class . '::' . 'email']),
+            new ValidationRule(name: 'other', callable: Validation::class . '::' . 'email'),
             $rule,
         );
     }
@@ -117,7 +118,7 @@ class ValidationSetTest extends TestCase
         $rule = $set['other'];
         $this->assertInstanceOf(ValidationRule::class, $rule);
         $this->assertEquals(
-            new ValidationRule(['name' => 'other', 'callable' => Validation::class . '::' . 'email']),
+            new ValidationRule(name: 'other', callable: Validation::class . '::' . 'email'),
             $rule,
         );
     }
@@ -237,5 +238,23 @@ class ValidationSetTest extends TestCase
 
         $set->allowEmpty(false);
         $this->assertFalse($set->isEmptyAllowed());
+    }
+
+    public function testAddDuplicateName(): void
+    {
+        $rules = new ValidationSet();
+        $rules->add('myUniqueName', ['callable' => fn() => false]);
+
+        $this->expectException(CakeException::class);
+        $rules->add('myUniqueName', ['callable' => fn() => true]);
+    }
+
+    public function testHasName(): void
+    {
+        $rules = new ValidationSet();
+        $rules->add('myUniqueName', ['callable' => fn() => false]);
+
+        $this->assertTrue($rules->has('myUniqueName'));
+        $this->assertFalse($rules->has('myMadeUpName'));
     }
 }

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -100,15 +100,11 @@ class ValidatorTest extends TestCase
         $validator->add('title', 'another', ['rule' => 'alphanumeric']);
         $this->assertCount(2, $set);
 
-        $validator->add('body', 'another', ['rule' => 'crazy']);
+        $validator->add('body', 'another', ['rule' => 'alphaNumeric']);
         $this->assertCount(1, $validator->field('body'));
         $this->assertCount(2, $validator);
 
-        $validator->add('email', 'notBlank');
-        $result = $validator->field('email')->rule('notBlank')->get('callable');
-        $this->assertSame([Validation::class, 'notBlank'], $result);
-
-        $rule = new ValidationRule(['callable' => [Validation::class, 'notBlank']]);
+        $rule = new ValidationRule([Validation::class, 'notBlank']);
         $validator->add('field', 'myrule', $rule);
         $result = $validator->field('field')->rule('myrule');
         $this->assertSame($rule, $result);
@@ -157,7 +153,7 @@ class ValidatorTest extends TestCase
         $this->assertCount(1, $validator->field('user'));
 
         $rule = $validator->field('user')->rule(Validator::NESTED);
-        $this->assertSame('create', $rule->get('on'));
+        $this->assertSame('create', $rule->on);
 
         $errors = $validator->validate(['user' => 'string']);
         $this->assertArrayHasKey('user', $errors);
@@ -214,7 +210,7 @@ class ValidatorTest extends TestCase
         $this->assertCount(1, $validator->field('comments'));
 
         $rule = $validator->field('comments')->rule(Validator::NESTED);
-        $this->assertSame('create', $rule->get('on'));
+        $this->assertSame('create', $rule->on);
 
         $errors = $validator->validate(['comments' => 'string']);
         $this->assertArrayHasKey('comments', $errors);
@@ -265,14 +261,14 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $validator->add('title', 'not-blank', ['rule' => 'notBlank']);
-        $validator->add('title', 'foo', ['rule' => 'bar']);
+        $validator->add('title', 'foo', ['rule' => 'alphaNumeric']);
         $this->assertCount(2, $validator->field('title'));
         $validator->remove('title');
         $this->assertCount(0, $validator->field('title'));
         $validator->remove('title');
 
         $validator->add('title', 'not-blank', ['rule' => 'notBlank']);
-        $validator->add('title', 'foo', ['rule' => 'bar']);
+        $validator->add('title', 'foo', ['rule' => 'alphaNumeric']);
         $this->assertCount(2, $validator->field('title'));
         $validator->remove('title', 'foo');
         $this->assertCount(1, $validator->field('title'));
@@ -2954,10 +2950,9 @@ class ValidatorTest extends TestCase
 
         $rule = $validator->field('username')->rule($method);
         $this->assertNotEmpty($rule, "Rule was not found for {$method}");
-        $this->assertNotNull($rule->get('message'), 'Message is not present when it should be');
-        $this->assertNull($rule->get('on'), 'On clause is present when it should not be');
-        $this->assertSame([Validation::class, $name], $rule->get('callable'), 'Rule name does not match');
-        $this->assertEquals($pass, $rule->get('pass'), 'Passed options are different');
+        $this->assertNotNull($rule->message, 'Message is not present when it should be');
+        $this->assertNull($rule->on, 'On clause is present when it should not be');
+        $this->assertEquals($pass, $rule->pass, 'Passed options are different');
 
         $validator->remove('username', $method);
         if ($extra !== null) {
@@ -2967,8 +2962,8 @@ class ValidatorTest extends TestCase
         }
 
         $rule = $validator->field('username')->rule($method);
-        $this->assertSame('the message', $rule->get('message'), 'Error messages are not the same');
-        $this->assertSame('create', $rule->get('on'), 'On clause is wrong');
+        $this->assertSame('the message', $rule->message, 'Error messages are not the same');
+        $this->assertSame('create', $rule->on, 'On clause is wrong');
     }
 
     /**
@@ -3060,7 +3055,7 @@ class ValidatorTest extends TestCase
 
         $this->assertSame(
             $expectedMessage,
-            $validator->field($fieldName)->rule($rule)->get('message'),
+            $validator->field($fieldName)->rule($rule)->message,
         );
 
         $noI18nValidator = new NoI18nValidator();
@@ -3072,7 +3067,7 @@ class ValidatorTest extends TestCase
 
         $this->assertSame(
             $expectedMessage,
-            $noI18nValidator->field($fieldName)->rule($rule)->get('message'),
+            $noI18nValidator->field($fieldName)->rule($rule)->message,
         );
     }
 }

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -21,6 +21,7 @@ use Cake\Validation\Validation;
 use Cake\Validation\ValidationRule;
 use Cake\Validation\ValidationSet;
 use Cake\Validation\Validator;
+use Closure;
 use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use Locale;
@@ -104,7 +105,7 @@ class ValidatorTest extends TestCase
         $this->assertCount(1, $validator->field('body'));
         $this->assertCount(2, $validator);
 
-        $rule = new ValidationRule([Validation::class, 'notBlank']);
+        $rule = new ValidationRule(Closure::fromCallable([Validation::class, 'notBlank']));
         $validator->add('field', 'myrule', $rule);
         $result = $validator->field('field')->rule('myrule');
         $this->assertSame($rule, $result);

--- a/tests/test_app/TestApp/Model/Behavior/ValidationBehavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/ValidationBehavior.php
@@ -32,9 +32,4 @@ class ValidationBehavior extends Behavior
     {
         return $validator->add('name', 'behaviorRule');
     }
-
-    public function customValidationRule(mixed $value, array $context): bool
-    {
-        return false;
-    }
 }


### PR DESCRIPTION
The validator callback is now passed to the ValidationRule constructor instead of just passing the rule method name and passing the providers when processing the rule.

While this is technically a breaking change it shouldn't cause much issue when upgrading from 5.x as validator setup remains the same and users don't need to create `ValidationRule` instances directly. Only thing to be mindful of is to set any custom providers before adding rules.
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
