### PR TITLE
5.x: Remove PHPStan silencing for getBehavior() proxy calls.

### DIFF
--- a/src/Command/CounterCacheCommand.php
+++ b/src/Command/CounterCacheCommand.php
@@ -72,8 +72,7 @@ class CounterCacheCommand extends Command
             $methodArgs['page'] = (int)$args->getOption('page');
         }
 
-        /** @phpstan-ignore-next-line */
-        $table->updateCounterCache(...$methodArgs);
+        $table->getBehavior('CounterCache')->updateCounterCache(...$methodArgs);
 
         $io->success('Counter cache updated successfully.');
 

--- a/src/Command/CounterCacheCommand.php
+++ b/src/Command/CounterCacheCommand.php
@@ -72,6 +72,7 @@ class CounterCacheCommand extends Command
             $methodArgs['page'] = (int)$args->getOption('page');
         }
 
+        /** @var \Cake\ORM\Table<array{CounterCache: \Cake\ORM\Behavior\CounterCacheBehavior}> $table */
         $table->getBehavior('CounterCache')->updateCounterCache(...$methodArgs);
 
         $io->success('Counter cache updated successfully.');


### PR DESCRIPTION
Following https://github.com/cakephp/cakephp/pull/18323
Shouldnt this be possible now without silencing?

or do we need a https://github.com/CakeDC/cakephp-phpstan/ rule on top for it to work?