### PR TITLE
5.next: getDisplayField() cannot return null.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -663,9 +663,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Returns the display field.
      *
-     * @return array<string>|string|null
+     * @return array<string>|string
      */
-    public function getDisplayField(): array|string|null
+    public function getDisplayField(): array|string
     {
         if ($this->_displayField !== null) {
             return $this->_displayField;


### PR DESCRIPTION
Should be BC as extending code would have a wider range of return type.