### PR TITLE
Fix mysql column generation

### DIFF
--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -286,6 +286,9 @@ class Mysql extends Driver
                 /** @phpstan-ignore-next-line */
                 $this->_version = $matches[1];
             }
+            if (str_contains($this->_version, '-')) {
+                [$this->_version,] = explode('-', $this->_version);
+            }
         }
 
         return $this->_version;

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -286,9 +286,6 @@ class Mysql extends Driver
                 /** @phpstan-ignore-next-line */
                 $this->_version = $matches[1];
             }
-            if (str_contains($this->_version, '-')) {
-                [$this->_version,] = explode('-', $this->_version);
-            }
         }
 
         return $this->_version;

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -725,11 +725,21 @@ class MysqlSchemaDialect extends SchemaDialect
             $out .= " SRID {$column['srid']}";
         }
         if (
-            in_array($column['type'], TableSchemaInterface::GEOSPATIAL_TYPES)
-            && isset($column['default'])
+            isset($column['default']) &&
+            in_array(
+                $column['type'],
+                array_merge(
+                    TableSchemaInterface::GEOSPATIAL_TYPES,
+                    [
+                        TableSchemaInterface::TYPE_BINARY,
+                        TableSchemaInterface::TYPE_JSON,
+                        TableSchemaInterface::TYPE_TEXT
+                    ],
+                ),
+            )
         ) {
-            // Geospatial types need to be wrapped in () to create an expression.
-            $out .= ' DEFAULT (' . $this->_driver->schemaValue($column['default']). ')';
+            // Complex types need default values to be wrapped in () to create an expression.
+            $out .= ' DEFAULT (' . $this->_driver->schemaValue($column['default']) . ')';
             unset($column['default']);
         }
 

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -724,6 +724,14 @@ class MysqlSchemaDialect extends SchemaDialect
         if (isset($column['srid']) && in_array($column['type'], TableSchemaInterface::GEOSPATIAL_TYPES)) {
             $out .= " SRID {$column['srid']}";
         }
