### PR TITLE
Deprecate calling of attached behavior methods on the table instance.

### DIFF
--- a/src/Command/CounterCacheCommand.php
+++ b/src/Command/CounterCacheCommand.php
@@ -72,8 +72,11 @@ class CounterCacheCommand extends Command
             $methodArgs['page'] = (int)$args->getOption('page');
         }
 
-        /** @phpstan-ignore-next-line */
-        $table->updateCounterCache(...$methodArgs);
+        /**
+         * @psalm-suppress UndefinedMethod
+         * @phpstan-ignore-next-line
+         */
+        $table->getBehavior('CounterCache')->updateCounterCache(...$methodArgs);
 
         $io->success('Counter cache updated successfully.');
 

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -353,6 +353,7 @@ class Behavior implements EventListenerInterface
      *
      * @return array
      * @throws \ReflectionException
+     * @deprecated 5.3.0 Calling behavior methods on the table instance is deprecated.
      */
     public function implementedMethods(): array
     {

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -24,6 +24,7 @@ use Cake\Event\EventDispatcherTrait;
 use Cake\ORM\Exception\MissingBehaviorException;
 use Cake\ORM\Query\SelectQuery;
 use LogicException;
+use function Cake\Core\deprecationWarning;
 
 /**
  * BehaviorRegistry is used as a registry for loaded behaviors and handles loading
@@ -262,6 +263,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      *
      * @param string $method The method to check for.
      * @return bool
+     * @deprec version 5.3.0 Calling behavior methods on the table instance is deprecated.
      */
     public function hasMethod(string $method): bool
     {
@@ -293,9 +295,19 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @param array $args The arguments you want to invoke the method with.
      * @return mixed The return value depends on the underlying behavior method.
      * @throws \BadMethodCallException When the method is unknown.
+     * @deprecated 5.3.0 Calling behavior methods on the table instance is deprecated.
      */
     public function call(string $method, array $args = []): mixed
     {
+        deprecationWarning(
+            '5.3.0',
+            sprintf(
+                'Calling behavior methods on the table instance is deprecated.'
+                . '  Use `$table->getBehavior(\'YourBehavior\')->%s()` instead.',
+                $method,
+            ),
+        );
+
         $method = strtolower($method);
         if ($this->hasMethod($method) && $this->has($this->_methodMap[$method][0])) {
             [$behavior, $callMethod] = $this->_methodMap[$method];

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -263,7 +263,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      *
      * @param string $method The method to check for.
      * @return bool
-     * @deprec version 5.3.0 Calling behavior methods on the table instance is deprecated.
+     * @deprecated 5.3.0 Calling behavior methods on the table instance is deprecated.
      */
     public function hasMethod(string $method): bool
     {

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -638,7 +638,7 @@ class CounterCacheBehaviorTest extends TestCase
         $user = $this->_getUser(1);
         $this->assertSame(0, $user->get('post_count'));
 
-        $this->post->updateCounterCache('Users');
+        $this->post->getBehavior('CounterCache')->updateCounterCache('Users');
 
         $user = $this->_getUser(1);
         $this->assertSame(2, $user->get('post_count'));
@@ -647,7 +647,7 @@ class CounterCacheBehaviorTest extends TestCase
 
         $this->user->updateAll(['post_count' => 0], []);
 
-        $this->post->updateCounterCache(limit: 1, page: 2);
+        $this->post->getBehavior('CounterCache')->updateCounterCache(limit: 1, page: 2);
 
         $user = $this->_getUser(1);
         $this->assertSame(0, $user->get('post_count'));

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -150,7 +150,7 @@ class TranslateBehaviorEavTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
 
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
         $results = $table->find()->all()->combine('title', 'body', 'id')->toArray();
         $expected = [
             1 => ['Title #1' => 'Content #1'],
@@ -183,7 +183,7 @@ class TranslateBehaviorEavTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
         $results = $table->find('translations')
             ->limit(1)
             ->formatResults(function ($results) {
@@ -313,7 +313,7 @@ class TranslateBehaviorEavTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Comments');
         $table->addBehavior('Translate', ['fields' => ['comment']]);
-        $table->setLocale('spa');
+        $table->getBehavior('Translate')->setLocale('spa');
         $results = $table->find()
             ->where(['Comments.id' => 6])
             ->all()
@@ -331,7 +331,7 @@ class TranslateBehaviorEavTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
         $results = $table->find()
             ->where(['Articles.id' => 2])
             ->all();
@@ -358,16 +358,16 @@ class TranslateBehaviorEavTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
 
-        $this->assertSame('en_US', $table->getLocale());
+        $this->assertSame('en_US', $table->getBehavior('Translate')->getLocale());
 
-        $table->setLocale('fr_FR');
-        $this->assertSame('fr_FR', $table->getLocale());
+        $table->getBehavior('Translate')->setLocale('fr_FR');
+        $this->assertSame('fr_FR', $table->getBehavior('Translate')->getLocale());
 
-        $table->setLocale(null);
-        $this->assertSame('en_US', $table->getLocale());
+        $table->getBehavior('Translate')->setLocale(null);
+        $this->assertSame('en_US', $table->getBehavior('Translate')->getLocale());
 
         I18n::setLocale('fr_FR');
-        $this->assertSame('fr_FR', $table->getLocale());
+        $this->assertSame('fr_FR', $table->getBehavior('Translate')->getLocale());
     }
 
     /**
@@ -384,15 +384,15 @@ class TranslateBehaviorEavTest extends TestCase
         $expectedSameLocale = 'Articles.title';
         $expectedOtherLocale = 'Articles_title_translation.content';
 
-        $field = $table->translationField('title');
+        $field = $table->getBehavior('Translate')->translationField('title');
         $this->assertSame($expectedSameLocale, $field);
 
         I18n::setLocale('es_ES');
-        $field = $table->translationField('title');
+        $field = $table->getBehavior('Translate')->translationField('title');
         $this->assertSame($expectedOtherLocale, $field);
 
         I18n::setLocale('en');
-        $field = $table->translationField('title');
+        $field = $table->getBehavior('Translate')->translationField('title');
         $this->assertSame($expectedOtherLocale, $field);
 
         $table->removeBehavior('Translate');
@@ -403,19 +403,19 @@ class TranslateBehaviorEavTest extends TestCase
         ]);
 
         I18n::setLocale('de_DE');
-        $field = $table->translationField('title');
+        $field = $table->getBehavior('Translate')->translationField('title');
         $this->assertSame($expectedSameLocale, $field);
 
         I18n::setLocale('en_US');
-        $field = $table->translationField('title');
+        $field = $table->getBehavior('Translate')->translationField('title');
         $this->assertSame($expectedOtherLocale, $field);
 
-        $table->setLocale('de_DE');
-        $field = $table->translationField('title');
+        $table->getBehavior('Translate')->setLocale('de_DE');
+        $field = $table->getBehavior('Translate')->translationField('title');
         $this->assertSame($expectedSameLocale, $field);
 
-        $table->setLocale('es');
-        $field = $table->translationField('title');
+        $table->getBehavior('Translate')->setLocale('es');
+        $field = $table->getBehavior('Translate')->translationField('title');
         $this->assertSame($expectedOtherLocale, $field);
     }
 
@@ -428,7 +428,7 @@ class TranslateBehaviorEavTest extends TestCase
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
 
         $expected = 'Articles.foo';
-        $field = $table->translationField('foo');
+        $field = $table->getBehavior('Translate')->translationField('foo');
         $this->assertSame($expected, $field);
     }
 
@@ -439,7 +439,7 @@ class TranslateBehaviorEavTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
 
         $results = $table->find('list')->toArray();
         $expected = [1 => 'Title #1', 2 => 'Title #2', 3 => 'Title #3'];
@@ -453,7 +453,7 @@ class TranslateBehaviorEavTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
 
         $this->assertSame(3, $table->find()->count());
     }
@@ -574,7 +574,7 @@ class TranslateBehaviorEavTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $table->setLocale('cze');
+        $table->getBehavior('Translate')->setLocale('cze');
         $results = $table->find('translations', locales: ['deu', 'cze']);
         $expected = [
             [
@@ -615,8 +615,8 @@ class TranslateBehaviorEavTest extends TestCase
         $comments = $table->associations()->get('Comments')->getTarget();
         $comments->addBehavior('Translate', ['fields' => ['comment']]);
 
-        $table->setLocale('eng');
-        $comments->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
+        $comments->getBehavior('Translate')->setLocale('eng');
 
         $results = $table->find()->contain(['Comments' => function ($q) {
             return $q->select(['id', 'comment', 'article_id']);
@@ -690,8 +690,8 @@ class TranslateBehaviorEavTest extends TestCase
         $comments = $table->associations()->get('Comments')->getTarget();
         $comments->addBehavior('Translate', ['fields' => ['comment']]);
 
-        $table->setLocale('cze');
-        $comments->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('cze');
+        $comments->getBehavior('Translate')->setLocale('eng');
         $results = $table->find('translations')->contain([
             'Comments' => function ($q) {
                 return $q->find('translations')->select(['id', 'comment', 'article_id']);
@@ -742,8 +742,8 @@ class TranslateBehaviorEavTest extends TestCase
         $authors = $table->belongsTo('Authors')->getTarget();
         $authors->addBehavior('Translate', ['fields' => ['name']]);
 
-        $table->setLocale('eng');
-        $authors->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
+        $authors->getBehavior('Translate')->setLocale('eng');
 
         $results = $table->find()
             ->select(['title', 'body'])
@@ -790,8 +790,8 @@ class TranslateBehaviorEavTest extends TestCase
         $authors = $table->belongsTo('Authors')->getTarget();
         $authors->addBehavior('Translate', ['fields' => ['name']]);
 
-        $table->setLocale('eng');
-        $authors->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
+        $authors->getBehavior('Translate')->setLocale('eng');
 
         $entity = $table->get(1);
         $result = $table->loadInto($entity, ['Authors']);
@@ -818,7 +818,7 @@ class TranslateBehaviorEavTest extends TestCase
         $table->belongsToMany('Tags', [
             'through' => $specialTags,
         ]);
-        $specialTags->setLocale('eng');
+        $specialTags->getBehavior('Translate')->setLocale('eng');
 
         $result = $table->get(2, ...['contain' => 'Tags']);
         $this->assertNotEmpty($result);
@@ -836,7 +836,7 @@ class TranslateBehaviorEavTest extends TestCase
         $authors = $table->belongsTo('Authors')->getTarget();
         $authors->addBehavior('Translate', ['fields' => ['name']]);
 
-        $authors->setLocale('eng');
+        $authors->getBehavior('Translate')->setLocale('eng');
 
         $entity = $table->get(1);
         $this->assertNotEmpty($entity);
@@ -882,7 +882,7 @@ class TranslateBehaviorEavTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
         $article = $table->find()->first();
         $this->assertSame(1, $article->get('id'));
         $article->set('title', 'New translated article');
@@ -894,12 +894,12 @@ class TranslateBehaviorEavTest extends TestCase
         $this->assertSame('New translated article', $article->get('title'));
         $this->assertSame('Content #1', $article->get('body'));
 
-        $table->setLocale(null);
+        $table->getBehavior('Translate')->setLocale(null);
         $article = $table->find()->first();
         $this->assertSame(1, $article->get('id'));
         $this->assertSame('First Article', $article->get('title'));
 
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
         $article->set('title', 'Wow, such translated article');
         $article->set('body', 'A translated body');
         $table->save($article);
@@ -918,7 +918,7 @@ class TranslateBehaviorEavTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $table->setLocale('fra');
+        $table->getBehavior('Translate')->setLocale('fra');
 
         $article = $table->find()->first();
         $this->assertSame(1, $article->get('id'));
@@ -1125,7 +1125,7 @@ class TranslateBehaviorEavTest extends TestCase
         $this->assertSame('First Article', $article->get('title'));
         $this->assertSame('First Article Body', $article->get('body'));
 
-        $table->setLocale('fra');
+        $table->getBehavior('Translate')->setLocale('fra');
         $article = $table->find()->first();
         $this->assertSame(1, $article->get('id'));
         $this->assertSame('Le titre', $article->get('title'));
@@ -1141,7 +1141,7 @@ class TranslateBehaviorEavTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $table->setLocale('fra');
+        $table->getBehavior('Translate')->setLocale('fra');
 
         $article = $table->find()->first();
         $this->assertSame(1, $article->get('id'));
@@ -1265,7 +1265,7 @@ class TranslateBehaviorEavTest extends TestCase
         $table = $this->getTableLocator()->get('Comments');
         /** @var \Cake\ORM\Table|\Cake\ORM\Behavior\TranslateBehavior $table */
         $table->addBehavior('Translate', ['fields' => ['comment']]);
-        $table->setLocale('spa');
+        $table->getBehavior('Translate')->setLocale('spa');
         $query = $table->find()->where(['Comments.id' => 6]);
         $query2 = $table->find()->where(['Comments.id' => 5]);
         $query->union($query2);
@@ -1345,11 +1345,11 @@ class TranslateBehaviorEavTest extends TestCase
             'fields' => ['title', 'body'],
             'onlyTranslated' => true,
         ]);
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
         $results = $table->find()->where(['Articles.id' => 1])->all();
         $this->assertCount(1, $results);
 
-        $table->setLocale('fr');
+        $table->getBehavior('Translate')->setLocale('fr');
         $results = $table->find()->where(['Articles.id' => 1])->all();
         $this->assertCount(0, $results);
     }
@@ -1367,19 +1367,19 @@ class TranslateBehaviorEavTest extends TestCase
             'fields' => ['comment'],
             'onlyTranslated' => true,
         ]);
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
         $results = $table->find('translations')->all();
         $this->assertCount(4, $results);
 
-        $table->setLocale('spa');
+        $table->getBehavior('Translate')->setLocale('spa');
         $results = $table->find('translations')->all();
         $this->assertCount(1, $results);
 
-        $table->setLocale('spa');
+        $table->getBehavior('Translate')->setLocale('spa');
         $results = $table->find('translations', filterByCurrentLocale: false)->all();
         $this->assertCount(6, $results);
 
-        $table->setLocale('spa');
+        $table->getBehavior('Translate')->setLocale('spa');
         $results = $table->find('translations')->all();
         $this->assertCount(1, $results);
     }
@@ -1395,7 +1395,7 @@ class TranslateBehaviorEavTest extends TestCase
             'fields' => ['title', 'body', 'description'],
             'allowEmptyTranslations' => false,
         ]);
