### PR TITLE
Configurize default fixtureStrategy.

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -274,7 +274,9 @@ abstract class TestCase extends BaseTestCase
      */
     protected function getFixtureStrategy(): FixtureStrategyInterface
     {
-        return new TruncateStrategy();
+        $className = Configure::read('TestCase.fixtureStrategy') ?: TruncateStrategy::class;
+
+        return new $className();
     }
 
     /**

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -275,7 +275,7 @@ abstract class TestCase extends BaseTestCase
     protected function getFixtureStrategy(): FixtureStrategyInterface
     {
         /** @var class-string<\Cake\TestSuite\Fixture\FixtureStrategyInterface> $className */
-        $className = Configure::read('TestCase.fixtureStrategy') ?: TruncateStrategy::class;
+        $className = Configure::read('TestSuite.fixtureStrategy') ?: TruncateStrategy::class;
 
         return new $className();
     }

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -274,6 +274,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function getFixtureStrategy(): FixtureStrategyInterface
     {
+        /** @var class-string<\Cake\TestSuite\Fixture\FixtureStrategyInterface> $className */
         $className = Configure::read('TestCase.fixtureStrategy') ?: TruncateStrategy::class;
 
         return new $className();


### PR DESCRIPTION
Docs mention that you can create base classes
https://book.cakephp.org/4/en/development/testing.html#fixture-state-managers

But since those are usually spread across different types and namespaces, this can become cumbersome.
Would it be acceptable to find some kind of default config opt-in?

If not set, nothing would change, so sounds fully BC.