### PR TITLE
Fix for invisible validation issue.

### DIFF
--- a/src/Datasource/RuleInvoker.php
+++ b/src/Datasource/RuleInvoker.php
@@ -121,18 +121,6 @@ class RuleInvoker
             return true;
         }
 
-        if (empty($this->options['errorField'])) {
-            // If no errorField is specified but the rule didn't return true,
-            // we should still set a general error on the entity
-            if ($pass !== false && is_string($pass)) {
-                $entity->setError('_rule', [$pass]);
-            } elseif ($pass !== false) {
-                $entity->setError('_rule', ['Application rule failed']);
-            }
-
-            return false;
-        }
-
         $message = $this->options['message'] ?? 'invalid';
         if (is_string($pass)) {
             $message = $pass;
@@ -145,7 +133,8 @@ class RuleInvoker
         } else {
             $message = [$message];
         }
-        $errorField = $this->options['errorField'];
+
+        $errorField = $this->options['errorField'] ?? ($this->name ?? '_rule');
         $entity->setError($errorField, $message);
 
         if ($entity instanceof InvalidPropertyInterface && isset($entity->{$errorField})) {

--- a/src/Datasource/RuleInvoker.php
+++ b/src/Datasource/RuleInvoker.php
@@ -117,8 +117,20 @@ class RuleInvoker
     {
         $rule = $this->rule;
         $pass = $rule($entity, $this->options + $scope);
-        if ($pass === true || empty($this->options['errorField'])) {
-            return $pass === true;
+        if ($pass === true) {
+            return true;
+        }
+
+        if (empty($this->options['errorField'])) {
+            // If no errorField is specified but the rule didn't return true,
+            // we should still set a general error on the entity
+            if ($pass !== false && is_string($pass)) {
+                $entity->setError('_rule', [$pass]);
+            } elseif ($pass !== false) {
+                $entity->setError('_rule', ['Application rule failed']);
+            }
+
+            return false;
         }
 
         $message = $this->options['message'] ?? 'invalid';

--- a/tests/TestCase/Datasource/RulesCheckerTest.php
+++ b/tests/TestCase/Datasource/RulesCheckerTest.php
@@ -186,7 +186,8 @@ class RulesCheckerTest extends TestCase
         });
 
         $this->assertFalse($rules->check($entity, RulesChecker::CREATE));
-        $this->assertEmpty($entity->getErrors());
+        // When no errorField is specified, errors are set on '_rule' field
+        $this->assertEquals(['_rule' => ['invalid']], $entity->getErrors());
     }
 
     public function testRemove(): void

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -1157,7 +1157,7 @@ class RulesCheckerIntegrationTest extends TestCase
     }
 
     /**
-     * Test adding rules with no errorField do not accept strings
+     * Test adding rules with no errorField now sets errors under _rule key
      */
     public function testCustomErrorMessageFromRuleNoErrorField(): void
     {
@@ -1172,7 +1172,8 @@ class RulesCheckerIntegrationTest extends TestCase
         });
 
         $this->assertFalse($table->save($entity));
-        $this->assertEmpty($entity->getErrors());
+        $this->assertNotEmpty($entity->getErrors());
+        $this->assertEquals(['So much nope'], $entity->getError('_rule'));
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3110,7 +3110,12 @@ class TableTest extends TestCase
         $this->assertFalse($result);
 
         // There should be errors here, due to comment not being savable.
-        debug($article->getErrors());
+        $errors = $article->getErrors();
+        $this->assertNotEmpty($errors);
+        $this->assertArrayHasKey('comments', $errors);
+        $this->assertArrayHasKey(0, $errors['comments']);
+        $this->assertArrayHasKey('_rule', $errors['comments'][0]);
+        $this->assertSame(['Xyz'], $errors['comments'][0]['_rule']);
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -55,6 +55,7 @@ use Cake\ORM\Query\UpdateQuery;
 use Cake\ORM\ResultSet;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 use Cake\Validation\Validator;
@@ -3068,6 +3069,48 @@ class TableTest extends TestCase
         $this->expectException(PersistenceFailedException::class);
 
         $table->saveManyOrFail($entities);
+    }
+
+    public function testSaveWithBuildRulesFailWithErrorMessage(): void
+    {
+        $Articles = new class extends Table {
+            public function initialize(array $config): void
+            {
+                $this->setAlias('Articles');
+                $this->setTable('articles');
+                $this->hasMany('Comments');
+            }
+        };
+        $Comments = new class extends Table {
+            public function initialize(array $config): void
+            {
+                $this->setAlias('Comments');
+                $this->setTable('comments');
+            }
+
+            public function buildRules(RulesChecker $rules): RulesChecker
+            {
+                return $rules->add(function () {
+                    return 'Xyz';
+                });
+            }
+        };
+        TableRegistry::getTableLocator()->set('Comments', $Comments);
+
+        $article = $Articles->newEntity([
+            'title' => 'First Article',
+            'body' => 'First Article Body',
+            'published' => 'Y',
+            'comments' => [
+                '_ids' => [1],
+            ],
+        ]);
+
+        $result = $Articles->save($article, ['associated' => ['Comments']]);
+        $this->assertFalse($result);
+
+        // There should be errors here, due to comment not being savable.
+        debug($article->getErrors());
     }
 
     /**


### PR DESCRIPTION
Is this a valid test case for the scenario in https://github.com/cakephp/cakephp/issues/18241 ?
It does not show any error messages that we can display the user in the form or give back via flash message.
But I think somehow we should be able to do that, otherwise domain rule validation is even less useful compared to normal validation.