-        $table->setLocale('spa');
+        $table->getBehavior('Translate')->setLocale('spa');
         $result = $table->find()->first();
         $this->assertNull($result->description);
     }
@@ -1957,13 +1957,13 @@ class TranslateBehaviorEavTest extends TestCase
         $table->Comments->belongsTo('Authors')->setForeignKey('user_id');
 
         $table->Comments->addBehavior('Translate', ['fields' => ['comment']]);
-        $table->Comments->setLocale('abc');
+        $table->Comments->getBehavior('Translate')->setLocale('abc');
 
         $table->Comments->Authors->addBehavior('Translate', ['fields' => ['name']]);
-        $table->Comments->Authors->setLocale('xyz');
+        $table->Comments->Authors->getBehavior('Translate')->setLocale('xyz');
 
-        $this->assertNotEquals($table->Comments->getLocale(), I18n::getLocale());
-        $this->assertNotEquals($table->Comments->Authors->getLocale(), I18n::getLocale());
+        $this->assertNotEquals($table->Comments->getBehavior('Translate')->getLocale(), I18n::getLocale());
+        $this->assertNotEquals($table->Comments->Authors->getBehavior('Translate')->getLocale(), I18n::getLocale());
 
         $result = $table
             ->find()
@@ -1983,9 +1983,9 @@ class TranslateBehaviorEavTest extends TestCase
         $table->hasMany('Comments');
 
         $table->Comments->addBehavior('Translate', ['fields' => ['comment']]);
