### PR TITLE
Raise 5.3 PHP min to 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1', '8.3']
+        php-version: ['8.2', '8.4']
         db-type: [sqlite, pgsql]
         include:
-          - php-version: '8.1'
+          - php-version: '8.2'
             db-type: 'mariadb'
-          - php-version: '8.1'
+          - php-version: '8.2'
             db-type: 'mysql'
             dependencies: 'lowest'
           - php-version: '8.2'
@@ -91,7 +91,7 @@ jobs:
         composer-options: "${{ matrix.composer-options }}"
 
     - name: Setup problem matchers for PHPUnit
-      if: matrix.php-version == '8.1' && matrix.db-type == 'mysql'
+      if: matrix.php-version == '8.2' && matrix.db-type == 'mysql'
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Run PHPUnit
@@ -104,7 +104,7 @@ jobs:
         if [[ ${{ matrix.db-type }} == 'mariadb' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp'; fi
         if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_URL='postgres://postgres:postgres@127.0.0.1/postgres'; fi
 
-        if [[ ${{ matrix.php-version }} == '8.1' ]]; then
+        if [[ ${{ matrix.php-version }} == '8.2' ]]; then
           export CODECOVERAGE=1
           vendor/bin/phpunit --display-warnings --display-incomplete --coverage-clover=coverage.xml
           CAKE_TEST_AUTOQUOTE=1 vendor/bin/phpunit --display-deprecations --display-warnings --display-incomplete --testsuite=database
@@ -115,7 +115,7 @@ jobs:
         fi
 
     - name: Submit code coverage
-      if: matrix.php-version == '8.1'
+      if: matrix.php-version == '8.2'
       uses: codecov/codecov-action@v5
       with:
         files: coverage.xml,coverage-functions.xml
@@ -123,11 +123,11 @@ jobs:
 
   testsuite-windows:
     runs-on: windows-2022
-    name: Windows - PHP 8.1 & SQL Server
+    name: Windows - PHP 8.2 & SQL Server
 
     env:
       EXTENSIONS: mbstring, intl, apcu, redis, pdo_sqlsrv
-      PHP_VERSION: '8.1'
+      PHP_VERSION: '8.2'
 
     steps:
     - uses: actions/checkout@v4
@@ -201,7 +201,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           extensions: mbstring, intl
           coverage: none
           tools: phive, cs2pr

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "mikey179/vfsstream": "^1.6.10",
         "mockery/mockery": "^1.6",
         "paragonie/csp-builder": "^2.3 || ^3.0",
-        "phpunit/phpunit": "^10.5.5 || ^11.1.3 || ^12.0.9"
+        "phpunit/phpunit": "^11.1.3 || ^12.0.9"
     },
     "suggest": {
         "ext-curl": "To enable more efficient network calls in Http\\Client.",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/src/Cache/composer.json
+++ b/src/Cache/composer.json
@@ -22,7 +22,7 @@
         "source": "https://github.com/cakephp/cache"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "cakephp/core": "5.3.*@dev",
         "psr/simple-cache": "^2.0 || ^3.0"
     },

--- a/src/Collection/composer.json
+++ b/src/Collection/composer.json
@@ -23,7 +23,7 @@
         "source": "https://github.com/cakephp/collection"
     },
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Console/composer.json
+++ b/src/Console/composer.json
@@ -23,7 +23,7 @@
         "source": "https://github.com/cakephp/console"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "cakephp/core": "5.3.*@dev",
         "cakephp/event": "5.3.*@dev",
         "cakephp/log": "5.3.*@dev",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -22,7 +22,7 @@
         "source": "https://github.com/cakephp/core"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "cakephp/utility": "5.3.*@dev",
         "league/container": "^4.2",
         "psr/container": "^1.1 || ^2.0"

--- a/src/Database/composer.json
+++ b/src/Database/composer.json
@@ -24,7 +24,7 @@
         "source": "https://github.com/cakephp/database"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "cakephp/core": "5.3.*@dev",
         "cakephp/chronos": "^3.1",
         "cakephp/datasource": "5.3.*@dev",

--- a/src/Datasource/composer.json
+++ b/src/Datasource/composer.json
@@ -24,7 +24,7 @@
         "source": "https://github.com/cakephp/datasource"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "cakephp/core": "5.3.*@dev",
         "psr/simple-cache": "^2.0 || ^3.0"
     },

--- a/src/Event/composer.json
+++ b/src/Event/composer.json
@@ -23,7 +23,7 @@
         "source": "https://github.com/cakephp/event"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "cakephp/core": "5.3.*@dev"
     },
     "autoload": {

--- a/src/Form/composer.json
+++ b/src/Form/composer.json
@@ -21,7 +21,7 @@
         "source": "https://github.com/cakephp/form"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "cakephp/event": "5.3.*@dev",
         "cakephp/validation":"5.3.*@dev"
     },

--- a/src/Http/composer.json
+++ b/src/Http/composer.json
@@ -25,7 +25,7 @@
         "source": "https://github.com/cakephp/http"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "cakephp/core": "5.3.*@dev",
         "cakephp/event": "5.3.*@dev",
         "cakephp/utility": "5.3.*@dev",

--- a/src/I18n/composer.json
+++ b/src/I18n/composer.json
@@ -28,7 +28,7 @@
         "source": "https://github.com/cakephp/i18n"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "ext-intl": "*",
         "cakephp/core": "5.3.*@dev",
         "cakephp/chronos": "^3.1"

--- a/src/Log/composer.json
+++ b/src/Log/composer.json
@@ -23,7 +23,7 @@
         "source": "https://github.com/cakephp/log"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "cakephp/core": "5.3.*@dev",
         "psr/log": "^3.0"
     },

--- a/src/ORM/composer.json
+++ b/src/ORM/composer.json
@@ -23,7 +23,7 @@
         "source": "https://github.com/cakephp/orm"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "cakephp/collection": "5.3.*@dev",
         "cakephp/core": "5.3.*@dev",
         "cakephp/datasource": "5.3.*@dev",

--- a/src/Utility/composer.json
+++ b/src/Utility/composer.json
@@ -25,7 +25,7 @@
         "source": "https://github.com/cakephp/utility"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "cakephp/core": "5.3.*@dev"
     },
     "autoload": {

--- a/src/Validation/composer.json
+++ b/src/Validation/composer.json
@@ -22,7 +22,7 @@
         "source": "https://github.com/cakephp/validation"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "cakephp/core": "5.3.*@dev",
         "cakephp/utility": "5.3.*@dev",
         "psr/http-message": "^1.1 || ^2.0"


### PR DESCRIPTION
The next CakePHP 5.x release should definitly be 8.2+
Given that this is many months away and 8.1 will not even have security updates anymore end of the year
Easy enough to use 8.2-8.4 until then.
https://www.php.net/supported-versions.php

This allows us to drop PHPUnit 10, and only keep 11/12 support moving forward in 5.x.