### PR TITLE
Add override attribute as per psalm.

### DIFF
--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -135,6 +135,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      * @throws \Cake\Cache\Exception\InvalidArgumentException If $keys is neither an array nor a Traversable,
      *   or if any of the $keys are not a legal value.
      */
+    #[\Override]
     public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
         $this->ensureValidType($keys);
@@ -158,6 +159,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      * @throws \Cake\Cache\Exception\InvalidArgumentException If $values is neither an array nor a Traversable,
      *   or if any of the $values are not a legal value.
      */
+    #[\Override]
     public function setMultiple(iterable $values, DateInterval|int|null $ttl = null): bool
     {
         $this->ensureValidType($values, self::CHECK_KEY);
@@ -195,6 +197,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      * @throws \Cake\Cache\Exception\InvalidArgumentException If $keys is neither an array nor a Traversable,
      *   or if any of the $keys are not a legal value.
      */
+    #[\Override]
     public function deleteMultiple(iterable $keys): bool
     {
         $this->ensureValidType($keys);
@@ -221,6 +224,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      * @return bool
      * @throws \Cake\Cache\Exception\InvalidArgumentException If the $key string is not a legal value.
      */
+    #[\Override]
     public function has(string $key): bool
     {
         return $this->get($key) !== null;
@@ -234,6 +238,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      * @return mixed The value of the item from the cache, or $default in case of cache miss.
      * @throws \Cake\Cache\Exception\InvalidArgumentException If the $key string is not a legal value.
      */
+    #[\Override]
     abstract public function get(string $key, mixed $default = null): mixed;
 
     /**
@@ -248,6 +253,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      * @throws \Cake\Cache\Exception\InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
+    #[\Override]
     abstract public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool;
 
     /**
@@ -257,6 +263,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      * @param int $offset How much to add
      * @return int|false New incremented value, false otherwise
      */
+    #[\Override]
     abstract public function increment(string $key, int $offset = 1): int|false;
 
     /**
@@ -266,6 +273,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      * @param int $offset How much to subtract
      * @return int|false New incremented value, false otherwise
      */
+    #[\Override]
     abstract public function decrement(string $key, int $offset = 1): int|false;
 
     /**
@@ -274,6 +282,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      * @param string $key Identifier for the data
      * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
      */
+    #[\Override]
     abstract public function delete(string $key): bool;
 
     /**
@@ -281,6 +290,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      *
      * @return bool True if the cache was successfully cleared, false otherwise
      */
+    #[\Override]
     abstract public function clear(): bool;
 
     /**
@@ -293,6 +303,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      * @param mixed $value Data to be cached.
      * @return bool True if the data was successfully cached, false on failure.
      */
+    #[\Override]
     public function add(string $key, mixed $value): bool
     {
         $cachedValue = $this->get($key);
@@ -311,6 +322,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      * @param string $group name of the group to be cleared
      * @return bool
      */
+    #[\Override]
     abstract public function clearGroup(string $group): bool;
 
     /**

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -38,6 +38,7 @@ class CacheRegistry extends ObjectRegistry
      * @param string $class Partial classname to resolve.
      * @return class-string<\Cake\Cache\CacheEngine>|null Either the correct classname or null.
      */
+    #[\Override]
     protected function _resolveClassName(string $class): ?string
     {
         /** @var class-string<\Cake\Cache\CacheEngine>|null */
@@ -54,6 +55,7 @@ class CacheRegistry extends ObjectRegistry
      * @return void
      * @throws \BadMethodCallException
      */
+    #[\Override]
     protected function _throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new BadMethodCallException(sprintf('Cache engine `%s` is not available.', $class));
@@ -70,6 +72,7 @@ class CacheRegistry extends ObjectRegistry
      * @return \Cake\Cache\CacheEngine The constructed CacheEngine class.
      * @throws \Cake\Core\Exception\CakeException When the cache engine cannot be initialized.
      */
+    #[\Override]
     protected function _create(object|string $class, string $alias, array $config): CacheEngine
     {
         if (is_object($class)) {
@@ -99,6 +102,7 @@ class CacheRegistry extends ObjectRegistry
      * @param string $name The adapter name.
      * @return $this
      */
+    #[\Override]
     public function unload(string $name)
     {
         unset($this->_loaded[$name]);

--- a/src/Cache/Engine/ApcuEngine.php
+++ b/src/Cache/Engine/ApcuEngine.php
@@ -42,6 +42,7 @@ class ApcuEngine extends CacheEngine
      * @param array<string, mixed> $config array of setting for the engine
      * @return bool True if the engine has been successfully initialized, false if not
      */
+    #[\Override]
     public function init(array $config = []): bool
     {
         if (!extension_loaded('apcu')) {
@@ -62,6 +63,7 @@ class ApcuEngine extends CacheEngine
      * @return bool True on success and false on failure.
      * @link https://secure.php.net/manual/en/function.apcu-store.php
      */
+    #[\Override]
     public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
     {
         $key = $this->_key($key);
@@ -79,6 +81,7 @@ class ApcuEngine extends CacheEngine
      *   has expired, or if there was an error fetching it
      * @link https://secure.php.net/manual/en/function.apcu-fetch.php
      */
+    #[\Override]
     public function get(string $key, mixed $default = null): mixed
     {
         $value = apcu_fetch($this->_key($key), $success);
@@ -97,6 +100,7 @@ class ApcuEngine extends CacheEngine
      * @return int|false New incremented value, false otherwise
      * @link https://secure.php.net/manual/en/function.apcu-inc.php
      */
+    #[\Override]
     public function increment(string $key, int $offset = 1): int|false
     {
         $key = $this->_key($key);
@@ -112,6 +116,7 @@ class ApcuEngine extends CacheEngine
      * @return int|false New decremented value, false otherwise
      * @link https://secure.php.net/manual/en/function.apcu-dec.php
      */
+    #[\Override]
     public function decrement(string $key, int $offset = 1): int|false
     {
         $key = $this->_key($key);
@@ -126,6 +131,7 @@ class ApcuEngine extends CacheEngine
      * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
      * @link https://secure.php.net/manual/en/function.apcu-delete.php
      */
+    #[\Override]
     public function delete(string $key): bool
     {
         $key = $this->_key($key);
@@ -140,6 +146,7 @@ class ApcuEngine extends CacheEngine
      * @link https://secure.php.net/manual/en/function.apcu-cache-info.php
      * @link https://secure.php.net/manual/en/function.apcu-delete.php
      */
+    #[\Override]
     public function clear(): bool
     {
         if (class_exists(APCUIterator::class, false)) {
@@ -171,6 +178,7 @@ class ApcuEngine extends CacheEngine
      * @return bool True if the data was successfully cached, false on failure.
      * @link https://secure.php.net/manual/en/function.apcu-add.php
      */
+    #[\Override]
     public function add(string $key, mixed $value): bool
     {
         $key = $this->_key($key);
@@ -188,6 +196,7 @@ class ApcuEngine extends CacheEngine
      * @link https://secure.php.net/manual/en/function.apcu-fetch.php
      * @link https://secure.php.net/manual/en/function.apcu-store.php
      */
+    #[\Override]
     public function groups(): array
     {
         if (!$this->_compiledGroupNames) {
@@ -230,6 +239,7 @@ class ApcuEngine extends CacheEngine
      * @return bool success
      * @link https://secure.php.net/manual/en/function.apcu-inc.php
      */
+    #[\Override]
     public function clearGroup(string $group): bool
     {
         $success = false;

--- a/src/Cache/Engine/ArrayEngine.php
+++ b/src/Cache/Engine/ArrayEngine.php
@@ -50,6 +50,7 @@ class ArrayEngine extends CacheEngine
      *   for it or let the driver take care of that.
      * @return bool True on success and false on failure.
      */
+    #[\Override]
     public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
     {
         $key = $this->_key($key);
@@ -67,6 +68,7 @@ class ArrayEngine extends CacheEngine
      * @return mixed The cached data, or default value if the data doesn't exist, has
      * expired, or if there was an error fetching it.
      */
+    #[\Override]
     public function get(string $key, mixed $default = null): mixed
     {
         $key = $this->_key($key);
@@ -93,6 +95,7 @@ class ArrayEngine extends CacheEngine
      * @param int $offset How much to increment
      * @return int|false New incremented value, false otherwise
      */
+    #[\Override]
     public function increment(string $key, int $offset = 1): int|false
     {
         if ($this->get($key) === null) {
@@ -111,6 +114,7 @@ class ArrayEngine extends CacheEngine
      * @param int $offset How much to subtract
      * @return int|false New decremented value, false otherwise
      */
+    #[\Override]
     public function decrement(string $key, int $offset = 1): int|false
     {
         if ($this->get($key) === null) {
@@ -128,6 +132,7 @@ class ArrayEngine extends CacheEngine
      * @param string $key Identifier for the data
      * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
      */
+    #[\Override]
     public function delete(string $key): bool
     {
         $key = $this->_key($key);
@@ -141,6 +146,7 @@ class ArrayEngine extends CacheEngine
      *
      * @return bool True Returns true.
      */
+    #[\Override]
     public function clear(): bool
     {
         $this->data = [];
@@ -155,6 +161,7 @@ class ArrayEngine extends CacheEngine
      *
      * @return array<string>
      */
+    #[\Override]
     public function groups(): array
     {
         $result = [];
@@ -177,6 +184,7 @@ class ArrayEngine extends CacheEngine
      * @param string $group The group to clear.
      * @return bool success
      */
+    #[\Override]
     public function clearGroup(string $group): bool
     {
         $key = $this->_config['prefix'] . $group;

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -86,6 +86,7 @@ class FileEngine extends CacheEngine
      * @param array<string, mixed> $config array of setting for the engine
      * @return bool True if the engine has been successfully initialized, false if not
      */
+    #[\Override]
     public function init(array $config = []): bool
     {
         parent::init($config);
@@ -111,6 +112,7 @@ class FileEngine extends CacheEngine
      *   for it or let the driver take care of that.
      * @return bool True on success and false on failure.
      */
+    #[\Override]
     public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
     {
         if ($value === '' || !$this->_init) {
@@ -155,6 +157,7 @@ class FileEngine extends CacheEngine
      * @return mixed The cached data, or default value if the data doesn't exist, has
      *   expired, or if there was an error fetching it
      */
+    #[\Override]
     public function get(string $key, mixed $default = null): mixed
     {
         $key = $this->_key($key);
@@ -207,6 +210,7 @@ class FileEngine extends CacheEngine
      * @return bool True if the value was successfully deleted, false if it didn't
      *   exist or couldn't be removed
      */
+    #[\Override]
     public function delete(string $key): bool
     {
         $key = $this->_key($key);
@@ -232,6 +236,7 @@ class FileEngine extends CacheEngine
      *
      * @return bool True if the cache was successfully cleared, false otherwise
      */
+    #[\Override]
     public function clear(): bool
     {
         if (!$this->_init) {
@@ -331,6 +336,7 @@ class FileEngine extends CacheEngine
      * @return int|false
      * @throws \LogicException
      */
+    #[\Override]
     public function decrement(string $key, int $offset = 1): int|false
     {
         throw new LogicException('Files cannot be atomically decremented.');
@@ -344,6 +350,7 @@ class FileEngine extends CacheEngine
      * @return int|false
      * @throws \LogicException
      */
+    #[\Override]
     public function increment(string $key, int $offset = 1): int|false
     {
         throw new LogicException('Files cannot be atomically incremented.');
@@ -433,6 +440,7 @@ class FileEngine extends CacheEngine
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _key(string $key): string
     {
         $key = parent::_key($key);
@@ -446,6 +454,7 @@ class FileEngine extends CacheEngine
      * @param string $group The group to clear.
      * @return bool success
      */
+    #[\Override]
     public function clearGroup(string $group): bool
     {
         unset($this->_File);

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -102,6 +102,7 @@ class MemcachedEngine extends CacheEngine
      * @throws \Cake\Cache\Exception\InvalidArgumentException When you try use authentication without
      *   Memcached compiled with SASL support
      */
+    #[\Override]
     public function init(array $config = []): bool
     {
         if (!extension_loaded('memcached')) {
@@ -303,6 +304,7 @@ class MemcachedEngine extends CacheEngine
      * @return bool True if the data was successfully cached, false on failure
      * @see https://www.php.net/manual/en/memcached.set.php
      */
+    #[\Override]
     public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
     {
         $duration = $this->duration($ttl);
@@ -319,6 +321,7 @@ class MemcachedEngine extends CacheEngine
      *   for it or let the driver take care of that.
      * @return bool Whether the write was successful or not.
      */
+    #[\Override]
     public function setMultiple(iterable $values, DateInterval|int|null $ttl = null): bool
     {
         $cacheData = [];
@@ -338,6 +341,7 @@ class MemcachedEngine extends CacheEngine
      * @return mixed The cached data, or default value if the data doesn't exist, has
      * expired, or if there was an error fetching it.
      */
+    #[\Override]
     public function get(string $key, mixed $default = null): mixed
     {
         $key = $this->_key($key);
@@ -357,6 +361,7 @@ class MemcachedEngine extends CacheEngine
      * @return iterable<string, mixed> An array containing, for each of the given $keys, the cached data or
      *   `$default` if cached data could not be retrieved.
      */
+    #[\Override]
     public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
         $cacheKeys = [];
@@ -384,6 +389,7 @@ class MemcachedEngine extends CacheEngine
      * @param int $offset How much to increment
      * @return int|false New incremented value, false otherwise
      */
+    #[\Override]
     public function increment(string $key, int $offset = 1): int|false
     {
         return $this->_Memcached->increment($this->_key($key), $offset);
@@ -396,6 +402,7 @@ class MemcachedEngine extends CacheEngine
      * @param int $offset How much to subtract
      * @return int|false New decremented value, false otherwise
      */
+    #[\Override]
     public function decrement(string $key, int $offset = 1): int|false
     {
         return $this->_Memcached->decrement($this->_key($key), $offset);
@@ -408,6 +415,7 @@ class MemcachedEngine extends CacheEngine
      * @return bool True if the value was successfully deleted, false if it didn't
      *   exist or couldn't be removed.
      */
+    #[\Override]
     public function delete(string $key): bool
     {
         return $this->_Memcached->delete($this->_key($key));
@@ -420,6 +428,7 @@ class MemcachedEngine extends CacheEngine
      * @return bool of boolean values that are true if the key was successfully
      *   deleted, false if it didn't exist or couldn't be removed.
      */
+    #[\Override]
     public function deleteMultiple(iterable $keys): bool
     {
         $cacheKeys = [];
@@ -435,6 +444,7 @@ class MemcachedEngine extends CacheEngine
      *
      * @return bool True if the cache was successfully cleared, false otherwise
      */
+    #[\Override]
     public function clear(): bool
     {
         $keys = $this->_Memcached->getAllKeys();
@@ -458,6 +468,7 @@ class MemcachedEngine extends CacheEngine
      * @param mixed $value Data to be cached.
      * @return bool True if the data was successfully cached, false on failure.
      */
+    #[\Override]
     public function add(string $key, mixed $value): bool
     {
         $duration = $this->_config['duration'];
@@ -473,6 +484,7 @@ class MemcachedEngine extends CacheEngine
      *
      * @return array<string>
      */
+    #[\Override]
     public function groups(): array
     {
         if (!$this->_compiledGroupNames) {
@@ -508,6 +520,7 @@ class MemcachedEngine extends CacheEngine
      * @param string $group name of the group to be cleared
      * @return bool success
      */
+    #[\Override]
     public function clearGroup(string $group): bool
     {
         return (bool)$this->_Memcached->increment($this->_config['prefix'] . $group);

--- a/src/Cache/Engine/NullEngine.php
+++ b/src/Cache/Engine/NullEngine.php
@@ -29,6 +29,7 @@ class NullEngine extends CacheEngine
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function init(array $config = []): bool
     {
         return true;
@@ -37,6 +38,7 @@ class NullEngine extends CacheEngine
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
     {
         return true;
@@ -45,6 +47,7 @@ class NullEngine extends CacheEngine
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setMultiple(iterable $values, DateInterval|int|null $ttl = null): bool
     {
         return true;
@@ -53,6 +56,7 @@ class NullEngine extends CacheEngine
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function get(string $key, mixed $default = null): mixed
     {
         return $default;
@@ -61,6 +65,7 @@ class NullEngine extends CacheEngine
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
         $result = [];
@@ -75,6 +80,7 @@ class NullEngine extends CacheEngine
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function increment(string $key, int $offset = 1): int|false
     {
         return 1;
@@ -83,6 +89,7 @@ class NullEngine extends CacheEngine
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function decrement(string $key, int $offset = 1): int|false
     {
         return 0;
@@ -91,6 +98,7 @@ class NullEngine extends CacheEngine
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function delete(string $key): bool
     {
         return true;
@@ -99,6 +107,7 @@ class NullEngine extends CacheEngine
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function deleteMultiple(iterable $keys): bool
     {
         return true;
@@ -107,6 +116,7 @@ class NullEngine extends CacheEngine
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function clear(): bool
     {
         return true;
@@ -115,6 +125,7 @@ class NullEngine extends CacheEngine
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function clearGroup(string $group): bool
     {
         return true;

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -80,6 +80,7 @@ class RedisEngine extends CacheEngine
      * @param array<string, mixed> $config array of setting for the engine
      * @return bool True if the engine has been successfully initialized, false if not
      */
+    #[\Override]
     public function init(array $config = []): bool
     {
         if (!extension_loaded('redis')) {
@@ -214,6 +215,7 @@ class RedisEngine extends CacheEngine
      *   for it or let the driver take care of that.
      * @return bool True if the data was successfully cached, false on failure
      */
+    #[\Override]
     public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
     {
         $key = $this->_key($key);
@@ -235,6 +237,7 @@ class RedisEngine extends CacheEngine
      * @return mixed The cached data, or the default if the data doesn't exist, has
      *   expired, or if there was an error fetching it
      */
+    #[\Override]
     public function get(string $key, mixed $default = null): mixed
     {
         $value = $this->_Redis->get($this->_key($key));
@@ -252,6 +255,7 @@ class RedisEngine extends CacheEngine
      * @param int $offset How much to increment
      * @return int|false New incremented value, false otherwise
      */
+    #[\Override]
     public function increment(string $key, int $offset = 1): int|false
     {
         $duration = $this->_config['duration'];
@@ -272,6 +276,7 @@ class RedisEngine extends CacheEngine
      * @param int $offset How much to subtract
      * @return int|false New decremented value, false otherwise
      */
+    #[\Override]
     public function decrement(string $key, int $offset = 1): int|false
     {
         $duration = $this->_config['duration'];
@@ -291,6 +296,7 @@ class RedisEngine extends CacheEngine
      * @param string $key Identifier for the data
      * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
      */
+    #[\Override]
     public function delete(string $key): bool
     {
         $key = $this->_key($key);
@@ -318,6 +324,7 @@ class RedisEngine extends CacheEngine
      *
      * @return bool True if the cache was successfully cleared, false otherwise
      */
+    #[\Override]
     public function clear(): bool
     {
         $this->_Redis->setOption(Redis::OPT_SCAN, (string)Redis::SCAN_RETRY);
@@ -382,6 +389,7 @@ class RedisEngine extends CacheEngine
      * @return bool True if the data was successfully cached, false on failure.
      * @link https://github.com/phpredis/phpredis#set
      */
+    #[\Override]
     public function add(string $key, mixed $value): bool
     {
         $duration = $this->_config['duration'];
@@ -402,6 +410,7 @@ class RedisEngine extends CacheEngine
      *
      * @return array<string>
      */
+    #[\Override]
     public function groups(): array
     {
         $result = [];
@@ -424,6 +433,7 @@ class RedisEngine extends CacheEngine
      * @param string $group name of the group to be cleared
      * @return bool success
      */
+    #[\Override]
     public function clearGroup(string $group): bool
     {
         return (bool)$this->_Redis->incr($this->_config['prefix'] . $group);

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -822,6 +822,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      *
      * @return array The data to convert to JSON
      */
+    #[\Override]
     public function jsonSerialize(): array;
 
     /**
@@ -1175,6 +1176,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      *
      * @return int
      */
+    #[\Override]
     public function count(): int;
 
     /**

--- a/src/Collection/Iterator/BufferedIterator.php
+++ b/src/Collection/Iterator/BufferedIterator.php
@@ -86,6 +86,7 @@ class BufferedIterator extends Collection
      *
      * @return mixed
      */
+    #[\Override]
     public function key(): mixed
     {
         return $this->_key;
@@ -96,6 +97,7 @@ class BufferedIterator extends Collection
      *
      * @return mixed
      */
+    #[\Override]
     public function current(): mixed
     {
         return $this->_current;
@@ -106,6 +108,7 @@ class BufferedIterator extends Collection
      *
      * @return void
      */
+    #[\Override]
     public function rewind(): void
     {
         if ($this->_index === 0 && !$this->_started) {
@@ -123,6 +126,7 @@ class BufferedIterator extends Collection
      *
      * @return bool
      */
+    #[\Override]
     public function valid(): bool
     {
         if ($this->_buffer->offsetExists($this->_index)) {
@@ -154,6 +158,7 @@ class BufferedIterator extends Collection
      *
      * @return void
      */
+    #[\Override]
     public function next(): void
     {
         $this->_index++;
@@ -172,6 +177,7 @@ class BufferedIterator extends Collection
      *
      * @return int
      */
+    #[\Override]
     public function count(): int
     {
         if (!$this->_started) {
@@ -190,6 +196,7 @@ class BufferedIterator extends Collection
      *
      * @return array
      */
+    #[\Override]
     public function __serialize(): array
     {
         if (!$this->_finished) {
@@ -205,6 +212,7 @@ class BufferedIterator extends Collection
      * @param array $data Data array.
      * @return void
      */
+    #[\Override]
     public function __unserialize(array $data): void
     {
         $this->__construct([]);

--- a/src/Collection/Iterator/ExtractIterator.php
+++ b/src/Collection/Iterator/ExtractIterator.php
@@ -68,6 +68,7 @@ class ExtractIterator extends Collection
      *
      * @return mixed
      */
+    #[\Override]
     public function current(): mixed
     {
         $extractor = $this->_extractor;
@@ -78,6 +79,7 @@ class ExtractIterator extends Collection
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function unwrap(): Iterator
     {
         $iterator = $this->getInnerIterator();

--- a/src/Collection/Iterator/FilterIterator.php
+++ b/src/Collection/Iterator/FilterIterator.php
@@ -61,6 +61,7 @@ class FilterIterator extends Collection
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function unwrap(): Iterator
     {
         /** @var \IteratorIterator $filter */

--- a/src/Collection/Iterator/InsertIterator.php
+++ b/src/Collection/Iterator/InsertIterator.php
@@ -86,6 +86,7 @@ class InsertIterator extends Collection
      *
      * @return void
      */
+    #[\Override]
     public function next(): void
     {
         parent::next();
@@ -101,6 +102,7 @@ class InsertIterator extends Collection
      *
      * @return mixed
      */
+    #[\Override]
     public function current(): mixed
     {
         $row = parent::current();
@@ -127,6 +129,7 @@ class InsertIterator extends Collection
      *
      * @return void
      */
+    #[\Override]
     public function rewind(): void
     {
         parent::rewind();

--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -129,6 +129,7 @@ class MapReduce implements IteratorAggregate
      *
      * @return \Traversable
      */
+    #[\Override]
     public function getIterator(): Traversable
     {
         if (!$this->_executed) {

--- a/src/Collection/Iterator/NestIterator.php
+++ b/src/Collection/Iterator/NestIterator.php
@@ -53,6 +53,7 @@ class NestIterator extends Collection implements RecursiveIterator
      *
      * @return \RecursiveIterator<mixed, mixed>
      */
+    #[\Override]
     public function getChildren(): RecursiveIterator
     {
         $property = $this->_propertyExtractor($this->_nestKey);
@@ -66,6 +67,7 @@ class NestIterator extends Collection implements RecursiveIterator
      *
      * @return bool
      */
+    #[\Override]
     public function hasChildren(): bool
     {
         $property = $this->_propertyExtractor($this->_nestKey);

--- a/src/Collection/Iterator/NoChildrenIterator.php
+++ b/src/Collection/Iterator/NoChildrenIterator.php
@@ -33,6 +33,7 @@ class NoChildrenIterator extends Collection implements RecursiveIterator
      *
      * @return bool
      */
+    #[\Override]
     public function hasChildren(): bool
     {
         return false;
@@ -43,6 +44,7 @@ class NoChildrenIterator extends Collection implements RecursiveIterator
      *
      * @return \RecursiveIterator<mixed, mixed>
      */
+    #[\Override]
     public function getChildren(): RecursiveIterator
     {
         return new static([]);

--- a/src/Collection/Iterator/ReplaceIterator.php
+++ b/src/Collection/Iterator/ReplaceIterator.php
@@ -66,6 +66,7 @@ class ReplaceIterator extends Collection
      *
      * @return mixed
      */
+    #[\Override]
     public function current(): mixed
     {
         return ($this->_callback)(parent::current(), $this->key(), $this->_innerIterator);
@@ -74,6 +75,7 @@ class ReplaceIterator extends Collection
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function unwrap(): Iterator
     {
         $iterator = $this->_innerIterator;

--- a/src/Collection/Iterator/SortIterator.php
+++ b/src/Collection/Iterator/SortIterator.php
@@ -100,6 +100,7 @@ class SortIterator extends Collection
      *
      * @return \Iterator
      */
+    #[\Override]
     public function unwrap(): Iterator
     {
         /** @var \Iterator */

--- a/src/Collection/Iterator/StoppableIterator.php
+++ b/src/Collection/Iterator/StoppableIterator.php
@@ -71,6 +71,7 @@ class StoppableIterator extends Collection
      *
      * @return bool
      */
+    #[\Override]
     public function valid(): bool
     {
         if (!parent::valid()) {
@@ -87,6 +88,7 @@ class StoppableIterator extends Collection
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function unwrap(): Iterator
     {
         $iterator = $this->_innerIterator;

--- a/src/Collection/Iterator/TreePrinter.php
+++ b/src/Collection/Iterator/TreePrinter.php
@@ -90,6 +90,7 @@ class TreePrinter extends RecursiveIteratorIterator implements CollectionInterfa
      *
      * @return mixed
      */
+    #[\Override]
     public function key(): mixed
     {
         $extractor = $this->_key;
@@ -102,6 +103,7 @@ class TreePrinter extends RecursiveIteratorIterator implements CollectionInterfa
      *
      * @return string
      */
+    #[\Override]
     public function current(): string
     {
         $extractor = $this->_value;
@@ -116,6 +118,7 @@ class TreePrinter extends RecursiveIteratorIterator implements CollectionInterfa
      *
      * @return void
      */
+    #[\Override]
     public function next(): void
     {
         parent::next();

--- a/src/Collection/Iterator/UnfoldIterator.php
+++ b/src/Collection/Iterator/UnfoldIterator.php
@@ -68,6 +68,7 @@ class UnfoldIterator extends IteratorIterator implements RecursiveIterator
      *
      * @return bool
      */
+    #[\Override]
     public function hasChildren(): bool
     {
         return true;
@@ -79,6 +80,7 @@ class UnfoldIterator extends IteratorIterator implements RecursiveIterator
      *
      * @return \RecursiveIterator<mixed, mixed>
      */
+    #[\Override]
     public function getChildren(): RecursiveIterator
     {
         $current = $this->current();

--- a/src/Collection/Iterator/ZipIterator.php
+++ b/src/Collection/Iterator/ZipIterator.php
@@ -94,6 +94,7 @@ class ZipIterator implements CollectionInterface
      *
      * @return mixed
      */
+    #[\Override]
     public function current(): mixed
     {
         $current = $this->multipleIterator->current();
@@ -109,6 +110,7 @@ class ZipIterator implements CollectionInterface
      *
      * @return mixed
      */
+    #[\Override]
     public function key(): mixed
     {
         return $this->multipleIterator->key();
@@ -119,6 +121,7 @@ class ZipIterator implements CollectionInterface
      *
      * @return void
      */
+    #[\Override]
     public function next(): void
     {
         $this->multipleIterator->next();
@@ -129,6 +132,7 @@ class ZipIterator implements CollectionInterface
      *
      * @return void
      */
+    #[\Override]
     public function rewind(): void
     {
         $this->multipleIterator->rewind();
@@ -139,6 +143,7 @@ class ZipIterator implements CollectionInterface
      *
      * @return bool
      */
+    #[\Override]
     public function valid(): bool
     {
         return $this->multipleIterator->valid();

--- a/src/Command/CacheClearCommand.php
+++ b/src/Command/CacheClearCommand.php
@@ -31,6 +31,7 @@ class CacheClearCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'cache clear';
@@ -39,6 +40,7 @@ class CacheClearCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Clear all data in a single cache engine.';
@@ -51,6 +53,7 @@ class CacheClearCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to be defined
      * @return \Cake\Console\ConsoleOptionParser The built parser.
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser = parent::buildOptionParser($parser);
@@ -73,6 +76,7 @@ class CacheClearCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $name = (string)$args->getArgument('engine');

--- a/src/Command/CacheClearGroupCommand.php
+++ b/src/Command/CacheClearGroupCommand.php
@@ -32,6 +32,7 @@ class CacheClearGroupCommand extends Command
      *
      * @return string
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'cache clear_group';
@@ -40,6 +41,7 @@ class CacheClearGroupCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Clear all data in a single cache group.';
@@ -52,6 +54,7 @@ class CacheClearGroupCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to be defined
      * @return \Cake\Console\ConsoleOptionParser The built parser.
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser = parent::buildOptionParser($parser);
@@ -75,6 +78,7 @@ class CacheClearGroupCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $group = (string)$args->getArgument('group');

--- a/src/Command/CacheClearallCommand.php
+++ b/src/Command/CacheClearallCommand.php
@@ -31,6 +31,7 @@ class CacheClearallCommand extends Command
      *
      * @return string
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'cache clear_all';
@@ -39,6 +40,7 @@ class CacheClearallCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Clear all data in all configured cache engines.';
@@ -51,6 +53,7 @@ class CacheClearallCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to be defined
      * @return \Cake\Console\ConsoleOptionParser The built parser.
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser = parent::buildOptionParser($parser);
@@ -66,6 +69,7 @@ class CacheClearallCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $engines = Cache::configured();

--- a/src/Command/CacheListCommand.php
+++ b/src/Command/CacheListCommand.php
@@ -29,6 +29,7 @@ class CacheListCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'cache list';
@@ -37,6 +38,7 @@ class CacheListCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Show a list of configured caches.';
@@ -49,6 +51,7 @@ class CacheListCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to be defined
      * @return \Cake\Console\ConsoleOptionParser The built parser.
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser = parent::buildOptionParser($parser);
@@ -64,6 +67,7 @@ class CacheListCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $engines = Cache::configured();

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -42,6 +42,7 @@ class Command extends BaseCommand
      * @return int|null|void The exit code or null for success
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io)
     {
     }

--- a/src/Command/CompletionCommand.php
+++ b/src/Command/CompletionCommand.php
@@ -37,6 +37,7 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Used by shells like bash to autocomplete command name, options and arguments';
@@ -48,6 +49,7 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
      * @param \Cake\Console\CommandCollection $commands The command collection
      * @return void
      */
+    #[\Override]
     public function setCommandCollection(CommandCollection $commands): void
     {
         $this->commands = $commands;
@@ -59,6 +61,7 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to build
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $modes = [
@@ -103,6 +106,7 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         return match ($args->getArgument('mode')) {

--- a/src/Command/CounterCacheCommand.php
+++ b/src/Command/CounterCacheCommand.php
@@ -28,6 +28,7 @@ class CounterCacheCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'counter_cache';
@@ -36,6 +37,7 @@ class CounterCacheCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Update counter cache for a model.';
@@ -51,6 +53,7 @@ class CounterCacheCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): int
     {
         $table = $this->fetchTable($args->getArgument('model'));
@@ -83,6 +86,7 @@ class CounterCacheCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(static::getDescription())

--- a/src/Command/Helper/BannerHelper.php
+++ b/src/Command/Helper/BannerHelper.php
@@ -72,6 +72,7 @@ class BannerHelper extends Helper
      * @param array $args The messages to output
      * @return void
      */
+    #[\Override]
     public function output(array $args): void
     {
         if ($args === []) {

--- a/src/Command/Helper/ProgressHelper.php
+++ b/src/Command/Helper/ProgressHelper.php
@@ -80,6 +80,7 @@ class ProgressHelper extends Helper
      * @param array $args The arguments/options to use when outputting the progress bar.
      * @return void
      */
+    #[\Override]
     public function output(array $args): void
     {
         $args += ['callback' => null];

--- a/src/Command/Helper/TableHelper.php
+++ b/src/Command/Helper/TableHelper.php
@@ -140,6 +140,7 @@ class TableHelper extends Helper
      * @param array $args The data to render out.
      * @return void
      */
+    #[\Override]
     public function output(array $args): void
     {
         if (!$args) {

--- a/src/Command/I18nCommand.php
+++ b/src/Command/I18nCommand.php
@@ -28,6 +28,7 @@ class I18nCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'I18n commands let you generate .pot files to power translations in your application.';
@@ -40,6 +41,7 @@ class I18nCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $io->out('<info>I18n Command</info>');
@@ -85,6 +87,7 @@ class I18nCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to update
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(static::getDescription());

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -119,6 +119,7 @@ class I18nExtractCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'i18n extract';
@@ -127,6 +128,7 @@ class I18nExtractCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Extract i18n POT files from application source files.';
@@ -182,6 +184,7 @@ class I18nExtractCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $plugin = '';
@@ -360,6 +363,7 @@ class I18nExtractCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to configure
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription([

--- a/src/Command/I18nInitCommand.php
+++ b/src/Command/I18nInitCommand.php
@@ -33,6 +33,7 @@ class I18nInitCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'i18n init';
@@ -41,6 +42,7 @@ class I18nInitCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Initialize a language PO file from the POT file.';
@@ -53,6 +55,7 @@ class I18nInitCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $language = $args->getArgument('language');
@@ -107,6 +110,7 @@ class I18nInitCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to update
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(static::getDescription())

--- a/src/Command/PluginAssetsCopyCommand.php
+++ b/src/Command/PluginAssetsCopyCommand.php
@@ -32,6 +32,7 @@ class PluginAssetsCopyCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'plugin assets copy';
@@ -40,6 +41,7 @@ class PluginAssetsCopyCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return "Copy plugin assets to app's webroot.";
@@ -55,6 +57,7 @@ class PluginAssetsCopyCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $this->io = $io;
@@ -73,6 +76,7 @@ class PluginAssetsCopyCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The option parser to update
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(

--- a/src/Command/PluginAssetsRemoveCommand.php
+++ b/src/Command/PluginAssetsRemoveCommand.php
@@ -32,6 +32,7 @@ class PluginAssetsRemoveCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'plugin assets remove';
@@ -40,6 +41,7 @@ class PluginAssetsRemoveCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return "Remove plugin assets from app's webroot.";
@@ -54,6 +56,7 @@ class PluginAssetsRemoveCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $this->io = $io;
@@ -82,6 +85,7 @@ class PluginAssetsRemoveCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The option parser to update
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(

--- a/src/Command/PluginAssetsSymlinkCommand.php
+++ b/src/Command/PluginAssetsSymlinkCommand.php
@@ -32,6 +32,7 @@ class PluginAssetsSymlinkCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'plugin assets symlink';
@@ -40,6 +41,7 @@ class PluginAssetsSymlinkCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return "Symlink (copy as fallback) plugin assets to app's webroot.";
@@ -56,6 +58,7 @@ class PluginAssetsSymlinkCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $this->io = $io;
@@ -74,6 +77,7 @@ class PluginAssetsSymlinkCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The option parser to update
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(

--- a/src/Command/PluginListCommand.php
+++ b/src/Command/PluginListCommand.php
@@ -31,6 +31,7 @@ class PluginListCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'plugin list';
@@ -39,6 +40,7 @@ class PluginListCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Displays all currently available plugins.';
@@ -51,6 +53,7 @@ class PluginListCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $loadedPluginsCollection = Plugin::getCollection();
@@ -93,6 +96,7 @@ class PluginListCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The option parser to update
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(static::getDescription());

--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -42,6 +42,7 @@ class PluginLoadCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'plugin load';
@@ -50,6 +51,7 @@ class PluginLoadCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Command for loading plugins.';
@@ -62,6 +64,7 @@ class PluginLoadCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $plugin = (string)$args->getArgument('plugin');
@@ -142,6 +145,7 @@ class PluginLoadCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The option parser to update
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         return $parser

--- a/src/Command/PluginLoadedCommand.php
+++ b/src/Command/PluginLoadedCommand.php
@@ -29,6 +29,7 @@ class PluginLoadedCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'plugin loaded';
@@ -37,6 +38,7 @@ class PluginLoadedCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Displays all currently loaded plugins.';
@@ -49,6 +51,7 @@ class PluginLoadedCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $loaded = Plugin::loaded();
@@ -63,6 +66,7 @@ class PluginLoadedCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The option parser to update
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(static::getDescription());

--- a/src/Command/PluginUnloadCommand.php
+++ b/src/Command/PluginUnloadCommand.php
@@ -37,6 +37,7 @@ class PluginUnloadCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'plugin unload';
@@ -45,6 +46,7 @@ class PluginUnloadCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Command for unloading plugins.';
@@ -57,6 +59,7 @@ class PluginUnloadCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $plugin = (string)$args->getArgument('plugin');
@@ -114,6 +117,7 @@ class PluginUnloadCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The option parser to update
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(

--- a/src/Command/RoutesCheckCommand.php
+++ b/src/Command/RoutesCheckCommand.php
@@ -32,6 +32,7 @@ class RoutesCheckCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'routes check';
@@ -40,6 +41,7 @@ class RoutesCheckCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Check a URL string against the routes.';
@@ -53,6 +55,7 @@ class RoutesCheckCommand extends Command
      * @return int|null The exit code or null for success
      * @throws \JsonException
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $url = $args->getArgument('url');
@@ -92,6 +95,7 @@ class RoutesCheckCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The option parser to update
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription([

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -29,6 +29,7 @@ class RoutesCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Get the list of routes connected in this application.';
@@ -42,6 +43,7 @@ class RoutesCommand extends Command
      * @return int|null The exit code or null for success
      * @throws \JsonException
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $header = ['Route name', 'URI template', 'Plugin', 'Prefix', 'Controller', 'Action', 'Method(s)'];
@@ -141,6 +143,7 @@ class RoutesCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The option parser to update
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser

--- a/src/Command/RoutesGenerateCommand.php
+++ b/src/Command/RoutesGenerateCommand.php
@@ -30,6 +30,7 @@ class RoutesGenerateCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'routes generate';
@@ -38,6 +39,7 @@ class RoutesGenerateCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Check a routing array against the routes.';
@@ -50,6 +52,7 @@ class RoutesGenerateCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         try {
@@ -97,6 +100,7 @@ class RoutesGenerateCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The option parser to update
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription([

--- a/src/Command/SchemacacheBuildCommand.php
+++ b/src/Command/SchemacacheBuildCommand.php
@@ -34,6 +34,7 @@ class SchemacacheBuildCommand extends Command
      *
      * @return string
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'schema_cache build';
@@ -42,6 +43,7 @@ class SchemacacheBuildCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Build all metadata caches for the connection.';
@@ -54,6 +56,7 @@ class SchemacacheBuildCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         try {
@@ -83,6 +86,7 @@ class SchemacacheBuildCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The option parser to update
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription([

--- a/src/Command/SchemacacheClearCommand.php
+++ b/src/Command/SchemacacheClearCommand.php
@@ -34,6 +34,7 @@ class SchemacacheClearCommand extends Command
      *
      * @return string
      */
+    #[\Override]
     public static function defaultName(): string
     {
         return 'schema_cache clear';
@@ -42,6 +43,7 @@ class SchemacacheClearCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Clear all metadata caches for the connection.';
@@ -54,6 +56,7 @@ class SchemacacheClearCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         try {
@@ -83,6 +86,7 @@ class SchemacacheClearCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The option parser to update
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription([

--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -73,6 +73,7 @@ class ServerCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'PHP Built-in Server for CakePHP';
@@ -132,6 +133,7 @@ class ServerCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $this->startup($args, $io);
@@ -164,6 +166,7 @@ class ServerCommand extends Command
      * @param \Cake\Console\ConsoleOptionParser $parser The option parser to update
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription([

--- a/src/Command/VersionCommand.php
+++ b/src/Command/VersionCommand.php
@@ -28,6 +28,7 @@ class VersionCommand extends Command
     /**
      * @inheritDoc
      */
+    #[\Override]
     public static function getDescription(): string
     {
         return 'Show the CakePHP version.';
@@ -40,6 +41,7 @@ class VersionCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $io->out(Configure::version());

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -62,6 +62,7 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setName(string $name)
     {
         assert(
@@ -168,6 +169,7 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function run(array $argv, ConsoleIo $io): ?int
     {
         $this->initialize();

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -43,6 +43,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setCommandCollection(CommandCollection $commands): void
     {
         $this->commands = $commands;
@@ -55,6 +56,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null
      */
+    #[\Override]
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $commands = $this->commands->getIterator();
@@ -223,6 +225,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to build
      * @return \Cake\Console\ConsoleOptionParser
      */
+    #[\Override]
     protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -148,6 +148,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * @return \Traversable
      * @psalm-return \Traversable<string, \Cake\Console\CommandInterface|class-string<\Cake\Console\CommandInterface>>
      */
+    #[\Override]
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->commands);
@@ -160,6 +161,7 @@ class CommandCollection implements IteratorAggregate, Countable
      *
      * @return int
      */
+    #[\Override]
     public function count(): int
     {
         return count($this->commands);

--- a/src/Console/CommandFactory.php
+++ b/src/Console/CommandFactory.php
@@ -42,6 +42,7 @@ class CommandFactory implements CommandFactoryInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function create(string $className): CommandInterface
     {
         if ($this->container?->has($className)) {

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -198,6 +198,7 @@ class CommandRunner implements EventDispatcherInterface
      *
      * @return \Cake\Event\EventManagerInterface
      */
+    #[\Override]
     public function getEventManager(): EventManagerInterface
     {
         if ($this->app instanceof PluginApplicationInterface) {
@@ -213,6 +214,7 @@ class CommandRunner implements EventDispatcherInterface
      * @param \Cake\Event\EventManagerInterface $eventManager The event manager to set.
      * @return $this
      */
+    #[\Override]
     public function setEventManager(EventManagerInterface $eventManager)
     {
         if ($this->app instanceof EventDispatcherInterface) {

--- a/src/Console/HelperRegistry.php
+++ b/src/Console/HelperRegistry.php
@@ -54,6 +54,7 @@ class HelperRegistry extends ObjectRegistry
      * @param string $class Partial classname to resolve.
      * @return class-string<\Cake\Console\Helper>|null Either the correct class name or null.
      */
+    #[\Override]
     protected function _resolveClassName(string $class): ?string
     {
         /** @var class-string<\Cake\Console\Helper>|null */
@@ -71,6 +72,7 @@ class HelperRegistry extends ObjectRegistry
      * @return void
      * @throws \Cake\Console\Exception\MissingHelperException
      */
+    #[\Override]
     protected function _throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new MissingHelperException([
@@ -89,6 +91,7 @@ class HelperRegistry extends ObjectRegistry
      * @param array<string, mixed> $config An array of settings to use for the helper.
      * @return \Cake\Console\Helper The constructed helper class.
      */
+    #[\Override]
     protected function _create(object|string $class, string $alias, array $config): Helper
     {
         if (is_object($class)) {

--- a/src/Console/TestSuite/Constraint/ContentsContain.php
+++ b/src/Console/TestSuite/Constraint/ContentsContain.php
@@ -28,6 +28,7 @@ class ContentsContain extends ContentsBase
      * @param mixed $other Expected
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         return mb_strpos($this->contents, $other) !== false;
@@ -38,6 +39,7 @@ class ContentsContain extends ContentsBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf('is in %s.', $this->output);
@@ -46,6 +48,7 @@ class ContentsContain extends ContentsBase
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function additionalFailureDescription(mixed $other): string
     {
         return sprintf("actual result:\n%s", $this->contents);

--- a/src/Console/TestSuite/Constraint/ContentsContainRow.php
+++ b/src/Console/TestSuite/Constraint/ContentsContainRow.php
@@ -30,6 +30,7 @@ class ContentsContainRow extends ContentsRegExp
      * @param mixed $other Row
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         $row = array_map(function ($cell) {
@@ -46,6 +47,7 @@ class ContentsContainRow extends ContentsRegExp
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf('row was in %s', $this->output);
@@ -55,6 +57,7 @@ class ContentsContainRow extends ContentsRegExp
      * @param mixed $other Expected content
      * @return string
      */
+    #[\Override]
     public function failureDescription(mixed $other): string
     {
         return '`' . (new Exporter())->shortenedExport($other) . '` ' . $this->toString();

--- a/src/Console/TestSuite/Constraint/ContentsEmpty.php
+++ b/src/Console/TestSuite/Constraint/ContentsEmpty.php
@@ -28,6 +28,7 @@ class ContentsEmpty extends ContentsBase
      * @param mixed $other Expected
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         return $this->contents === '';
@@ -38,6 +39,7 @@ class ContentsEmpty extends ContentsBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf('%s is empty.', $this->output);
@@ -49,6 +51,7 @@ class ContentsEmpty extends ContentsBase
      * @param mixed $other Value
      * @return string
      */
+    #[\Override]
     protected function failureDescription(mixed $other): string
     {
         return $this->toString();
@@ -57,6 +60,7 @@ class ContentsEmpty extends ContentsBase
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function additionalFailureDescription(mixed $other): string
     {
         return sprintf("actual result:\n%s", $this->contents);

--- a/src/Console/TestSuite/Constraint/ContentsNotContain.php
+++ b/src/Console/TestSuite/Constraint/ContentsNotContain.php
@@ -28,6 +28,7 @@ class ContentsNotContain extends ContentsBase
      * @param mixed $other Expected
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         return mb_strpos($this->contents, $other) === false;
@@ -38,6 +39,7 @@ class ContentsNotContain extends ContentsBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf('is not in %s.', $this->output);
@@ -46,6 +48,7 @@ class ContentsNotContain extends ContentsBase
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function additionalFailureDescription(mixed $other): string
     {
         return sprintf("actual result:\n%s", $this->contents);

--- a/src/Console/TestSuite/Constraint/ContentsRegExp.php
+++ b/src/Console/TestSuite/Constraint/ContentsRegExp.php
@@ -28,6 +28,7 @@ class ContentsRegExp extends ContentsBase
      * @param mixed $other Expected
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         return preg_match($other, $this->contents) > 0;
@@ -38,6 +39,7 @@ class ContentsRegExp extends ContentsBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf('PCRE pattern found in %s', $this->output);
@@ -47,6 +49,7 @@ class ContentsRegExp extends ContentsBase
      * @param mixed $other Expected
      * @return string
      */
+    #[\Override]
     public function failureDescription(mixed $other): string
     {
         return '`' . $other . '` ' . $this->toString();
@@ -55,6 +58,7 @@ class ContentsRegExp extends ContentsBase
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function additionalFailureDescription(mixed $other): string
     {
         return sprintf("actual result:\n%s", $this->contents);

--- a/src/Console/TestSuite/Constraint/ExitCode.php
+++ b/src/Console/TestSuite/Constraint/ExitCode.php
@@ -59,6 +59,7 @@ class ExitCode extends Constraint
      * @param mixed $other Constraint check
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         return $other === $this->exitCode;
@@ -69,6 +70,7 @@ class ExitCode extends Constraint
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf('matches exit code `%s`', $this->exitCode ?? 'null');
@@ -80,6 +82,7 @@ class ExitCode extends Constraint
      * @param mixed $other Expected
      * @return string
      */
+    #[\Override]
     public function failureDescription(mixed $other): string
     {
         return '`' . $other . '` ' . $this->toString();
@@ -88,6 +91,7 @@ class ExitCode extends Constraint
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function additionalFailureDescription(mixed $other): string
     {
         return sprintf(

--- a/src/Console/TestSuite/StubConsoleInput.php
+++ b/src/Console/TestSuite/StubConsoleInput.php
@@ -58,6 +58,7 @@ class StubConsoleInput extends ConsoleInput
      *
      * @return string The value of the reply
      */
+    #[\Override]
     public function read(): string
     {
         $this->currentIndex += 1;
@@ -82,6 +83,7 @@ class StubConsoleInput extends ConsoleInput
      * @param int $timeout An optional time to wait for data
      * @return bool True for data available, false otherwise
      */
+    #[\Override]
     public function dataAvailable(int $timeout = 0): bool
     {
         return true;

--- a/src/Console/TestSuite/StubConsoleOutput.php
+++ b/src/Console/TestSuite/StubConsoleOutput.php
@@ -60,6 +60,7 @@ class StubConsoleOutput extends ConsoleOutput
      * @param int $newlines Number of newlines to append
      * @return int
      */
+    #[\Override]
     public function write(array|string $message, int $newlines = 1): int
     {
         foreach ((array)$message as $line) {

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -171,6 +171,7 @@ class Component implements EventListenerInterface
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         $eventMap = [

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -96,6 +96,7 @@ class FlashComponent extends Component
      * @return $this
      * @throws \Cake\Core\Exception\CakeException When trying to set a key that is invalid.
      */
+    #[\Override]
     public function setConfig(array|string $key, mixed $value = null, bool $merge = true)
     {
         $this->flash()->setConfig($key, $value, $merge);
@@ -110,6 +111,7 @@ class FlashComponent extends Component
      * @param mixed $default The return value when the key does not exist.
      * @return mixed Configuration data at the named key or null if the key does not exist.
      */
+    #[\Override]
     public function getConfig(?string $key = null, mixed $default = null): mixed
     {
         return $this->flash()->getConfig($key, $default);
@@ -122,6 +124,7 @@ class FlashComponent extends Component
      * @return mixed Configuration data at the named key
      * @throws \InvalidArgumentException
      */
+    #[\Override]
     public function getConfigOrFail(string $key): mixed
     {
         return $this->flash()->getConfigOrFail($key);
@@ -134,6 +137,7 @@ class FlashComponent extends Component
      * @param mixed $value The value to set.
      * @return $this
      */
+    #[\Override]
     public function configShallow(array|string $key, mixed $value = null)
     {
         $this->flash()->configShallow($key, $value);

--- a/src/Controller/Component/FormProtectionComponent.php
+++ b/src/Controller/Component/FormProtectionComponent.php
@@ -133,6 +133,7 @@ class FormProtectionComponent extends Component
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         return [

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -108,6 +108,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      * @param string $class Partial classname to resolve.
      * @return class-string<\Cake\Controller\Component>|null Either the correct class name or null.
      */
+    #[\Override]
     protected function _resolveClassName(string $class): ?string
     {
         /** @var class-string<\Cake\Controller\Component>|null */
@@ -125,6 +126,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      * @return void
      * @throws \Cake\Controller\Exception\MissingComponentException
      */
+    #[\Override]
     protected function _throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new MissingComponentException([
@@ -144,6 +146,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      * @param array<string, mixed> $config An array of config to use for the component.
      * @return \Cake\Controller\Component The constructed component class.
      */
+    #[\Override]
     protected function _create(object|string $class, string $alias, array $config): Component
     {
         if (is_object($class)) {
@@ -183,6 +186,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      * @return \Cake\Core\ContainerInterface
      * @psalm-suppress OverriddenMethodAccess
      */
+    #[\Override]
     protected function getContainer(): ContainerInterface
     {
         if ($this->container === null) {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -579,6 +579,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         return [

--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -69,6 +69,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
      * @return \Cake\Controller\Controller
      * @throws \Cake\Http\Exception\MissingControllerException
      */
+    #[\Override]
     public function create(ServerRequestInterface $request): Controller
     {
         assert($request instanceof ServerRequest);
@@ -125,6 +126,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
      * @throws \Cake\Controller\Exception\MissingActionException If controller action is not found.
      * @throws \UnexpectedValueException If return value of action method is not null or ResponseInterface instance.
      */
+    #[\Override]
     public function invoke(mixed $controller): ResponseInterface
     {
         $this->controller = $controller;
@@ -147,6 +149,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
      * @param \Psr\Http\Message\ServerRequestInterface $request Request instance.
      * @return \Psr\Http\Message\ResponseInterface
      */
+    #[\Override]
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         assert($request instanceof ServerRequest);

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -32,6 +32,7 @@ class ErrorController extends Controller
      *
      * @return array<string>
      */
+    #[\Override]
     public function viewClasses(): array
     {
         return [JsonView::class];
@@ -44,6 +45,7 @@ class ErrorController extends Controller
      * @return \Cake\Http\Response|null|void
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function beforeRender(EventInterface $event)
     {
         $builder = $this->viewBuilder();

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -141,6 +141,7 @@ class BasePlugin implements PluginInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getName(): string
     {
         if ($this->name !== null) {
@@ -155,6 +156,7 @@ class BasePlugin implements PluginInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getPath(): string
     {
         if ($this->path !== null) {
@@ -174,6 +176,7 @@ class BasePlugin implements PluginInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getConfigPath(): string
     {
         if ($this->configPath !== null) {
@@ -187,6 +190,7 @@ class BasePlugin implements PluginInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getClassPath(): string
     {
         if ($this->classPath !== null) {
@@ -200,6 +204,7 @@ class BasePlugin implements PluginInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getTemplatePath(): string
     {
         if ($this->templatePath !== null) {
@@ -213,6 +218,7 @@ class BasePlugin implements PluginInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function enable(string $hook)
     {
         $this->checkHook($hook);
@@ -224,6 +230,7 @@ class BasePlugin implements PluginInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function disable(string $hook)
     {
         $this->checkHook($hook);
@@ -235,6 +242,7 @@ class BasePlugin implements PluginInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function isEnabled(string $hook): bool
     {
         $this->checkHook($hook);
@@ -263,6 +271,7 @@ class BasePlugin implements PluginInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function routes(RouteBuilder $routes): void
     {
         $path = $this->getConfigPath() . 'routes.php';
@@ -277,6 +286,7 @@ class BasePlugin implements PluginInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function bootstrap(PluginApplicationInterface $app): void
     {
         $bootstrap = $this->getConfigPath() . 'bootstrap.php';
@@ -288,6 +298,7 @@ class BasePlugin implements PluginInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function console(CommandCollection $commands): CommandCollection
     {
         return $commands->addMany($commands->discoverPlugin($this->getName()));
@@ -296,6 +307,7 @@ class BasePlugin implements PluginInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
         return $middlewareQueue;
@@ -307,6 +319,7 @@ class BasePlugin implements PluginInterface
      * @param \Cake\Core\ContainerInterface $container The container to add services to.
      * @return void
      */
+    #[\Override]
     public function services(ContainerInterface $container): void
     {
     }

--- a/src/Core/Configure/Engine/IniConfig.php
+++ b/src/Core/Configure/Engine/IniConfig.php
@@ -95,6 +95,7 @@ class IniConfig implements ConfigEngineInterface
      * @throws \Cake\Core\Exception\CakeException when files don't exist.
      *  Or when files contain '..' as this could lead to abusive reads.
      */
+    #[\Override]
     public function read(string $key): array
     {
         $file = $this->_getFilePath($key, true);
@@ -155,6 +156,7 @@ class IniConfig implements ConfigEngineInterface
      * @param array $data The data to convert to ini file.
      * @return bool Success.
      */
+    #[\Override]
     public function dump(string $key, array $data): bool
     {
         $result = [];

--- a/src/Core/Configure/Engine/JsonConfig.php
+++ b/src/Core/Configure/Engine/JsonConfig.php
@@ -72,6 +72,7 @@ class JsonConfig implements ConfigEngineInterface
      *   files contain '..' (as this could lead to abusive reads) or when there
      *   is an error parsing the JSON string.
      */
+    #[\Override]
     public function read(string $key): array
     {
         $file = $this->_getFilePath($key, true);
@@ -107,6 +108,7 @@ class JsonConfig implements ConfigEngineInterface
      * @param array $data Data to dump.
      * @return bool Success
      */
+    #[\Override]
     public function dump(string $key, array $data): bool
     {
         $filename = $this->_getFilePath($key);

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -77,6 +77,7 @@ class PhpConfig implements ConfigEngineInterface
      * @throws \Cake\Core\Exception\CakeException when files don't exist or they don't contain `$config`.
      *  Or when files contain '..' as this could lead to abusive reads.
      */
+    #[\Override]
     public function read(string $key): array
     {
         $file = $this->_getFilePath($key, true);
@@ -98,6 +99,7 @@ class PhpConfig implements ConfigEngineInterface
      * @param array $data Data to dump.
      * @return bool Success
      */
+    #[\Override]
     public function dump(string $key, array $data): bool
     {
         $contents = '<?php' . "\n" . 'return ' . var_export($data, true) . ';';

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -385,6 +385,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * @return \Traversable
      * @psalm-return \Traversable<string, TObject>
      */
+    #[\Override]
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_loaded);
@@ -395,6 +396,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      *
      * @return int
      */
+    #[\Override]
     public function count(): int
     {
         return count($this->_loaded);

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -301,6 +301,7 @@ class PluginCollection implements Iterator, Countable
      *
      * @return int
      */
+    #[\Override]
     public function count(): int
     {
         return count($this->plugins);
@@ -311,6 +312,7 @@ class PluginCollection implements Iterator, Countable
      *
      * @return void
      */
+    #[\Override]
     public function next(): void
     {
         $this->positions[$this->loopDepth]++;
@@ -321,6 +323,7 @@ class PluginCollection implements Iterator, Countable
      *
      * @return string
      */
+    #[\Override]
     public function key(): string
     {
         return $this->names[$this->positions[$this->loopDepth]];
@@ -331,6 +334,7 @@ class PluginCollection implements Iterator, Countable
      *
      * @return \Cake\Core\PluginInterface
      */
+    #[\Override]
     public function current(): PluginInterface
     {
         $position = $this->positions[$this->loopDepth];
@@ -344,6 +348,7 @@ class PluginCollection implements Iterator, Countable
      *
      * @return void
      */
+    #[\Override]
     public function rewind(): void
     {
         $this->positions[] = 0;
@@ -355,6 +360,7 @@ class PluginCollection implements Iterator, Countable
      *
      * @return bool
      */
+    #[\Override]
     public function valid(): bool
     {
         $valid = isset($this->names[$this->positions[$this->loopDepth]]);

--- a/src/Core/ServiceProvider.php
+++ b/src/Core/ServiceProvider.php
@@ -44,6 +44,7 @@ abstract class ServiceProvider extends AbstractServiceProvider implements Bootab
      *
      * @return \Cake\Core\ContainerInterface
      */
+    #[\Override]
     public function getContainer(): DefinitionContainerInterface
     {
         $container = parent::getContainer();
@@ -68,6 +69,7 @@ abstract class ServiceProvider extends AbstractServiceProvider implements Bootab
      *
      * @return void
      */
+    #[\Override]
     public function boot(): void
     {
         $this->bootstrap($this->getContainer());
@@ -96,6 +98,7 @@ abstract class ServiceProvider extends AbstractServiceProvider implements Bootab
      *
      * @return void
      */
+    #[\Override]
     public function register(): void
     {
         $this->services($this->getContainer());
@@ -111,6 +114,7 @@ abstract class ServiceProvider extends AbstractServiceProvider implements Bootab
      * @param string $id Identifier.
      * @return bool
      */
+    #[\Override]
     public function provides(string $id): bool
     {
         if (!$this->provides) {

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -207,6 +207,7 @@ class Connection implements ConnectionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function config(): array
     {
         return $this->_config;
@@ -215,6 +216,7 @@ class Connection implements ConnectionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function configName(): string
     {
         return $this->_config['name'] ?? '';
@@ -247,6 +249,7 @@ class Connection implements ConnectionInterface
      * @param string $role Connection role ('read' or 'write')
      * @return \Cake\Database\Driver
      */
+    #[\Override]
     public function getDriver(string $role = self::ROLE_WRITE): Driver
     {
         assert($role === self::ROLE_READ || $role === self::ROLE_WRITE);
@@ -742,6 +745,7 @@ class Connection implements ConnectionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setCacher(CacheInterface $cacher)
     {
         $this->cacher = $cacher;
@@ -752,6 +756,7 @@ class Connection implements ConnectionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getCacher(): CacheInterface
     {
         if ($this->cacher !== null) {

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -1046,6 +1046,7 @@ abstract class Driver implements LoggerAwareInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -116,6 +116,7 @@ class Mysql extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function connect(): void
     {
         if ($this->pdo !== null) {
@@ -167,6 +168,7 @@ class Mysql extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function run(Query $query): StatementInterface
     {
         $statement = $this->prepare($query);
@@ -191,6 +193,7 @@ class Mysql extends Driver
      *
      * @return bool true if it is valid to use this driver
      */
+    #[\Override]
     public function enabled(): bool
     {
         return in_array('mysql', PDO::getAvailableDrivers(), true);
@@ -199,6 +202,7 @@ class Mysql extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function schemaDialect(): SchemaDialect
     {
         return $this->_schemaDialect ?? ($this->_schemaDialect = new MysqlSchemaDialect($this));
@@ -207,6 +211,7 @@ class Mysql extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function schema(): string
     {
         return $this->_config['database'];
@@ -217,6 +222,7 @@ class Mysql extends Driver
      *
      * @return string
      */
+    #[\Override]
     public function disableForeignKeySQL(): string
     {
         return 'SET foreign_key_checks = 0';
@@ -225,6 +231,7 @@ class Mysql extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function enableForeignKeySQL(): string
     {
         return 'SET foreign_key_checks = 1';
@@ -233,6 +240,7 @@ class Mysql extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function supports(DriverFeatureEnum $feature): bool
     {
         $versionCompare = function () use ($feature) {
@@ -275,6 +283,7 @@ class Mysql extends Driver
      *
      * @return string
      */
+    #[\Override]
     public function version(): string
     {
         if ($this->_version === null) {

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -80,6 +80,7 @@ class Postgres extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function connect(): void
     {
         if ($this->pdo !== null) {
@@ -139,6 +140,7 @@ class Postgres extends Driver
      *
      * @return bool true if it is valid to use this driver
      */
+    #[\Override]
     public function enabled(): bool
     {
         return in_array('pgsql', PDO::getAvailableDrivers(), true);
@@ -147,6 +149,7 @@ class Postgres extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function schemaDialect(): SchemaDialect
     {
         return $this->_schemaDialect ?? ($this->_schemaDialect = new PostgresSchemaDialect($this));
@@ -182,6 +185,7 @@ class Postgres extends Driver
      *
      * @return string
      */
+    #[\Override]
     public function disableForeignKeySQL(): string
     {
         return 'SET CONSTRAINTS ALL DEFERRED';
@@ -190,6 +194,7 @@ class Postgres extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function enableForeignKeySQL(): string
     {
         return 'SET CONSTRAINTS ALL IMMEDIATE';
@@ -198,6 +203,7 @@ class Postgres extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function supports(DriverFeatureEnum $feature): bool
     {
         return match ($feature) {
@@ -216,6 +222,7 @@ class Postgres extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _transformDistinct(SelectQuery $query): SelectQuery
     {
         return $query;
@@ -224,6 +231,7 @@ class Postgres extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _insertQueryTranslator(InsertQuery $query): InsertQuery
     {
         if (!$query->clause('epilog')) {
@@ -236,6 +244,7 @@ class Postgres extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _expressionTranslators(): array
     {
         return [
@@ -354,6 +363,7 @@ class Postgres extends Driver
      *
      * @return \Cake\Database\PostgresCompiler
      */
+    #[\Override]
     public function newCompiler(): QueryCompiler
     {
         return new PostgresCompiler();

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -107,6 +107,7 @@ class Sqlite extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function connect(): void
     {
         if ($this->pdo !== null) {
@@ -163,6 +164,7 @@ class Sqlite extends Driver
      *
      * @return bool true if it is valid to use this driver
      */
+    #[\Override]
     public function enabled(): bool
     {
         return in_array('sqlite', PDO::getAvailableDrivers(), true);
@@ -173,6 +175,7 @@ class Sqlite extends Driver
      *
      * @return string
      */
+    #[\Override]
     public function disableForeignKeySQL(): string
     {
         return 'PRAGMA foreign_keys = OFF';
@@ -181,6 +184,7 @@ class Sqlite extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function enableForeignKeySQL(): string
     {
         return 'PRAGMA foreign_keys = ON';
@@ -189,6 +193,7 @@ class Sqlite extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function supports(DriverFeatureEnum $feature): bool
     {
         return match ($feature) {
@@ -213,6 +218,7 @@ class Sqlite extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function schemaDialect(): SchemaDialect
     {
         return $this->_schemaDialect ?? ($this->_schemaDialect = new SqliteSchemaDialect($this));
@@ -221,6 +227,7 @@ class Sqlite extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _expressionTranslators(): array
     {
         return [

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -110,6 +110,7 @@ class Sqlserver extends Driver
      * @throws \InvalidArgumentException if an unsupported setting is in the driver config
      * @return void
      */
+    #[\Override]
     public function connect(): void
     {
         if ($this->pdo !== null) {
@@ -182,6 +183,7 @@ class Sqlserver extends Driver
      *
      * @return bool true if it is valid to use this driver
      */
+    #[\Override]
     public function enabled(): bool
     {
         return in_array('sqlsrv', PDO::getAvailableDrivers(), true);
@@ -190,6 +192,7 @@ class Sqlserver extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function prepare(Query|string $query): StatementInterface
     {
         $options = [
@@ -227,6 +230,7 @@ class Sqlserver extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function savePointSQL($name): string
     {
         return 'SAVE TRANSACTION t' . $name;
@@ -235,6 +239,7 @@ class Sqlserver extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function releaseSavePointSQL($name): string
     {
         // SQLServer has no release save point operation.
@@ -244,6 +249,7 @@ class Sqlserver extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function rollbackSavePointSQL($name): string
     {
         return 'ROLLBACK TRANSACTION t' . $name;
@@ -252,6 +258,7 @@ class Sqlserver extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function disableForeignKeySQL(): string
     {
         return 'EXEC sp_MSforeachtable "ALTER TABLE ? NOCHECK CONSTRAINT all"';
@@ -260,6 +267,7 @@ class Sqlserver extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function enableForeignKeySQL(): string
     {
         return 'EXEC sp_MSforeachtable "ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all"';
@@ -268,6 +276,7 @@ class Sqlserver extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function supports(DriverFeatureEnum $feature): bool
     {
         return match ($feature) {
@@ -286,6 +295,7 @@ class Sqlserver extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function schemaDialect(): SchemaDialect
     {
         return $this->_schemaDialect ??= new SqlserverSchemaDialect($this);
@@ -296,6 +306,7 @@ class Sqlserver extends Driver
      *
      * @return \Cake\Database\SqlserverCompiler
      */
+    #[\Override]
     public function newCompiler(): QueryCompiler
     {
         return new SqlserverCompiler();
@@ -304,6 +315,7 @@ class Sqlserver extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _selectQueryTranslator(SelectQuery $query): SelectQuery
     {
         $limit = $query->clause('limit');
@@ -402,6 +414,7 @@ class Sqlserver extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _transformDistinct(SelectQuery $query): SelectQuery
     {
         if (!is_array($query->clause('distinct'))) {
@@ -453,6 +466,7 @@ class Sqlserver extends Driver
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _expressionTranslators(): array
     {
         return [

--- a/src/Database/Expression/AggregateExpression.php
+++ b/src/Database/Expression/AggregateExpression.php
@@ -81,6 +81,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function partition(ExpressionInterface|Closure|array|string $partitions)
     {
         $this->getWindow()->partition($partitions);
@@ -91,6 +92,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function order(ExpressionInterface|Closure|array|string $fields)
     {
         deprecationWarning(
@@ -104,6 +106,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function orderBy(ExpressionInterface|Closure|array|string $fields)
     {
         $this->getWindow()->orderBy($fields);
@@ -114,6 +117,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function range(ExpressionInterface|string|int|null $start, ExpressionInterface|string|int|null $end = 0)
     {
         $this->getWindow()->range($start, $end);
@@ -124,6 +128,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function rows(?int $start, ?int $end = 0)
     {
         $this->getWindow()->rows($start, $end);
@@ -134,6 +139,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function groups(?int $start, ?int $end = 0)
     {
         $this->getWindow()->groups($start, $end);
@@ -144,6 +150,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function frame(
         string $type,
         ExpressionInterface|string|int|null $startOffset,
@@ -159,6 +166,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function excludeCurrent()
     {
         $this->getWindow()->excludeCurrent();
@@ -169,6 +177,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function excludeGroup()
     {
         $this->getWindow()->excludeGroup();
@@ -179,6 +188,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function excludeTies()
     {
         $this->getWindow()->excludeTies();
@@ -199,6 +209,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         $sql = parent::sql($binder);
@@ -219,6 +230,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function traverse(Closure $callback)
     {
         parent::traverse($callback);
@@ -237,6 +249,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function count(): int
     {
         $count = parent::count();
@@ -252,6 +265,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
      *
      * @return void
      */
+    #[\Override]
     public function __clone()
     {
         parent::__clone();

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -74,6 +74,7 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         $parts = [
@@ -101,6 +102,7 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function traverse(Closure $callback)
     {
         foreach ([$this->_field, $this->_from, $this->_to] as $part) {

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -439,6 +439,7 @@ class CaseStatementExpression implements ExpressionInterface, TypedResultInterfa
      * @return string
      * @see CaseStatementExpression::then()
      */
+    #[\Override]
     public function getReturnType(): string
     {
         if ($this->returnType !== null) {
@@ -475,6 +476,7 @@ class CaseStatementExpression implements ExpressionInterface, TypedResultInterfa
      * @param string $type The type name to use.
      * @return $this
      */
+    #[\Override]
     public function setReturnType(string $type)
     {
         $this->returnType = $type;
@@ -515,6 +517,7 @@ class CaseStatementExpression implements ExpressionInterface, TypedResultInterfa
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         if ($this->whenBuffer !== null) {
@@ -544,6 +547,7 @@ class CaseStatementExpression implements ExpressionInterface, TypedResultInterfa
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function traverse(Closure $callback)
     {
         if ($this->whenBuffer !== null) {

--- a/src/Database/Expression/CommonTableExpression.php
+++ b/src/Database/Expression/CommonTableExpression.php
@@ -183,6 +183,7 @@ class CommonTableExpression implements ExpressionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         $fields = '';
@@ -205,6 +206,7 @@ class CommonTableExpression implements ExpressionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function traverse(Closure $callback)
     {
         $callback($this->name);

--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -141,6 +141,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         $field = $this->_field;
@@ -166,6 +167,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function traverse(Closure $callback)
     {
         if ($this->_field instanceof ExpressionInterface) {

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -108,6 +108,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
      * @return $this
      * @psalm-suppress MoreSpecificImplementedParamType
      */
+    #[\Override]
     public function add(ExpressionInterface|array|string $conditions, array $types = [], bool $prepend = false)
     {
         $put = $prepend ? 'array_unshift' : 'array_push';
@@ -144,6 +145,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         $parts = [];
@@ -172,6 +174,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
      *
      * @return int
      */
+    #[\Override]
     public function count(): int
     {
         return 1 + count($this->_conditions);

--- a/src/Database/Expression/IdentifierExpression.php
+++ b/src/Database/Expression/IdentifierExpression.php
@@ -99,6 +99,7 @@ class IdentifierExpression implements ExpressionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         $sql = $this->_identifier;
@@ -112,6 +113,7 @@ class IdentifierExpression implements ExpressionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function traverse(Closure $callback)
     {
         return $this;

--- a/src/Database/Expression/OrderByExpression.php
+++ b/src/Database/Expression/OrderByExpression.php
@@ -44,6 +44,7 @@ class OrderByExpression extends QueryExpression
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         $order = [];
@@ -67,6 +68,7 @@ class OrderByExpression extends QueryExpression
      * @param array $types list of types associated on fields referenced in $conditions
      * @return void
      */
+    #[\Override]
     protected function _addConditions(array $conditions, array $types): void
     {
         foreach ($conditions as $key => $val) {

--- a/src/Database/Expression/OrderClauseExpression.php
+++ b/src/Database/Expression/OrderClauseExpression.php
@@ -50,6 +50,7 @@ class OrderClauseExpression implements ExpressionInterface, FieldInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         $field = $this->_field;
@@ -66,6 +67,7 @@ class OrderClauseExpression implements ExpressionInterface, FieldInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function traverse(Closure $callback)
     {
         if ($this->_field instanceof ExpressionInterface) {

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -485,6 +485,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @return int
      */
+    #[\Override]
     public function count(): int
     {
         return count($this->_conditions);
@@ -513,6 +514,7 @@ class QueryExpression implements ExpressionInterface, Countable
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         $len = $this->count();
@@ -539,6 +541,7 @@ class QueryExpression implements ExpressionInterface, Countable
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function traverse(Closure $callback)
     {
         foreach ($this->_conditions as $c) {

--- a/src/Database/Expression/StringExpression.php
+++ b/src/Database/Expression/StringExpression.php
@@ -69,6 +69,7 @@ class StringExpression implements ExpressionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         $placeholder = $binder->placeholder('c');
@@ -80,6 +81,7 @@ class StringExpression implements ExpressionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function traverse(Closure $callback)
     {
         return $this;

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -72,6 +72,7 @@ class TupleComparison extends ComparisonExpression
      * @param mixed $value The value to compare
      * @return void
      */
+    #[\Override]
     public function setValue(mixed $value): void
     {
         if ($this->isMulti()) {
@@ -92,6 +93,7 @@ class TupleComparison extends ComparisonExpression
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         $template = '(%s) %s (%s)';
@@ -164,6 +166,7 @@ class TupleComparison extends ComparisonExpression
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _bindValue(mixed $value, ValueBinder $binder, ?string $type = null): string
     {
         $placeholder = $binder->placeholder('tuple');
@@ -175,6 +178,7 @@ class TupleComparison extends ComparisonExpression
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function traverse(Closure $callback)
     {
         $fields = (array)$this->getField();

--- a/src/Database/Expression/UnaryExpression.php
+++ b/src/Database/Expression/UnaryExpression.php
@@ -77,6 +77,7 @@ class UnaryExpression implements ExpressionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         $operand = $this->_value;
@@ -94,6 +95,7 @@ class UnaryExpression implements ExpressionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function traverse(Closure $callback)
     {
         if ($this->_value instanceof ExpressionInterface) {

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -211,6 +211,7 @@ class ValuesExpression implements ExpressionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         if (!$this->_values && $this->_query === null) {
@@ -262,6 +263,7 @@ class ValuesExpression implements ExpressionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function traverse(Closure $callback)
     {
         if ($this->_query) {

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -248,6 +248,7 @@ class WhenThenExpression implements ExpressionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         if ($this->when === null) {
@@ -288,6 +289,7 @@ class WhenThenExpression implements ExpressionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function traverse(Closure $callback)
     {
         if ($this->when instanceof ExpressionInterface) {

--- a/src/Database/Expression/WindowExpression.php
+++ b/src/Database/Expression/WindowExpression.php
@@ -88,6 +88,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function partition(ExpressionInterface|Closure|array|string $partitions)
     {
         if (!$partitions) {
@@ -116,6 +117,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function order(ExpressionInterface|Closure|array|string $fields)
     {
         deprecationWarning(
@@ -129,6 +131,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function orderBy(ExpressionInterface|Closure|array|string $fields)
     {
         if (!$fields) {
@@ -149,6 +152,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function range(ExpressionInterface|string|int|null $start, ExpressionInterface|string|int|null $end = 0)
     {
         return $this->frame(self::RANGE, $start, self::PRECEDING, $end, self::FOLLOWING);
@@ -157,6 +161,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function rows(?int $start, ?int $end = 0)
     {
         return $this->frame(self::ROWS, $start, self::PRECEDING, $end, self::FOLLOWING);
@@ -165,6 +170,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function groups(?int $start, ?int $end = 0)
     {
         return $this->frame(self::GROUPS, $start, self::PRECEDING, $end, self::FOLLOWING);
@@ -173,6 +179,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function frame(
         string $type,
         ExpressionInterface|string|int|null $startOffset,
@@ -198,6 +205,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function excludeCurrent()
     {
         $this->exclusion = 'CURRENT ROW';
@@ -208,6 +216,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function excludeGroup()
     {
         $this->exclusion = 'GROUP';
@@ -218,6 +227,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function excludeTies()
     {
         $this->exclusion = 'TIES';
@@ -228,6 +238,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(ValueBinder $binder): string
     {
         $clauses = [];
@@ -275,6 +286,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function traverse(Closure $callback)
     {
         $callback($this->name);

--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -156,6 +156,7 @@ class LoggedQuery implements JsonSerializable, Stringable
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function jsonSerialize(): array
     {
         $error = $this->error;
@@ -181,6 +182,7 @@ class LoggedQuery implements JsonSerializable, Stringable
      *
      * @return string
      */
+    #[\Override]
     public function __toString(): string
     {
         if ($this->params) {

--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -44,6 +44,7 @@ class QueryLogger extends BaseLog
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function log($level, string|Stringable $message, array $context = []): void
     {
         $context += [

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -276,6 +276,7 @@ abstract class Query implements ExpressionInterface, Stringable
      * @param \Cake\Database\ValueBinder|null $binder Value binder that generates parameter placeholders
      * @return string
      */
+    #[\Override]
     public function sql(?ValueBinder $binder = null): string
     {
         if (!$binder) {
@@ -307,6 +308,7 @@ abstract class Query implements ExpressionInterface, Stringable
      * @param \Closure $callback Callback to be executed for each part
      * @return $this
      */
+    #[\Override]
     public function traverse(Closure $callback)
     {
         foreach ($this->_parts as $name => $part) {
@@ -1822,6 +1824,7 @@ abstract class Query implements ExpressionInterface, Stringable
      *
      * @return string
      */
+    #[\Override]
     public function __toString(): string
     {
         return $this->sql();

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -399,6 +399,7 @@ class SelectQuery extends Query implements IteratorAggregate
      * @return $this
      * @throws \InvalidArgumentException If page number < 1.
      */
+    #[\Override]
     public function page(int $num, ?int $limit = null)
     {
         if ($num < 1) {
@@ -575,6 +576,7 @@ class SelectQuery extends Query implements IteratorAggregate
      *
      * @return \Traversable
      */
+    #[\Override]
     public function getIterator(): Traversable
     {
         if ($this->bufferedResults) {
@@ -774,6 +776,7 @@ class SelectQuery extends Query implements IteratorAggregate
      *
      * @return void
      */
+    #[\Override]
     public function __clone()
     {
         parent::__clone();
@@ -790,6 +793,7 @@ class SelectQuery extends Query implements IteratorAggregate
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function __debugInfo(): array
     {
         $return = parent::__debugInfo();

--- a/src/Database/Retry/ErrorCodeWaitStrategy.php
+++ b/src/Database/Retry/ErrorCodeWaitStrategy.php
@@ -50,6 +50,7 @@ class ErrorCodeWaitStrategy implements RetryStrategyInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function shouldRetry(Exception $exception, int $retryCount): bool
     {
         if (

--- a/src/Database/Retry/ReconnectStrategy.php
+++ b/src/Database/Retry/ReconnectStrategy.php
@@ -77,6 +77,7 @@ class ReconnectStrategy implements RetryStrategyInterface
      * Checks whether the exception was caused by a lost connection,
      * and returns true if it was able to successfully reconnect.
      */
+    #[\Override]
     public function shouldRetry(Exception $exception, int $retryCount): bool
     {
         $message = $exception->getMessage();

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -69,6 +69,7 @@ class CachedCollection implements CollectionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function listTables(): array
     {
         return $this->collection->listTables();
@@ -92,6 +93,7 @@ class CachedCollection implements CollectionInterface
      * @return \Cake\Database\Schema\TableSchemaInterface Object with column metadata.
      * @throws \Cake\Database\Exception\DatabaseException when table cannot be described.
      */
+    #[\Override]
     public function describe(string $name, array $options = []): TableSchemaInterface
     {
         $options += ['forceRefresh' => false];

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -67,6 +67,7 @@ class Collection implements CollectionInterface
      *
      * @return array<string> The list of tables and views in the connected database/schema.
      */
+    #[\Override]
     public function listTables(): array
     {
         return $this->getDialect()->listTables();
@@ -82,6 +83,7 @@ class Collection implements CollectionInterface
      * @return \Cake\Database\Schema\TableSchemaInterface Object with column metadata.
      * @throws \Cake\Database\Exception\DatabaseException when table cannot be described.
      */
+    #[\Override]
     public function describe(string $name, array $options = []): TableSchemaInterface
     {
         return $this->getDialect()->describe($name);

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -34,6 +34,7 @@ class MysqlSchemaDialect extends SchemaDialect
      *    getting tables from.
      * @return array<mixed> An array of (sql, params) to execute.
      */
+    #[\Override]
     public function listTablesSql(array $config): array
     {
         return ['SHOW FULL TABLES FROM ' . $this->_driver->quoteIdentifier($config['database']), []];
@@ -57,6 +58,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeColumnSql(string $tableName, array $config): array
     {
         $sql = $this->describeColumnQuery($tableName);
@@ -114,6 +116,7 @@ class MysqlSchemaDialect extends SchemaDialect
      * @param string $tableName The name of the table to describe columns on.
      * @return array
      */
+    #[\Override]
     public function describeColumns(string $tableName): array
     {
         $sql = $this->describeColumnQuery($tableName);
@@ -190,6 +193,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeIndexSql(string $tableName, array $config): array
     {
         $sql = $this->describeIndexQuery($tableName);
@@ -211,6 +215,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeIndexes(string $tableName): array
     {
         $sql = $this->describeIndexQuery($tableName);
@@ -254,6 +259,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeOptionsSql(string $tableName, array $config): array
     {
         return ['SHOW TABLE STATUS WHERE Name = ?', [$tableName]];
@@ -262,6 +268,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function convertOptionsDescription(TableSchema $schema, array $row): void
     {
         $schema->setOptions([
@@ -273,6 +280,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeOptions(string $tableName): array
     {
         [, $name] = $this->splitTablename($tableName);
@@ -414,6 +422,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function convertColumnDescription(TableSchema $schema, array $row): void
     {
         $field = $this->_convertColumn($row['Type']);
@@ -433,6 +442,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function convertIndexDescription(TableSchema $schema, array $row): void
     {
         $type = null;
@@ -493,6 +503,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeForeignKeySql(string $tableName, array $config): array
     {
         $sql = 'SELECT * FROM information_schema.key_column_usage AS kcu
@@ -510,6 +521,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function convertForeignKeyDescription(TableSchema $schema, array $row): void
     {
         $data = [
@@ -526,6 +538,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeForeignKeys(string $tableName): array
     {
         [$database, $name] = $this->splitTablename($tableName);
@@ -568,6 +581,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function truncateTableSql(TableSchema $schema): array
     {
         return [sprintf('TRUNCATE TABLE `%s`', $schema->name())];
@@ -576,6 +590,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function createTableSql(TableSchema $schema, array $columns, array $constraints, array $indexes): array
     {
         $content = implode(",\n", array_merge($columns, $constraints, $indexes));
@@ -602,6 +617,7 @@ class MysqlSchemaDialect extends SchemaDialect
      * @param array $column The column metadata
      * @return string Generated SQL fragment for a column
      */
+    #[\Override]
     public function columnDefinitionSql(array $column): string
     {
         $name = $column['name'];
@@ -811,6 +827,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function columnSql(TableSchema $schema, string $name): string
     {
         $data = $schema->getColumn($name);
@@ -843,6 +860,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function constraintSql(TableSchema $schema, string $name): string
     {
         $data = $schema->getConstraint($name);
@@ -871,6 +889,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function addConstraintSql(TableSchema $schema): array
     {
         $sqlPattern = 'ALTER TABLE %s ADD %s;';
@@ -891,6 +910,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function dropConstraintSql(TableSchema $schema): array
     {
         $sqlPattern = 'ALTER TABLE %s DROP FOREIGN KEY %s;';
@@ -912,6 +932,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function indexSql(TableSchema $schema, string $name): string
     {
         $data = $schema->getIndex($name);

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -37,6 +37,7 @@ class PostgresSchemaDialect extends SchemaDialect
      *    getting tables from.
      * @return array An array of (sql, params) to execute.
      */
+    #[\Override]
     public function listTablesSql(array $config): array
     {
         $sql = 'SELECT table_name as name FROM information_schema.tables
@@ -65,6 +66,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeColumnSql(string $tableName, array $config): array
     {
         $sql = $this->describeColumnQuery();
@@ -207,6 +209,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function convertColumnDescription(TableSchema $schema, array $row): void
     {
         $field = $this->_convertColumn($row['type']);
@@ -273,6 +276,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeColumns(string $tableName): array
     {
         $config = $this->_driver->config();
@@ -385,6 +389,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeIndexSql(string $tableName, array $config): array
     {
         $sql = $this->describeIndexQuery();
@@ -396,6 +401,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function convertIndexDescription(TableSchema $schema, array $row): void
     {
         $type = TableSchema::INDEX_INDEX;
@@ -426,6 +432,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeIndexes(string $tableName): array
     {
         [$schema, $name] = $this->splitTablename($tableName);
@@ -482,6 +489,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeForeignKeySql(string $tableName, array $config): array
     {
         $sql = $this->describeForeignKeyQuery();
@@ -493,6 +501,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function convertForeignKeyDescription(TableSchema $schema, array $row): void
     {
         $data = [
@@ -508,6 +517,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeForeignKeys(string $tableName): array
     {
         [$schema, $name] = $this->splitTablename($tableName);
@@ -579,6 +589,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeOptions(string $tableName): array
     {
         return [];
@@ -587,6 +598,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _convertOnClause(string $clause): string
     {
         if ($clause === 'r') {
@@ -605,6 +617,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function columnSql(TableSchema $schema, string $name): string
     {
         $data = $schema->getColumn($name);
@@ -753,6 +766,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function addConstraintSql(TableSchema $schema): array
     {
         $sqlPattern = 'ALTER TABLE %s ADD %s;';
@@ -773,6 +787,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function dropConstraintSql(TableSchema $schema): array
     {
         $sqlPattern = 'ALTER TABLE %s DROP CONSTRAINT %s;';
@@ -794,6 +809,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function indexSql(TableSchema $schema, string $name): string
     {
         $data = $schema->getIndex($name);
@@ -814,6 +830,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function constraintSql(TableSchema $schema, string $name): string
     {
         $data = $schema->getConstraint($name);
@@ -859,6 +876,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function createTableSql(TableSchema $schema, array $columns, array $constraints, array $indexes): array
     {
         $content = array_merge($columns, $constraints);
@@ -892,6 +910,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function truncateTableSql(TableSchema $schema): array
     {
         $name = $this->_driver->quoteIdentifier($schema->name());
@@ -907,6 +926,7 @@ class PostgresSchemaDialect extends SchemaDialect
      * @param \Cake\Database\Schema\TableSchema $schema Table instance
      * @return array SQL statements to drop a table.
      */
+    #[\Override]
     public function dropTableSql(TableSchema $schema): array
     {
         $sql = sprintf(

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -169,6 +169,7 @@ class SqliteSchemaDialect extends SchemaDialect
      *    getting tables from.
      * @return array An array of (sql, params) to execute.
      */
+    #[\Override]
     public function listTablesSql(array $config): array
     {
         return [
@@ -198,6 +199,7 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeColumnSql(string $tableName, array $config): array
     {
         $sql = $this->describeColumnQuery($tableName);
@@ -208,6 +210,7 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function convertColumnDescription(TableSchema $schema, array $row): void
     {
         $field = $this->_convertColumn($row['type']);
@@ -263,6 +266,7 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeColumns(string $tableName): array
     {
         $config = $this->_driver->config();
@@ -324,6 +328,7 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeIndexSql(string $tableName, array $config): array
     {
         $sql = $this->describeIndexQuery($tableName);
@@ -389,6 +394,7 @@ class SqliteSchemaDialect extends SchemaDialect
      * @return void
      * @deprecated 5.2.0 Use `describeIndexes` instead.
      */
+    #[\Override]
     public function convertIndexDescription(TableSchema $schema, array $row): void
     {
         // Skip auto-indexes created for non-ROWID primary keys.
@@ -484,6 +490,7 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeIndexes(string $tableName): array
     {
         $config = $this->_driver->config();
@@ -553,6 +560,7 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeForeignKeySql(string $tableName, array $config): array
     {
         $sql = sprintf(
@@ -566,6 +574,7 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function convertForeignKeyDescription(TableSchema $schema, array $row): void
     {
         $sql = sprintf(
@@ -604,6 +613,7 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeForeignKeys(string $tableName): array
     {
         $config = $this->_driver->config();
@@ -657,6 +667,7 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeOptions(string $tableName): array
     {
         return [];
@@ -670,6 +681,7 @@ class SqliteSchemaDialect extends SchemaDialect
      * @return string SQL fragment.
      * @throws \Cake\Database\Exception\DatabaseException when the column type is unknown
      */
+    #[\Override]
     public function columnSql(TableSchema $schema, string $name): string
     {
         $data = $schema->getColumn($name);
@@ -709,6 +721,7 @@ class SqliteSchemaDialect extends SchemaDialect
      * @param array $column The column metadata
      * @return string Generated SQL fragment for a column
      */
+    #[\Override]
     public function columnDefinitionSql(array $column): string
     {
         $name = $column['name'];
@@ -857,6 +870,7 @@ class SqliteSchemaDialect extends SchemaDialect
      * @param string $name The name of the column.
      * @return string SQL fragment.
      */
+    #[\Override]
     public function constraintSql(TableSchema $schema, string $name): string
     {
         $data = $schema->getConstraint($name);
@@ -914,6 +928,7 @@ class SqliteSchemaDialect extends SchemaDialect
      * @param \Cake\Database\Schema\TableSchema $schema The table instance the foreign key constraints are.
      * @return array SQL fragment.
      */
+    #[\Override]
     public function addConstraintSql(TableSchema $schema): array
     {
         return [];
@@ -928,6 +943,7 @@ class SqliteSchemaDialect extends SchemaDialect
      * @param \Cake\Database\Schema\TableSchema $schema The table instance the foreign key constraints are.
      * @return array SQL fragment.
      */
+    #[\Override]
     public function dropConstraintSql(TableSchema $schema): array
     {
         return [];
@@ -936,6 +952,7 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function indexSql(TableSchema $schema, string $name): string
     {
         $data = $schema->getIndex($name);
@@ -956,6 +973,7 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function createTableSql(TableSchema $schema, array $columns, array $constraints, array $indexes): array
     {
         $lines = array_merge($columns, $constraints);
@@ -973,6 +991,7 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function truncateTableSql(TableSchema $schema): array
     {
         $name = $schema->name();

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -35,6 +35,7 @@ class SqlserverSchemaDialect extends SchemaDialect
      *    getting tables from.
      * @return array An array of (sql, params) to execute.
      */
+    #[\Override]
     public function listTablesSql(array $config): array
     {
         $sql = "SELECT TABLE_NAME
@@ -69,6 +70,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeColumnSql(string $tableName, array $config): array
     {
         $sql = $this->describeColumnQuery();
@@ -232,6 +234,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function convertColumnDescription(TableSchema $schema, array $row): void
     {
         $field = $this->_convertColumn(
@@ -275,6 +278,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeColumns(string $tableName): array
     {
         [$schema, $name] = $this->splitTablename($tableName);
@@ -348,6 +352,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeIndexSql(string $tableName, array $config): array
     {
         $sql = $this->describeIndexQuery();
@@ -381,6 +386,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function convertIndexDescription(TableSchema $schema, array $row): void
     {
         $type = TableSchema::INDEX_INDEX;
@@ -421,6 +427,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeIndexes(string $tableName): array
     {
         [$schema, $name] = $this->splitTablename($tableName);
@@ -482,6 +489,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeForeignKeys(string $tableName): array
     {
         [$schema, $name] = $this->splitTablename($tableName);
@@ -518,6 +526,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeForeignKeySql(string $tableName, array $config): array
     {
         $sql = $this->describeForeignKeyQuery();
@@ -529,6 +538,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function convertForeignKeyDescription(TableSchema $schema, array $row): void
     {
         $data = [
@@ -545,6 +555,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function describeOptions(string $tableName): array
     {
         return [];
@@ -553,6 +564,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _foreignOnClause(string $on): string
     {
         $parent = parent::_foreignOnClause($on);
@@ -563,6 +575,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _convertOnClause(string $clause): string
     {
         return match ($clause) {
@@ -577,6 +590,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function columnSql(TableSchema $schema, string $name): string
     {
         $data = $schema->getColumn($name);
@@ -740,6 +754,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function addConstraintSql(TableSchema $schema): array
     {
         $sqlPattern = 'ALTER TABLE %s ADD %s;';
@@ -760,6 +775,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function dropConstraintSql(TableSchema $schema): array
     {
         $sqlPattern = 'ALTER TABLE %s DROP CONSTRAINT %s;';
@@ -781,6 +797,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function indexSql(TableSchema $schema, string $name): string
     {
         $data = $schema->getIndex($name);
@@ -801,6 +818,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function constraintSql(TableSchema $schema, string $name): string
     {
         $data = $schema->getConstraint($name);
@@ -846,6 +864,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function createTableSql(TableSchema $schema, array $columns, array $constraints, array $indexes): array
     {
         $content = array_merge($columns, $constraints);
@@ -892,6 +911,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function truncateTableSql(TableSchema $schema): array
     {
         $name = $this->_driver->quoteIdentifier($schema->name());

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -332,6 +332,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function name(): string
     {
         return $this->_table;
@@ -340,6 +341,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function addColumn(string $name, $attrs)
     {
         if (is_string($attrs)) {
@@ -359,6 +361,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function removeColumn(string $name)
     {
         unset($this->_columns[$name], $this->_typeMap[$name]);
@@ -369,6 +372,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function columns(): array
     {
         return array_keys($this->_columns);
@@ -377,6 +381,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getColumn(string $name): ?array
     {
         if (!isset($this->_columns[$name])) {
@@ -391,6 +396,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getColumnType(string $name): ?string
     {
         if (!isset($this->_columns[$name])) {
@@ -403,6 +409,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setColumnType(string $name, string $type)
     {
         if (!isset($this->_columns[$name])) {
@@ -428,6 +435,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function hasColumn(string $name): bool
     {
         return isset($this->_columns[$name]);
@@ -436,6 +444,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function baseColumnType(string $column): ?string
     {
         if (isset($this->_columns[$column]['baseType'])) {
@@ -458,6 +467,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function typeMap(): array
     {
         return $this->_typeMap;
@@ -466,6 +476,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function isNullable(string $name): bool
     {
         if (!isset($this->_columns[$name])) {
@@ -478,6 +489,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function defaultValues(): array
     {
         $defaults = [];
@@ -497,6 +509,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function addIndex(string $name, $attrs)
     {
         if (is_string($attrs)) {
@@ -535,6 +548,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function indexes(): array
     {
         return array_keys($this->_indexes);
@@ -543,6 +557,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getIndex(string $name): ?array
     {
         if (!isset($this->_indexes[$name])) {
@@ -555,6 +570,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getPrimaryKey(): array
     {
         foreach ($this->_constraints as $data) {
@@ -569,6 +585,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function addConstraint(string $name, $attrs)
     {
         if (is_string($attrs)) {
@@ -632,6 +649,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function dropConstraint(string $name)
     {
         if (isset($this->_constraints[$name])) {
@@ -646,6 +664,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      *
      * @return bool
      */
+    #[\Override]
     public function hasAutoincrement(): bool
     {
         foreach ($this->_columns as $column) {
@@ -688,6 +707,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function constraints(): array
     {
         return array_keys($this->_constraints);
@@ -696,6 +716,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getConstraint(string $name): ?array
     {
         return $this->_constraints[$name] ?? null;
@@ -704,6 +725,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setOptions(array $options)
     {
         $this->_options = $options + $this->_options;
@@ -714,6 +736,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getOptions(): array
     {
         return $this->_options;
@@ -722,6 +745,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setTemporary(bool $temporary)
     {
         $this->_temporary = $temporary;
@@ -732,6 +756,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function isTemporary(): bool
     {
         return $this->_temporary;
@@ -740,6 +765,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function createSql(Connection $connection): array
     {
         $dialect = $connection->getDriver()->schemaDialect();
@@ -762,6 +788,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function dropSql(Connection $connection): array
     {
         $dialect = $connection->getDriver()->schemaDialect();
@@ -772,6 +799,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function truncateSql(Connection $connection): array
     {
         $dialect = $connection->getDriver()->schemaDialect();
@@ -782,6 +810,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function addConstraintSql(Connection $connection): array
     {
         $dialect = $connection->getDriver()->schemaDialect();
@@ -792,6 +821,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function dropConstraintSql(Connection $connection): array
     {
         $dialect = $connection->getDriver()->schemaDialect();

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -62,6 +62,7 @@ class SqlserverCompiler extends QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string
      */
+    #[\Override]
     protected function _buildWithPart(array $parts, Query $query, ValueBinder $binder): string
     {
         $expressions = [];
@@ -84,6 +85,7 @@ class SqlserverCompiler extends QueryCompiler
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string
      */
+    #[\Override]
     protected function _buildInsertPart(array $parts, Query $query, ValueBinder $binder): string
     {
         if (!isset($parts[0])) {

--- a/src/Database/Statement/SqliteStatement.php
+++ b/src/Database/Statement/SqliteStatement.php
@@ -31,6 +31,7 @@ class SqliteStatement extends Statement
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function execute(?array $params = null): bool
     {
         $this->affectedRows = null;
@@ -41,6 +42,7 @@ class SqliteStatement extends Statement
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function rowCount(): int
     {
         if ($this->affectedRows !== null) {

--- a/src/Database/Statement/SqlserverStatement.php
+++ b/src/Database/Statement/SqlserverStatement.php
@@ -28,6 +28,7 @@ class SqlserverStatement extends Statement
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function performBind(string|int $column, mixed $value, int $type): void
     {
         if ($type === PDO::PARAM_LOB) {

--- a/src/Database/Statement/Statement.php
+++ b/src/Database/Statement/Statement.php
@@ -64,6 +64,7 @@ class Statement implements StatementInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function bind(array $params, array $types): void
     {
         if (!$params) {
@@ -86,6 +87,7 @@ class Statement implements StatementInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function bindValue(string|int $column, mixed $value, string|int|null $type = 'string'): void
     {
         $type ??= 'string';
@@ -122,6 +124,7 @@ class Statement implements StatementInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getBoundParams(): array
     {
         return $this->params;
@@ -141,6 +144,7 @@ class Statement implements StatementInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function execute(?array $params = null): bool
     {
         return $this->statement->execute($params);
@@ -149,6 +153,7 @@ class Statement implements StatementInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function fetch(string|int $mode = PDO::FETCH_NUM): mixed
     {
         $mode = $this->convertMode($mode);
@@ -167,6 +172,7 @@ class Statement implements StatementInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function fetchAssoc(): array
     {
         return $this->fetch(PDO::FETCH_ASSOC) ?: [];
@@ -175,6 +181,7 @@ class Statement implements StatementInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function fetchColumn(int $position): mixed
     {
         $row = $this->fetch(PDO::FETCH_NUM);
@@ -188,6 +195,7 @@ class Statement implements StatementInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function fetchAll(string|int $mode = PDO::FETCH_NUM): array
     {
         $mode = $this->convertMode($mode);
@@ -222,6 +230,7 @@ class Statement implements StatementInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function closeCursor(): void
     {
         $this->statement->closeCursor();
@@ -230,6 +239,7 @@ class Statement implements StatementInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function rowCount(): int
     {
         return $this->statement->rowCount();
@@ -238,6 +248,7 @@ class Statement implements StatementInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function columnCount(): int
     {
         return $this->statement->columnCount();
@@ -246,6 +257,7 @@ class Statement implements StatementInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function errorCode(): string
     {
         return $this->statement->errorCode() ?: '';
@@ -254,6 +266,7 @@ class Statement implements StatementInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function errorInfo(): array
     {
         return $this->statement->errorInfo();
@@ -262,6 +275,7 @@ class Statement implements StatementInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function lastInsertId(?string $table = null, ?string $column = null): string|int
     {
         if ($column && $this->columnCount()) {
@@ -280,6 +294,7 @@ class Statement implements StatementInterface
      *
      * @return string
      */
+    #[\Override]
     public function queryString(): string
     {
         return $this->statement->queryString;
@@ -290,6 +305,7 @@ class Statement implements StatementInterface
      *
      * @return \Generator
      */
+    #[\Override]
     public function getIterator(): Generator
     {
         $this->statement->setFetchMode(PDO::FETCH_ASSOC);

--- a/src/Database/Type/BaseType.php
+++ b/src/Database/Type/BaseType.php
@@ -45,6 +45,7 @@ abstract class BaseType implements TypeInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getName(): ?string
     {
         return $this->_name;
@@ -53,6 +54,7 @@ abstract class BaseType implements TypeInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getBaseType(): ?string
     {
         return $this->_name;
@@ -61,6 +63,7 @@ abstract class BaseType implements TypeInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function toStatement(mixed $value, Driver $driver): int
     {
         if ($value === null) {
@@ -73,6 +76,7 @@ abstract class BaseType implements TypeInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function newId(): mixed
     {
         return null;

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -37,6 +37,7 @@ class BinaryType extends BaseType
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return resource|string
      */
+    #[\Override]
     public function toDatabase(mixed $value, Driver $driver): mixed
     {
         return $value;
@@ -50,6 +51,7 @@ class BinaryType extends BaseType
      * @return resource|null
      * @throws \Cake\Core\Exception\CakeException
      */
+    #[\Override]
     public function toPHP(mixed $value, Driver $driver): mixed
     {
         if ($value === null) {
@@ -67,6 +69,7 @@ class BinaryType extends BaseType
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function toStatement(mixed $value, Driver $driver): int
     {
         return PDO::PARAM_LOB;
@@ -81,6 +84,7 @@ class BinaryType extends BaseType
      * @param mixed $value The value to convert.
      * @return mixed Converted value.
      */
+    #[\Override]
     public function marshal(mixed $value): mixed
     {
         return $value;

--- a/src/Database/Type/BinaryUuidType.php
+++ b/src/Database/Type/BinaryUuidType.php
@@ -38,6 +38,7 @@ class BinaryUuidType extends BaseType
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return mixed
      */
+    #[\Override]
     public function toDatabase(mixed $value, Driver $driver): mixed
     {
         if (!is_string($value)) {
@@ -57,6 +58,7 @@ class BinaryUuidType extends BaseType
      *
      * @return string A new primary key value.
      */
+    #[\Override]
     public function newId(): string
     {
         return Text::uuid();
@@ -70,6 +72,7 @@ class BinaryUuidType extends BaseType
      * @return resource|string|null
      * @throws \Cake\Core\Exception\CakeException
      */
+    #[\Override]
     public function toPHP(mixed $value, Driver $driver): mixed
     {
         if ($value === null) {
@@ -88,6 +91,7 @@ class BinaryUuidType extends BaseType
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function toStatement(mixed $value, Driver $driver): int
     {
         return PDO::PARAM_LOB;
@@ -102,6 +106,7 @@ class BinaryUuidType extends BaseType
      * @param mixed $value The value to convert.
      * @return mixed Converted value.
      */
+    #[\Override]
     public function marshal(mixed $value): mixed
     {
         return $value;

--- a/src/Database/Type/BoolType.php
+++ b/src/Database/Type/BoolType.php
@@ -34,6 +34,7 @@ class BoolType extends BaseType implements BatchCastingInterface
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return bool|null
      */
+    #[\Override]
     public function toDatabase(mixed $value, Driver $driver): ?bool
     {
         if ($value === true || $value === false || $value === null) {
@@ -58,6 +59,7 @@ class BoolType extends BaseType implements BatchCastingInterface
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return bool|null
      */
+    #[\Override]
     public function toPHP(mixed $value, Driver $driver): ?bool
     {
         if ($value === null || is_bool($value)) {
@@ -74,6 +76,7 @@ class BoolType extends BaseType implements BatchCastingInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function manyToPHP(array $values, array $fields, Driver $driver): array
     {
         foreach ($fields as $field) {
@@ -96,6 +99,7 @@ class BoolType extends BaseType implements BatchCastingInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function toStatement(mixed $value, Driver $driver): int
     {
         if ($value === null) {
@@ -111,6 +115,7 @@ class BoolType extends BaseType implements BatchCastingInterface
      * @param mixed $value The value to convert.
      * @return bool|null Converted value.
      */
+    #[\Override]
     public function marshal(mixed $value): ?bool
     {
         if ($value === null || $value === '') {

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -129,6 +129,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return string|null
      */
+    #[\Override]
     public function toDatabase(mixed $value, Driver $driver): ?string
     {
         if ($value === null || is_string($value)) {
@@ -205,6 +206,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
      * @param \Cake\Database\Driver $driver Object from which database preferences and configuration will be extracted
      * @return \Cake\I18n\DateTime|\DateTimeImmutable|null
      */
+    #[\Override]
     public function toPHP(mixed $value, Driver $driver): DateTime|DateTimeImmutable|null
     {
         if ($value === null) {
@@ -255,6 +257,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function manyToPHP(array $values, array $fields, Driver $driver): array
     {
         foreach ($fields as $field) {
@@ -294,6 +297,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
      * @param mixed $value Request data
      * @return \DateTimeInterface|null
      */
+    #[\Override]
     public function marshal(mixed $value): ?DateTimeInterface
     {
         if ($value instanceof DateTimeInterface) {
@@ -467,6 +471,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function toStatement(mixed $value, Driver $driver): int
     {
         return PDO::PARAM_STR;

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -81,6 +81,7 @@ class DateType extends BaseType implements BatchCastingInterface
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return string|null
      */
+    #[\Override]
     public function toDatabase(mixed $value, Driver $driver): ?string
     {
         if ($value === null || is_string($value)) {
@@ -103,6 +104,7 @@ class DateType extends BaseType implements BatchCastingInterface
      * @param \Cake\Database\Driver $driver Object from which database preferences and configuration will be extracted
      * @return \Cake\Chronos\ChronosDate|null
      */
+    #[\Override]
     public function toPHP(mixed $value, Driver $driver): ?ChronosDate
     {
         if ($value === null) {
@@ -124,6 +126,7 @@ class DateType extends BaseType implements BatchCastingInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function manyToPHP(array $values, array $fields, Driver $driver): array
     {
         foreach ($fields as $field) {
@@ -155,6 +158,7 @@ class DateType extends BaseType implements BatchCastingInterface
      * @param mixed $value Request data
      * @return \Cake\Chronos\ChronosDate|null
      */
+    #[\Override]
     public function marshal(mixed $value): ?ChronosDate
     {
         if ($value instanceof $this->_className) {

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -53,6 +53,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
      * @return string|float|int|null
      * @throws \InvalidArgumentException
      */
+    #[\Override]
     public function toDatabase(mixed $value, Driver $driver): string|float|int|null
     {
         if ($value === null || $value === '') {
@@ -85,6 +86,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return string|null
      */
+    #[\Override]
     public function toPHP(mixed $value, Driver $driver): ?string
     {
         if ($value === null) {
@@ -97,6 +99,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function manyToPHP(array $values, array $fields, Driver $driver): array
     {
         foreach ($fields as $field) {
@@ -113,6 +116,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function toStatement(mixed $value, Driver $driver): int
     {
         return PDO::PARAM_STR;
@@ -124,6 +128,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
      * @param mixed $value The value to convert.
      * @return string|null Converted value.
      */
+    #[\Override]
     public function marshal(mixed $value): ?string
     {
         if ($value === null || $value === '') {

--- a/src/Database/Type/EnumType.php
+++ b/src/Database/Type/EnumType.php
@@ -86,6 +86,7 @@ class EnumType extends BaseType
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return string|int|null
      */
+    #[\Override]
     public function toDatabase(mixed $value, Driver $driver): string|int|null
     {
         if ($value === null) {
@@ -131,6 +132,7 @@ class EnumType extends BaseType
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return \BackedEnum|null
      */
+    #[\Override]
     public function toPHP(mixed $value, Driver $driver): ?BackedEnum
     {
         if ($value === null) {
@@ -150,6 +152,7 @@ class EnumType extends BaseType
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function toStatement(mixed $value, Driver $driver): int
     {
         if ($this->backingType === 'int') {
@@ -165,6 +168,7 @@ class EnumType extends BaseType
      * @param mixed $value The value to convert.
      * @return \BackedEnum|null Converted value.
      */
+    #[\Override]
     public function marshal(mixed $value): ?BackedEnum
     {
         if ($value === null) {

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -50,6 +50,7 @@ class FloatType extends BaseType implements BatchCastingInterface
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return float|null
      */
+    #[\Override]
     public function toDatabase(mixed $value, Driver $driver): ?float
     {
         if ($value === null || $value === '') {
@@ -66,6 +67,7 @@ class FloatType extends BaseType implements BatchCastingInterface
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return float|null
      */
+    #[\Override]
     public function toPHP(mixed $value, Driver $driver): ?float
     {
         if ($value === null) {
@@ -78,6 +80,7 @@ class FloatType extends BaseType implements BatchCastingInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function manyToPHP(array $values, array $fields, Driver $driver): array
     {
         foreach ($fields as $field) {
@@ -94,6 +97,7 @@ class FloatType extends BaseType implements BatchCastingInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function toStatement(mixed $value, Driver $driver): int
     {
         return PDO::PARAM_STR;
@@ -105,6 +109,7 @@ class FloatType extends BaseType implements BatchCastingInterface
      * @param mixed $value The value to convert.
      * @return string|float|null Converted value.
      */
+    #[\Override]
     public function marshal(mixed $value): string|float|null
     {
         if ($value === null || $value === '') {

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -52,6 +52,7 @@ class IntegerType extends BaseType implements BatchCastingInterface
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return int|null
      */
+    #[\Override]
     public function toDatabase(mixed $value, Driver $driver): ?int
     {
         if ($value === null || $value === '') {
@@ -70,6 +71,7 @@ class IntegerType extends BaseType implements BatchCastingInterface
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return int|null
      */
+    #[\Override]
     public function toPHP(mixed $value, Driver $driver): ?int
     {
         if ($value === null) {
@@ -82,6 +84,7 @@ class IntegerType extends BaseType implements BatchCastingInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function manyToPHP(array $values, array $fields, Driver $driver): array
     {
         foreach ($fields as $field) {
@@ -100,6 +103,7 @@ class IntegerType extends BaseType implements BatchCastingInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function toStatement(mixed $value, Driver $driver): int
     {
         return PDO::PARAM_INT;
@@ -111,6 +115,7 @@ class IntegerType extends BaseType implements BatchCastingInterface
      * @param mixed $value The value to convert.
      * @return int|null Converted value.
      */
+    #[\Override]
     public function marshal(mixed $value): ?int
     {
         if ($value === '' || !is_numeric($value)) {

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -48,6 +48,7 @@ class JsonType extends BaseType implements BatchCastingInterface
      * @throws \InvalidArgumentException
      * @throws \JsonException
      */
+    #[\Override]
     public function toDatabase(mixed $value, Driver $driver): ?string
     {
         if (is_resource($value)) {
@@ -68,6 +69,7 @@ class JsonType extends BaseType implements BatchCastingInterface
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return mixed
      */
+    #[\Override]
     public function toPHP(mixed $value, Driver $driver): mixed
     {
         if (!is_string($value)) {
@@ -80,6 +82,7 @@ class JsonType extends BaseType implements BatchCastingInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function manyToPHP(array $values, array $fields, Driver $driver): array
     {
         foreach ($fields as $field) {
@@ -96,6 +99,7 @@ class JsonType extends BaseType implements BatchCastingInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function toStatement(mixed $value, Driver $driver): int
     {
         return PDO::PARAM_STR;
@@ -107,6 +111,7 @@ class JsonType extends BaseType implements BatchCastingInterface
      * @param mixed $value The value to convert.
      * @return mixed Converted value.
      */
+    #[\Override]
     public function marshal(mixed $value): mixed
     {
         return $value;

--- a/src/Database/Type/StringType.php
+++ b/src/Database/Type/StringType.php
@@ -35,6 +35,7 @@ class StringType extends BaseType implements OptionalConvertInterface
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return string|null
      */
+    #[\Override]
     public function toDatabase(mixed $value, Driver $driver): ?string
     {
         if ($value === null || is_string($value)) {
@@ -63,6 +64,7 @@ class StringType extends BaseType implements OptionalConvertInterface
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return string|null
      */
+    #[\Override]
     public function toPHP(mixed $value, Driver $driver): ?string
     {
         if ($value === null) {
@@ -75,6 +77,7 @@ class StringType extends BaseType implements OptionalConvertInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function toStatement(mixed $value, Driver $driver): int
     {
         return PDO::PARAM_STR;
@@ -86,6 +89,7 @@ class StringType extends BaseType implements OptionalConvertInterface
      * @param mixed $value The value to convert.
      * @return string|null Converted value.
      */
+    #[\Override]
     public function marshal(mixed $value): ?string
     {
         if ($value === null || is_array($value)) {
@@ -100,6 +104,7 @@ class StringType extends BaseType implements OptionalConvertInterface
      *
      * @return bool False as database results are returned already as strings
      */
+    #[\Override]
     public function requiresToPhpCast(): bool
     {
         return false;

--- a/src/Database/Type/TimeType.php
+++ b/src/Database/Type/TimeType.php
@@ -83,6 +83,7 @@ class TimeType extends BaseType implements BatchCastingInterface
      * @param mixed $value Request data
      * @return \Cake\Chronos\ChronosTime|null
      */
+    #[\Override]
     public function marshal(mixed $value): ?ChronosTime
     {
         if ($value instanceof $this->_className) {
@@ -133,6 +134,7 @@ class TimeType extends BaseType implements BatchCastingInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function manyToPHP(array $values, array $fields, Driver $driver): array
     {
         foreach ($fields as $field) {
@@ -155,6 +157,7 @@ class TimeType extends BaseType implements BatchCastingInterface
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return mixed
      */
+    #[\Override]
     public function toDatabase(mixed $value, Driver $driver): mixed
     {
         if ($value === null || is_string($value)) {
@@ -173,6 +176,7 @@ class TimeType extends BaseType implements BatchCastingInterface
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return \Cake\Chronos\ChronosTime|null
      */
+    #[\Override]
     public function toPHP(mixed $value, Driver $driver): ?ChronosTime
     {
         if ($value === null) {

--- a/src/Database/Type/UuidType.php
+++ b/src/Database/Type/UuidType.php
@@ -31,6 +31,7 @@ class UuidType extends StringType
      * @param \Cake\Database\Driver $driver object from which database preferences and configuration will be extracted
      * @return string|null
      */
+    #[\Override]
     public function toDatabase(mixed $value, Driver $driver): ?string
     {
         if ($value === null || $value === '' || $value === false) {
@@ -45,6 +46,7 @@ class UuidType extends StringType
      *
      * @return string A new primary key value.
      */
+    #[\Override]
     public function newId(): string
     {
         return Text::uuid();
@@ -56,6 +58,7 @@ class UuidType extends StringType
      * @param mixed $value The value to convert.
      * @return string|null Converted value.
      */
+    #[\Override]
     public function marshal(mixed $value): ?string
     {
         if ($value === null || $value === '' || is_array($value)) {

--- a/src/Datasource/ConnectionRegistry.php
+++ b/src/Datasource/ConnectionRegistry.php
@@ -37,6 +37,7 @@ class ConnectionRegistry extends ObjectRegistry
      * @param string $class Partial classname to resolve.
      * @return class-string<\Cake\Datasource\ConnectionInterface>|null Either the correct class name or null.
      */
+    #[\Override]
     protected function _resolveClassName(string $class): ?string
     {
         /** @var class-string<\Cake\Datasource\ConnectionInterface>|null */
@@ -53,6 +54,7 @@ class ConnectionRegistry extends ObjectRegistry
      * @return void
      * @throws \Cake\Datasource\Exception\MissingDatasourceException
      */
+    #[\Override]
     protected function _throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new MissingDatasourceException([
@@ -74,6 +76,7 @@ class ConnectionRegistry extends ObjectRegistry
      * @param array<string, mixed> $config An array of settings to use for the datasource.
      * @return \Cake\Datasource\ConnectionInterface A connection with the correct settings.
      */
+    #[\Override]
     protected function _create(object|string $class, string $alias, array $config): ConnectionInterface
     {
         if (is_string($class)) {
@@ -95,6 +98,7 @@ class ConnectionRegistry extends ObjectRegistry
      * @param string $name The adapter name.
      * @return $this
      */
+    #[\Override]
     public function unload(string $name)
     {
         unset($this->_loaded[$name]);

--- a/src/Datasource/Locator/AbstractLocator.php
+++ b/src/Datasource/Locator/AbstractLocator.php
@@ -47,6 +47,7 @@ abstract class AbstractLocator implements LocatorInterface
      * @throws \Cake\Core\Exception\CakeException When trying to get alias for which instance
      *   has already been created with different options.
      */
+    #[\Override]
     public function get(string $alias, array $options = []): RepositoryInterface
     {
         $storeOptions = $options;
@@ -80,6 +81,7 @@ abstract class AbstractLocator implements LocatorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function set(string $alias, RepositoryInterface $repository): RepositoryInterface
     {
         return $this->instances[$alias] = $repository;
@@ -88,6 +90,7 @@ abstract class AbstractLocator implements LocatorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function exists(string $alias): bool
     {
         return isset($this->instances[$alias]);
@@ -96,6 +99,7 @@ abstract class AbstractLocator implements LocatorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function remove(string $alias): void
     {
         unset(
@@ -107,6 +111,7 @@ abstract class AbstractLocator implements LocatorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function clear(): void
     {
         $this->instances = [];

--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -199,6 +199,7 @@ class NumericPaginator implements PaginatorInterface
      * @return \Cake\Datasource\Paging\PaginatedInterface
      * @throws \Cake\Datasource\Paging\Exception\PageOutOfBoundsException
      */
+    #[\Override]
     public function paginate(
         mixed $target,
         array $params = [],

--- a/src/Datasource/Paging/PaginatedResultSet.php
+++ b/src/Datasource/Paging/PaginatedResultSet.php
@@ -58,6 +58,7 @@ class PaginatedResultSet implements IteratorAggregate, JsonSerializable, Paginat
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function count(): int
     {
         return $this->params['count'];
@@ -80,6 +81,7 @@ class PaginatedResultSet implements IteratorAggregate, JsonSerializable, Paginat
      *
      * @return \Traversable<T> The paginated items result set.
      */
+    #[\Override]
     public function items(): Traversable
     {
         return $this->results;
@@ -90,6 +92,7 @@ class PaginatedResultSet implements IteratorAggregate, JsonSerializable, Paginat
      *
      * @return array
      */
+    #[\Override]
     public function jsonSerialize(): array
     {
         return iterator_to_array($this->items());
@@ -98,6 +101,7 @@ class PaginatedResultSet implements IteratorAggregate, JsonSerializable, Paginat
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function totalCount(): ?int
     {
         return $this->params['totalCount'];
@@ -106,6 +110,7 @@ class PaginatedResultSet implements IteratorAggregate, JsonSerializable, Paginat
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function perPage(): int
     {
         return $this->params['perPage'];
@@ -114,6 +119,7 @@ class PaginatedResultSet implements IteratorAggregate, JsonSerializable, Paginat
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function pageCount(): ?int
     {
         return $this->params['pageCount'];
@@ -122,6 +128,7 @@ class PaginatedResultSet implements IteratorAggregate, JsonSerializable, Paginat
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function currentPage(): int
     {
         return $this->params['currentPage'];
@@ -130,6 +137,7 @@ class PaginatedResultSet implements IteratorAggregate, JsonSerializable, Paginat
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function hasPrevPage(): bool
     {
         return $this->params['hasPrevPage'];
@@ -138,6 +146,7 @@ class PaginatedResultSet implements IteratorAggregate, JsonSerializable, Paginat
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function hasNextPage(): bool
     {
         return $this->params['hasNextPage'];
@@ -146,6 +155,7 @@ class PaginatedResultSet implements IteratorAggregate, JsonSerializable, Paginat
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function pagingParam(string $name): mixed
     {
         return $this->params[$name] ?? null;
@@ -154,6 +164,7 @@ class PaginatedResultSet implements IteratorAggregate, JsonSerializable, Paginat
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function pagingParams(): array
     {
         return $this->params;
@@ -162,6 +173,7 @@ class PaginatedResultSet implements IteratorAggregate, JsonSerializable, Paginat
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getIterator(): Traversable
     {
         return $this->results;

--- a/src/Datasource/Paging/SimplePaginator.php
+++ b/src/Datasource/Paging/SimplePaginator.php
@@ -37,6 +37,7 @@ class SimplePaginator extends NumericPaginator
      * @param array $data Paging data.
      * @return \Cake\Datasource\ResultSetInterface
      */
+    #[\Override]
     protected function getItems(QueryInterface $query, array $data): ResultSetInterface
     {
         return $query->limit($data['options']['limit'] + 1)->all();
@@ -45,6 +46,7 @@ class SimplePaginator extends NumericPaginator
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function buildParams(array $data): array
     {
         $hasNextPage = false;
@@ -70,6 +72,7 @@ class SimplePaginator extends NumericPaginator
      * @param array $pagingParams
      * @return \Cake\Datasource\Paging\PaginatedInterface
      */
+    #[\Override]
     protected function buildPaginated(ResultSetInterface $items, array $pagingParams): PaginatedInterface
     {
         if (count($items) > $this->pagingParams['perPage']) {
@@ -86,6 +89,7 @@ class SimplePaginator extends NumericPaginator
      * @param array $data Pagination data.
      * @return int|null
      */
+    #[\Override]
     protected function getCount(QueryInterface $query, array $data): ?int
     {
         return null;

--- a/src/Datasource/ResultSetDecorator.php
+++ b/src/Datasource/ResultSetDecorator.php
@@ -31,6 +31,7 @@ class ResultSetDecorator extends Collection implements ResultSetInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function __debugInfo(): array
     {
         $parentInfo = parent::__debugInfo();

--- a/src/Error/Debug/ArrayItemNode.php
+++ b/src/Error/Debug/ArrayItemNode.php
@@ -48,6 +48,7 @@ class ArrayItemNode implements NodeInterface
      *
      * @return \Cake\Error\Debug\NodeInterface
      */
+    #[\Override]
     public function getValue(): NodeInterface
     {
         return $this->value;
@@ -66,6 +67,7 @@ class ArrayItemNode implements NodeInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getChildren(): array
     {
         return [$this->value];

--- a/src/Error/Debug/ArrayNode.php
+++ b/src/Error/Debug/ArrayNode.php
@@ -54,6 +54,7 @@ class ArrayNode implements NodeInterface
      *
      * @return array<\Cake\Error\Debug\ArrayItemNode>
      */
+    #[\Override]
     public function getValue(): array
     {
         return $this->items;
@@ -64,6 +65,7 @@ class ArrayNode implements NodeInterface
      *
      * @return array<\Cake\Error\Debug\ArrayItemNode>
      */
+    #[\Override]
     public function getChildren(): array
     {
         return $this->items;

--- a/src/Error/Debug/ClassNode.php
+++ b/src/Error/Debug/ClassNode.php
@@ -64,6 +64,7 @@ class ClassNode implements NodeInterface
      *
      * @return string
      */
+    #[\Override]
     public function getValue(): string
     {
         return $this->class;
@@ -84,6 +85,7 @@ class ClassNode implements NodeInterface
      *
      * @return array<\Cake\Error\Debug\PropertyNode>
      */
+    #[\Override]
     public function getChildren(): array
     {
         return $this->properties;

--- a/src/Error/Debug/ConsoleFormatter.php
+++ b/src/Error/Debug/ConsoleFormatter.php
@@ -81,6 +81,7 @@ class ConsoleFormatter implements FormatterInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function formatWrapper(string $contents, array $location): string
     {
         $lineInfo = '';
@@ -104,6 +105,7 @@ class ConsoleFormatter implements FormatterInterface
      * @param \Cake\Error\Debug\NodeInterface $node The node tree to dump.
      * @return string
      */
+    #[\Override]
     public function dump(NodeInterface $node): string
     {
         $indent = 0;

--- a/src/Error/Debug/HtmlFormatter.php
+++ b/src/Error/Debug/HtmlFormatter.php
@@ -63,6 +63,7 @@ class HtmlFormatter implements FormatterInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function formatWrapper(string $contents, array $location): string
     {
         $lineInfo = '';
@@ -104,6 +105,7 @@ class HtmlFormatter implements FormatterInterface
      * @param \Cake\Error\Debug\NodeInterface $node The node tree to dump.
      * @return string
      */
+    #[\Override]
     public function dump(NodeInterface $node): string
     {
         $html = $this->export($node, 0);

--- a/src/Error/Debug/PropertyNode.php
+++ b/src/Error/Debug/PropertyNode.php
@@ -55,6 +55,7 @@ class PropertyNode implements NodeInterface
      *
      * @return \Cake\Error\Debug\NodeInterface
      */
+    #[\Override]
     public function getValue(): NodeInterface
     {
         return $this->value;
@@ -83,6 +84,7 @@ class PropertyNode implements NodeInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getChildren(): array
     {
         return [$this->value];

--- a/src/Error/Debug/ReferenceNode.php
+++ b/src/Error/Debug/ReferenceNode.php
@@ -52,6 +52,7 @@ class ReferenceNode implements NodeInterface
      *
      * @return string
      */
+    #[\Override]
     public function getValue(): string
     {
         return $this->class;
@@ -70,6 +71,7 @@ class ReferenceNode implements NodeInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getChildren(): array
     {
         return [];

--- a/src/Error/Debug/ScalarNode.php
+++ b/src/Error/Debug/ScalarNode.php
@@ -58,6 +58,7 @@ class ScalarNode implements NodeInterface
      *
      * @return resource|string|float|int|bool|null
      */
+    #[\Override]
     public function getValue(): mixed
     {
         return $this->value;
@@ -66,6 +67,7 @@ class ScalarNode implements NodeInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getChildren(): array
     {
         return [];

--- a/src/Error/Debug/SpecialNode.php
+++ b/src/Error/Debug/SpecialNode.php
@@ -41,6 +41,7 @@ class SpecialNode implements NodeInterface
      *
      * @return string
      */
+    #[\Override]
     public function getValue(): string
     {
         return $this->value;
@@ -49,6 +50,7 @@ class SpecialNode implements NodeInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getChildren(): array
     {
         return [];

--- a/src/Error/Debug/TextFormatter.php
+++ b/src/Error/Debug/TextFormatter.php
@@ -31,6 +31,7 @@ class TextFormatter implements FormatterInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function formatWrapper(string $contents, array $location): string
     {
         $template = <<<TEXT
@@ -54,6 +55,7 @@ TEXT;
      * @param \Cake\Error\Debug\NodeInterface $node The node tree to dump.
      * @return string
      */
+    #[\Override]
     public function dump(NodeInterface $node): string
     {
         $indent = 0;

--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -58,6 +58,7 @@ class ErrorLogger implements ErrorLoggerInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function log($level, Stringable|string $message, array $context = []): void
     {
         Log::write($level, $message, $context);
@@ -66,6 +67,7 @@ class ErrorLogger implements ErrorLoggerInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function logError(PhpError $error, ?ServerRequestInterface $request = null, bool $includeTrace = false): void
     {
         $message = $this->getErrorMessage($error, $includeTrace);
@@ -112,6 +114,7 @@ class ErrorLogger implements ErrorLoggerInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function logException(
         Throwable $exception,
         ?ServerRequestInterface $request = null,

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -109,6 +109,7 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
      * @return \Psr\Http\Message\ResponseInterface A response
      */
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         try {

--- a/src/Error/Renderer/ConsoleErrorRenderer.php
+++ b/src/Error/Renderer/ConsoleErrorRenderer.php
@@ -56,6 +56,7 @@ class ConsoleErrorRenderer implements ErrorRendererInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function write(string $out): void
     {
         $this->output->write($out);
@@ -64,6 +65,7 @@ class ConsoleErrorRenderer implements ErrorRendererInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function render(PhpError $error, bool $debug): string
     {
         $trace = '';

--- a/src/Error/Renderer/ConsoleExceptionRenderer.php
+++ b/src/Error/Renderer/ConsoleExceptionRenderer.php
@@ -66,6 +66,7 @@ class ConsoleExceptionRenderer implements ExceptionRendererInterface
      *
      * @return \Psr\Http\Message\ResponseInterface|string
      */
+    #[\Override]
     public function render(): ResponseInterface|string
     {
         $exceptions = [$this->error];
@@ -132,6 +133,7 @@ class ConsoleExceptionRenderer implements ExceptionRendererInterface
      * @param \Psr\Http\Message\ResponseInterface|string $output The output to print.
      * @return void
      */
+    #[\Override]
     public function write(ResponseInterface|string $output): void
     {
         if (is_string($output)) {

--- a/src/Error/Renderer/HtmlErrorRenderer.php
+++ b/src/Error/Renderer/HtmlErrorRenderer.php
@@ -31,6 +31,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function write(string $out): void
     {
         // Output to stdout which is the server response.
@@ -40,6 +41,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function render(PhpError $error, bool $debug): string
     {
         if (!$debug) {

--- a/src/Error/Renderer/TextErrorRenderer.php
+++ b/src/Error/Renderer/TextErrorRenderer.php
@@ -29,6 +29,7 @@ class TextErrorRenderer implements ErrorRendererInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function write(string $out): void
     {
         echo $out;
@@ -37,6 +38,7 @@ class TextErrorRenderer implements ErrorRendererInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function render(PhpError $error, bool $debug): string
     {
         if (!$debug) {

--- a/src/Error/Renderer/TextExceptionRenderer.php
+++ b/src/Error/Renderer/TextExceptionRenderer.php
@@ -47,6 +47,7 @@ class TextExceptionRenderer implements ExceptionRendererInterface
      *
      * @return \Psr\Http\Message\ResponseInterface|string
      */
+    #[\Override]
     public function render(): ResponseInterface|string
     {
         return sprintf(
@@ -65,6 +66,7 @@ class TextExceptionRenderer implements ExceptionRendererInterface
      * @param \Psr\Http\Message\ResponseInterface|string $output The output to print.
      * @return void
      */
+    #[\Override]
     public function write(ResponseInterface|string $output): void
     {
         assert(is_string($output));

--- a/src/Error/Renderer/WebExceptionRenderer.php
+++ b/src/Error/Renderer/WebExceptionRenderer.php
@@ -210,6 +210,7 @@ class WebExceptionRenderer implements ExceptionRendererInterface
      *
      * @return \Psr\Http\Message\ResponseInterface The response to be sent.
      */
+    #[\Override]
     public function render(): ResponseInterface
     {
         $exception = $this->error;
@@ -283,6 +284,7 @@ class WebExceptionRenderer implements ExceptionRendererInterface
      * @param \Psr\Http\Message\ResponseInterface|string $output The response to output.
      * @return void
      */
+    #[\Override]
     public function write(ResponseInterface|string $output): void
     {
         if (is_string($output)) {

--- a/src/Event/Decorator/ConditionDecorator.php
+++ b/src/Event/Decorator/ConditionDecorator.php
@@ -30,6 +30,7 @@ class ConditionDecorator extends AbstractDecorator
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function __invoke(mixed ...$args): mixed
     {
         if (!$this->canTrigger($args[0])) {

--- a/src/Event/Decorator/SubjectFilterDecorator.php
+++ b/src/Event/Decorator/SubjectFilterDecorator.php
@@ -33,6 +33,7 @@ class SubjectFilterDecorator extends AbstractDecorator
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function __invoke(mixed ...$args): mixed
     {
         if (!$this->canTrigger($args[0])) {

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -93,6 +93,7 @@ class Event implements EventInterface
      *
      * @return string
      */
+    #[\Override]
     public function getName(): string
     {
         return $this->_name;
@@ -107,6 +108,7 @@ class Event implements EventInterface
      * @throws \Cake\Core\Exception\CakeException
      * @psalm-return TSubject
      */
+    #[\Override]
     public function getSubject(): object
     {
         if ($this->_subject === null) {
@@ -121,6 +123,7 @@ class Event implements EventInterface
      *
      * @return void
      */
+    #[\Override]
     public function stopPropagation(): void
     {
         $this->_stopped = true;
@@ -131,6 +134,7 @@ class Event implements EventInterface
      *
      * @return bool True if the event is stopped
      */
+    #[\Override]
     public function isStopped(): bool
     {
         return $this->_stopped;
@@ -141,6 +145,7 @@ class Event implements EventInterface
      *
      * @return mixed
      */
+    #[\Override]
     public function getResult(): mixed
     {
         return $this->result;
@@ -154,6 +159,7 @@ class Event implements EventInterface
      * @param mixed $value The value to set.
      * @return $this
      */
+    #[\Override]
     public function setResult(mixed $value = null)
     {
         $this->result = $value;
@@ -164,6 +170,7 @@ class Event implements EventInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getData(?string $key = null): mixed
     {
         if ($key !== null) {
@@ -176,6 +183,7 @@ class Event implements EventInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setData(array|string $key, $value = null)
     {
         if (is_array($key)) {

--- a/src/Event/EventList.php
+++ b/src/Event/EventList.php
@@ -61,6 +61,7 @@ class EventList implements ArrayAccess, Countable
      * @param mixed $offset An offset to check for.
      * @return bool True on success or false on failure.
      */
+    #[\Override]
     public function offsetExists(mixed $offset): bool
     {
         return isset($this->_events[$offset]);
@@ -73,6 +74,7 @@ class EventList implements ArrayAccess, Countable
      * @param mixed $offset The offset to retrieve.
      * @return \Cake\Event\EventInterface<object>|null
      */
+    #[\Override]
     public function offsetGet(mixed $offset): ?EventInterface
     {
         if (!$this->offsetExists($offset)) {
@@ -90,6 +92,7 @@ class EventList implements ArrayAccess, Countable
      * @param mixed $value The value to set.
      * @return void
      */
+    #[\Override]
     public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->_events[$offset] = $value;
@@ -102,6 +105,7 @@ class EventList implements ArrayAccess, Countable
      * @param mixed $offset The offset to unset.
      * @return void
      */
+    #[\Override]
     public function offsetUnset(mixed $offset): void
     {
         unset($this->_events[$offset]);
@@ -113,6 +117,7 @@ class EventList implements ArrayAccess, Countable
      * @link https://secure.php.net/manual/en/countable.count.php
      * @return int The custom count as an integer.
      */
+    #[\Override]
     public function count(): int
     {
         return count($this->_events);

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -99,6 +99,7 @@ class EventManager implements EventManagerInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function on(
         EventListenerInterface|string $eventKey,
         callable|array $options = [],
@@ -153,6 +154,7 @@ class EventManager implements EventManagerInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function off(
         EventListenerInterface|callable|string $eventKey,
         EventListenerInterface|callable|null $callable = null,
@@ -286,6 +288,7 @@ class EventManager implements EventManagerInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function dispatch(EventInterface|string $event): EventInterface
     {
         if (is_string($event)) {
@@ -346,6 +349,7 @@ class EventManager implements EventManagerInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function listeners(string $eventKey): array
     {
         $localListeners = [];

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -122,6 +122,7 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         if (method_exists($this, 'buildValidator')) {

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -119,11 +119,13 @@ abstract class BaseApplication implements
      * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to set in your App Class
      * @return \Cake\Http\MiddlewareQueue
      */
+    #[\Override]
     abstract public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue;
 
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function pluginMiddleware(MiddlewareQueue $middleware): MiddlewareQueue
     {
         foreach ($this->plugins->with('middleware') as $plugin) {
@@ -136,6 +138,7 @@ abstract class BaseApplication implements
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function addPlugin($name, array $config = [])
     {
         if (is_string($name)) {
@@ -181,6 +184,7 @@ abstract class BaseApplication implements
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function bootstrap(): void
     {
         require_once $this->configDir . 'bootstrap.php';
@@ -195,6 +199,7 @@ abstract class BaseApplication implements
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function pluginBootstrap(): void
     {
         foreach ($this->plugins->with('bootstrap') as $plugin) {
@@ -210,6 +215,7 @@ abstract class BaseApplication implements
      * @param \Cake\Routing\RouteBuilder $routes A route builder to add routes into.
      * @return void
      */
+    #[\Override]
     public function routes(RouteBuilder $routes): void
     {
         // Only load routes if the router is empty
@@ -224,6 +230,7 @@ abstract class BaseApplication implements
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function pluginRoutes(RouteBuilder $routes): RouteBuilder
     {
         foreach ($this->plugins->with('routes') as $plugin) {
@@ -242,6 +249,7 @@ abstract class BaseApplication implements
      * @param \Cake\Console\CommandCollection $commands The CommandCollection to add commands into.
      * @return \Cake\Console\CommandCollection The updated collection.
      */
+    #[\Override]
     public function console(CommandCollection $commands): CommandCollection
     {
         return $commands->addMany($commands->autoDiscover());
@@ -250,6 +258,7 @@ abstract class BaseApplication implements
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function pluginConsole(CommandCollection $commands): CommandCollection
     {
         foreach ($this->plugins->with('console') as $plugin) {
@@ -263,6 +272,7 @@ abstract class BaseApplication implements
      * @param \Cake\Event\EventManagerInterface $eventManager The global event manager to register listeners on
      * @return \Cake\Event\EventManagerInterface
      */
+    #[\Override]
     public function pluginEvents(EventManagerInterface $eventManager): EventManagerInterface
     {
         foreach ($this->plugins->with('events') as $plugin) {
@@ -280,6 +290,7 @@ abstract class BaseApplication implements
      *
      * @return \Cake\Core\ContainerInterface
      */
+    #[\Override]
     public function getContainer(): ContainerInterface
     {
         return $this->container ??= $this->buildContainer();
@@ -315,6 +326,7 @@ abstract class BaseApplication implements
      * @param \Cake\Core\ContainerInterface $container The Container to update.
      * @return void
      */
+    #[\Override]
     public function services(ContainerInterface $container): void
     {
     }
@@ -325,6 +337,7 @@ abstract class BaseApplication implements
      * @param \Cake\Event\EventManagerInterface $eventManager The global event manager to register listeners on
      * @return \Cake\Event\EventManagerInterface
      */
+    #[\Override]
     public function events(EventManagerInterface $eventManager): EventManagerInterface
     {
         return $eventManager;
@@ -340,6 +353,7 @@ abstract class BaseApplication implements
      * @param \Psr\Http\Message\ServerRequestInterface $request The request
      * @return \Psr\Http\Message\ResponseInterface
      */
+    #[\Override]
     public function handle(
         ServerRequestInterface $request,
     ): ResponseInterface {

--- a/src/Http/CallbackStream.php
+++ b/src/Http/CallbackStream.php
@@ -36,6 +36,7 @@ class CallbackStream extends BaseCallbackStream
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getContents(): string
     {
         $callback = $this->detach();

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -465,6 +465,7 @@ class Client implements EventDispatcherInterface, ClientInterface
      * @return \Psr\Http\Message\ResponseInterface Response instance.
      * @throws \Psr\Http\Client\ClientExceptionInterface If an error happens while processing the request.
      */
+    #[\Override]
     public function sendRequest(RequestInterface $request): ResponseInterface
     {
         return $this->send($request, $this->_config);

--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -39,6 +39,7 @@ class Curl implements AdapterInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function send(RequestInterface $request, array $options): array
     {
         if (!extension_loaded('curl')) {

--- a/src/Http/Client/Adapter/Mock.php
+++ b/src/Http/Client/Adapter/Mock.php
@@ -74,6 +74,7 @@ class Mock implements AdapterInterface
      * @param array<string, mixed> $options Unused.
      * @return array<\Cake\Http\Client\Response> The matched response or an empty array for no matches.
      */
+    #[\Override]
     public function send(RequestInterface $request, array $options): array
     {
         $found = null;

--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -69,6 +69,7 @@ class Stream implements AdapterInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function send(RequestInterface $request, array $options): array
     {
         $this->_stream = null;

--- a/src/Http/Client/ClientEvent.php
+++ b/src/Http/Client/ClientEvent.php
@@ -51,6 +51,7 @@ class ClientEvent extends Event
      *
      * @return \Cake\Http\Client\Response|null
      */
+    #[\Override]
     public function getResult(): ?Response
     {
         return $this->result;
@@ -62,6 +63,7 @@ class ClientEvent extends Event
      * @param mixed $value The value to set.
      * @return $this
      */
+    #[\Override]
     public function setResult(mixed $value = null)
     {
         if ($value !== null && !$value instanceof Response) {

--- a/src/Http/Client/Exception/NetworkException.php
+++ b/src/Http/Client/Exception/NetworkException.php
@@ -54,6 +54,7 @@ class NetworkException extends RuntimeException implements NetworkExceptionInter
      *
      * @return \Psr\Http\Message\RequestInterface
      */
+    #[\Override]
     public function getRequest(): RequestInterface
     {
         return $this->request;

--- a/src/Http/Client/Exception/RequestException.php
+++ b/src/Http/Client/Exception/RequestException.php
@@ -55,6 +55,7 @@ class RequestException extends RuntimeException implements RequestExceptionInter
      *
      * @return \Psr\Http\Message\RequestInterface
      */
+    #[\Override]
     public function getRequest(): RequestInterface
     {
         return $this->request;

--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -207,6 +207,7 @@ class FormData implements Countable, Stringable
      *
      * @return int
      */
+    #[\Override]
     public function count(): int
     {
         return count($this->_parts);
@@ -260,6 +261,7 @@ class FormData implements Countable, Stringable
      *
      * @return string
      */
+    #[\Override]
     public function __toString(): string
     {
         if ($this->isMultipart()) {

--- a/src/Http/Client/FormDataPart.php
+++ b/src/Http/Client/FormDataPart.php
@@ -183,6 +183,7 @@ class FormDataPart implements Stringable
      *
      * @return string
      */
+    #[\Override]
     public function __toString(): string
     {
         $out = '';

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -250,6 +250,7 @@ class Response extends Message implements ResponseInterface
      *
      * @return int The status code.
      */
+    #[\Override]
     public function getStatusCode(): int
     {
         return $this->code;
@@ -262,6 +263,7 @@ class Response extends Message implements ResponseInterface
      * @param string $reasonPhrase The status reason phrase.
      * @return static A copy of the current object with an updated status code.
      */
+    #[\Override]
     public function withStatus(int $code, string $reasonPhrase = ''): static
     {
         $new = clone $this;
@@ -276,6 +278,7 @@ class Response extends Message implements ResponseInterface
      *
      * @return string The current reason phrase.
      */
+    #[\Override]
     public function getReasonPhrase(): string
     {
         return $this->reasonPhrase;

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -335,6 +335,7 @@ class Cookie implements CookieInterface
      *
      * @return string
      */
+    #[\Override]
     public function toHeaderValue(): string
     {
         $value = $this->value;
@@ -373,6 +374,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function withName(string $name): static
     {
         $this->validateName($name);
@@ -385,6 +387,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getId(): string
     {
         return "{$this->name};{$this->domain};{$this->path}";
@@ -393,6 +396,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getName(): string
     {
         return $this->name;
@@ -422,6 +426,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getValue(): array|string
     {
         return $this->value;
@@ -430,6 +435,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getScalarValue(): string
     {
         if ($this->isExpanded) {
@@ -446,6 +452,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function withValue(array|string|float|int|bool $value): static
     {
         $new = clone $this;
@@ -469,6 +476,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function withPath(string $path): static
     {
         $new = clone $this;
@@ -480,6 +488,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getPath(): string
     {
         return $this->path;
@@ -488,6 +497,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function withDomain(string $domain): static
     {
         $new = clone $this;
@@ -499,6 +509,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getDomain(): string
     {
         return $this->domain;
@@ -507,6 +518,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function isSecure(): bool
     {
         return $this->secure;
@@ -515,6 +527,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function withSecure(bool $secure): static
     {
         $new = clone $this;
@@ -526,6 +539,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function withHttpOnly(bool $httpOnly): static
     {
         $new = clone $this;
@@ -537,6 +551,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function isHttpOnly(): bool
     {
         return $this->httpOnly;
@@ -545,6 +560,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function withExpiry(DateTimeInterface $dateTime): static
     {
         if ($dateTime instanceof DateTime) {
@@ -560,6 +576,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getExpiry(): ?DateTimeInterface
     {
         return $this->expiresAt;
@@ -568,6 +585,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getExpiresTimestamp(): ?int
     {
         if (!$this->expiresAt) {
@@ -580,6 +598,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getFormattedExpires(): string
     {
         if (!$this->expiresAt) {
@@ -592,6 +611,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function isExpired(?DateTimeInterface $time = null): bool
     {
         $time = $time ?: new DateTimeImmutable('now', new DateTimeZone('UTC'));
@@ -609,6 +629,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function withNeverExpire(): static
     {
         $new = clone $this;
@@ -620,6 +641,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function withExpired(): static
     {
         $new = clone $this;
@@ -631,6 +653,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getSameSite(): ?SameSiteEnum
     {
         return $this->sameSite;
@@ -639,6 +662,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function withSameSite(SameSiteEnum|string|null $sameSite): static
     {
         $new = clone $this;
@@ -764,6 +788,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getOptions(): array
     {
         $options = [
@@ -784,6 +809,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function toArray(): array
     {
         return [

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -102,6 +102,7 @@ class CookieCollection implements IteratorAggregate, Countable
      *
      * @return int
      */
+    #[\Override]
     public function count(): int
     {
         return count($this->cookies);
@@ -237,6 +238,7 @@ class CookieCollection implements IteratorAggregate, Countable
      *
      * @return \Traversable<string, \Cake\Http\Cookie\CookieInterface>
      */
+    #[\Override]
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->cookies);

--- a/src/Http/Middleware/BodyParserMiddleware.php
+++ b/src/Http/Middleware/BodyParserMiddleware.php
@@ -151,6 +151,7 @@ class BodyParserMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
      * @return \Psr\Http\Message\ResponseInterface A response.
      */
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if (!in_array($request->getMethod(), $this->methods, true)) {

--- a/src/Http/Middleware/ClosureDecoratorMiddleware.php
+++ b/src/Http/Middleware/ClosureDecoratorMiddleware.php
@@ -62,6 +62,7 @@ class ClosureDecoratorMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Server\RequestHandlerInterface $handler Request handler instance.
      * @return \Psr\Http\Message\ResponseInterface
      */
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         return ($this->callable)(

--- a/src/Http/Middleware/CspMiddleware.php
+++ b/src/Http/Middleware/CspMiddleware.php
@@ -81,6 +81,7 @@ class CspMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
      * @return \Psr\Http\Message\ResponseInterface A response.
      */
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if ($this->getConfig('scriptNonce')) {

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -118,6 +118,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
      * @return \Psr\Http\Message\ResponseInterface A response.
      */
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $method = $request->getMethod();

--- a/src/Http/Middleware/EncryptedCookieMiddleware.php
+++ b/src/Http/Middleware/EncryptedCookieMiddleware.php
@@ -84,6 +84,7 @@ class EncryptedCookieMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
      * @return \Psr\Http\Message\ResponseInterface A response.
      */
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if ($request->getCookieParams()) {
@@ -108,6 +109,7 @@ class EncryptedCookieMiddleware implements MiddlewareInterface
      *
      * @return string
      */
+    #[\Override]
     protected function _getCookieEncryptionKey(): string
     {
         return $this->key;

--- a/src/Http/Middleware/HttpsEnforcerMiddleware.php
+++ b/src/Http/Middleware/HttpsEnforcerMiddleware.php
@@ -81,6 +81,7 @@ class HttpsEnforcerMiddleware implements MiddlewareInterface
      * @return \Psr\Http\Message\ResponseInterface A response.
      * @throws \Cake\Http\Exception\BadRequestException
      */
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if ($request instanceof ServerRequest && is_array($this->config['trustedProxies'])) {

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -269,6 +269,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
      * @return \Psr\Http\Message\ResponseInterface A response.
      */
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);

--- a/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
@@ -94,6 +94,7 @@ class SessionCsrfProtectionMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
      * @return \Psr\Http\Message\ResponseInterface A response.
      */
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $method = $request->getMethod();

--- a/src/Http/MiddlewareApplication.php
+++ b/src/Http/MiddlewareApplication.php
@@ -35,11 +35,13 @@ abstract class MiddlewareApplication implements HttpApplicationInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     abstract public function bootstrap(): void;
 
     /**
      * @inheritDoc
      */
+    #[\Override]
     abstract public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue;
 
     /**
@@ -48,6 +50,7 @@ abstract class MiddlewareApplication implements HttpApplicationInterface
      * @param \Psr\Http\Message\ServerRequestInterface $request The request
      * @return \Psr\Http\Message\ResponseInterface
      */
+    #[\Override]
     public function handle(
         ServerRequestInterface $request,
     ): ResponseInterface {

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -239,6 +239,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      *
      * @return int
      */
+    #[\Override]
     public function count(): int
     {
         return count($this->queue);
@@ -251,6 +252,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return void
      * @see \SeekableIterator::seek()
      */
+    #[\Override]
     public function seek(int $position): void
     {
         if (!isset($this->queue[$position])) {
@@ -266,6 +268,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return void
      * @see \Iterator::rewind()
      */
+    #[\Override]
     public function rewind(): void
     {
         $this->position = 0;
@@ -277,6 +280,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return \Psr\Http\Server\MiddlewareInterface
      * @see \Iterator::current()
      */
+    #[\Override]
     public function current(): MiddlewareInterface
     {
         if (!isset($this->queue[$this->position])) {
@@ -296,6 +300,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return int
      * @see \Iterator::key()
      */
+    #[\Override]
     public function key(): int
     {
         return $this->position;
@@ -307,6 +312,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return void
      * @see \Iterator::next()
      */
+    #[\Override]
     public function next(): void
     {
         ++$this->position;
@@ -318,6 +324,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return bool
      * @see \Iterator::valid()
      */
+    #[\Override]
     public function valid(): bool
     {
         return isset($this->queue[$this->position]);

--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -33,6 +33,7 @@ class RequestFactory implements RequestFactoryInterface
      * @return \Psr\Http\Message\RequestInterface
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function createRequest(string $method, $uri): RequestInterface
     {
         return new Request($uri, $method);

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -339,6 +339,7 @@ class Response implements ResponseInterface, Stringable
      *
      * @return int Status code.
      */
+    #[\Override]
     public function getStatusCode(): int
     {
         return $this->_status;
@@ -373,6 +374,7 @@ class Response implements ResponseInterface, Stringable
      * @return static
      * @throws \InvalidArgumentException For invalid status code arguments.
      */
+    #[\Override]
     public function withStatus(int $code, string $reasonPhrase = ''): static
     {
         $new = clone $this;
@@ -423,6 +425,7 @@ class Response implements ResponseInterface, Stringable
      * @link https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
      * @return string Reason phrase; must return an empty string if none present.
      */
+    #[\Override]
     public function getReasonPhrase(): string
     {
         return $this->_reasonPhrase;
@@ -964,6 +967,7 @@ class Response implements ResponseInterface, Stringable
      *
      * @return string
      */
+    #[\Override]
     public function __toString(): string
     {
         $this->stream->rewind();

--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -32,6 +32,7 @@ class ResponseFactory implements ResponseFactoryInterface
      *   in the generated response. If none is provided, implementations MAY use
      *   the defaults as suggested in the HTTP specification.
      */
+    #[\Override]
     public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface
     {
         return (new Response())->withStatus($code, $reasonPhrase);

--- a/src/Http/Runner.php
+++ b/src/Http/Runner.php
@@ -66,6 +66,7 @@ class Runner implements RequestHandlerInterface
      * @param \Psr\Http\Message\ServerRequestInterface $request The server request
      * @return \Psr\Http\Message\ResponseInterface An updated response
      */
+    #[\Override]
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         if (

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -175,6 +175,7 @@ class Server implements EventDispatcherInterface
      *
      * @return \Cake\Event\EventManagerInterface
      */
+    #[\Override]
     public function getEventManager(): EventManagerInterface
     {
         if ($this->app instanceof EventDispatcherInterface) {
@@ -193,6 +194,7 @@ class Server implements EventDispatcherInterface
      * @return $this
      * @throws \InvalidArgumentException
      */
+    #[\Override]
     public function setEventManager(EventManagerInterface $eventManager)
     {
         if ($this->app instanceof EventDispatcherInterface) {

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -799,6 +799,7 @@ class ServerRequest implements ServerRequestInterface
      * @return array<string, array<string>> An associative array of headers and their values.
      * @link https://www.php-fig.org/psr/psr-7/ This method is part of the PSR-7 server request interface.
      */
+    #[\Override]
     public function getHeaders(): array
     {
         $headers = [];
@@ -827,6 +828,7 @@ class ServerRequest implements ServerRequestInterface
      * @return bool Whether the header is defined.
      * @link https://www.php-fig.org/psr/psr-7/ This method is part of the PSR-7 server request interface.
      */
+    #[\Override]
     public function hasHeader(string $name): bool
     {
         $name = $this->normalizeHeaderName($name);
@@ -845,6 +847,7 @@ class ServerRequest implements ServerRequestInterface
      *   If the header doesn't exist, an empty array will be returned.
      * @link https://www.php-fig.org/psr/psr-7/ This method is part of the PSR-7 server request interface.
      */
+    #[\Override]
     public function getHeader(string $name): array
     {
         $name = $this->normalizeHeaderName($name);
@@ -862,6 +865,7 @@ class ServerRequest implements ServerRequestInterface
      * @return string Header values collapsed into a comma separated string.
      * @link https://www.php-fig.org/psr/psr-7/ This method is part of the PSR-7 server request interface.
      */
+    #[\Override]
     public function getHeaderLine(string $name): string
     {
         $value = $this->getHeader($name);
@@ -878,6 +882,7 @@ class ServerRequest implements ServerRequestInterface
      * @link https://www.php-fig.org/psr/psr-7/ This method is part of the PSR-7 server request interface.
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function withHeader(string $name, $value): static
     {
         $new = clone $this;
@@ -899,6 +904,7 @@ class ServerRequest implements ServerRequestInterface
      * @link https://www.php-fig.org/psr/psr-7/ This method is part of the PSR-7 server request interface.
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function withAddedHeader(string $name, $value): static
     {
         $new = clone $this;
@@ -920,6 +926,7 @@ class ServerRequest implements ServerRequestInterface
      * @return static
      * @link https://www.php-fig.org/psr/psr-7/ This method is part of the PSR-7 server request interface.
      */
+    #[\Override]
     public function withoutHeader(string $name): static
     {
         $new = clone $this;
@@ -943,6 +950,7 @@ class ServerRequest implements ServerRequestInterface
      * @return string The name of the HTTP method used.
      * @link https://www.php-fig.org/psr/psr-7/ This method is part of the PSR-7 server request interface.
      */
+    #[\Override]
     public function getMethod(): string
     {
         return (string)$this->getEnv('REQUEST_METHOD');
@@ -955,6 +963,7 @@ class ServerRequest implements ServerRequestInterface
      * @return static A new instance with the updated method.
      * @link https://www.php-fig.org/psr/psr-7/ This method is part of the PSR-7 server request interface.
      */
+    #[\Override]
     public function withMethod(string $method): static
     {
         $new = clone $this;
@@ -979,6 +988,7 @@ class ServerRequest implements ServerRequestInterface
      * @return array
      * @link https://www.php-fig.org/psr/psr-7/ This method is part of the PSR-7 server request interface.
      */
+    #[\Override]
     public function getServerParams(): array
     {
         return $this->_environment;
@@ -991,6 +1001,7 @@ class ServerRequest implements ServerRequestInterface
      * @return array
      * @link https://www.php-fig.org/psr/psr-7/ This method is part of the PSR-7 server request interface.
      */
+    #[\Override]
     public function getQueryParams(): array
     {
         return $this->query;
@@ -1003,6 +1014,7 @@ class ServerRequest implements ServerRequestInterface
      * @return static A new instance with the updated query string data.
      * @link https://www.php-fig.org/psr/psr-7/ This method is part of the PSR-7 server request interface.
      */
+    #[\Override]
     public function withQueryParams(array $query): static
     {
         $new = clone $this;
@@ -1282,6 +1294,7 @@ class ServerRequest implements ServerRequestInterface
      *
      * @return array<string, mixed> An array of cookie data.
      */
+    #[\Override]
     public function getCookieParams(): array
     {
         return $this->cookies;
@@ -1293,6 +1306,7 @@ class ServerRequest implements ServerRequestInterface
      * @param array $cookies The new cookie data to use.
      * @return static
      */
+    #[\Override]
     public function withCookieParams(array $cookies): static
     {
         $new = clone $this;
@@ -1312,6 +1326,7 @@ class ServerRequest implements ServerRequestInterface
      * @return object|array|null The deserialized body parameters, if any.
      *     These will typically be an array.
      */
+    #[\Override]
     public function getParsedBody(): object|array|null
     {
         return $this->data;
@@ -1325,6 +1340,7 @@ class ServerRequest implements ServerRequestInterface
      * @return static
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function withParsedBody($data): static
     {
         $new = clone $this;
@@ -1338,6 +1354,7 @@ class ServerRequest implements ServerRequestInterface
      *
      * @return string HTTP protocol version.
      */
+    #[\Override]
     public function getProtocolVersion(): string
     {
         if ($this->protocol) {
@@ -1364,6 +1381,7 @@ class ServerRequest implements ServerRequestInterface
      * @param string $version HTTP protocol version
      * @return static
      */
+    #[\Override]
     public function withProtocolVersion(string $version): static
     {
         if (!preg_match('/^(1\.[01]|2)$/', $version)) {
@@ -1524,6 +1542,7 @@ class ServerRequest implements ServerRequestInterface
      * @param mixed $value The value of the attribute.
      * @return static
      */
+    #[\Override]
     public function withAttribute(string $name, mixed $value): static
     {
         $new = clone $this;
@@ -1543,6 +1562,7 @@ class ServerRequest implements ServerRequestInterface
      * @return static
      * @throws \InvalidArgumentException
      */
+    #[\Override]
     public function withoutAttribute(string $name): static
     {
         $new = clone $this;
@@ -1563,6 +1583,7 @@ class ServerRequest implements ServerRequestInterface
      * @param mixed $default The default value if the attribute has not been set.
      * @return mixed
      */
+    #[\Override]
     public function getAttribute(string $name, mixed $default = null): mixed
     {
         if (in_array($name, $this->emulatedAttributes, true)) {
@@ -1587,6 +1608,7 @@ class ServerRequest implements ServerRequestInterface
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function getAttributes(): array
     {
         $emulated = [
@@ -1620,6 +1642,7 @@ class ServerRequest implements ServerRequestInterface
      *
      * @return array
      */
+    #[\Override]
     public function getUploadedFiles(): array
     {
         return $this->uploadedFiles;
@@ -1632,6 +1655,7 @@ class ServerRequest implements ServerRequestInterface
      * @return static
      * @throws \InvalidArgumentException when $files contains an invalid object.
      */
+    #[\Override]
     public function withUploadedFiles(array $uploadedFiles): static
     {
         $this->validateUploadedFiles($uploadedFiles, '');
@@ -1668,6 +1692,7 @@ class ServerRequest implements ServerRequestInterface
      *
      * @return \Psr\Http\Message\StreamInterface Returns the body as a stream.
      */
+    #[\Override]
     public function getBody(): StreamInterface
     {
         return $this->stream;
@@ -1679,6 +1704,7 @@ class ServerRequest implements ServerRequestInterface
      * @param \Psr\Http\Message\StreamInterface $body The new request body
      * @return static
      */
+    #[\Override]
     public function withBody(StreamInterface $body): static
     {
         $new = clone $this;
@@ -1693,6 +1719,7 @@ class ServerRequest implements ServerRequestInterface
      * @return \Psr\Http\Message\UriInterface Returns a UriInterface instance
      *   representing the URI of the request.
      */
+    #[\Override]
     public function getUri(): UriInterface
     {
         return $this->uri;
@@ -1708,6 +1735,7 @@ class ServerRequest implements ServerRequestInterface
      * @param bool $preserveHost Whether the host should be retained.
      * @return static
      */
+    #[\Override]
     public function withUri(UriInterface $uri, bool $preserveHost = false): static
     {
         $new = clone $this;
@@ -1742,6 +1770,7 @@ class ServerRequest implements ServerRequestInterface
      * @param string $requestTarget The request target.
      * @return static
      */
+    #[\Override]
     public function withRequestTarget(string $requestTarget): static
     {
         $new = clone $this;
@@ -1760,6 +1789,7 @@ class ServerRequest implements ServerRequestInterface
      *
      * @return string
      */
+    #[\Override]
     public function getRequestTarget(): string
     {
         if ($this->requestTarget !== null) {

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -168,6 +168,7 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
      * @return \Psr\Http\Message\ServerRequestInterface
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function createServerRequest(string $method, $uri, array $serverParams = []): ServerRequestInterface
     {
         $serverParams['REQUEST_METHOD'] = $method;

--- a/src/Http/Session/CacheSession.php
+++ b/src/Http/Session/CacheSession.php
@@ -59,6 +59,7 @@ class CacheSession implements SessionHandlerInterface
      * @param string $name The session name.
      * @return bool Success
      */
+    #[\Override]
     public function open(string $path, string $name): bool
     {
         return true;
@@ -69,6 +70,7 @@ class CacheSession implements SessionHandlerInterface
      *
      * @return bool Success
      */
+    #[\Override]
     public function close(): bool
     {
         return true;
@@ -80,6 +82,7 @@ class CacheSession implements SessionHandlerInterface
      * @param string $id ID that uniquely identifies session in cache.
      * @return string|false Session data or false if it does not exist.
      */
+    #[\Override]
     public function read(string $id): string|false
     {
         return Cache::read($id, $this->_options['config']) ?? '';
@@ -92,6 +95,7 @@ class CacheSession implements SessionHandlerInterface
      * @param string $data The data to be saved.
      * @return bool True for successful write, false otherwise.
      */
+    #[\Override]
     public function write(string $id, string $data): bool
     {
         if (!$id) {
@@ -107,6 +111,7 @@ class CacheSession implements SessionHandlerInterface
      * @param string $id ID that uniquely identifies session in cache.
      * @return bool Always true.
      */
+    #[\Override]
     public function destroy(string $id): bool
     {
         Cache::delete($id, $this->_options['config']);
@@ -120,6 +125,7 @@ class CacheSession implements SessionHandlerInterface
      * @param int $max_lifetime Sessions that have not updated for the last maxlifetime seconds will be removed.
      * @return int|false
      */
+    #[\Override]
     public function gc(int $max_lifetime): int|false
     {
         return 0;

--- a/src/Http/Session/DatabaseSession.php
+++ b/src/Http/Session/DatabaseSession.php
@@ -89,6 +89,7 @@ class DatabaseSession implements SessionHandlerInterface
      * @param string $name The session name.
      * @return bool Success
      */
+    #[\Override]
     public function open(string $path, string $name): bool
     {
         return true;
@@ -99,6 +100,7 @@ class DatabaseSession implements SessionHandlerInterface
      *
      * @return bool Success
      */
+    #[\Override]
     public function close(): bool
     {
         return true;
@@ -110,6 +112,7 @@ class DatabaseSession implements SessionHandlerInterface
      * @param string $id ID that uniquely identifies session in database.
      * @return string|false Session data or false if it does not exist.
      */
+    #[\Override]
     public function read(string $id): string|false
     {
         $pkField = $this->_table->getPrimaryKey();
@@ -145,6 +148,7 @@ class DatabaseSession implements SessionHandlerInterface
      * @param string $data The data to be saved.
      * @return bool True for successful write, false otherwise.
      */
+    #[\Override]
     public function write(string $id, string $data): bool
     {
         if (!$id) {
@@ -168,6 +172,7 @@ class DatabaseSession implements SessionHandlerInterface
      * @param string $id ID that uniquely identifies session in database.
      * @return bool True for successful delete, false otherwise.
      */
+    #[\Override]
     public function destroy(string $id): bool
     {
         /** @var string $pkField */
@@ -183,6 +188,7 @@ class DatabaseSession implements SessionHandlerInterface
      * @param int $max_lifetime Sessions that have not updated for the last maxlifetime seconds will be removed.
      * @return int|false The number of deleted sessions on success, or false on failure.
      */
+    #[\Override]
     public function gc(int $max_lifetime): int|false
     {
         return $this->_table->deleteAll(['expires <' => time()]);

--- a/src/Http/StreamFactory.php
+++ b/src/Http/StreamFactory.php
@@ -33,6 +33,7 @@ class StreamFactory implements StreamFactoryInterface
      *
      * @param string $content String content with which to populate the stream.
      */
+    #[\Override]
     public function createStream(string $content = ''): StreamInterface
     {
         $resource = fopen('php://temp', 'r+');
@@ -56,6 +57,7 @@ class StreamFactory implements StreamFactoryInterface
      * @throws \RuntimeException If the file cannot be opened.
      * @throws \InvalidArgumentException If the mode is invalid.
      */
+    #[\Override]
     public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
     {
         if (!is_readable($filename)) {
@@ -72,6 +74,7 @@ class StreamFactory implements StreamFactoryInterface
      *
      * @param resource $resource The PHP resource to use as the basis for the stream.
      */
+    #[\Override]
     public function createStreamFromResource($resource): StreamInterface
     {
         return new Stream($resource);

--- a/src/Http/UploadedFileFactory.php
+++ b/src/Http/UploadedFileFactory.php
@@ -42,6 +42,7 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
      * @param string|null $clientMediaType The media type as provided by the client, if any.
      * @throws \InvalidArgumentException If the file resource is not readable.
      */
+    #[\Override]
     public function createUploadedFile(
         StreamInterface $stream,
         ?int $size = null,

--- a/src/Http/UriFactory.php
+++ b/src/Http/UriFactory.php
@@ -34,6 +34,7 @@ class UriFactory implements UriFactoryInterface
      * @param string $uri The URI to parse.
      * @throws \InvalidArgumentException If the given URI cannot be parsed.
      */
+    #[\Override]
     public function createUri(string $uri = ''): UriInterface
     {
         return new Uri($uri);

--- a/src/I18n/Date.php
+++ b/src/I18n/Date.php
@@ -117,6 +117,7 @@ class Date extends ChronosDate implements JsonSerializable, Stringable
      * @return void
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public static function setToStringFormat($format): void
     {
         static::$_toStringFormat = $format;
@@ -179,6 +180,7 @@ class Date extends ChronosDate implements JsonSerializable, Stringable
      * @param \Cake\Chronos\DifferenceFormatterInterface|null $formatter Difference formatter
      * @return \Cake\I18n\RelativeTimeFormatter
      */
+    #[\Override]
     public static function diffFormatter(?DifferenceFormatterInterface $formatter = null): RelativeTimeFormatter
     {
         if ($formatter) {
@@ -308,6 +310,7 @@ class Date extends ChronosDate implements JsonSerializable, Stringable
      *
      * @return string|int
      */
+    #[\Override]
     public function jsonSerialize(): mixed
     {
         if (static::$_jsonEncodeFormat instanceof Closure) {
@@ -320,6 +323,7 @@ class Date extends ChronosDate implements JsonSerializable, Stringable
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function __toString(): string
     {
         return (string)$this->i18nFormat();

--- a/src/I18n/DateTime.php
+++ b/src/I18n/DateTime.php
@@ -211,6 +211,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
      * @return void
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public static function setToStringFormat($format): void
     {
         static::$_toStringFormat = $format;
@@ -222,6 +223,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
      *
      * @return void
      */
+    #[\Override]
     public static function resetToStringFormat(): void
     {
         static::setToStringFormat([IntlDateFormatter::SHORT, IntlDateFormatter::SHORT]);
@@ -356,6 +358,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
      * @param \Cake\Chronos\DifferenceFormatterInterface|null $formatter Difference formatter
      * @return \Cake\I18n\RelativeTimeFormatter
      */
+    #[\Override]
     public static function diffFormatter(?DifferenceFormatterInterface $formatter = null): RelativeTimeFormatter
     {
         if ($formatter) {
@@ -588,6 +591,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
      *
      * @return string|int
      */
+    #[\Override]
     public function jsonSerialize(): mixed
     {
         if (static::$_jsonEncodeFormat instanceof Closure) {
@@ -600,6 +604,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function __toString(): string
     {
         return (string)$this->i18nFormat();

--- a/src/I18n/Formatter/IcuFormatter.php
+++ b/src/I18n/Formatter/IcuFormatter.php
@@ -35,6 +35,7 @@ class IcuFormatter implements FormatterInterface
      * @return string The formatted message
      * @throws \Cake\I18n\Exception\I18nException
      */
+    #[\Override]
     public function format(string $locale, string $message, array $tokenValues): string
     {
         if ($message === '') {

--- a/src/I18n/Formatter/SprintfFormatter.php
+++ b/src/I18n/Formatter/SprintfFormatter.php
@@ -33,6 +33,7 @@ class SprintfFormatter implements FormatterInterface
      * @param array $tokenValues The list of values to interpolate in the message
      * @return string The formatted message
      */
+    #[\Override]
     public function format(string $locale, string $message, array $tokenValues): string
     {
         return vsprintf($message, $tokenValues);

--- a/src/I18n/Middleware/LocaleSelectorMiddleware.php
+++ b/src/I18n/Middleware/LocaleSelectorMiddleware.php
@@ -54,6 +54,7 @@ class LocaleSelectorMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
      * @return \Psr\Http\Message\ResponseInterface A response.
      */
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $locale = Locale::acceptFromHttp($request->getHeaderLine('Accept-Language'));

--- a/src/I18n/RelativeTimeFormatter.php
+++ b/src/I18n/RelativeTimeFormatter.php
@@ -36,6 +36,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
      * @return string The difference between the two days in a human readable format.
      * @see \Cake\Chronos\Chronos::diffForHumans
      */
+    #[\Override]
     public function diffForHumans(
         ChronosDate|DateTimeInterface $first,
         ChronosDate|DateTimeInterface|null $second = null,

--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -82,6 +82,7 @@ class Time extends ChronosTime implements JsonSerializable, Stringable
      * @return void
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public static function setToStringFormat($format): void
     {
         static::$_toStringFormat = $format;
@@ -93,6 +94,7 @@ class Time extends ChronosTime implements JsonSerializable, Stringable
      *
      * @return void
      */
+    #[\Override]
     public static function resetToStringFormat(): void
     {
         static::setToStringFormat(IntlDateFormatter::SHORT);
@@ -221,6 +223,7 @@ class Time extends ChronosTime implements JsonSerializable, Stringable
      *
      * @return string|int
      */
+    #[\Override]
     public function jsonSerialize(): mixed
     {
         if (static::$_jsonEncodeFormat instanceof Closure) {
@@ -233,6 +236,7 @@ class Time extends ChronosTime implements JsonSerializable, Stringable
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function __toString(): string
     {
         return (string)$this->i18nFormat();

--- a/src/Log/Engine/ArrayLog.php
+++ b/src/Log/Engine/ArrayLog.php
@@ -59,6 +59,7 @@ class ArrayLog extends BaseLog
      * @see \Cake\Log\Log::$_levels
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function log($level, Stringable|string $message, array $context = []): void
     {
         $message = $this->interpolate($message, $context);

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -91,6 +91,7 @@ class ConsoleLog extends BaseLog
      * @see \Cake\Log\Log::$_levels
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function log($level, Stringable|string $message, array $context = []): void
     {
         $message = $this->interpolate($message, $context);

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -121,6 +121,7 @@ class FileLog extends BaseLog
      * @see \Cake\Log\Log::$_levels
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function log($level, Stringable|string $message, array $context = []): void
     {
         $message = $this->interpolate($message, $context);

--- a/src/Log/Engine/SyslogLog.php
+++ b/src/Log/Engine/SyslogLog.php
@@ -99,6 +99,7 @@ class SyslogLog extends BaseLog
      * @see \Cake\Log\Log::$_levels
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function log($level, Stringable|string $message, array $context = []): void
     {
         if (!$this->_open) {

--- a/src/Log/Formatter/DefaultFormatter.php
+++ b/src/Log/Formatter/DefaultFormatter.php
@@ -34,6 +34,7 @@ class DefaultFormatter extends AbstractFormatter
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function format($level, string $message, array $context = []): string
     {
         if ($this->_config['includeDate']) {

--- a/src/Log/Formatter/JsonFormatter.php
+++ b/src/Log/Formatter/JsonFormatter.php
@@ -32,6 +32,7 @@ class JsonFormatter extends AbstractFormatter
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function format($level, string $message, array $context = []): string
     {
         $log = ['date' => date($this->_config['dateFormat']), 'level' => (string)$level, 'message' => $message];

--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -36,6 +36,7 @@ class LogEngineRegistry extends ObjectRegistry
      * @param string $class Partial classname to resolve.
      * @return class-string<\Psr\Log\LoggerInterface>|null Either the correct class name or null.
      */
+    #[\Override]
     protected function _resolveClassName(string $class): ?string
     {
         /** @var class-string<\Psr\Log\LoggerInterface>|null */
@@ -52,6 +53,7 @@ class LogEngineRegistry extends ObjectRegistry
      * @return void
      * @throws \Cake\Core\Exception\CakeException
      */
+    #[\Override]
     protected function _throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new CakeException(sprintf('Could not load class `%s`.', $class));
@@ -67,6 +69,7 @@ class LogEngineRegistry extends ObjectRegistry
      * @param array<string, mixed> $config An array of settings to use for the logger.
      * @return \Psr\Log\LoggerInterface The constructed logger class.
      */
+    #[\Override]
     protected function _create(callable|object|string $class, string $alias, array $config): LoggerInterface
     {
         if (is_string($class)) {
@@ -87,6 +90,7 @@ class LogEngineRegistry extends ObjectRegistry
      * @param string $name The logger name.
      * @return $this
      */
+    #[\Override]
     public function unload(string $name)
     {
         unset($this->_loaded[$name]);

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -606,6 +606,7 @@ class Mailer implements EventListenerInterface
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         return [];

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -1850,6 +1850,7 @@ class Message implements JsonSerializable
      * @return array Serializable array of configuration properties.
      * @throws \Exception When a view var object can not be properly serialized.
      */
+    #[\Override]
     public function jsonSerialize(): array
     {
         $array = [];

--- a/src/Mailer/Transport/DebugTransport.php
+++ b/src/Mailer/Transport/DebugTransport.php
@@ -30,6 +30,7 @@ class DebugTransport extends AbstractTransport
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function send(Message $message): array
     {
         $headers = $message->getHeadersString(

--- a/src/Mailer/Transport/MailTransport.php
+++ b/src/Mailer/Transport/MailTransport.php
@@ -30,6 +30,7 @@ class MailTransport extends AbstractTransport
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function send(Message $message): array
     {
         $this->checkRecipient($message);

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -191,6 +191,7 @@ class SmtpTransport extends AbstractTransport
      * @return array{headers: string, message: string}
      * @throws \Cake\Network\Exception\SocketException
      */
+    #[\Override]
     public function send(Message $message): array
     {
         $this->checkRecipient($message);

--- a/src/Mailer/TransportRegistry.php
+++ b/src/Mailer/TransportRegistry.php
@@ -35,6 +35,7 @@ class TransportRegistry extends ObjectRegistry
      * @param string $class Partial classname to resolve or transport instance.
      * @return class-string<\Cake\Mailer\AbstractTransport>|null Either the correct classname or null.
      */
+    #[\Override]
     protected function _resolveClassName(string $class): ?string
     {
         /** @var class-string<\Cake\Mailer\AbstractTransport>|null */
@@ -51,6 +52,7 @@ class TransportRegistry extends ObjectRegistry
      * @return void
      * @throws \BadMethodCallException
      */
+    #[\Override]
     protected function _throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new BadMethodCallException(sprintf('Mailer transport `%s` is not available.', $class));
@@ -66,6 +68,7 @@ class TransportRegistry extends ObjectRegistry
      * @param array<string, mixed> $config An array of settings to use for the cache engine.
      * @return \Cake\Mailer\AbstractTransport The constructed transport class.
      */
+    #[\Override]
     protected function _create(object|string $class, string $alias, array $config): AbstractTransport
     {
         if (is_object($class)) {
@@ -81,6 +84,7 @@ class TransportRegistry extends ObjectRegistry
      * @param string $name The adapter name.
      * @return $this
      */
+    #[\Override]
     public function unload(string $name)
     {
         unset($this->_loaded[$name]);

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -50,6 +50,7 @@ class BelongsTo extends Association
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getForeignKey(): array|string|false
     {
         if (!isset($this->_foreignKey)) {
@@ -66,6 +67,7 @@ class BelongsTo extends Association
      *  no join conditions will be generated automatically.
      * @return $this
      */
+    #[\Override]
     public function setForeignKey(array|string|false $key)
     {
         $this->_foreignKey = $key;
@@ -82,6 +84,7 @@ class BelongsTo extends Association
      * @param array<string, mixed> $options The options for the original delete.
      * @return bool Success.
      */
+    #[\Override]
     public function cascadeDelete(EntityInterface $entity, array $options = []): bool
     {
         return true;
@@ -92,6 +95,7 @@ class BelongsTo extends Association
      *
      * @return string
      */
+    #[\Override]
     protected function _propertyName(): string
     {
         [, $name] = pluginSplit($this->_name);
@@ -107,6 +111,7 @@ class BelongsTo extends Association
      * @param \Cake\ORM\Table $side The potential Table with ownership
      * @return bool
      */
+    #[\Override]
     public function isOwningSide(Table $side): bool
     {
         return $side === $this->getTarget();
@@ -117,6 +122,7 @@ class BelongsTo extends Association
      *
      * @return string
      */
+    #[\Override]
     public function type(): string
     {
         return self::MANY_TO_ONE;
@@ -134,6 +140,7 @@ class BelongsTo extends Association
      * the saved entity
      * @see \Cake\ORM\Table::save()
      */
+    #[\Override]
     public function saveAssociated(EntityInterface $entity, array $options = []): EntityInterface|false
     {
         $targetEntity = $entity->get($this->getProperty());
@@ -172,6 +179,7 @@ class BelongsTo extends Association
      * @throws \Cake\Database\Exception\DatabaseException if the number of columns in the foreignKey do not
      * match the number of columns in the target table primaryKey
      */
+    #[\Override]
     protected function _joinCondition(array $options): array
     {
         $conditions = [];
@@ -207,6 +215,7 @@ class BelongsTo extends Association
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function eagerLoader(array $options): Closure
     {
         $loader = new SelectLoader([

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -193,6 +193,7 @@ class BelongsToMany extends Association
      * @return bool if the 'matching' key in $option is true then this function
      * will return true, false otherwise
      */
+    #[\Override]
     public function canBeJoined(array $options = []): bool
     {
         return !empty($options['matching']);
@@ -201,6 +202,7 @@ class BelongsToMany extends Association
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getForeignKey(): array|string|false
     {
         if (!isset($this->_foreignKey)) {
@@ -236,6 +238,7 @@ class BelongsToMany extends Association
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function defaultRowValue(array $row, bool $joined): array
     {
         $sourceAlias = $this->getSource()->getAlias();
@@ -471,6 +474,7 @@ class BelongsToMany extends Association
      * @param array<string, mixed> $options Any extra options or overrides to be taken in account
      * @return void
      */
+    #[\Override]
     public function attachTo(SelectQuery $query, array $options = []): void
     {
         if (!empty($options['negateMatch'])) {
@@ -509,6 +513,7 @@ class BelongsToMany extends Association
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _appendNotMatching(SelectQuery $query, array $options): void
     {
         if (empty($options['negateMatch'])) {
@@ -551,6 +556,7 @@ class BelongsToMany extends Association
      *
      * @return string
      */
+    #[\Override]
     public function type(): string
     {
         return self::MANY_TO_MANY;
@@ -562,6 +568,7 @@ class BelongsToMany extends Association
      * @param array<string, mixed> $options list of options passed to attachTo method
      * @return array
      */
+    #[\Override]
     protected function _joinCondition(array $options): array
     {
         return [];
@@ -570,6 +577,7 @@ class BelongsToMany extends Association
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function eagerLoader(array $options): Closure
     {
         $name = $this->_junctionAssociationName();
@@ -601,6 +609,7 @@ class BelongsToMany extends Association
      * @param array<string, mixed> $options The options for the original delete.
      * @return bool Success.
      */
+    #[\Override]
     public function cascadeDelete(EntityInterface $entity, array $options = []): bool
     {
         if (!$this->getDependent()) {
@@ -648,6 +657,7 @@ class BelongsToMany extends Association
      * @param \Cake\ORM\Table $side The potential Table with ownership
      * @return bool
      */
+    #[\Override]
     public function isOwningSide(Table $side): bool
     {
         return true;
@@ -706,6 +716,7 @@ class BelongsToMany extends Association
      * @see \Cake\ORM\Table::save()
      * @see \Cake\ORM\Association\BelongsToMany::replaceLinks()
      */
+    #[\Override]
     public function saveAssociated(EntityInterface $entity, array $options = []): EntityInterface|false
     {
         $targetEntity = $entity->get($this->getProperty());
@@ -992,6 +1003,7 @@ class BelongsToMany extends Association
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setConditions(Closure|array $conditions)
     {
         parent::setConditions($conditions);
@@ -1103,6 +1115,7 @@ class BelongsToMany extends Association
      * @see \Cake\ORM\Table::find()
      * @return \Cake\ORM\Query\SelectQuery
      */
+    #[\Override]
     public function find(array|string|null $type = null, mixed ...$args): SelectQuery
     {
         $type = $type ?: $this->getFinder();
@@ -1522,6 +1535,7 @@ class BelongsToMany extends Association
      * @param array<string, mixed> $options original list of options passed in constructor
      * @return void
      */
+    #[\Override]
     protected function _options(array $options): void
     {
         if (!empty($options['targetForeignKey'])) {

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -100,6 +100,7 @@ class HasMany extends Association
      * @param \Cake\ORM\Table $side The potential Table with ownership
      * @return bool
      */
+    #[\Override]
     public function isOwningSide(Table $side): bool
     {
         return $side === $this->getSource();
@@ -147,6 +148,7 @@ class HasMany extends Association
      * @see \Cake\ORM\Table::save()
      * @throws \InvalidArgumentException when the association data cannot be traversed.
      */
+    #[\Override]
     public function saveAssociated(EntityInterface $entity, array $options = []): EntityInterface|false
     {
         $targetEntities = $entity->get($this->getProperty());
@@ -596,6 +598,7 @@ class HasMany extends Association
      *
      * @return string
      */
+    #[\Override]
     public function type(): string
     {
         return self::ONE_TO_MANY;
@@ -608,6 +611,7 @@ class HasMany extends Association
      * @return bool if the 'matching' key in $option is true then this function
      * will return true, false otherwise
      */
+    #[\Override]
     public function canBeJoined(array $options = []): bool
     {
         return !empty($options['matching']);
@@ -616,6 +620,7 @@ class HasMany extends Association
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getForeignKey(): array|string|false
     {
         if (!isset($this->_foreignKey)) {
@@ -651,6 +656,7 @@ class HasMany extends Association
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function defaultRowValue(array $row, bool $joined): array
     {
         $sourceAlias = $this->getSource()->getAlias();
@@ -667,6 +673,7 @@ class HasMany extends Association
      * @param array<string, mixed> $options original list of options passed in constructor
      * @return void
      */
+    #[\Override]
     protected function _options(array $options): void
     {
         if (!empty($options['saveStrategy'])) {
@@ -680,6 +687,7 @@ class HasMany extends Association
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function eagerLoader(array $options): Closure
     {
         $loader = new SelectLoader([
@@ -700,6 +708,7 @@ class HasMany extends Association
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function cascadeDelete(EntityInterface $entity, array $options = []): bool
     {
         $helper = new DependentDeleteHelper();

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -48,6 +48,7 @@ class HasOne extends Association
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getForeignKey(): array|string|false
     {
         if (!isset($this->_foreignKey)) {
@@ -64,6 +65,7 @@ class HasOne extends Association
      *  no join conditions will be generated automatically.
      * @return $this
      */
+    #[\Override]
     public function setForeignKey(array|string|false $key)
     {
         $this->_foreignKey = $key;
@@ -76,6 +78,7 @@ class HasOne extends Association
      *
      * @return string
      */
+    #[\Override]
     protected function _propertyName(): string
     {
         [, $name] = pluginSplit($this->_name);
@@ -91,6 +94,7 @@ class HasOne extends Association
      * @param \Cake\ORM\Table $side The potential Table with ownership
      * @return bool
      */
+    #[\Override]
     public function isOwningSide(Table $side): bool
     {
         return $side === $this->getSource();
@@ -101,6 +105,7 @@ class HasOne extends Association
      *
      * @return string
      */
+    #[\Override]
     public function type(): string
     {
         return self::ONE_TO_ONE;
@@ -118,6 +123,7 @@ class HasOne extends Association
      * the saved entity
      * @see \Cake\ORM\Table::save()
      */
+    #[\Override]
     public function saveAssociated(EntityInterface $entity, array $options = []): EntityInterface|false
     {
         $targetEntity = $entity->get($this->getProperty());
@@ -149,6 +155,7 @@ class HasOne extends Association
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function eagerLoader(array $options): Closure
     {
         $loader = new SelectLoader([
@@ -168,6 +175,7 @@ class HasOne extends Association
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function cascadeDelete(EntityInterface $entity, array $options = []): bool
     {
         $helper = new DependentDeleteHelper();

--- a/src/ORM/Association/Loader/SelectWithPivotLoader.php
+++ b/src/ORM/Association/Loader/SelectWithPivotLoader.php
@@ -80,6 +80,7 @@ class SelectWithPivotLoader extends SelectLoader
      * @return \Cake\ORM\Query\SelectQuery
      * @throws \InvalidArgumentException When a key is required for associations but not selected.
      */
+    #[\Override]
     protected function _buildQuery(array $options): SelectQuery
     {
         $name = $this->junctionAssociationName;
@@ -137,6 +138,7 @@ class SelectWithPivotLoader extends SelectLoader
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _assertFieldsPresent(SelectQuery $fetchQuery, array $key): void
     {
         // _buildQuery() manually adds in required fields from junction table
@@ -149,6 +151,7 @@ class SelectWithPivotLoader extends SelectLoader
      * @param array<string, mixed> $options the options to use for getting the link field.
      * @return array<string>|string
      */
+    #[\Override]
     protected function _linkField(array $options): array|string
     {
         $links = [];
@@ -174,6 +177,7 @@ class SelectWithPivotLoader extends SelectLoader
      * @return array<string, mixed>
      * @throws \Cake\Database\Exception\DatabaseException when the association property is not part of the results set.
      */
+    #[\Override]
     protected function _buildResultMap(SelectQuery $fetchQuery, array $options): array
     {
         $resultMap = [];

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -379,6 +379,7 @@ class AssociationCollection implements IteratorAggregate
      *
      * @return \Traversable<string, \Cake\ORM\Association>
      */
+    #[\Override]
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_items);

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -262,6 +262,7 @@ class Behavior implements EventListenerInterface
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         $eventMap = [

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -76,6 +76,7 @@ class TimestampBehavior extends Behavior
      * @param array<string, mixed> $config The config for this behavior.
      * @return void
      */
+    #[\Override]
     public function initialize(array $config): void
     {
         if (isset($config['events'])) {
@@ -130,6 +131,7 @@ class TimestampBehavior extends Behavior
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         /** @var array<string, mixed> */

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -171,6 +171,7 @@ class EavStrategy implements TranslateStrategyInterface
      * @param \ArrayObject<string, mixed> $options The options for the query
      * @return void
      */
+    #[\Override]
     public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options): void
     {
         $locale = Hash::get($options, 'locale', $this->getLocale());
@@ -238,6 +239,7 @@ class EavStrategy implements TranslateStrategyInterface
      * @param \ArrayObject<string, mixed> $options the options passed to the save method
      * @return void
      */
+    #[\Override]
     public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void
     {
         $locale = $entity->has('_locale') ? $entity->get('_locale') : $this->getLocale();
@@ -342,6 +344,7 @@ class EavStrategy implements TranslateStrategyInterface
      * @param string $field Field name to be aliased.
      * @return string
      */
+    #[\Override]
     public function translationField(string $field): string
     {
         $table = $this->table;
@@ -413,6 +416,7 @@ class EavStrategy implements TranslateStrategyInterface
      * @param \Cake\Collection\CollectionInterface $results Results to modify.
      * @return \Cake\Collection\CollectionInterface
      */
+    #[\Override]
     public function groupTranslations(CollectionInterface $results): CollectionInterface
     {
         return $results->map(function ($row) {

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -129,6 +129,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
      * @param \ArrayObject<string, mixed> $options The options for the query.
      * @return void
      */
+    #[\Override]
     public function beforeFind(EventInterface $event, SelectQuery $query, ArrayObject $options): void
     {
         $locale = Hash::get($options, 'locale', $this->getLocale());
@@ -354,6 +355,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
      * @param \ArrayObject<string, mixed> $options the options passed to the save method.
      * @return void
      */
+    #[\Override]
     public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void
     {
         $locale = $entity->has('_locale') ? $entity->get('_locale') : $this->getLocale();
@@ -447,6 +449,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function buildMarshalMap(Marshaller $marshaller, array $map, array $options): array
     {
         $this->translatedFields();
@@ -464,6 +467,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
      * @param string $field Field name to be aliased.
      * @return string
      */
+    #[\Override]
     public function translationField(string $field): string
     {
         if ($this->getLocale() === $this->getConfig('defaultLocale')) {
@@ -554,6 +558,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
      * @param \Cake\Collection\CollectionInterface $results Results to modify.
      * @return \Cake\Collection\CollectionInterface
      */
+    #[\Override]
     public function groupTranslations(CollectionInterface $results): CollectionInterface
     {
         return $results->map(function ($row) {

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -128,6 +128,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
      * @param array<string, mixed> $config The config for this behavior.
      * @return void
      */
+    #[\Override]
     public function initialize(array $config): void
     {
         $this->getStrategy();
@@ -210,6 +211,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         return [
@@ -262,6 +264,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
      * @param array<string, mixed> $options The options array used in the marshalling call.
      * @return array A map of `[property => callable]` of additional properties to marshal.
      */
+    #[\Override]
     public function buildMarshalMap(Marshaller $marshaller, array $map, array $options): array
     {
         return $this->getStrategy()->buildMarshalMap($marshaller, $map, $options);

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -85,6 +85,7 @@ class TreeBehavior extends Behavior
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function initialize(array $config): void
     {
         $this->_config['leftField'] = new IdentifierExpression($this->_config['left']);

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -107,6 +107,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @param string $class Partial classname to resolve.
      * @return class-string<\Cake\ORM\Behavior>|null Either the correct class name or null.
      */
+    #[\Override]
     protected function _resolveClassName(string $class): ?string
     {
         /** @var class-string<\Cake\ORM\Behavior>|null */
@@ -124,6 +125,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @return void
      * @throws \Cake\ORM\Exception\MissingBehaviorException
      */
+    #[\Override]
     protected function _throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new MissingBehaviorException([
@@ -143,6 +145,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @param array<string, mixed> $config An array of config to use for the behavior.
      * @return \Cake\ORM\Behavior The constructed behavior class.
      */
+    #[\Override]
     protected function _create(object|string $class, string $alias, array $config): Behavior
     {
         if (is_object($class)) {
@@ -218,6 +221,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @param \Cake\ORM\Behavior $object instance to store in the registry
      * @return $this
      */
+    #[\Override]
     public function set(string $name, object $object)
     {
         parent::set($name, $object);
@@ -237,6 +241,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * @param string $name The name of the object to remove from the registry.
      * @return $this
      */
+    #[\Override]
     public function unload(string $name)
     {
         $instance = $this->get($name);

--- a/src/ORM/Locator/LocatorInterface.php
+++ b/src/ORM/Locator/LocatorInterface.php
@@ -54,6 +54,7 @@ interface LocatorInterface extends BaseLocatorInterface
      * @param array<string, mixed> $options The options you want to build the table with.
      * @return \Cake\ORM\Table
      */
+    #[\Override]
     public function get(string $alias, array $options = []): Table;
 
     /**
@@ -64,5 +65,6 @@ interface LocatorInterface extends BaseLocatorInterface
      * @return \Cake\ORM\Table
      * @psalm-suppress MoreSpecificImplementedParamType
      */
+    #[\Override]
     public function set(string $alias, RepositoryInterface $repository): Table;
 }

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -138,6 +138,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setConfig(array|string $alias, ?array $options = null)
     {
         if (!is_string($alias)) {
@@ -161,6 +162,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getConfig(?string $alias = null): array
     {
         if ($alias === null) {
@@ -206,6 +208,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
      * @return \Cake\ORM\Table
      * @throws \RuntimeException When you try to configure an alias that already exists.
      */
+    #[\Override]
     public function get(string $alias, array $options = []): Table
     {
         /** @var \Cake\ORM\Table */
@@ -215,6 +218,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function createInstance(string $alias, array $options): Table
     {
         if (!str_contains($alias, '\\')) {
@@ -327,6 +331,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
      * @return \Cake\ORM\Table
      * @psalm-suppress MoreSpecificImplementedParamType
      */
+    #[\Override]
     public function set(string $alias, RepositoryInterface $repository): Table
     {
         return $this->instances[$alias] = $repository;
@@ -335,6 +340,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function clear(): void
     {
         parent::clear();
@@ -359,6 +365,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function remove(string $alias): void
     {
         parent::remove($alias);

--- a/src/ORM/Query/DeleteQuery.php
+++ b/src/ORM/Query/DeleteQuery.php
@@ -43,6 +43,7 @@ class DeleteQuery extends DbDeleteQuery
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(?ValueBinder $binder = null): string
     {
         if (empty($this->_parts['from'])) {

--- a/src/ORM/Query/InsertQuery.php
+++ b/src/ORM/Query/InsertQuery.php
@@ -43,6 +43,7 @@ class InsertQuery extends DbInsertQuery
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(?ValueBinder $binder = null): string
     {
         if (empty($this->_parts['into'])) {

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -229,6 +229,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @return \Cake\Datasource\ResultSetInterface<\Cake\Datasource\EntityInterface|array>
      */
+    #[\Override]
     public function getIterator(): ResultSetInterface
     {
         return $this->all();
@@ -319,6 +320,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * @param string|null $alias the alias used to prefix the field
      * @return array<string, string>
      */
+    #[\Override]
     public function aliasField(string $field, ?string $alias = null): array
     {
         if (str_contains($field, '.')) {
@@ -342,6 +344,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * @param string|null $defaultAlias The default alias
      * @return array<int|string, string|\Cake\Database\Expression\IdentifierExpression>
      */
+    #[\Override]
     public function aliasFields(array $fields, ?string $defaultAlias = null): array
     {
         $aliased = [];
@@ -367,6 +370,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @return \Cake\Datasource\ResultSetInterface<mixed>
      */
+    #[\Override]
     public function all(): ResultSetInterface
     {
         if ($this->_results !== null) {
@@ -393,6 +397,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @return array
      */
+    #[\Override]
     public function toArray(): array
     {
         return $this->all()->toArray();
@@ -578,6 +583,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @return mixed The first result from the ResultSet.
      */
+    #[\Override]
     public function first(): mixed
     {
         if ($this->_dirty) {
@@ -691,6 +697,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * @return $this
      * @see getOptions()
      */
+    #[\Override]
     public function applyOptions(array $options)
     {
         $valid = [
@@ -796,6 +803,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * @param bool $overwrite whether to reset fields with passed list or not
      * @return $this
      */
+    #[\Override]
     public function select(
         ExpressionInterface|Table|Association|Closure|array|string|float|int $fields = [],
         bool $overwrite = false,
@@ -1374,6 +1382,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * Handles cloning eager loaders.
      */
+    #[\Override]
     public function __clone()
     {
         parent::__clone();
@@ -1391,6 +1400,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @return int
      */
+    #[\Override]
     public function count(): int
     {
         return $this->_resultsCount ??= $this->_performCount();
@@ -1546,6 +1556,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(?ValueBinder $binder = null): string
     {
         $this->triggerBeforeFind();
@@ -1675,6 +1686,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * @return static<TSubject> Returns a modified query.
      * @psalm-suppress MoreSpecificReturnType
      */
+    #[\Override]
     public function find(string $finder, mixed ...$args): static
     {
         $table = $this->getRepository();
@@ -1701,6 +1713,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @return void
      */
+    #[\Override]
     protected function _dirty(): void
     {
         $this->_results = null;
@@ -1711,6 +1724,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function __debugInfo(): array
     {
         $eagerLoader = $this->getEagerLoader();
@@ -1733,6 +1747,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @return \Cake\Datasource\ResultSetInterface<(\Cake\Datasource\EntityInterface|mixed)> The data to convert to JSON.
      */
+    #[\Override]
     public function jsonSerialize(): ResultSetInterface
     {
         return $this->all();

--- a/src/ORM/Query/UpdateQuery.php
+++ b/src/ORM/Query/UpdateQuery.php
@@ -43,6 +43,7 @@ class UpdateQuery extends DbUpdateQuery
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sql(?ValueBinder $binder = null): string
     {
         if (empty($this->_parts['update'])) {

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -36,6 +36,7 @@ class ResultSet extends Collection implements ResultSetInterface
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function __debugInfo(): array
     {
         $key = $this->key();

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -416,6 +416,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param string $alias Table alias
      * @return $this
      */
+    #[\Override]
     public function setAlias(string $alias)
     {
         $this->_alias = $alias;
@@ -428,6 +429,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @return string
      */
+    #[\Override]
     public function getAlias(): string
     {
         if ($this->_alias === null) {
@@ -452,6 +454,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param string $field The field to alias.
      * @return string The field prefixed with the table alias.
      */
+    #[\Override]
     public function aliasField(string $field): string
     {
         if (str_contains($field, '.')) {
@@ -467,6 +470,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param string $registryAlias The key used to access this object.
      * @return $this
      */
+    #[\Override]
     public function setRegistryAlias(string $registryAlias)
     {
         $this->_registryAlias = $registryAlias;
@@ -479,6 +483,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @return string
      */
+    #[\Override]
     public function getRegistryAlias(): string
     {
         return $this->_registryAlias ??= $this->getAlias();
@@ -611,6 +616,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param string $field The field to check for.
      * @return bool True if the field exists, false if it does not.
      */
+    #[\Override]
     public function hasField(string $field): bool
     {
         return $this->getSchema()->getColumn($field) !== null;
@@ -1275,6 +1281,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param mixed ...$args Arguments that match up to finder-specific parameters
      * @return \Cake\ORM\Query\SelectQuery The query builder
      */
+    #[\Override]
     public function find(string $type = 'all', mixed ...$args): SelectQuery
     {
         return $this->callFinder($type, $this->selectQuery(), ...$args);
@@ -1504,6 +1511,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *      incorrect number of elements.
      * @see \Cake\Datasource\RepositoryInterface::find()
      */
+    #[\Override]
     public function get(
         mixed $primaryKey,
         array|string $finder = 'all',
@@ -1734,6 +1742,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @return \Cake\ORM\Query\SelectQuery
      */
+    #[\Override]
     public function query(): SelectQuery
     {
         return $this->selectQuery();
@@ -1802,6 +1811,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param \Cake\Database\Expression\QueryExpression|\Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
      * @return int Count Returns the affected rows.
      */
+    #[\Override]
     public function updateAll(
         QueryExpression|Closure|array|string $fields,
         QueryExpression|Closure|array|string|null $conditions,
@@ -1828,6 +1838,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * can take.
      * @return int Returns the number of affected rows.
      */
+    #[\Override]
     public function deleteAll(QueryExpression|Closure|array|string|null $conditions): int
     {
         $statement = $this->deleteQuery()
@@ -1840,6 +1851,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function exists(QueryExpression|Closure|array|string|null $conditions): bool
     {
         return (bool)count(
@@ -1938,6 +1950,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @return \Cake\Datasource\EntityInterface|false
      * @throws \Cake\ORM\Exception\RolledbackTransactionException If the transaction is aborted in the afterSave event.
      */
+    #[\Override]
     public function save(
         EntityInterface $entity,
         array $options = [],
@@ -2425,6 +2438,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array<string, mixed> $options The options for the delete.
      * @return bool success
      */
+    #[\Override]
     public function delete(EntityInterface $entity, array $options = []): bool
     {
         $options = new ArrayObject($options + [
@@ -2887,6 +2901,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @return \Cake\Datasource\EntityInterface
      */
+    #[\Override]
     public function newEmptyEntity(): EntityInterface
     {
         $class = $this->getEntityClass();
@@ -2953,6 +2968,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @return \Cake\Datasource\EntityInterface
      * @see \Cake\ORM\Marshaller::one()
      */
+    #[\Override]
     public function newEntity(array $data, array $options = []): EntityInterface
     {
         $options['associated'] ??= $this->_associations->keys();
@@ -2992,6 +3008,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array<string, mixed> $options A list of options for the objects hydration.
      * @return array<\Cake\Datasource\EntityInterface> An array of hydrated records.
      */
+    #[\Override]
     public function newEntities(array $data, array $options = []): array
     {
         $options['associated'] ??= $this->_associations->keys();
@@ -3050,6 +3067,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @return \Cake\Datasource\EntityInterface
      * @see \Cake\ORM\Marshaller::merge()
      */
+    #[\Override]
     public function patchEntity(EntityInterface $entity, array $data, array $options = []): EntityInterface
     {
         $options['associated'] ??= $this->_associations->keys();
@@ -3088,6 +3106,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array<string, mixed> $options A list of options for the objects hydration.
      * @return array<\Cake\Datasource\EntityInterface>
      */
+    #[\Override]
     public function patchEntities(iterable $entities, array $data, array $options = []): array
     {
         $options['associated'] ??= $this->_associations->keys();
@@ -3184,6 +3203,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         $eventMap = [

--- a/src/Routing/Middleware/AssetMiddleware.php
+++ b/src/Routing/Middleware/AssetMiddleware.php
@@ -63,6 +63,7 @@ class AssetMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
      * @return \Psr\Http\Message\ResponseInterface A response.
      */
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $url = $request->getUri()->getPath();

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -84,6 +84,7 @@ class RoutingMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
      * @return \Psr\Http\Message\ResponseInterface A response.
      */
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $this->loadRoutes();

--- a/src/Routing/Route/DashedRoute.php
+++ b/src/Routing/Route/DashedRoute.php
@@ -61,6 +61,7 @@ class DashedRoute extends Route
      * @param string $method The HTTP method.
      * @return array|null An array of request parameters, or null on failure.
      */
+    #[\Override]
     public function parse(string $url, string $method = ''): ?array
     {
         $params = parent::parse($url, $method);
@@ -94,6 +95,7 @@ class DashedRoute extends Route
      *   directory.
      * @return string|null Either a string URL or null.
      */
+    #[\Override]
     public function match(array $url, array $context = []): ?string
     {
         $url = $this->_dasherize($url);

--- a/src/Routing/Route/EntityRoute.php
+++ b/src/Routing/Route/EntityRoute.php
@@ -41,6 +41,7 @@ class EntityRoute extends Route
      *   directory.
      * @return string|null Either a string URL or null.
      */
+    #[\Override]
     public function match(array $url, array $context = []): ?string
     {
         if (!$this->_compiledRoute) {

--- a/src/Routing/Route/InflectedRoute.php
+++ b/src/Routing/Route/InflectedRoute.php
@@ -42,6 +42,7 @@ class InflectedRoute extends Route
      * @param string $method The HTTP method being matched.
      * @return array|null An array of request parameters, or null on failure.
      */
+    #[\Override]
     public function parse(string $url, string $method = ''): ?array
     {
         $params = parent::parse($url, $method);
@@ -73,6 +74,7 @@ class InflectedRoute extends Route
      *   directory.
      * @return string|null Either a string URL for the parameters if they match or null.
      */
+    #[\Override]
     public function match(array $url, array $context = []): ?string
     {
         $url = $this->_underscore($url);

--- a/src/Routing/Route/PluginShortRoute.php
+++ b/src/Routing/Route/PluginShortRoute.php
@@ -30,6 +30,7 @@ class PluginShortRoute extends InflectedRoute
      * @param string $method The HTTP method
      * @return array|null An array of request parameters, or null on failure.
      */
+    #[\Override]
     public function parse(string $url, string $method = ''): ?array
     {
         $params = parent::parse($url, $method);
@@ -51,6 +52,7 @@ class PluginShortRoute extends InflectedRoute
      *   directory.
      * @return string|null Either a string URL for the parameters if they match or null.
      */
+    #[\Override]
     public function match(array $url, array $context = []): ?string
     {
         if (isset($url['controller'], $url['plugin']) && $url['plugin'] !== $url['controller']) {

--- a/src/Routing/Route/RedirectRoute.php
+++ b/src/Routing/Route/RedirectRoute.php
@@ -62,6 +62,7 @@ class RedirectRoute extends Route
      * @throws \Cake\Http\Exception\RedirectException An exception is raised on successful match.
      *   This is used to halt route matching and signal to the middleware that a redirect should happen.
      */
+    #[\Override]
     public function parse(string $url, string $method = ''): ?array
     {
         $params = parent::parse($url, $method);
@@ -97,6 +98,7 @@ class RedirectRoute extends Route
      * @param array $context Array of request context parameters.
      * @return string|null Always null, string return result unused.
      */
+    #[\Override]
     public function match(array $url, array $context = []): ?string
     {
         return null;

--- a/src/TestSuite/Constraint/Email/MailContains.php
+++ b/src/TestSuite/Constraint/Email/MailContains.php
@@ -36,6 +36,7 @@ class MailContains extends MailConstraintBase
      * @param mixed $other Constraint check
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         $other = preg_quote($other, '/');
@@ -87,6 +88,7 @@ class MailContains extends MailConstraintBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         if ($this->at) {

--- a/src/TestSuite/Constraint/Email/MailContainsAttachment.php
+++ b/src/TestSuite/Constraint/Email/MailContainsAttachment.php
@@ -29,6 +29,7 @@ class MailContainsAttachment extends MailContains
      * @param mixed $other Constraint check
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         [$expectedFilename, $expectedFileInfo] = $other;
@@ -53,6 +54,7 @@ class MailContainsAttachment extends MailContains
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         if ($this->at) {
@@ -68,6 +70,7 @@ class MailContainsAttachment extends MailContains
      * @param mixed $other Value
      * @return string
      */
+    #[\Override]
     protected function failureDescription(mixed $other): string
     {
         [$expectedFilename] = $other;

--- a/src/TestSuite/Constraint/Email/MailContainsHtml.php
+++ b/src/TestSuite/Constraint/Email/MailContainsHtml.php
@@ -35,6 +35,7 @@ class MailContainsHtml extends MailContains
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         if ($this->at) {

--- a/src/TestSuite/Constraint/Email/MailContainsText.php
+++ b/src/TestSuite/Constraint/Email/MailContainsText.php
@@ -35,6 +35,7 @@ class MailContainsText extends MailContains
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         if ($this->at) {

--- a/src/TestSuite/Constraint/Email/MailCount.php
+++ b/src/TestSuite/Constraint/Email/MailCount.php
@@ -29,6 +29,7 @@ class MailCount extends MailConstraintBase
      * @param mixed $other Constraint check
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         return count($this->getMessages()) === $other;
@@ -39,6 +40,7 @@ class MailCount extends MailConstraintBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'emails were sent';

--- a/src/TestSuite/Constraint/Email/MailSentFrom.php
+++ b/src/TestSuite/Constraint/Email/MailSentFrom.php
@@ -33,6 +33,7 @@ class MailSentFrom extends MailSentWith
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         if ($this->at) {

--- a/src/TestSuite/Constraint/Email/MailSentTo.php
+++ b/src/TestSuite/Constraint/Email/MailSentTo.php
@@ -33,6 +33,7 @@ class MailSentTo extends MailSentWith
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         if ($this->at) {

--- a/src/TestSuite/Constraint/Email/MailSentWith.php
+++ b/src/TestSuite/Constraint/Email/MailSentWith.php
@@ -50,6 +50,7 @@ class MailSentWith extends MailConstraintBase
      * @param mixed $other Constraint check
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         $emails = $this->getMessages();
@@ -75,6 +76,7 @@ class MailSentWith extends MailConstraintBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         if ($this->at) {

--- a/src/TestSuite/Constraint/Email/MailSubjectContains.php
+++ b/src/TestSuite/Constraint/Email/MailSubjectContains.php
@@ -31,6 +31,7 @@ class MailSubjectContains extends MailConstraintBase
      * @param mixed $other Constraint check
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         if (!is_string($other)) {
@@ -75,6 +76,7 @@ class MailSubjectContains extends MailConstraintBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         if ($this->at) {

--- a/src/TestSuite/Constraint/Email/NoMailSent.php
+++ b/src/TestSuite/Constraint/Email/NoMailSent.php
@@ -29,6 +29,7 @@ class NoMailSent extends MailConstraintBase
      * @param mixed $other Constraint check
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         return $this->getMessages() === [];
@@ -39,6 +40,7 @@ class NoMailSent extends MailConstraintBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'no emails were sent';
@@ -50,6 +52,7 @@ class NoMailSent extends MailConstraintBase
      * @param mixed $other Value
      * @return string
      */
+    #[\Override]
     protected function failureDescription(mixed $other): string
     {
         return $this->toString();

--- a/src/TestSuite/Constraint/EventFired.php
+++ b/src/TestSuite/Constraint/EventFired.php
@@ -55,6 +55,7 @@ class EventFired extends Constraint
      * @param mixed $other Constraint check
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         $list = $this->_eventManager->getEventList();
@@ -67,6 +68,7 @@ class EventFired extends Constraint
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'was fired';

--- a/src/TestSuite/Constraint/EventFiredWith.php
+++ b/src/TestSuite/Constraint/EventFiredWith.php
@@ -64,6 +64,7 @@ class EventFiredWith extends Constraint
      * @return bool
      * @throws \PHPUnit\Framework\AssertionFailedError
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         $firedEvents = [];
@@ -110,6 +111,7 @@ class EventFiredWith extends Constraint
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return "was fired with `{$this->_dataKey}` matching `" . json_encode($this->_dataValue) . '`';

--- a/src/TestSuite/Constraint/Response/BodyContains.php
+++ b/src/TestSuite/Constraint/Response/BodyContains.php
@@ -49,6 +49,7 @@ class BodyContains extends ResponseBase
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         $method = 'mb_strpos';
@@ -64,6 +65,7 @@ class BodyContains extends ResponseBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'is in response body';

--- a/src/TestSuite/Constraint/Response/BodyEmpty.php
+++ b/src/TestSuite/Constraint/Response/BodyEmpty.php
@@ -29,6 +29,7 @@ class BodyEmpty extends ResponseBase
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         return empty($this->_getBodyAsString());
@@ -39,6 +40,7 @@ class BodyEmpty extends ResponseBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'response body is empty';
@@ -50,6 +52,7 @@ class BodyEmpty extends ResponseBase
      * @param mixed $other Value
      * @return string
      */
+    #[\Override]
     protected function failureDescription(mixed $other): string
     {
         return $this->toString();

--- a/src/TestSuite/Constraint/Response/BodyEquals.php
+++ b/src/TestSuite/Constraint/Response/BodyEquals.php
@@ -29,6 +29,7 @@ class BodyEquals extends ResponseBase
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         return $this->_getBodyAsString() === $other;
@@ -39,6 +40,7 @@ class BodyEquals extends ResponseBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'matches response body';

--- a/src/TestSuite/Constraint/Response/BodyNotContains.php
+++ b/src/TestSuite/Constraint/Response/BodyNotContains.php
@@ -29,6 +29,7 @@ class BodyNotContains extends BodyContains
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         return parent::matches($other) === false;
@@ -39,6 +40,7 @@ class BodyNotContains extends BodyContains
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'is not in response body';

--- a/src/TestSuite/Constraint/Response/BodyNotEmpty.php
+++ b/src/TestSuite/Constraint/Response/BodyNotEmpty.php
@@ -29,6 +29,7 @@ class BodyNotEmpty extends BodyEmpty
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         return parent::matches($other) === false;
@@ -39,6 +40,7 @@ class BodyNotEmpty extends BodyEmpty
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'response body is not empty';

--- a/src/TestSuite/Constraint/Response/BodyNotEquals.php
+++ b/src/TestSuite/Constraint/Response/BodyNotEquals.php
@@ -29,6 +29,7 @@ class BodyNotEquals extends BodyEquals
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         return parent::matches($other) === false;
@@ -39,6 +40,7 @@ class BodyNotEquals extends BodyEquals
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'does not match response body';

--- a/src/TestSuite/Constraint/Response/BodyNotRegExp.php
+++ b/src/TestSuite/Constraint/Response/BodyNotRegExp.php
@@ -29,6 +29,7 @@ class BodyNotRegExp extends BodyRegExp
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         return parent::matches($other) === false;
@@ -39,6 +40,7 @@ class BodyNotRegExp extends BodyRegExp
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'PCRE pattern not found in response body';

--- a/src/TestSuite/Constraint/Response/BodyRegExp.php
+++ b/src/TestSuite/Constraint/Response/BodyRegExp.php
@@ -29,6 +29,7 @@ class BodyRegExp extends ResponseBase
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         return preg_match($other, $this->_getBodyAsString()) > 0;
@@ -39,6 +40,7 @@ class BodyRegExp extends ResponseBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'PCRE pattern found in response body';
@@ -48,6 +50,7 @@ class BodyRegExp extends ResponseBase
      * @param mixed $other Expected
      * @return string
      */
+    #[\Override]
     public function failureDescription(mixed $other): string
     {
         return '`' . $other . '`' . ' ' . $this->toString();

--- a/src/TestSuite/Constraint/Response/ContentType.php
+++ b/src/TestSuite/Constraint/Response/ContentType.php
@@ -37,6 +37,7 @@ class ContentType extends ResponseBase
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         $mimeType = MimeType::getMimeType($other);
@@ -52,6 +53,7 @@ class ContentType extends ResponseBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'is set as the Content-Type (`' . $this->response->getType() . '`)';

--- a/src/TestSuite/Constraint/Response/CookieEncryptedEquals.php
+++ b/src/TestSuite/Constraint/Response/CookieEncryptedEquals.php
@@ -66,6 +66,7 @@ class CookieEncryptedEquals extends CookieEquals
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         $cookie = $this->response->getCookie($this->cookieName);
@@ -78,6 +79,7 @@ class CookieEncryptedEquals extends CookieEquals
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf("is encrypted in cookie '%s'", $this->cookieName);
@@ -88,6 +90,7 @@ class CookieEncryptedEquals extends CookieEquals
      *
      * @return string
      */
+    #[\Override]
     protected function _getCookieEncryptionKey(): string
     {
         return $this->key;

--- a/src/TestSuite/Constraint/Response/CookieEquals.php
+++ b/src/TestSuite/Constraint/Response/CookieEquals.php
@@ -55,6 +55,7 @@ class CookieEquals extends ResponseBase
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         $cookie = $this->readCookie($this->cookieName);
@@ -67,6 +68,7 @@ class CookieEquals extends ResponseBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf("is in cookie '%s'", $this->cookieName);

--- a/src/TestSuite/Constraint/Response/CookieNotSet.php
+++ b/src/TestSuite/Constraint/Response/CookieNotSet.php
@@ -29,6 +29,7 @@ class CookieNotSet extends CookieSet
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         return parent::matches($other) === false;
@@ -39,6 +40,7 @@ class CookieNotSet extends CookieSet
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'cookie is not set';

--- a/src/TestSuite/Constraint/Response/CookieSet.php
+++ b/src/TestSuite/Constraint/Response/CookieSet.php
@@ -36,6 +36,7 @@ class CookieSet extends ResponseBase
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         $cookie = $this->readCookie($other);
@@ -48,6 +49,7 @@ class CookieSet extends ResponseBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'cookie is set';

--- a/src/TestSuite/Constraint/Response/FileSent.php
+++ b/src/TestSuite/Constraint/Response/FileSent.php
@@ -36,6 +36,7 @@ class FileSent extends ResponseBase
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         return $this->response->getFile() !== null;
@@ -46,6 +47,7 @@ class FileSent extends ResponseBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'file was sent';
@@ -57,6 +59,7 @@ class FileSent extends ResponseBase
      * @param mixed $other Value
      * @return string
      */
+    #[\Override]
     protected function failureDescription(mixed $other): string
     {
         return $this->toString();

--- a/src/TestSuite/Constraint/Response/FileSentAs.php
+++ b/src/TestSuite/Constraint/Response/FileSentAs.php
@@ -36,6 +36,7 @@ class FileSentAs extends ResponseBase
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         $file = $this->response->getFile();
@@ -51,6 +52,7 @@ class FileSentAs extends ResponseBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'file was sent';

--- a/src/TestSuite/Constraint/Response/HeaderContains.php
+++ b/src/TestSuite/Constraint/Response/HeaderContains.php
@@ -29,6 +29,7 @@ class HeaderContains extends HeaderEquals
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         return mb_strpos($this->response->getHeaderLine($this->headerName), $other) !== false;
@@ -39,6 +40,7 @@ class HeaderContains extends HeaderEquals
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf(

--- a/src/TestSuite/Constraint/Response/HeaderEquals.php
+++ b/src/TestSuite/Constraint/Response/HeaderEquals.php
@@ -49,6 +49,7 @@ class HeaderEquals extends ResponseBase
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         return $this->response->getHeaderLine($this->headerName) === $other;
@@ -59,6 +60,7 @@ class HeaderEquals extends ResponseBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         $responseHeader = $this->response->getHeaderLine($this->headerName);

--- a/src/TestSuite/Constraint/Response/HeaderNotContains.php
+++ b/src/TestSuite/Constraint/Response/HeaderNotContains.php
@@ -29,6 +29,7 @@ class HeaderNotContains extends HeaderContains
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         return parent::matches($other) === false;
@@ -39,6 +40,7 @@ class HeaderNotContains extends HeaderContains
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf(

--- a/src/TestSuite/Constraint/Response/HeaderNotSet.php
+++ b/src/TestSuite/Constraint/Response/HeaderNotSet.php
@@ -29,6 +29,7 @@ class HeaderNotSet extends HeaderSet
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         return parent::matches($other) === false;
@@ -39,6 +40,7 @@ class HeaderNotSet extends HeaderSet
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf('did not have header `%s`', $this->headerName);

--- a/src/TestSuite/Constraint/Response/HeaderSet.php
+++ b/src/TestSuite/Constraint/Response/HeaderSet.php
@@ -49,6 +49,7 @@ class HeaderSet extends ResponseBase
      * @return bool
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         return $this->response->hasHeader($this->headerName);
@@ -59,6 +60,7 @@ class HeaderSet extends ResponseBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf("response has header '%s'", $this->headerName);
@@ -70,6 +72,7 @@ class HeaderSet extends ResponseBase
      * @param mixed $other Value
      * @return string
      */
+    #[\Override]
     protected function failureDescription(mixed $other): string
     {
         return $this->toString();

--- a/src/TestSuite/Constraint/Response/StatusCode.php
+++ b/src/TestSuite/Constraint/Response/StatusCode.php
@@ -27,6 +27,7 @@ class StatusCode extends StatusCodeBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf('matches response status code `%d`', $this->response->getStatusCode());
@@ -38,6 +39,7 @@ class StatusCode extends StatusCodeBase
      * @param mixed $other Expected code
      * @return string
      */
+    #[\Override]
     public function failureDescription(mixed $other): string
     {
         return '`' . $other . '` ' . $this->toString();

--- a/src/TestSuite/Constraint/Response/StatusCodeBase.php
+++ b/src/TestSuite/Constraint/Response/StatusCodeBase.php
@@ -35,6 +35,7 @@ abstract class StatusCodeBase extends ResponseBase
      * @psalm-suppress MoreSpecificImplementedParamType
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
+    #[\Override]
     public function matches($other): bool
     {
         if (!$other) {
@@ -66,6 +67,7 @@ abstract class StatusCodeBase extends ResponseBase
      * @param mixed $other Value
      * @return string
      */
+    #[\Override]
     protected function failureDescription(mixed $other): string
     {
         /** @psalm-suppress InternalMethod */

--- a/src/TestSuite/Constraint/Response/StatusError.php
+++ b/src/TestSuite/Constraint/Response/StatusError.php
@@ -32,6 +32,7 @@ class StatusError extends StatusCodeBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf('%d is between 400 and 429', $this->response->getStatusCode());

--- a/src/TestSuite/Constraint/Response/StatusFailure.php
+++ b/src/TestSuite/Constraint/Response/StatusFailure.php
@@ -32,6 +32,7 @@ class StatusFailure extends StatusCodeBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf('%d is between 500 and 505', $this->response->getStatusCode());

--- a/src/TestSuite/Constraint/Response/StatusOk.php
+++ b/src/TestSuite/Constraint/Response/StatusOk.php
@@ -32,6 +32,7 @@ class StatusOk extends StatusCodeBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf('%d is between 200 and 204', $this->response->getStatusCode());

--- a/src/TestSuite/Constraint/Response/StatusSuccess.php
+++ b/src/TestSuite/Constraint/Response/StatusSuccess.php
@@ -32,6 +32,7 @@ class StatusSuccess extends StatusCodeBase
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf('%d is between 200 and 308', $this->response->getStatusCode());

--- a/src/TestSuite/Constraint/Session/FlashParamEquals.php
+++ b/src/TestSuite/Constraint/Session/FlashParamEquals.php
@@ -75,6 +75,7 @@ class FlashParamEquals extends Constraint
      * @param mixed $other Value to compare with
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         // Server::run calls Session::close at the end of the request.
@@ -104,6 +105,7 @@ class FlashParamEquals extends Constraint
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         if ($this->at !== null) {

--- a/src/TestSuite/Constraint/Session/SessionEquals.php
+++ b/src/TestSuite/Constraint/Session/SessionEquals.php
@@ -46,6 +46,7 @@ class SessionEquals extends Constraint
      * @param mixed $other Value to compare with
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         // Server::run calls Session::close at the end of the request.
@@ -60,6 +61,7 @@ class SessionEquals extends Constraint
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf("is in session path '%s'", $this->path);

--- a/src/TestSuite/Constraint/Session/SessionHasKey.php
+++ b/src/TestSuite/Constraint/Session/SessionHasKey.php
@@ -46,6 +46,7 @@ class SessionHasKey extends Constraint
      * @param mixed $other Value to compare with
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         // Server::run calls Session::close at the end of the request.
@@ -60,6 +61,7 @@ class SessionHasKey extends Constraint
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return 'is a path present in the session';

--- a/src/TestSuite/Constraint/View/LayoutFileEquals.php
+++ b/src/TestSuite/Constraint/View/LayoutFileEquals.php
@@ -27,6 +27,7 @@ class LayoutFileEquals extends TemplateFileEquals
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf('equals layout file `%s`', $this->filename);

--- a/src/TestSuite/Constraint/View/TemplateFileEquals.php
+++ b/src/TestSuite/Constraint/View/TemplateFileEquals.php
@@ -45,6 +45,7 @@ class TemplateFileEquals extends Constraint
      * @param mixed $other Expected filename
      * @return bool
      */
+    #[\Override]
     public function matches(mixed $other): bool
     {
         return str_contains($this->filename, $other);
@@ -55,6 +56,7 @@ class TemplateFileEquals extends Constraint
      *
      * @return string
      */
+    #[\Override]
     public function toString(): string
     {
         return sprintf('equals template file `%s`', $this->filename);

--- a/src/TestSuite/Fixture/Extension/PHPUnitExtension.php
+++ b/src/TestSuite/Fixture/Extension/PHPUnitExtension.php
@@ -32,6 +32,7 @@ class PHPUnitExtension implements Extension
      * @param \PHPUnit\Runner\Extension\ParameterCollection $parameters
      * @return void
      */
+    #[\Override]
     public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
     {
         $facade->registerSubscriber(

--- a/src/TestSuite/Fixture/Extension/PHPUnitStartedSubscriber.php
+++ b/src/TestSuite/Fixture/Extension/PHPUnitStartedSubscriber.php
@@ -30,6 +30,7 @@ class PHPUnitStartedSubscriber implements PHPUnitStarted
      * @param \PHPUnit\Event\TestSuite\Started $event The event
      * @return void
      */
+    #[\Override]
     public function notify(Started $event): void
     {
         ConnectionHelper::addTestAliases();

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -94,6 +94,7 @@ class TestFixture implements FixtureInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function connection(): string
     {
         return $this->connection;
@@ -102,6 +103,7 @@ class TestFixture implements FixtureInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function sourceName(): string
     {
         return $this->table;
@@ -172,6 +174,7 @@ class TestFixture implements FixtureInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function insert(ConnectionInterface $connection): bool
     {
         assert($connection instanceof Connection);
@@ -235,6 +238,7 @@ class TestFixture implements FixtureInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function truncate(ConnectionInterface $connection): bool
     {
         assert($connection instanceof Connection);

--- a/src/TestSuite/Fixture/TransactionFixtureStrategy.php
+++ b/src/TestSuite/Fixture/TransactionFixtureStrategy.php
@@ -48,6 +48,7 @@ class TransactionFixtureStrategy implements FixtureStrategyInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setupTest(array $fixtureNames): void
     {
         $this->fixtures = $this->helper->loadFixtures($fixtureNames);
@@ -78,6 +79,7 @@ class TransactionFixtureStrategy implements FixtureStrategyInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function teardownTest(): void
     {
         $this->helper->runPerConnection(function (Connection $connection): void {

--- a/src/TestSuite/Fixture/TransactionStrategy.php
+++ b/src/TestSuite/Fixture/TransactionStrategy.php
@@ -48,6 +48,7 @@ class TransactionStrategy implements FixtureStrategyInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setupTest(array $fixtureNames): void
     {
         if (!$fixtureNames) {
@@ -83,6 +84,7 @@ class TransactionStrategy implements FixtureStrategyInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function teardownTest(): void
     {
         $this->helper->runPerConnection(function (Connection $connection): void {

--- a/src/TestSuite/Fixture/TruncateFixtureStrategy.php
+++ b/src/TestSuite/Fixture/TruncateFixtureStrategy.php
@@ -42,6 +42,7 @@ class TruncateFixtureStrategy implements FixtureStrategyInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setupTest(array $fixtureNames): void
     {
         $this->fixtures = $this->helper->loadFixtures($fixtureNames);
@@ -51,6 +52,7 @@ class TruncateFixtureStrategy implements FixtureStrategyInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function teardownTest(): void
     {
         $this->helper->truncate($this->fixtures);

--- a/src/TestSuite/Fixture/TruncateStrategy.php
+++ b/src/TestSuite/Fixture/TruncateStrategy.php
@@ -42,6 +42,7 @@ class TruncateStrategy implements FixtureStrategyInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setupTest(array $fixtureNames): void
     {
         if (!$fixtureNames) {
@@ -55,6 +56,7 @@ class TruncateStrategy implements FixtureStrategyInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function teardownTest(): void
     {
         $this->helper->truncate($this->fixtures);

--- a/src/TestSuite/Stub/TestExceptionRenderer.php
+++ b/src/TestSuite/Stub/TestExceptionRenderer.php
@@ -48,6 +48,7 @@ class TestExceptionRenderer implements ExceptionRendererInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function render(): ResponseInterface
     {
         throw new LogicException('You cannot use this class to render exceptions.');
@@ -59,6 +60,7 @@ class TestExceptionRenderer implements ExceptionRendererInterface
      * @param \Psr\Http\Message\ResponseInterface|string $output The output or response to send.
      * @return void
      */
+    #[\Override]
     public function write(ResponseInterface|string $output): void
     {
     }

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -204,6 +204,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @return void
      */
+    #[\Override]
     protected function setUp(): void
     {
         parent::setUp();
@@ -224,6 +225,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @return void
      */
+    #[\Override]
     protected function tearDown(): void
     {
         parent::tearDown();
@@ -327,6 +329,7 @@ abstract class TestCase extends BaseTestCase
              * @param \Cake\Http\MiddlewareQueue $middlewareQueue
              * @return \Cake\Http\MiddlewareQueue
              */
+            #[\Override]
             public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
             {
                 return $middlewareQueue;

--- a/src/TestSuite/TestEmailTransport.php
+++ b/src/TestSuite/TestEmailTransport.php
@@ -40,6 +40,7 @@ class TestEmailTransport extends DebugTransport
      * @param \Cake\Mailer\Message $message Message
      * @return array{headers: string, message: string}
      */
+    #[\Override]
     public function send(Message $message): array
     {
         static::$messages[] = clone $message;

--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -192,6 +192,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
      * @param string $index name of the rule
      * @return bool
      */
+    #[\Override]
     public function offsetExists(mixed $index): bool
     {
         return isset($this->_rules[$index]);
@@ -203,6 +204,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
      * @param string $index name of the rule
      * @return \Cake\Validation\ValidationRule
      */
+    #[\Override]
     public function offsetGet(mixed $index): ValidationRule
     {
         return $this->_rules[$index];
@@ -215,6 +217,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
      * @param \Cake\Validation\ValidationRule|array $value Rule to add to $index
      * @return void
      */
+    #[\Override]
     public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->add($offset, $value);
@@ -226,6 +229,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
      * @param string $index name of the rule
      * @return void
      */
+    #[\Override]
     public function offsetUnset(mixed $index): void
     {
         unset($this->_rules[$index]);
@@ -236,6 +240,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
      *
      * @return \Traversable<string, \Cake\Validation\ValidationRule>
      */
+    #[\Override]
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_rules);
@@ -246,6 +251,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
      *
      * @return int
      */
+    #[\Override]
     public function count(): int
     {
         return count($this->_rules);

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -377,6 +377,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string $field name of the field to check
      * @return bool
      */
+    #[\Override]
     public function offsetExists(mixed $field): bool
     {
         return isset($this->_fields[$field]);
@@ -388,6 +389,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|int $field name of the field to check
      * @return \Cake\Validation\ValidationSet
      */
+    #[\Override]
     public function offsetGet(mixed $field): ValidationSet
     {
         return $this->field((string)$field);
@@ -400,6 +402,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param \Cake\Validation\ValidationSet|array $value set of rules to apply to field
      * @return void
      */
+    #[\Override]
     public function offsetSet(mixed $offset, mixed $value): void
     {
         if (!$value instanceof ValidationSet) {
@@ -418,6 +421,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string $field name of the field to unset
      * @return void
      */
+    #[\Override]
     public function offsetUnset(mixed $field): void
     {
         unset($this->_fields[$field]);
@@ -428,6 +432,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @return \Traversable<string, \Cake\Validation\ValidationSet>
      */
+    #[\Override]
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_fields);
@@ -438,6 +443,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @return int
      */
+    #[\Override]
     public function count(): int
     {
         return count($this->_fields);

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -33,6 +33,7 @@ class AjaxView extends View
      *
      * @return string
      */
+    #[\Override]
     public static function contentType(): string
     {
         return 'text/html';

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -261,6 +261,7 @@ abstract class Cell implements EventDispatcherInterface, Stringable
      * @return string Rendered cell
      * @throws \Error Include error details for PHP 7 fatal errors.
      */
+    #[\Override]
     public function __toString(): string
     {
         try {

--- a/src/View/Exception/MissingCellTemplateException.php
+++ b/src/View/Exception/MissingCellTemplateException.php
@@ -58,6 +58,7 @@ class MissingCellTemplateException extends MissingTemplateException
      * @return array<string, mixed>
      * @psalm-return array{name: string, file: string, paths: array<string>}
      */
+    #[\Override]
     public function getAttributes(): array
     {
         return [

--- a/src/View/Exception/MissingTemplateException.php
+++ b/src/View/Exception/MissingTemplateException.php
@@ -89,6 +89,7 @@ class MissingTemplateException extends CakeException
      * @return array<string, mixed>
      * @psalm-return array{file: string, paths: array<string>}
      */
+    #[\Override]
     public function getAttributes(): array
     {
         return [

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -100,6 +100,7 @@ class ArrayContext implements ContextInterface
      *
      * @return array<string>
      */
+    #[\Override]
     public function getPrimaryKey(): array
     {
         if (
@@ -120,6 +121,7 @@ class ArrayContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function isPrimaryKey(string $field): bool
     {
         $primaryKey = $this->getPrimaryKey();
@@ -136,6 +138,7 @@ class ArrayContext implements ContextInterface
      *
      * @return bool
      */
+    #[\Override]
     public function isCreate(): bool
     {
         $primary = $this->getPrimaryKey();
@@ -163,6 +166,7 @@ class ArrayContext implements ContextInterface
      *     context's schema should be used if it's not explicitly provided.
      * @return mixed
      */
+    #[\Override]
     public function val(string $field, array $options = []): mixed
     {
         $options += [
@@ -197,6 +201,7 @@ class ArrayContext implements ContextInterface
      * @param string $field A dot separated path to check required-ness for.
      * @return bool|null
      */
+    #[\Override]
     public function isRequired(string $field): ?bool
     {
         if (!is_array($this->_context['required'])) {
@@ -216,6 +221,7 @@ class ArrayContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getRequiredMessage(string $field): ?string
     {
         if (!is_array($this->_context['required'])) {
@@ -243,6 +249,7 @@ class ArrayContext implements ContextInterface
      * @param string $field A dot separated path to check required-ness for.
      * @return int|null
      */
+    #[\Override]
     public function getMaxLength(string $field): ?int
     {
         if (!is_array($this->_context['schema'])) {
@@ -255,6 +262,7 @@ class ArrayContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function fieldNames(): array
     {
         $schema = $this->_context['schema'];
@@ -271,6 +279,7 @@ class ArrayContext implements ContextInterface
      * @return string|null An abstract data type or null.
      * @see \Cake\Database\TypeFactory
      */
+    #[\Override]
     public function type(string $field): ?string
     {
         if (!is_array($this->_context['schema'])) {
@@ -289,6 +298,7 @@ class ArrayContext implements ContextInterface
      * @param string $field A dot separated path to get additional data on.
      * @return array An array of data describing the additional attributes on a field.
      */
+    #[\Override]
     public function attributes(string $field): array
     {
         if (!is_array($this->_context['schema'])) {
@@ -309,6 +319,7 @@ class ArrayContext implements ContextInterface
      * @param string $field A dot separated path to check errors on.
      * @return bool Returns true if the errors for the field are not empty.
      */
+    #[\Override]
     public function hasError(string $field): bool
     {
         if (empty($this->_context['errors'])) {
@@ -325,6 +336,7 @@ class ArrayContext implements ContextInterface
      * @return array An array of errors, an empty array will be returned when the
      *    context has no errors.
      */
+    #[\Override]
     public function error(string $field): array
     {
         if (empty($this->_context['errors'])) {

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -166,6 +166,7 @@ class EntityContext implements ContextInterface
      *
      * @return array<string>
      */
+    #[\Override]
     public function getPrimaryKey(): array
     {
         return (array)$this->_tables[$this->_rootName]->getPrimaryKey();
@@ -174,6 +175,7 @@ class EntityContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function isPrimaryKey(string $field): bool
     {
         $parts = explode('.', $field);
@@ -197,6 +199,7 @@ class EntityContext implements ContextInterface
      *
      * @return bool
      */
+    #[\Override]
     public function isCreate(): bool
     {
         $entity = $this->_context['entity'];
@@ -227,6 +230,7 @@ class EntityContext implements ContextInterface
      *     schema should be used if it's not explicitly provided.
      * @return mixed The value of the field or null on a miss.
      */
+    #[\Override]
     public function val(string $field, array $options = []): mixed
     {
         $options += [
@@ -477,6 +481,7 @@ class EntityContext implements ContextInterface
      * @param string $field The dot separated path to the field you want to check.
      * @return bool|null
      */
+    #[\Override]
     public function isRequired(string $field): ?bool
     {
         $parts = explode('.', $field);
@@ -502,6 +507,7 @@ class EntityContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getRequiredMessage(string $field): ?string
     {
         $parts = explode('.', $field);
@@ -526,6 +532,7 @@ class EntityContext implements ContextInterface
      * @param string $field The dot separated path to the field you want to check.
      * @return int|null
      */
+    #[\Override]
     public function getMaxLength(string $field): ?int
     {
         $parts = explode('.', $field);
@@ -555,6 +562,7 @@ class EntityContext implements ContextInterface
      *
      * @return array<string> Array of field names in the table/entity.
      */
+    #[\Override]
     public function fieldNames(): array
     {
         $table = $this->_getTable('0');
@@ -671,6 +679,7 @@ class EntityContext implements ContextInterface
      * @return string|null An abstract data type or null.
      * @see \Cake\Database\TypeFactory
      */
+    #[\Override]
     public function type(string $field): ?string
     {
         $parts = explode('.', $field);
@@ -685,6 +694,7 @@ class EntityContext implements ContextInterface
      * @param string $field A dot separated path to get additional data on.
      * @return array An array of data describing the additional attributes on a field.
      */
+    #[\Override]
     public function attributes(string $field): array
     {
         $parts = explode('.', $field);
@@ -705,6 +715,7 @@ class EntityContext implements ContextInterface
      * @param string $field A dot separated path to check errors on.
      * @return bool Returns true if the errors for the field are not empty.
      */
+    #[\Override]
     public function hasError(string $field): bool
     {
         return $this->error($field) !== [];
@@ -716,6 +727,7 @@ class EntityContext implements ContextInterface
      * @param string $field A dot separated path to check errors on.
      * @return array An array of errors.
      */
+    #[\Override]
     public function error(string $field): array
     {
         $parts = explode('.', $field);

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -65,6 +65,7 @@ class FormContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getPrimaryKey(): array
     {
         return [];
@@ -73,6 +74,7 @@ class FormContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function isPrimaryKey(string $field): bool
     {
         return false;
@@ -81,6 +83,7 @@ class FormContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function isCreate(): bool
     {
         return true;
@@ -89,6 +92,7 @@ class FormContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function val(string $field, array $options = []): mixed
     {
         $options += [
@@ -127,6 +131,7 @@ class FormContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function isRequired(string $field): ?bool
     {
         $validator = $this->_form->getValidator($this->_validator);
@@ -143,6 +148,7 @@ class FormContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getRequiredMessage(string $field): ?string
     {
         $parts = explode('.', $field);
@@ -164,6 +170,7 @@ class FormContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getMaxLength(string $field): ?int
     {
         $validator = $this->_form->getValidator($this->_validator);
@@ -187,6 +194,7 @@ class FormContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function fieldNames(): array
     {
         return $this->_form->getSchema()->fields();
@@ -195,6 +203,7 @@ class FormContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function type(string $field): ?string
     {
         return $this->_form->getSchema()->fieldType($field);
@@ -203,6 +212,7 @@ class FormContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function attributes(string $field): array
     {
         return array_intersect_key(
@@ -214,6 +224,7 @@ class FormContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function hasError(string $field): bool
     {
         $errors = $this->error($field);
@@ -224,6 +235,7 @@ class FormContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function error(string $field): array
     {
         return (array)Hash::get($this->_form->getErrors(), $field, []);

--- a/src/View/Form/NullContext.php
+++ b/src/View/Form/NullContext.php
@@ -36,6 +36,7 @@ class NullContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getPrimaryKey(): array
     {
         return [];
@@ -44,6 +45,7 @@ class NullContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function isPrimaryKey(string $field): bool
     {
         return false;
@@ -52,6 +54,7 @@ class NullContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function isCreate(): bool
     {
         return true;
@@ -60,6 +63,7 @@ class NullContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function val(string $field, array $options = []): mixed
     {
         return null;
@@ -68,6 +72,7 @@ class NullContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function isRequired(string $field): ?bool
     {
         return null;
@@ -76,6 +81,7 @@ class NullContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getRequiredMessage(string $field): ?string
     {
         return null;
@@ -84,6 +90,7 @@ class NullContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getMaxLength(string $field): ?int
     {
         return null;
@@ -92,6 +99,7 @@ class NullContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function fieldNames(): array
     {
         return [];
@@ -100,6 +108,7 @@ class NullContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function type(string $field): ?string
     {
         return null;
@@ -108,6 +117,7 @@ class NullContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function attributes(string $field): array
     {
         return [];
@@ -116,6 +126,7 @@ class NullContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function hasError(string $field): bool
     {
         return false;
@@ -124,6 +135,7 @@ class NullContext implements ContextInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function error(string $field): array
     {
         return [];

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -165,6 +165,7 @@ class Helper implements EventListenerInterface
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         $eventMap = [

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -88,6 +88,7 @@ class FlashHelper extends Helper
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         return [];

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2654,6 +2654,7 @@ class FormHelper extends Helper
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         return [];

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -1201,6 +1201,7 @@ class HtmlHelper extends Helper
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         return [];

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -134,6 +134,7 @@ class NumberHelper extends Helper
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         return [];

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1128,6 +1128,7 @@ class PaginatorHelper extends Helper
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         return [];

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -301,6 +301,7 @@ class TextHelper extends Helper
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         return [];

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -454,6 +454,7 @@ class TimeHelper extends Helper
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         return [];

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -51,6 +51,7 @@ class UrlHelper extends Helper
      * @param array<string, mixed> $config The configuration settings provided to this helper.
      * @return void
      */
+    #[\Override]
     public function initialize(array $config): void
     {
         parent::initialize($config);
@@ -252,6 +253,7 @@ class UrlHelper extends Helper
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function implementedEvents(): array
     {
         return [];

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -64,6 +64,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
      * @throws \Cake\View\Exception\MissingHelperException When a helper could not be found.
      *    App helpers are searched, and then plugin helpers.
      */
+    #[\Override]
     public function __isset(string $name): bool
     {
         if (isset($this->_loaded[$name])) {
@@ -94,6 +95,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
      * @param string $name Name of property to read
      * @return \Cake\View\Helper|null
      */
+    #[\Override]
     public function __get(string $name): ?Helper
     {
         // This calls __isset() and loading the named helper if it isn't already loaded.
@@ -112,6 +114,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
      * @param string $class Partial classname to resolve.
      * @return class-string<\Cake\View\Helper>|null Either the correct class name or null.
      */
+    #[\Override]
     protected function _resolveClassName(string $class): ?string
     {
         /** @var class-string<\Cake\View\Helper>|null */
@@ -129,6 +132,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
      * @return void
      * @throws \Cake\View\Exception\MissingHelperException
      */
+    #[\Override]
     protected function _throwMissingClassError(string $class, ?string $plugin): void
     {
         throw new MissingHelperException([
@@ -148,6 +152,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
      * @param array<string, mixed> $config An array of settings to use for the helper.
      * @return \Cake\View\Helper The constructed helper class.
      */
+    #[\Override]
     protected function _create(object|string $class, string $alias, array $config): Helper
     {
         if (is_object($class)) {

--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -100,6 +100,7 @@ class JsonView extends SerializedView
      *
      * @return string The JSON content type.
      */
+    #[\Override]
     public static function contentType(): string
     {
         return 'application/json';
@@ -112,6 +113,7 @@ class JsonView extends SerializedView
      * @param string|false|null $layout The layout being rendered.
      * @return string The rendered view.
      */
+    #[\Override]
     public function render(?string $template = null, string|false|null $layout = null): string
     {
         $return = parent::render($template, $layout);
@@ -133,6 +135,7 @@ class JsonView extends SerializedView
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _serialize(array|string $serialize): string
     {
         $data = $this->_dataToSerialize($serialize);

--- a/src/View/NegotiationRequiredView.php
+++ b/src/View/NegotiationRequiredView.php
@@ -32,6 +32,7 @@ class NegotiationRequiredView extends View
      *
      * @return string
      */
+    #[\Override]
     public static function contentType(): string
     {
         return static::TYPE_MATCH_ALL;
@@ -42,6 +43,7 @@ class NegotiationRequiredView extends View
      *
      * @return void
      */
+    #[\Override]
     public function initialize(): void
     {
         $response = $this->getResponse()->withStatus(406);
@@ -55,6 +57,7 @@ class NegotiationRequiredView extends View
      * @param string|false|null $layout Layout to use. False to disable.
      * @return string Rendered content.
      */
+    #[\Override]
     public function render(?string $template = null, string|false|null $layout = null): string
     {
         return '';

--- a/src/View/SerializedView.php
+++ b/src/View/SerializedView.php
@@ -46,6 +46,7 @@ abstract class SerializedView extends View
      *
      * @return $this
      */
+    #[\Override]
     public function loadHelpers()
     {
         if (!$this->getConfig('serialize')) {
@@ -72,6 +73,7 @@ abstract class SerializedView extends View
      * @return string The rendered view.
      * @throws \Cake\View\Exception\SerializationFailureException When serialization fails.
      */
+    #[\Override]
     public function render(?string $template = null, string|false|null $layout = null): string
     {
         $serialize = $this->serializeKeys();

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -608,6 +608,7 @@ class ViewBuilder implements JsonSerializable
      *
      * @return array Serializable array of configuration properties.
      */
+    #[\Override]
     public function jsonSerialize(): array
     {
         $properties = [

--- a/src/View/Widget/BasicWidget.php
+++ b/src/View/Widget/BasicWidget.php
@@ -73,6 +73,7 @@ class BasicWidget implements WidgetInterface
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string
      */
+    #[\Override]
     public function render(array $data, ContextInterface $context): string
     {
         $data = $this->mergeDefaults($data, $context);
@@ -198,6 +199,7 @@ class BasicWidget implements WidgetInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function secureFields(array $data): array
     {
         if (!isset($data['name']) || $data['name'] === '') {

--- a/src/View/Widget/ButtonWidget.php
+++ b/src/View/Widget/ButtonWidget.php
@@ -63,6 +63,7 @@ class ButtonWidget implements WidgetInterface
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string
      */
+    #[\Override]
     public function render(array $data, ContextInterface $context): string
     {
         $data += [
@@ -83,6 +84,7 @@ class ButtonWidget implements WidgetInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function secureFields(array $data): array
     {
         if (!isset($data['name']) || $data['name'] === '') {

--- a/src/View/Widget/CheckboxWidget.php
+++ b/src/View/Widget/CheckboxWidget.php
@@ -56,6 +56,7 @@ class CheckboxWidget extends BasicWidget
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string Generated HTML string.
      */
+    #[\Override]
     public function render(array $data, ContextInterface $context): string
     {
         $data += $this->mergeDefaults($data, $context);

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -109,6 +109,7 @@ class DateTimeWidget extends BasicWidget
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string HTML elements.
      */
+    #[\Override]
     public function render(array $data, ContextInterface $context): string
     {
         $data += $this->mergeDefaults($data, $context);
@@ -144,6 +145,7 @@ class DateTimeWidget extends BasicWidget
      * @param string $fieldName Field name.
      * @return array<string, mixed> Updated data array.
      */
+    #[\Override]
     protected function setStep(array $data, ContextInterface $context, string $fieldName): array
     {
         if (array_key_exists('step', $data)) {
@@ -234,6 +236,7 @@ class DateTimeWidget extends BasicWidget
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function secureFields(array $data): array
     {
         if (!isset($data['name']) || $data['name'] === '') {

--- a/src/View/Widget/FileWidget.php
+++ b/src/View/Widget/FileWidget.php
@@ -53,6 +53,7 @@ class FileWidget extends BasicWidget
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string HTML elements.
      */
+    #[\Override]
     public function render(array $data, ContextInterface $context): string
     {
         $data += $this->mergeDefaults($data, $context);

--- a/src/View/Widget/LabelWidget.php
+++ b/src/View/Widget/LabelWidget.php
@@ -72,6 +72,7 @@ class LabelWidget implements WidgetInterface
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string
      */
+    #[\Override]
     public function render(array $data, ContextInterface $context): string
     {
         $data += [
@@ -94,6 +95,7 @@ class LabelWidget implements WidgetInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function secureFields(array $data): array
     {
         return [];

--- a/src/View/Widget/MultiCheckboxWidget.php
+++ b/src/View/Widget/MultiCheckboxWidget.php
@@ -119,6 +119,7 @@ class MultiCheckboxWidget extends BasicWidget
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string
      */
+    #[\Override]
     public function render(array $data, ContextInterface $context): string
     {
         $data += $this->mergeDefaults($data, $context);

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -97,6 +97,7 @@ class RadioWidget extends BasicWidget
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string
      */
+    #[\Override]
     public function render(array $data, ContextInterface $context): string
     {
         $data += $this->mergeDefaults($data, $context);

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -119,6 +119,7 @@ class SelectBoxWidget extends BasicWidget
      * @return string A generated select box.
      * @throws \RuntimeException when the name attribute is empty.
      */
+    #[\Override]
     public function render(array $data, ContextInterface $context): string
     {
         $data += $this->mergeDefaults($data, $context);

--- a/src/View/Widget/TextareaWidget.php
+++ b/src/View/Widget/TextareaWidget.php
@@ -55,6 +55,7 @@ class TextareaWidget extends BasicWidget
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string HTML elements.
      */
+    #[\Override]
     public function render(array $data, ContextInterface $context): string
     {
         $data += $this->mergeDefaults($data, $context);

--- a/src/View/Widget/YearWidget.php
+++ b/src/View/Widget/YearWidget.php
@@ -71,6 +71,7 @@ class YearWidget extends BasicWidget
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string A generated select box.
      */
+    #[\Override]
     public function render(array $data, ContextInterface $context): string
     {
         $data += $this->mergeDefaults($data, $context);

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -101,6 +101,7 @@ class XmlView extends SerializedView
      *
      * @return string The JSON content type.
      */
+    #[\Override]
     public static function contentType(): string
     {
         return 'application/xml';
@@ -109,6 +110,7 @@ class XmlView extends SerializedView
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function _serialize(array|string $serialize): string
     {
         /** @var string $rootNode */


### PR DESCRIPTION
This is what psalm 6.10 with --alter wants to add

    tools/psalm --alter --issues=MissingOverrideAttribute

DO we want this?
The benefits are minor, right?

We would still need to run CS and then there is an extra use statement in there.