-        $table->Comments->setLocale('abc');
+        $table->Comments->getBehavior('Translate')->setLocale('abc');
 
-        $this->assertNotEquals($table->Comments->getLocale(), I18n::getLocale());
+        $this->assertNotEquals($table->Comments->getBehavior('Translate')->getLocale(), I18n::getLocale());
 
         $result = $table
             ->find()
@@ -2008,13 +2008,13 @@ class TranslateBehaviorEavTest extends TestCase
         $table->Comments->belongsTo('Authors')->setForeignKey('user_id');
 
         $table->Comments->addBehavior('Translate', ['fields' => ['comment']]);
-        $table->Comments->setLocale('abc');
+        $table->Comments->getBehavior('Translate')->setLocale('abc');
 
         $table->Comments->Authors->addBehavior('Translate', ['fields' => ['name']]);
-        $table->Comments->Authors->setLocale('xyz');
+        $table->Comments->Authors->getBehavior('Translate')->setLocale('xyz');
 
-        $this->assertNotEquals($table->Comments->getLocale(), I18n::getLocale());
-        $this->assertNotEquals($table->Comments->Authors->getLocale(), I18n::getLocale());
+        $this->assertNotEquals($table->Comments->getBehavior('Translate')->getLocale(), I18n::getLocale());
+        $this->assertNotEquals($table->Comments->Authors->getBehavior('Translate')->getLocale(), I18n::getLocale());
 
         $result = $table
             ->find()
