### PR TITLE
Revert "Allow null for Number helper methods that are commonly used for bake."

### DIFF
--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -56,20 +56,15 @@ class NumberHelper extends Helper
      * - `locale` - The locale name to use for formatting the number, e.g. fr_FR
      * - `before` - The string to place before whole numbers, e.g. '['
      * - `after` - The string to place after decimal numbers, e.g. ']'
-     * - `escape` - Whether to escape HTML in resulting string
-     * - `default` - The default value in case passed value is null
+     * - `escape` - Whether to escape html in resulting string
      *
-     * @param string|float|int|null $number A floating point number.
+     * @param string|float|int $number A floating point number.
      * @param array<string, mixed> $options An array with options.
      * @return string Formatted number
      * @link https://book.cakephp.org/5/en/views/helpers/number.html#formatting-numbers
      */
-    public function format(string|float|int|null $number, array $options = []): string
+    public function format(string|float|int $number, array $options = []): string
     {
-        if ($number === null) {
-            return $options['default'] ?? '';
-        }
-
         $formatted = Number::format($number, $options);
         $options += ['escape' => true];
 
@@ -95,20 +90,15 @@ class NumberHelper extends Helper
      * - `pattern` - An ICU number pattern to use for formatting the number. e.g #,##0.00
      * - `useIntlCode` - Whether to replace the currency symbol with the international
      *   currency code.
-     * - `escape` - Whether to escape HTML in resulting string
-     * - `default` - The default value in case passed value is null
+     * - `escape` - Whether to escape html in resulting string
      *
-     * @param string|float|null $number Value to format.
+     * @param string|float $number Value to format.
      * @param string|null $currency International currency name such as 'USD', 'EUR', 'JPY', 'CAD'
      * @param array<string, mixed> $options Options list.
      * @return string Number formatted as a currency.
      */
-    public function currency(string|float|null $number, ?string $currency = null, array $options = []): string
+    public function currency(string|float $number, ?string $currency = null, array $options = []): string
     {
-        if ($number === null) {
-            return $options['default'] ?? '';
-        }
-
         $formatted = Number::currency($number, $currency, $options);
         $options += ['escape' => true];
 

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -77,44 +77,4 @@ class NumberHelperTest extends TestCase
         $helper = new NumberHelper($this->View);
         $this->assertNotNull($helper->{$method}($arg));
     }
-
-    /**
-     * test format() and empty values
-     */
-    public function testFormatEmpty(): void
-    {
-        $helper = new NumberHelper($this->View);
-
-        $value = null;
-        $result = $helper->format($value);
-        $this->assertSame('', $result);
-
-        $result = $helper->format($value, ['default' => '-']);
-        $this->assertSame('-', $result);
-
-        // We should revisit this for 6.x
-        $value = '';
-        $result = $helper->format($value);
-        $this->assertSame('0', $result);
-    }
-
-    /**
-     * test currency() and empty values
-     */
-    public function testCurrencyEmpty(): void
-    {
-        $helper = new NumberHelper($this->View);
-
-        $value = null;
-        $result = $helper->currency($value);
-        $this->assertSame('', $result);
-
-        $result = $helper->currency($value, null, ['default' => '-']);
-        $this->assertSame('-', $result);
-
-        // We should revisit this for 6.x
-        $value = '';
-        $result = $helper->currency($value);
-        $this->assertNotEmpty($result);
-    }
 }


### PR DESCRIPTION
Reverts cakephp/cakephp#18272

Then we redo this for 5.3 with a clear migration guide

Refs https://github.com/cakephp/cakephp/issues/18316