### PR TITLE
5.next: Deprecate isEmpty() in favor of hasValue().

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -531,6 +531,8 @@ trait EntityTrait
      */
     public function isEmpty(string $field): bool
     {
+        deprecationWarning('5.3.0', 'isEmpty() is deprecated. Use hasValue() instead.');
+
         return !$this->hasValue($field);
     }
 

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -527,21 +527,11 @@ trait EntityTrait
      *
      * @param string $field The field to check.
      * @return bool
+     * @deprecated 5.3.0 Use hasValue() instead.
      */
     public function isEmpty(string $field): bool
     {
-        $value = $this->get($field);
-        if (
-            $value === null ||
-            (
-                $value === [] ||
-                $value === ''
-            )
-        ) {
-            return true;
-        }
-
-        return false;
+        return !$this->hasValue($field);
     }
 
     /**
@@ -562,7 +552,18 @@ trait EntityTrait
      */
     public function hasValue(string $field): bool
     {
-        return !$this->isEmpty($field);
+        $value = $this->get($field);
+        if (
+            $value === null ||
+            (
+                $value === [] ||
+                $value === ''
+            )
+        ) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -32,7 +32,7 @@ class Entity implements EntityInterface, InvalidPropertyInterface
      * Initializes the internal properties of this entity out of the
      * keys in an array. The following list of options can be used:
      *
-     * - useSetters: whether use internal setters for properties or not
+     * - useSetters: whether to use internal setters for properties or not
      * - markClean: whether to mark all properties as clean after setting them
      * - markNew: whether this instance has not yet been persisted
      * - guard: whether to prevent inaccessible properties from being set (default: false)


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/pull/18335

Note: The EntityInterface is already correct, it lists only hasValue()