@@ -2038,13 +2038,13 @@ class TranslateBehaviorEavTest extends TestCase
         $table->Articles->belongsToMany('Tags');
 
         $table->Articles->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $table->Articles->setLocale('abc');
+        $table->Articles->getBehavior('Translate')->setLocale('abc');
 
         $table->Articles->Tags->addBehavior('Translate', ['fields' => ['name']]);
-        $table->Articles->Tags->setLocale('xyz');
+        $table->Articles->Tags->getBehavior('Translate')->setLocale('xyz');
 
-        $this->assertNotEquals($table->Articles->getLocale(), I18n::getLocale());
-        $this->assertNotEquals($table->Articles->Tags->getLocale(), I18n::getLocale());
+        $this->assertNotEquals($table->Articles->getBehavior('Translate')->getLocale(), I18n::getLocale());
+        $this->assertNotEquals($table->Articles->Tags->getBehavior('Translate')->getLocale(), I18n::getLocale());
 
         $result = $table
             ->find()
@@ -2069,7 +2069,7 @@ class TranslateBehaviorEavTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $table->setLocale('fra');
+        $table->getBehavior('Translate')->setLocale('fra');
 
         $articles = $table->find()->all();
         $articles->each(function ($article): void {

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -208,7 +208,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
 
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
         $table->find()->select(['title'])->first();
 
         $expected = ['title', 'body'];
@@ -255,7 +255,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
             "The default locale doesn't need a join",
         );
 
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
 
         $query = $table->find()->select(['id']);
         $this->assertStringNotContainsString(
@@ -279,7 +279,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
 
         $query = $table->find();
         $this->assertStringContainsString(
@@ -310,7 +310,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
 
         $query = $table->find()->select(['id'])->where(['title' => 'First Article']);
         $this->assertStringContainsString(
@@ -330,7 +330,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $table->addBehavior('Translate', [
             'onlyTranslated' => true,
         ]);
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
 
         $query = $table->find()->select(['id'])->disableAutoFields();
         $this->assertStringContainsString(
@@ -342,7 +342,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $table
             ->removeBehavior('Translate')
             ->addBehavior('Translate');
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
 
         $query = $table->find('all', filterByCurrentLocale: true)->select(['id'])->disableAutoFields();
         $this->assertStringContainsString(
@@ -359,7 +359,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
 
         $query = $table->find()->select()->where(function (ExpressionInterface $exp) {
             return $exp->lt(new QueryExpression('1'), 50);
@@ -379,7 +379,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
 
         $query = $table->find()->select(['id'])->orderBy(['title' => 'desc']);
         $this->assertStringContainsString(
@@ -407,11 +407,11 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
 
         $table->belongsTo('Copy', ['className' => 'Articles', 'foreignKey' => 'author_id']);
         $table->Copy->addBehavior('Translate');
-        $table->Copy->setLocale('deu');
+        $table->Copy->getBehavior('Translate')->setLocale('deu');
 
         $query = $table->find()
             ->where(['Articles.id' => 3])
@@ -452,7 +452,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
             'translationTable' => 'articles_more_translations',
         ]);
 
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
         $results = $table->find()->all()->combine('title', 'subtitle', 'id')->toArray();
         $expected = [
             1 => ['Title #1' => 'SubTitle #1'],
@@ -485,7 +485,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
 
         $article = $table->find('all')
             ->select(['id'])
@@ -507,7 +507,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
 
         $article = $table->find('all')
             ->where(['id' => 1])
@@ -529,7 +529,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
 
         $article = $table->find('all')
             ->orderBy(['id' => 'desc'])
@@ -571,7 +571,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $table->belongsTo('Authors');
 
         $table->addBehavior('Translate');
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
 
         $query = $table
             ->find('translations')
@@ -614,8 +614,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $Articles->addBehavior('Translate');
         $Tags->addBehavior('Translate');
 
-        $Articles->setLocale('deu');
-        $Tags->setLocale('deu');
+        $Articles->getBehavior('Translate')->setLocale('deu');
+        $Tags->getBehavior('Translate')->setLocale('deu');
 
         $Articles->belongsToMany('Tags');
 
@@ -669,7 +669,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $articles->deleteAll('1=1');
 
         $articles->addBehavior('Translate');
-        $articles->setLocale('eng');
+        $articles->getBehavior('Translate')->setLocale('eng');
 
         $query = $comments
             ->find()
@@ -738,7 +738,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
-        $table->setLocale('zzz');
+        $table->getBehavior('Translate')->setLocale('zzz');
         $result = $table->get(1);
 
         $this->assertSame('', $result->title, 'The empty translation should be used');
@@ -755,7 +755,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $table->addBehavior('Translate', [
             'allowEmptyTranslations' => false,
         ]);
-        $table->setLocale('zzz');
+        $table->getBehavior('Translate')->setLocale('zzz');
         $result = $table->get(1);
 
         $this->assertSame('First Article', $result->title, 'The empty translation should be ignored');
@@ -776,7 +776,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
 
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
         $query = $table->find()->select();
         $query->select([
             'title',
@@ -834,15 +834,15 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $expectedSameLocale = 'Articles.title';
         $expectedOtherLocale = 'ArticlesTranslation.title';
 
-        $field = $table->translationField('title');
+        $field = $table->getBehavior('Translate')->translationField('title');
         $this->assertSame($expectedSameLocale, $field);
 
         I18n::setLocale('es_ES');
-        $field = $table->translationField('title');
+        $field = $table->getBehavior('Translate')->translationField('title');
         $this->assertSame($expectedOtherLocale, $field);
 
         I18n::setLocale('en');
-        $field = $table->translationField('title');
+        $field = $table->getBehavior('Translate')->translationField('title');
         $this->assertSame($expectedOtherLocale, $field);
 
         $table->removeBehavior('Translate');
@@ -852,19 +852,19 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         ]);
 
         I18n::setLocale('de_DE');
-        $field = $table->translationField('title');
+        $field = $table->getBehavior('Translate')->translationField('title');
         $this->assertSame($expectedSameLocale, $field);
 
         I18n::setLocale('en_US');
-        $field = $table->translationField('title');
+        $field = $table->getBehavior('Translate')->translationField('title');
         $this->assertSame($expectedOtherLocale, $field);
 
-        $table->setLocale('de_DE');
-        $field = $table->translationField('title');
+        $table->getBehavior('Translate')->setLocale('de_DE');
+        $field = $table->getBehavior('Translate')->translationField('title');
         $this->assertSame($expectedSameLocale, $field);
 
-        $table->setLocale('es');
-        $field = $table->translationField('title');
+        $table->getBehavior('Translate')->setLocale('es');
+        $field = $table->getBehavior('Translate')->translationField('title');
         $this->assertSame($expectedOtherLocale, $field);
     }
 
@@ -1006,8 +1006,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
 
         $table = $this->getTableLocator()->get('Comments');
         $table->addBehavior('Translate', ['fields' => ['comment']]);
-        $table->setLocale('spa');
-        $table->getStrategy()->getTranslationTable()->setEntityClass($shadowEntity::class);
+        $table->getBehavior('Translate')->setLocale('spa');
+        $table->getBehavior('Translate')->getStrategy()->getTranslationTable()->setEntityClass($shadowEntity::class);
 
         $entity = $table->get(1);
         $entity->comment = 'New Comment';
@@ -1195,7 +1195,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
     protected function _testFind($tableAlias = 'Articles'): void
     {
         $table = $this->getTableLocator()->get($tableAlias);
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
 
         $query = $table->find()->select();
         $result = array_intersect_key(
@@ -1221,7 +1221,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $table->setLocale('fra');
+        $table->getBehavior('Translate')->setLocale('fra');
 
         $articles = $table->find()->all();
         $articles->each(function ($article): void {

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -147,29 +147,29 @@ class TreeBehaviorTest extends TestCase
     {
         // direct children for the root node
         $table = $this->table;
-        $countDirect = $this->table->childCount($table->get(1), true);
+        $countDirect = $this->table->getBehavior('Tree')->childCount($table->get(1), true);
         $this->assertSame(2, $countDirect);
 
         // counts all the children of root
-        $count = $this->table->childCount($table->get(1), false);
+        $count = $this->table->getBehavior('Tree')->childCount($table->get(1), false);
         $this->assertSame(9, $count);
 
         // counts direct children
-        $count = $this->table->childCount($table->get(2), false);
+        $count = $this->table->getBehavior('Tree')->childCount($table->get(2), false);
         $this->assertSame(3, $count);
 
         // count children for a middle-node
-        $count = $this->table->childCount($table->get(6), false);
+        $count = $this->table->getBehavior('Tree')->childCount($table->get(6), false);
         $this->assertSame(4, $count);
 
         // count leaf children
-        $count = $this->table->childCount($table->get(10), false);
+        $count = $this->table->getBehavior('Tree')->childCount($table->get(10), false);
         $this->assertSame(0, $count);
 
         // test scoping
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
-        $count = $table->childCount($table->get(3), false);
+        $count = $table->getBehavior('Tree')->childCount($table->get(3), false);
         $this->assertSame(2, $count);
     }
 
@@ -182,7 +182,7 @@ class TreeBehaviorTest extends TestCase
         $node = $table->get(6);
         $node->unset('lft');
         $node->unset('rght');
-        $count = $this->table->childCount($node, false);
+        $count = $this->table->getBehavior('Tree')->childCount($node, false);
         $this->assertSame(4, $count);
     }
 
@@ -197,7 +197,7 @@ class TreeBehaviorTest extends TestCase
                 return $query->where(['menu' => 'main-menu']);
             },
         ]);
-        $count = $table->childCount($table->get(1), false);
+        $count = $table->getBehavior('Tree')->childCount($table->get(1), false);
         $this->assertSame(4, $count);
     }
 
@@ -284,7 +284,7 @@ class TreeBehaviorTest extends TestCase
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
 
         // moveUp
-        $table->moveUp($table->get(3), 1);
+        $table->getBehavior('Tree')->moveUp($table->get(3), 1);
         $expected = [
             ' 1:10 -  1:Link 1',
             '_ 2: 7 -  3:Link 3',
@@ -298,7 +298,7 @@ class TreeBehaviorTest extends TestCase
         $this->assertMpttValues($expected, $table);
 
         // moveDown
-        $table->moveDown($table->get(6), 1);
+        $table->getBehavior('Tree')->moveDown($table->get(6), 1);
         $expected = [
             ' 1:10 -  1:Link 1',
             '_ 2: 7 -  3:Link 3',
@@ -348,7 +348,7 @@ class TreeBehaviorTest extends TestCase
             ->where(['menu' => 'main-menu']);
 
         $options = ['keyPath' => 'url', 'valuePath' => 'id', 'spacer' => ' '];
-        $result = $table->formatTreeList($query, ...$options)->toArray();
+        $result = $table->getBehavior('Tree')->formatTreeList($query, ...$options)->toArray();
 
         $expected = [
             '/link1.html' => '1',
@@ -372,7 +372,7 @@ class TreeBehaviorTest extends TestCase
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
 
         // top level, won't move
-        $node = $this->table->moveUp($table->get(1), 10);
+        $node = $this->table->getBehavior('Tree')->moveUp($table->get(1), 10);
         $this->assertEquals(['lft' => 1, 'rght' => 10], $node->extract(['lft', 'rght']));
         $expected = [
             ' 1:10 -  1:Link 1',
@@ -387,8 +387,8 @@ class TreeBehaviorTest extends TestCase
         $this->assertMpttValues($expected, $table);
 
         // edge cases
-        $this->assertFalse($this->table->moveUp($table->get(1), 0));
-        $this->assertFalse($this->table->moveUp($table->get(1), -10));
+        $this->assertFalse($this->table->getBehavior('Tree')->moveUp($table->get(1), 0));
+        $this->assertFalse($this->table->getBehavior('Tree')->moveUp($table->get(1), -10));
         $expected = [
             ' 1:10 -  1:Link 1',
             '_ 2: 3 -  2:Link 2',
@@ -402,7 +402,7 @@ class TreeBehaviorTest extends TestCase
         $this->assertMpttValues($expected, $table);
 
         // move inner node
-        $node = $table->moveUp($table->get(3), 1);
+        $node = $table->getBehavior('Tree')->moveUp($table->get(3), 1);
         $this->assertEquals(['lft' => 2, 'rght' => 7], $node->extract(['lft', 'rght']));
         $expected = [
             ' 1:10 -  1:Link 1',
@@ -424,7 +424,7 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
-        $node = $table->moveUp($table->get(5), 1);
+        $node = $table->getBehavior('Tree')->moveUp($table->get(5), 1);
         $this->assertEquals(['lft' => 6, 'rght' => 7], $node->extract(['lft', 'rght']));
         $expected = [
             ' 1:10 -  1:Link 1',
@@ -446,7 +446,7 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
-        $table->moveUp($table->get(8), true);
+        $table->getBehavior('Tree')->moveUp($table->get(8), true);
         $expected = [
             ' 1: 2 -  8:Link 8',
             ' 3:12 -  1:Link 1',
@@ -470,7 +470,7 @@ class TreeBehaviorTest extends TestCase
         $node = $table->get(8);
         $node->unset('lft');
         $node->unset('rght');
-        $node = $table->moveUp($node, true);
+        $node = $table->getBehavior('Tree')->moveUp($node, true);
         $this->assertEquals(['lft' => 1, 'rght' => 2], $node->extract(['lft', 'rght']));
         $expected = [
             ' 1: 2 -  8:Link 8',
@@ -493,7 +493,7 @@ class TreeBehaviorTest extends TestCase
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
         // latest node, won't move
-        $node = $table->moveDown($table->get(8), 10);
+        $node = $table->getBehavior('Tree')->moveDown($table->get(8), 10);
         $this->assertEquals(['lft' => 15, 'rght' => 16], $node->extract(['lft', 'rght']));
         $expected = [
             ' 1:10 -  1:Link 1',
@@ -508,8 +508,8 @@ class TreeBehaviorTest extends TestCase
         $this->assertMpttValues($expected, $table);
 
         // edge cases
-        $this->assertFalse($this->table->moveDown($table->get(8), 0));
-        $this->assertFalse($this->table->moveDown($table->get(8), -10));
+        $this->assertFalse($this->table->getBehavior('Tree')->moveDown($table->get(8), 0));
+        $this->assertFalse($this->table->getBehavior('Tree')->moveDown($table->get(8), -10));
         $expected = [
             ' 1:10 -  1:Link 1',
             '_ 2: 3 -  2:Link 2',
@@ -523,7 +523,7 @@ class TreeBehaviorTest extends TestCase
         $this->assertMpttValues($expected, $table);
 
         // move inner node
-        $node = $table->moveDown($table->get(2), 1);
+        $node = $table->getBehavior('Tree')->moveDown($table->get(2), 1);
         $this->assertEquals(['lft' => 8, 'rght' => 9], $node->extract(['lft', 'rght']));
         $expected = [
             ' 1:10 -  1:Link 1',
@@ -545,7 +545,7 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
-        $node = $table->moveDown($table->get(5), 1);
+        $node = $table->getBehavior('Tree')->moveDown($table->get(5), 1);
         $this->assertEquals(['lft' => 6, 'rght' => 7], $node->extract(['lft', 'rght']));
         $expected = [
             ' 1:10 -  1:Link 1',
@@ -567,7 +567,7 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
-        $node = $table->moveDown($table->get(1), true);
+        $node = $table->getBehavior('Tree')->moveDown($table->get(1), true);
         $this->assertEquals(['lft' => 7, 'rght' => 16], $node->extract(['lft', 'rght']));
         $expected = [
             ' 1: 4 -  6:Link 6',
@@ -592,7 +592,7 @@ class TreeBehaviorTest extends TestCase
         $node = $table->get(1);
         $node->unset('lft');
         $node->unset('rght');
-        $node = $table->moveDown($node, true);
+        $node = $table->getBehavior('Tree')->moveDown($node, true);
         $this->assertEquals(['lft' => 7, 'rght' => 16], $node->extract(['lft', 'rght']));
         $expected = [
             ' 1: 4 -  6:Link 6',
@@ -609,7 +609,7 @@ class TreeBehaviorTest extends TestCase
 
     public function testMoveDownMultiplePositions(): void
     {
-        $node = $this->table->moveDown($this->table->get(3), 2);
+        $node = $this->table->getBehavior('Tree')->moveDown($this->table->get(3), 2);
         $this->assertEquals(['lft' => 7, 'rght' => 8], $node->extract(['lft', 'rght']));
         $expected = [
             ' 1:20 -  1:electronics',
@@ -640,7 +640,7 @@ class TreeBehaviorTest extends TestCase
             ->toArray();
         $table->updateAll(['lft' => null, 'rght' => null, 'depth' => null], []);
         $table->behaviors()->Tree->setConfig('level', 'depth');
-        $table->recover();
+        $table->getBehavior('Tree')->recover();
 
         $expected = [
             ' 1:20 -  1:electronics',
@@ -672,7 +672,7 @@ class TreeBehaviorTest extends TestCase
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
         $table->updateAll(['lft' => null, 'rght' => null], ['menu' => 'main-menu']);
-        $table->recover();
+        $table->getBehavior('Tree')->recover();
 
         $expected = [
             ' 1:10 -  1:Link 1',
@@ -711,7 +711,7 @@ class TreeBehaviorTest extends TestCase
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu'], 'recoverOrder' => ['MenuLinkTrees.title' => 'desc']]);
         $table->updateAll(['lft' => null, 'rght' => null], ['menu' => 'main-menu']);
-        $table->recover();
+        $table->getBehavior('Tree')->recover();
 
         $expected = [
             ' 1: 2 -  8:Link 8',
@@ -1256,7 +1256,7 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->table;
         $entity = $table->get(10);
-        $this->assertSame($entity, $table->removeFromTree($entity));
+        $this->assertSame($entity, $table->getBehavior('Tree')->removeFromTree($entity));
         $this->assertSame(21, $entity->lft);
         $this->assertSame(22, $entity->rght);
         $this->assertNull($entity->parent_id);
@@ -1284,7 +1284,7 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->table;
         $entity = $table->get(6);
-        $this->assertSame($entity, $table->removeFromTree($entity));
+        $this->assertSame($entity, $table->getBehavior('Tree')->removeFromTree($entity));
         $this->assertSame(21, $entity->lft);
         $this->assertSame(22, $entity->rght);
         $this->assertNull($entity->parent_id);
@@ -1311,7 +1311,7 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->table;
         $entity = $table->get(1);
-        $this->assertSame($entity, $table->removeFromTree($entity));
+        $this->assertSame($entity, $table->getBehavior('Tree')->removeFromTree($entity));
         $this->assertSame(21, $entity->lft);
         $this->assertSame(22, $entity->rght);
         $this->assertNull($entity->parent_id);
@@ -1358,16 +1358,16 @@ class TreeBehaviorTest extends TestCase
     public function testGetLevel(): void
     {
         $entity = $this->table->get(8);
-        $result = $this->table->getLevel($entity);
+        $result = $this->table->getBehavior('Tree')->getLevel($entity);
         $this->assertSame(3, $result);
 
-        $result = $this->table->getLevel($entity->id);
+        $result = $this->table->getBehavior('Tree')->getLevel($entity->id);
         $this->assertSame(3, $result);
 
-        $result = $this->table->getLevel(5);
+        $result = $this->table->getBehavior('Tree')->getLevel(5);
         $this->assertSame(2, $result);
 
-        $result = $this->table->getLevel(99999);
+        $result = $this->table->getBehavior('Tree')->getLevel(99999);
         $this->assertFalse($result);
     }
 

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -27,6 +27,7 @@ use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use LogicException;
 use Mockery;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use TestApp\Model\Behavior\SluggableBehavior;
 use TestPlugin\Model\Behavior\PersisterOneBehavior;
 
@@ -275,11 +276,14 @@ class BehaviorRegistryTest extends TestCase
      * Setup a behavior, then replace it with a mock to verify methods are called.
      * use dummy return values to verify the return value makes it back
      */
+    #[WithoutErrorHandler]
     public function testCall(): void
     {
-        $this->Behaviors->load('Sluggable');
-        $return = $this->Behaviors->call('slugify', ['some value']);
-        $this->assertSame('some-value', $return);
+        $this->deprecated(function () {
+            $this->Behaviors->load('Sluggable');
+            $return = $this->Behaviors->call('slugify', ['some value']);
+            $this->assertSame('some-value', $return);
+        });
     }
 
     /**

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -526,7 +526,7 @@ class QueryRegressionTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $table->setLocale('eng');
+        $table->getBehavior('Translate')->setLocale('eng');
         $query = $table->find('translations')
             ->orderBy(['Articles.id' => 'ASC'])
             ->limit(10)


### PR DESCRIPTION
Refs #18288

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