+        if (
+            in_array($column['type'], TableSchemaInterface::GEOSPATIAL_TYPES)
+            && isset($column['default'])
+        ) {
+            // Geospatial types need to be wrapped in () to create an expression.
+            $out .= ' DEFAULT (' . $this->_driver->schemaValue($column['default']). ')';
+            unset($column['default']);
+        }
 
         $dateTimeTypes = [
             TableSchemaInterface::TYPE_DATETIME,

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -125,10 +125,12 @@ class MysqlSchemaDialect extends SchemaDialect
         }
         foreach ($statement->fetchAll('assoc') as $row) {
             $field = $this->_convertColumn($row['Type']);
+            $default = $this->parseDefault($field['type'], $row);
+
             $field += [
                 'name' => $row['Field'],
                 'null' => $row['Null'] === 'YES',
-                'default' => $row['Default'],
+                'default' => $default,
                 'collate' => $row['Collation'],
                 'comment' => $row['Comment'],
                 'length' => null,
@@ -145,6 +147,36 @@ class MysqlSchemaDialect extends SchemaDialect
         }
 
         return $columns;
+    }
+
+    /**
+     * Parse the default value if required.
+     *
+     * @param string $type The type of column
+     * @param array $row a Row of schema reflection data
+     * @return ?string The default value of a column.
+     */
+    protected function parseDefault(string $type, array $row): ?string
+    {
+        $default = $row['Default'];
+        if (
+            is_string($default) &&
+            in_array(
+                $type,
+                array_merge(
+                    TableSchema::GEOSPATIAL_TYPES,
+                    [TableSchema::TYPE_BINARY, TableSchema::TYPE_JSON, TableSchema::TYPE_TEXT],
+                ),
+            )
+        ) {
+            // The default that comes back from MySQL for these types prefixes the collation type and
+            // surrounds the value with escaped single quotes, for example "_utf8mbf4\'abc\'", and so
+            // this converts that then down to the default value of "abc" to correspond to what the user
+            // would have specified in a migration.
+            $default = preg_replace("/^_(?:[a-zA-Z0-9]+?)\\\'(.*)\\\'$/", '\1', $default);
+        }
+
+        return $default;
     }
 
     /**
@@ -377,9 +409,10 @@ class MysqlSchemaDialect extends SchemaDialect
     public function convertColumnDescription(TableSchema $schema, array $row): void
     {
         $field = $this->_convertColumn($row['Type']);
+        $default = $this->parseDefault($field['type'], $row);
         $field += [
             'null' => $row['Null'] === 'YES',
-            'default' => $row['Default'],
+            'default' => $default,
             'collate' => $row['Collation'],
             'comment' => $row['Comment'],
         ];
@@ -724,21 +757,13 @@ class MysqlSchemaDialect extends SchemaDialect
         if (isset($column['srid']) && in_array($column['type'], TableSchemaInterface::GEOSPATIAL_TYPES)) {
             $out .= " SRID {$column['srid']}";
         }
-        if (
-            isset($column['default']) &&
-            in_array(
-                $column['type'],
-                array_merge(
-                    TableSchemaInterface::GEOSPATIAL_TYPES,
-                    [
-                        TableSchemaInterface::TYPE_BINARY,
-                        TableSchemaInterface::TYPE_JSON,
-                        TableSchemaInterface::TYPE_TEXT
-                    ],
-                ),
-            )
-        ) {
-            // Complex types need default values to be wrapped in () to create an expression.
+
+        $defaultExpressionTypes = array_merge(
+            TableSchemaInterface::GEOSPATIAL_TYPES,
+            [TableSchemaInterface::TYPE_BINARY, TableSchemaInterface::TYPE_TEXT, TableSchemaInterface::TYPE_JSON],
+        );
+        if (in_array($column['type'], $defaultExpressionTypes) && isset($column['default'])) {
+            // Geospatial, blob and text types need to be wrapped in () to create an expression.
             $out .= ' DEFAULT (' . $this->_driver->schemaValue($column['default']) . ')';
             unset($column['default']);
         }

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -173,14 +173,14 @@ class MysqlSchemaDialect extends SchemaDialect
             // surrounds the value with escaped single quotes, for example "_utf8mbf4\'abc\'", and so
             // this converts that then down to the default value of "abc" to correspond to what the user
             // would have specified in a migration.
-            $default = preg_replace("/^_(?:[a-zA-Z0-9]+?)\\\'(.*)\\\'$/", '\1', $default);
+            $default = (string)preg_replace("/^_(?:[a-zA-Z0-9]+?)\\\'(.*)\\\'$/", '\1', $default);
 
             // If the default is wrapped in a function, and has a collation marker on it, strip
             // the collation marker out
-            $default = preg_replace(
+            $default = (string)preg_replace(
                 "/^(?<prefix>[a-zA-Z0-9_]*\()(?<collation>_[a-zA-Z0-9]+)\\\'(?<args>.*)\\\'\)$/",
                 "\\1'\\3')",
-                $default
+                $default,
             );
         }
 

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -174,6 +174,14 @@ class MysqlSchemaDialect extends SchemaDialect
             // this converts that then down to the default value of "abc" to correspond to what the user
             // would have specified in a migration.
             $default = preg_replace("/^_(?:[a-zA-Z0-9]+?)\\\'(.*)\\\'$/", '\1', $default);
+
+            // If the default is wrapped in a function, and has a collation marker on it, strip
+            // the collation marker out
+            $default = preg_replace(
+                "/^(?<prefix>[a-zA-Z0-9_]*\()(?<collation>_[a-zA-Z0-9]+)\\\'(?<args>.*)\\\'\)$/",
+                "\\1'\\3')",
+                $default
+            );
         }
 
         return $default;

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -556,7 +556,7 @@ CREATE TABLE schema_geometry (
     id INTEGER,
     geo_line LINESTRING,
     geo_geometry GEOMETRY,
-    geo_point POINT DEFAULT ('POINT(10 10)'),
+    geo_point POINT DEFAULT (ST_PointFromText('POINT(10 10)')),
     geo_polygon POLYGON
 )
 SQL;
@@ -597,7 +597,7 @@ SQL;
             'geo_point' => [
                 'type' => 'point',
                 'null' => true,
-                'default' => 'POINT(10 10)',
+                'default' => "st_pointfromtext(_utf8mb4\\'POINT(10 10)\\')",
                 'precision' => null,
                 'length' => null,
                 'comment' => '',

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -1147,6 +1147,11 @@ SQL;
             ],
             [
                 'p',
+                ['type' => 'polygon', 'default' => 'POLYGON((30 10,40 40,20 40,10 20,30 10))'],
+                "`p` POLYGON DEFAULT ('POLYGON((30 10,40 40,20 40,10 20,30 10))')",
+            ],
+            [
+                'p',
                 ['type' => 'polygon', 'null' => false, 'srid' => 4326],
                 '`p` POLYGON NOT NULL SRID 4326',
             ],

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -275,6 +275,26 @@ class MysqlSchemaDialectTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
+    public function testConvertColumnBlobDefault(): void
+    {
+        $field = [
+            'Field' => 'field',
+            'Type' => 'binary',
+            'Null' => 'YES',
+            'Default' => "_utf8mb4\\'abc\\'",
+            'Collation' => 'utf8_general_ci',
+            'Comment' => 'Comment section',
+        ];
+        $driver = $this->getMockBuilder(Mysql::class)->getMock();
+        $dialect = new MysqlSchemaDialect($driver);
+
+        $table = new TableSchema('table');
+        $dialect->convertColumnDescription($table, $field);
+
+        $actual = $table->getColumn('field');
+        $this->assertSame('abc', $actual['default']);
+    }
+
     /**
      * Helper method for testing methods.
      *
@@ -537,7 +557,7 @@ CREATE TABLE schema_geometry (
     geo_line LINESTRING,
     geo_geometry GEOMETRY,
     geo_point POINT,
-    geo_polygon POLYGON
+    geo_polygon POLYGON DEFAULT ('POLYGON(0 0,10 10,20 20)')
 )
 SQL;
         $connection->execute($table);
@@ -586,7 +606,7 @@ SQL;
             'geo_polygon' => [
                 'type' => 'polygon',
                 'null' => true,
-                'default' => null,
+                'default' => 'POLYGON(0 0,10 10,20 20)',
                 'precision' => null,
                 'length' => null,
                 'comment' => '',
@@ -875,6 +895,11 @@ SQL;
                 'body',
                 ['type' => 'text', 'null' => false],
                 '`body` TEXT NOT NULL',
+            ],
+            [
+                'body',
+                ['type' => 'text', 'null' => false, 'default' => 'abc'],
+                '`body` TEXT NOT NULL DEFAULT (\'abc\')',
             ],
             [
                 'body',

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -1445,17 +1445,12 @@ SQL;
      */
     public function testCreateSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->_getMockedDriver('5.6.0');
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
             ->willReturn($driver);
