### PR TITLE
5.2: Throw deprecation on invalid short option collision.

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -397,7 +397,6 @@ class ConsoleOptionParser
         $this->_options[$name] = $option;
         asort($this->_options);
         if ($option->short()) {
-            debug($this->_shortOptions);
             if (isset($this->_shortOptions[$option->short()])) {
                 deprecationWarning('5.2.0', 'You cannot redefine short options. This will throw an error in 5.3.0+.');
             }

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -20,6 +20,7 @@ use Cake\Console\Exception\ConsoleException;
 use Cake\Console\Exception\MissingOptionException;
 use Cake\Utility\Inflector;
 use LogicException;
+use function Cake\Core\deprecationWarning;
 
 /**
  * Handles parsing the ARGV in the command line and provides support
@@ -396,6 +397,11 @@ class ConsoleOptionParser
         $this->_options[$name] = $option;
         asort($this->_options);
         if ($option->short()) {
+            debug($this->_shortOptions);
+            if (isset($this->_shortOptions[$option->short()])) {
+                deprecationWarning('5.2.0', 'You cannot redefine short options. This will throw an error in 5.3.0+.');
+            }
+
             $this->_shortOptions[$option->short()] = $name;
             asort($this->_shortOptions);
         }

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -25,6 +25,7 @@ use Cake\Console\TestSuite\StubConsoleInput;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\TestSuite\TestCase;
 use LogicException;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 
 /**
  * ConsoleOptionParserTest
@@ -186,6 +187,7 @@ class ConsoleOptionParserTest extends TestCase
     /**
      * test adding an option and using the short value for parsing throws deprecation if conflicting.
      */
+    #[WithoutErrorHandler]
     public function testAddOptionShortConflict(): void
     {
         $parser = new ConsoleOptionParser('test', false);

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -184,6 +184,23 @@ class ConsoleOptionParserTest extends TestCase
     }
 
     /**
+     * test adding an option and using the short value for parsing throws deprecation if conflicting.
+     */
+    public function testAddOptionShortConflict(): void
+    {
+        $parser = new ConsoleOptionParser('test', false);
+        $parser->addOption('test', [
+            'short' => 't',
+        ]);
+
+        $this->deprecated(function () use ($parser) {
+            $parser->addOption('other', [
+                'short' => 't',
+            ]);
+        });
+    }
+
+    /**
      * test adding an option and using the short value for parsing.
      */
     public function testAddOptionWithMultipleShort(): void


### PR DESCRIPTION
In 5.2 we can deprecate collision

In 5.3 we should throw an exception.

Resolves https://github.com/cakephp/cakephp/issues/18329

I wonder what the issue is with the test, it seems not to throw the deprecation.