### PR TITLE
Ensure a field's setter is not run if the value is unchanged.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -311,6 +311,12 @@ trait EntityTrait
                 continue;
             }
 
+            if ($options['asOriginal'] || $this->isModified($name, $value)) {
+                $this->setDirty($name, true);
+            } else {
+                continue;
+            }
+
             if ($options['setter']) {
                 $setter = static::_accessor($name, 'set');
                 if ($setter) {
@@ -327,14 +333,6 @@ trait EntityTrait
                 $this->_original[$name] = $this->_fields[$name];
             }
 
-            // Don't dirty scalar values and objects that didn't
-            // change. Arrays will always be marked as dirty because
-            // the original/updated list could contain references to the
-            // same objects, even though those objects may have changed internally.
-            if ($this->isModified($name, $value)) {
-                $this->setDirty($name, true);
-            }
-
             $this->_fields[$name] = $value;
         }
 
@@ -343,6 +341,12 @@ trait EntityTrait
 
     /**
      * Check if the provided value is same as existing value for a field.
+     *
+     * This check is used to determine if a field should be set as dirty or not.
+     * It will return `false` for scalar values and objects which haven't changed.
+     * For arrays `true` will be returned always because the original/updated list
+     * could contain references to the same objects, even though those objects
+     * may have changed internally.
      *
      * @param string $field The field to check.
      * @return bool
@@ -873,7 +877,7 @@ trait EntityTrait
      */
     public function isOriginalField(string $name): bool
     {
-        return in_array($name, $this->_originalFields);
+        return in_array($name, $this->_originalFields, true);
     }
 
     /**

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -76,6 +76,7 @@ class Entity implements EntityInterface, InvalidPropertyInterface
             }
 
             $this->patch($properties, [
+                'asOriginal' => true,
                 'setter' => $options['useSetters'],
                 'guard' => $options['guard'],
             ]);

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -273,9 +273,9 @@ class EntityTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     [
-                    ['a' => 'b', 'c' => 'd'], ['setter' => true, 'guard' => false],
+                    ['a' => 'b', 'c' => 'd'], ['setter' => true, 'guard' => false, 'asOriginal' => true],
                     ],
-                    [['foo' => 'bar'], ['setter' => false, 'guard' => false]],
+                    [['foo' => 'bar'], ['setter' => false, 'guard' => false, 'asOriginal' => true]],
                 ),
             );
 
@@ -295,7 +295,7 @@ class EntityTest extends TestCase
             ->getMock();
         $entity->expects($this->once())
             ->method('patch')
-            ->with(['foo' => 'bar'], ['setter' => true, 'guard' => true]);
+            ->with(['foo' => 'bar'], ['setter' => true, 'guard' => true, 'asOriginal' => true]);
         $entity->__construct(['foo' => 'bar'], ['guard' => true]);
     }
 

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1579,6 +1579,25 @@ class MarshallerTest extends TestCase
         $this->assertFalse($entity->isDirty('title'));
         $this->assertFalse($entity->isDirty('author_id'));
         $this->assertTrue($entity->isDirty('crazy'));
+
+        // https://github.com/cakephp/cakephp/issues/18346
+        $entity = new class ([
+            'title' => 'Foo',
+            'author_id' => 1,
+        ], ['useSetters' => false]) extends Entity {
+            protected function _setTitle(string $name): string
+            {
+                return 'The ' . $name;
+            }
+        };
+        $entity->clean();
+
+        $this->assertSame('Foo', $entity->title);
+        $marshall->merge($entity, ['title' => 'Foo', 'author_id' => 2]);
+        $this->assertSame('Foo', $entity->title, 'Setter should not be called as the value is unchanged');
+        $this->assertFalse($entity->isDirty('title'));
+        $this->assertTrue($entity->isDirty('author_id'));
+        $this->assertSame(2, $entity->author_id);
     }
 
     /**


### PR DESCRIPTION
Fixes #18346

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