-
-        $this->pdo
-            ->expects($this->any())
-            ->method('getAttribute')
-            ->willReturn('5.6.0');
 
         $table = (new TableSchema('posts'))->addColumn('id', [
                 'type' => 'integer',
@@ -1716,7 +1711,7 @@ SQL;
     /**
      * Get a schema instance with a mocked driver/pdo instances
      */
-    protected function _getMockedDriver(): Driver
+    protected function _getMockedDriver($version = '8.0.7'): Driver
     {
         $this->_needsConnection();
 
@@ -1740,7 +1735,7 @@ SQL;
 
         $driver->expects($this->any())
             ->method('version')
-            ->willReturn('8.0.7');
+            ->willReturn($version);
 
         $driver->connect();
 

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -896,11 +896,27 @@ SQL;
                 ['type' => 'text', 'null' => false, 'collate' => 'utf8_unicode_ci'],
                 '`body` TEXT COLLATE utf8_unicode_ci NOT NULL',
             ],
+            // JSON
+            [
+                'config',
+                ['type' => 'json', 'null' => false],
+                '`config` JSON NOT NULL',
+            ],
+            [
+                'config',
+                ['type' => 'json', 'null' => false, 'default' => '{"key":"val"}'],
+                '`config` JSON NOT NULL DEFAULT (\'{"key":"val"}\')',
+            ],
             // Blob / binary
             [
                 'body',
                 ['type' => 'binary', 'null' => false],
                 '`body` BLOB NOT NULL',
+            ],
+            [
+                'body',
+                ['type' => 'binary', 'null' => false, 'default' => 'abc'],
+                "`body` BLOB NOT NULL DEFAULT ('abc')",
             ],
             [
                 'body',
@@ -1708,19 +1724,23 @@ SQL;
             ->onlyMethods(['quote', 'getAttribute', 'quoteIdentifier'])
             ->disableOriginalConstructor()
             ->getMock();
-            $this->pdo->expects($this->any())
+        $this->pdo->expects($this->any())
             ->method('quote')
             ->willReturnCallback(function ($value) {
                 return "'{$value}'";
             });
 
         $driver = $this->getMockBuilder(Mysql::class)
-            ->onlyMethods(['createPdo'])
+            ->onlyMethods(['createPdo', 'version'])
             ->getMock();
 
         $driver->expects($this->any())
             ->method('createPdo')
             ->willReturn($this->pdo);
+
+        $driver->expects($this->any())
+            ->method('version')
+            ->willReturn('8.0.7');
 
         $driver->connect();
 

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -556,7 +556,7 @@ CREATE TABLE schema_geometry (
     id INTEGER,
     geo_line LINESTRING,
     geo_geometry GEOMETRY,
-    geo_point POINT DEFAULT (ST_PointFromText('POINT(10 10)')),
+    geo_point POINT DEFAULT (ST_GeometryFromText('POINT(10 10)')),
     geo_polygon POLYGON
 )
 SQL;
@@ -597,7 +597,7 @@ SQL;
             'geo_point' => [
                 'type' => 'point',
                 'null' => true,
-                'default' => "st_pointfromtext('POINT(10 10)')",
+                'default' => "st_geometryfromtext('POINT(10 10)')",
                 'precision' => null,
                 'length' => null,
                 'comment' => '',

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -597,7 +597,7 @@ SQL;
             'geo_point' => [
                 'type' => 'point',
                 'null' => true,
-                'default' => "st_pointfromtext(_utf8mb4\\'POINT(10 10)\\')",
+                'default' => "st_pointfromtext('POINT(10 10)')",
                 'precision' => null,
                 'length' => null,
                 'comment' => '',

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -556,8 +556,8 @@ CREATE TABLE schema_geometry (
     id INTEGER,
     geo_line LINESTRING,
     geo_geometry GEOMETRY,
-    geo_point POINT,
-    geo_polygon POLYGON DEFAULT ('POLYGON(0 0,10 10,20 20)')
+    geo_point POINT DEFAULT ('POINT(10 10)'),
+    geo_polygon POLYGON
 )
 SQL;
         $connection->execute($table);
@@ -597,7 +597,7 @@ SQL;
             'geo_point' => [
                 'type' => 'point',
                 'null' => true,
-                'default' => null,
+                'default' => 'POINT(10 10)',
                 'precision' => null,
                 'length' => null,
                 'comment' => '',
@@ -606,7 +606,7 @@ SQL;
             'geo_polygon' => [
                 'type' => 'polygon',
                 'null' => true,
-                'default' => 'POLYGON(0 0,10 10,20 20)',
+                'default' => '',
                 'precision' => null,
                 'length' => null,
                 'comment' => '',


### PR DESCRIPTION
Port functionality from migrations/phinx into cakephp/database. These changes improve the mysql adapter's ability to reflect and generate column defaults.

Once this merges I can open a pull request for migrations to switch over to using cakephp for column generation.