### PR TITLE
Allow league/container 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "composer/ca-bundle": "^1.5",
         "laminas/laminas-diactoros": "^3.3",
         "laminas/laminas-httphandlerrunner": "^2.6",
-        "league/container": "^4.2",
+        "league/container": "^4.2 | ^5.0",
         "psr/container": "^1.1 || ^2.0",
         "psr/http-client": "^1.0.2",
         "psr/http-factory": "^1.1",


### PR DESCRIPTION
The big change between league/container 4.2 and 5.0 was that 5.0 no longer supports PHP <8.1.
This project already requires PHP 8.1 or greater, so there's no reason we shouldn't allow the latest version of the league/container since it's dependencies already make sense.

https://github.com/thephpleague/container/blob/5.0.0/CHANGELOG.md#500