### PR TITLE
Improve ResultSet::__debugInfo().

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace Cake\Collection;
 
 use ArrayIterator;
-use Exception;
 use IteratorIterator;
+use SplFixedArray;
 
 /**
  * A collection is an immutable list of elements with a handful of functions to
@@ -31,6 +31,13 @@ class Collection extends IteratorIterator implements CollectionInterface
     use CollectionTrait;
 
     /**
+     * Whether or not the items in this collection are an array.
+     *
+     * @var bool
+     */
+    protected bool $innerIsArray = false;
+
+    /**
      * Constructor. You can provide an array or any traversable object
      *
      * @param iterable $items Items.
@@ -41,6 +48,8 @@ class Collection extends IteratorIterator implements CollectionInterface
         if (is_array($items)) {
             $items = new ArrayIterator($items);
         }
+
+        $this->innerIsArray = $items instanceof ArrayIterator || $items instanceof SplFixedArray;
 
         parent::__construct($items);
     }
@@ -74,14 +83,23 @@ class Collection extends IteratorIterator implements CollectionInterface
      */
     public function __debugInfo(): array
     {
-        try {
-            $count = $this->count();
-        } catch (Exception) {
-            $count = 'An exception occurred while getting count';
+        if ($this->innerIsArray) {
+            $index = $this->key();
+            $items = $this->toArray();
+
+            $this->rewind();
+            while ($this->key() !== $index) {
+                $this->next();
+            }
+
+            return [
+                'count' => count($items),
+                'items' => $items,
+            ];
         }
 
         return [
-            'count' => $count,
+            'innerIterator' => $this->unwrap(),
         ];
     }
 }

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -30,26 +30,4 @@ use Cake\Datasource\ResultSetInterface;
  */
 class ResultSet extends Collection implements ResultSetInterface
 {
-    /**
-     * Returns an array that can be used to describe the internal state of this
-     * object.
-     *
-     * @return array<string, mixed>
-     */
-    public function __debugInfo(): array
-    {
-        $key = $this->key();
-        $items = $this->toArray();
-
-        $this->rewind();
-        // Move the internal pointer to the previous position otherwise it creates problems with Xdebug
-        // https://github.com/cakephp/cakephp/issues/18234
-        while ($this->key() !== $key) {
-            $this->next();
-        }
-
-        return [
-            'items' => $items,
-        ];
-    }
 }

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -2025,6 +2025,7 @@ class CollectionTest extends TestCase
         $result = $collection->__debugInfo();
         $expected = [
             'count' => 3,
+            'items' => [1, 2, 3],
         ];
         $this->assertSame($expected, $result);
 
@@ -2032,6 +2033,7 @@ class CollectionTest extends TestCase
         $result = $collection->__debugInfo();
         $expected = [
             'count' => 3,
+            'items' => [1, 2, 3],
         ];
         $this->assertSame($expected, $result);
 
@@ -2040,17 +2042,11 @@ class CollectionTest extends TestCase
         $collection = new Collection($iterator);
 
         $result = $collection->__debugInfo();
-        $expected = [
-            'count' => 3,
-        ];
-        $this->assertSame($expected, $result);
+        $this->assertStringContainsString('NoRewindIterator', $result['innerIterator']::class);
 
         // Calling it again will in this case not rewind
         $result = $collection->__debugInfo();
-        $expected = [
-            'count' => 0,
-        ];
-        $this->assertSame($expected, $result);
+        $this->assertStringContainsString('NoRewindIterator', $result['innerIterator']::class);
 
         $filter = function ($value): void {
             throw new Exception('filter exception');
@@ -2059,10 +2055,7 @@ class CollectionTest extends TestCase
         $collection = new Collection($iterator);
 
         $result = $collection->__debugInfo();
-        $expected = [
-            'count' => 'An exception occurred while getting count',
-        ];
-        $this->assertSame($expected, $result);
+        $this->assertStringContainsString('CallbackFilterIterator', $result['innerIterator']::class);
     }
 
     /**

--- a/tests/TestCase/ORM/ResultSetFactoryTest.php
+++ b/tests/TestCase/ORM/ResultSetFactoryTest.php
@@ -92,6 +92,7 @@ class ResultSetFactoryTest extends TestCase
         $query = $this->table->find('all');
         $results = $query->all();
         $expected = [
+            'count' => 3,
             'items' => $results->toArray(),
         ];
         $this->assertSame($expected, $results->__debugInfo());

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -232,6 +232,7 @@ class ResultSetTest extends TestCase
         $query = $this->table->find('all');
         $results = $query->all();
         $expected = [
+            'count' => 3,
             'items' => $results->toArray(),
         ];
         $this->assertSame($expected, $results->__debugInfo());


### PR DESCRIPTION
Currently is executes all inner iterators to get the items list as an array. This can cause memory issues when for e.g. using non buffered resultset which could contain a large amount of records.

Refs #18236

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
