### PR TITLE
Deprecated accessing request params through ServerRequest::getParam('?').

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -30,6 +30,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use Psr\Http\Message\UriInterface;
+use function Cake\Core\deprecationWarning;
 use function Cake\Core\env;
 
 /**
@@ -1514,6 +1515,13 @@ class ServerRequest implements ServerRequestInterface
      */
     public function getParam(string $name, mixed $default = null): mixed
     {
+        if ($name === '?') {
+            deprecationWarning(
+                '5.3.0',
+                'Using `$request->getParam("?")` is deprecated. Use `$request->getQueryParams()` instead.',
+            );
+        }
+
         return Hash::get($this->params, $name, $default);
     }
 

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -29,6 +29,7 @@ use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use Laminas\Diactoros\Uri;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -1223,6 +1224,22 @@ class ServerRequestTest extends TestCase
             ],
         ]);
         $this->assertSame($expected, $request->getParam($toRead));
+    }
+
+    #[WithoutErrorHandler]
+    public function testGetParamQueryParamsDeprecation(): void
+    {
+        $this->deprecated(function () {
+            $request = new ServerRequest([
+                'url' => '/',
+                'params' => [
+                    'action' => 'index',
+                    '?' => ['foo' => 'bar'],
+                ],
+            ]);
+
+            $this->assertSame(['foo' => 'bar'], $request->getParam('?'));
+        });
     }
 
     /**


### PR DESCRIPTION
Having query params stored at multiple locations causes descrepancies in the code base. In the future the query params stored under '?' will be dropped for the request params array.

Refs #18343
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
