### PR TITLE
Use upper case HTTP GET method

### DIFF
--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -119,7 +119,7 @@ class Curl implements AdapterInterface
         $out[CURLOPT_POSTFIELDS] = $body->getContents();
         // GET requests with bodies require custom request to be used.
         if ($out[CURLOPT_POSTFIELDS] !== '' && isset($out[CURLOPT_HTTPGET])) {
-            $out[CURLOPT_CUSTOMREQUEST] = 'get';
+            $out[CURLOPT_CUSTOMREQUEST] = 'GET';
         }
         if ($out[CURLOPT_POSTFIELDS] === '') {
             unset($out[CURLOPT_POSTFIELDS]);

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -149,7 +149,7 @@ class CurlTest extends TestCase
             ],
             CURLOPT_HTTPGET => true,
             CURLOPT_POSTFIELDS => '{"some":"body"}',
-            CURLOPT_CUSTOMREQUEST => 'get',
+            CURLOPT_CUSTOMREQUEST => 'GET',
             CURLOPT_TIMEOUT => 5,
             CURLOPT_CAINFO => $this->caFile,
         ];


### PR DESCRIPTION
According to [RFC 9110 HTTP methods are case-sensitive but by convention should be defined in uppercase](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1-5) .

Certain applications might restrict allowed methods to 'GET' and thereby only allow the uppercase version. Currently, in such scenarios, you will encounter a 405 Method Not Allowed error when trying to send a GET request with a body using this Http Client.

For better adherence to the standard conventions and avoiding such rare edge case scenarios, I propose this small change.

Also see discussion in https://github.com/cakephp/cakephp/pull/13965
