### PR TITLE
Update getBehavior annotation to allow better code analyse on applica…

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -848,6 +848,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @template TName of key-of<TBehaviors>
      * @phpstan-param TName $name The behavior alias to get from the registry.
      * @phpstan-return TBehaviors[TName]
+     * @psalm-return \Cake\ORM\Behavior
      * @throws \InvalidArgumentException If the behavior does not exist.
      */
     public function getBehavior(string $name): Behavior

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -155,7 +155,7 @@ use function Cake\Core\namespaceSplit;
  *
  * @see \Cake\Event\EventManager for reference on the events system.
  * @link https://book.cakephp.org/5/en/orm/table-objects.html#event-list
- * @phpstan-template TBehaviors of array<string, \Cake\ORM\Behavior>
+ * @template TBehaviors of array<string, \Cake\ORM\Behavior>
  * @implements \Cake\Event\EventDispatcherInterface<\Cake\ORM\Table>
  */
 class Table implements RepositoryInterface, EventListenerInterface, EventDispatcherInterface, ValidatorAwareInterface
@@ -845,7 +845,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @param string $name The behavior alias to get from the registry.
      * @return \Cake\ORM\Behavior
-     * @phpstan-template TName of key-of<TBehaviors>
+     * @template TName of key-of<TBehaviors>
      * @phpstan-param TName $name The behavior alias to get from the registry.
      * @phpstan-return TBehaviors[TName]
      * @throws \InvalidArgumentException If the behavior does not exist.

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -155,7 +155,7 @@ use function Cake\Core\namespaceSplit;
  *
  * @see \Cake\Event\EventManager for reference on the events system.
  * @link https://book.cakephp.org/5/en/orm/table-objects.html#event-list
- * @template TBehaviors of array<string, \Cake\ORM\Behavior>
+ * @phpstan-template TBehaviors of array<string, \Cake\ORM\Behavior>
  * @implements \Cake\Event\EventDispatcherInterface<\Cake\ORM\Table>
  */
 class Table implements RepositoryInterface, EventListenerInterface, EventDispatcherInterface, ValidatorAwareInterface
@@ -843,9 +843,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Get a behavior from the registry.
      *
-     * @template TName of key-of<TBehaviors>
-     * @param TName $name The behavior alias to get from the registry.
-     * @return TBehaviors[TName]
+     * @param string $name The behavior alias to get from the registry.
+     * @return \Cake\ORM\Behavior
+     * @phpstan-template TName of key-of<TBehaviors>
+     * @phpstan-param TName $name The behavior alias to get from the registry.
+     * @phpstan-return TBehaviors[TName]
      * @throws \InvalidArgumentException If the behavior does not exist.
      */
     public function getBehavior(string $name): Behavior

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -155,6 +155,7 @@ use function Cake\Core\namespaceSplit;
  *
  * @see \Cake\Event\EventManager for reference on the events system.
  * @link https://book.cakephp.org/5/en/orm/table-objects.html#event-list
+ * @template TBehaviors of array<string, \Cake\ORM\Behavior>
  * @implements \Cake\Event\EventDispatcherInterface<\Cake\ORM\Table>
  */
 class Table implements RepositoryInterface, EventListenerInterface, EventDispatcherInterface, ValidatorAwareInterface
@@ -842,8 +843,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Get a behavior from the registry.
      *
-     * @param string $name The behavior alias to get from the registry.
-     * @return \Cake\ORM\Behavior
+     * @template TName of key-of<TBehaviors>
+     * @param TName $name The behavior alias to get from the registry.
+     * @return TBehaviors[TName]
      * @throws \InvalidArgumentException If the behavior does not exist.
      */
     public function getBehavior(string $name): Behavior


### PR DESCRIPTION
Related to https://github.com/CakeDC/cakephp-phpstan/issues/44 and https://github.com/cakephp/cakephp/pull/18318

Add annotation to improve static analyse.

Application models will be able to use a phpdoc to set possible return types for Table::getBehavior

```
/**
 * Usuarios Model
 *
 * @extends \Cake\ORM\Table<array{Register: \CakeDC\Users\Model\Behavior\RegisterBehavior, Filterable: \PlumSearch\Model\Behavior\FilterableBehavior, MyC: \App\Model\Behavior\PasswordBehavior, Tree: \App\Model\Behavior\TreeBehavior}>
 */
class UsersTable extends Table
{
    use DefaultOrderTrait;

    /**
     * Initialize method
     *
     * @param array $config The configuration for the Table.
     * @return void
     */
    public function initialize(array $config): void
    {
        parent::initialize($config);

        $this->addBehavior('CakeDC/Users.Register');
        $this->addBehavior('MyC', ['className' => 'Password']);
        $this->addBehavior('Tree');
    }

    public function register()
    {
          //This will not result in phpstan error
          debug($this->getBehavior('Filterable')->filters());
    }
}

