### PR TITLE
Fix up debug/cli auto-detect

### DIFF
--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -34,6 +34,7 @@ class PluginLoadCommand extends Command
      * @var array<string>
      */
     protected static $devTags = ['dev', 'testing', 'static analysis'];
+
     /**
      * @var array<string>
      */

--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -89,6 +89,7 @@ class PluginLoadCommand extends Command
             }
         }
 
+        $path = null;
         try {
             $path = Plugin::getCollection()->findPath($plugin);
         } catch (MissingPluginException $e) {
@@ -100,7 +101,7 @@ class PluginLoadCommand extends Command
             }
         }
 
-        $recommendations = $this->recommendations($path);
+        $recommendations = $path ? $this->recommendations($path) : [];
         foreach ($recommendations as $name => $v) {
             if (isset($options[$name]) && $options[$name] === $v) {
                 continue;
@@ -115,10 +116,6 @@ class PluginLoadCommand extends Command
             }
 
             $options[$name] = $v;
-        }
-
-        if (!empty($options['onlyDebug'])) {
-            $options['optional'] = true;
         }
 
         $result = $this->modifyConfigFile($plugin, $options);
@@ -176,7 +173,7 @@ class PluginLoadCommand extends Command
         }
 
         $content = file_get_contents($file);
-        $array = json_decode($content, true);
+        $array = $content ? json_decode($content, true) : [];
         $keywords = $array['keywords'] ?? [];
         if (!$keywords) {
             return [];
@@ -192,6 +189,10 @@ class PluginLoadCommand extends Command
             if (in_array($tag, $keywords, true)) {
                 $recommendations['onlyCli'] = true;
             }
+        }
+
+        if (!empty($recommendations['onlyDebug'])) {
+            $recommendations['optional'] = true;
         }
 
         return $recommendations;

--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -31,6 +31,15 @@ use Cake\Utility\Hash;
 class PluginLoadCommand extends Command
 {
     /**
+     * @var array<string>
+     */
+    protected static $devTags = ['dev', 'testing', 'static analysis'];
+    /**
+     * @var array<string>
+     */
+    protected static $cliTags = ['cli', 'command line', 'shell'];
+
+    /**
      * Config file
      *
      * @var string
@@ -81,7 +90,7 @@ class PluginLoadCommand extends Command
         }
 
         try {
-            Plugin::getCollection()->findPath($plugin);
+            $path = Plugin::getCollection()->findPath($plugin);
         } catch (MissingPluginException $e) {
             if (empty($options['optional'])) {
                 $io->err($e->getMessage());
@@ -89,6 +98,27 @@ class PluginLoadCommand extends Command
 
                 return static::CODE_ERROR;
             }
+        }
+
+        $recommendations = $this->recommendations($path);
+        foreach ($recommendations as $name => $v) {
+            if (isset($options[$name]) && $options[$name] === $v) {
+                continue;
+            }
+
+            $option = $name . ': ' . ($v ? 'true' : 'false');
+            $question = 'Based on the plugin composer keywords, this seems to be `' . $option . '`. ';
+            $question .= 'Do you want to change this?';
+            $in = $io->askChoice($question, ['y', 'n'], 'y');
+            if ($in !== 'y') {
+                continue;
+            }
+
+            $options[$name] = $v;
+        }
+
+        if (!empty($options['onlyDebug'])) {
+            $options['optional'] = true;
         }
 
         $result = $this->modifyConfigFile($plugin, $options);
@@ -125,13 +155,46 @@ class PluginLoadCommand extends Command
         } else {
             $array = var_export($config, true);
         }
-        $contents = '<?php' . "\n\n" . 'return ' . $array . ';' . "\n";
 
+        $contents = '<?php' . "\n\n" . 'return ' . $array . ';' . "\n";
         if (file_put_contents($this->configFile, $contents)) {
             return static::CODE_SUCCESS;
         }
 
         return static::CODE_ERROR;
+    }
+
+    /**
+     * @param string $path
+     * @return array<string, bool>
+     */
+    protected function recommendations(string $path): array
+    {
+        $file = $path . 'composer.json';
+        if (!file_exists($file)) {
+            return [];
+        }
+
+        $content = file_get_contents($file);
+        $array = json_decode($content, true);
+        $keywords = $array['keywords'] ?? [];
+        if (!$keywords) {
+            return [];
+        }
+
+        $recommendations = [];
+        foreach (static::$devTags as $tag) {
+            if (in_array($tag, $keywords, true)) {
+                $recommendations['onlyDebug'] = true;
+            }
+        }
+        foreach (static::$cliTags as $tag) {
+            if (in_array($tag, $keywords, true)) {
+                $recommendations['onlyCli'] = true;
+            }
+        }
+
+        return $recommendations;
     }
 
     /**

--- a/tests/TestCase/Command/PluginListCommandTest.php
+++ b/tests/TestCase/Command/PluginListCommandTest.php
@@ -82,8 +82,8 @@ class PluginListCommandTest extends TestCase
 declare(strict_types=1);
 return [
     'plugins' => [
-        'TestPlugin' => '/config/path',
-        'OtherPlugin' => '/config/path'
+        'TestPlugin' => '/config/path/',
+        'OtherPlugin' => '/config/path/'
     ]
 ];
 PHP;
@@ -122,8 +122,8 @@ PHP;
 declare(strict_types=1);
 return [
     'plugins' => [
-        'TestPlugin' => '/config/path',
-        'OtherPlugin' => '/config/path'
+        'TestPlugin' => '/config/path/',
+        'OtherPlugin' => '/config/path/'
     ]
 ];
 PHP;
@@ -155,8 +155,8 @@ PHP;
 declare(strict_types=1);
 return [
     'plugins' => [
-        'TestPlugin' => '/config/path',
-        'OtherPlugin' => '/config/path'
+        'TestPlugin' => '/config/path/',
+        'OtherPlugin' => '/config/path/'
     ]
 ];
 PHP;

--- a/tests/TestCase/Command/PluginLoadCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadCommandTest.php
@@ -103,6 +103,24 @@ class PluginLoadCommandTest extends TestCase
     }
 
     /**
+     * Test recommendations for keywords in composer.json
+     */
+    public function testLoadRecommendations(): void
+    {
+        $this->exec('plugin load TestPluginFour', ['y', 'y', 'y']);
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+        Plugin::getCollection()->remove('TestPluginFour');
+
+        $config = include $this->configFile;
+        $expected = [
+            'onlyDebug' => true,
+            'onlyCli' => true,
+            'optional' => true,
+        ];
+        $this->assertEquals($expected, $config['TestPluginFour']);
+    }
+
+    /**
      * Test loading an unknown plugin
      */
     public function testLoadUnknownPlugin(): void

--- a/tests/TestCase/Core/PluginCollectionTest.php
+++ b/tests/TestCase/Core/PluginCollectionTest.php
@@ -261,7 +261,7 @@ class PluginCollectionTest extends TestCase
 declare(strict_types=1);
 return [
     'plugins' => [
-        'TestPlugin' => '/config/path'
+        'TestPlugin' => '/config/path/'
     ]
 ];
 PHP;
@@ -272,7 +272,7 @@ PHP;
         $path = $plugins->findPath('TestPlugin');
         unlink($configPath);
 
-        $this->assertSame('/config/path', $path);
+        $this->assertSame('/config/path/', $path);
     }
 
     public function testFindPathConfigureData(): void

--- a/tests/TestCase/Core/PluginConfigTest.php
+++ b/tests/TestCase/Core/PluginConfigTest.php
@@ -64,8 +64,8 @@ class PluginConfigTest extends TestCase
 <?php
 return [
     'plugins' => [
-        'TestPlugin' => '/config/path',
-        'OtherPlugin' => '/config/path',
+        'TestPlugin' => '/config/path/',
+        'OtherPlugin' => '/config/path/',
     ]
 ];
 PHP;
@@ -116,8 +116,8 @@ PHP;
 <?php
 return [
     'plugins' => [
-        'TestPlugin' => '/config/path',
-        'OtherPlugin' => '/config/path',
+        'TestPlugin' => '/config/path/',
+        'OtherPlugin' => '/config/path/',
     ]
 ];
 PHP;
@@ -157,8 +157,8 @@ PHP;
 <?php
 return [
     'plugins' => [
-        'OtherPlugin' => '/config/path',
-        'AnotherPlugin' => '/config/path'
+        'OtherPlugin' => '/config/path/',
+        'AnotherPlugin' => '/config/path/'
     ]
 ];
 PHP;
@@ -208,8 +208,8 @@ PHP;
 <?php
 return [
     'plugins' => [
-        'TestPlugin' => '/config/path',
-        'OtherPlugin' => '/config/path',
+        'TestPlugin' => '/config/path/',
+        'OtherPlugin' => '/config/path/',
     ]
 ];
 PHP;
@@ -243,8 +243,8 @@ PHP;
 <?php
 return [
     'plugins' => [
-        'TestPlugin' => '/config/path',
-        'OtherPlugin' => '/config/path',
+        'TestPlugin' => '/config/path/',
+        'OtherPlugin' => '/config/path/',
     ]
 ];
 PHP;

--- a/tests/test_app/Plugin/TestPluginFour/composer.json
+++ b/tests/test_app/Plugin/TestPluginFour/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "cakephp/test-plugin",
+    "description": "CakePHP Test Plugin",
+    "type": "cakephp-plugin",
+    "keywords": [
+        "cakephp",
+        "test",
+        "cli",
+        "dev"
+    ]
+}


### PR DESCRIPTION
Composer has this handy part of 
```php
$devTags = ['dev', 'testing', 'static analysis'];
```
and
```php
$io->warning('The package'.$plural.' you required '.$plural2.' recommended to be placed in require-dev (because '.$plural3.' tagged as "'.implode('", "', $pkgDevTags).'") but you did not use --dev.');
if ($io->askConfirmation('<info>Do you want to re-run the command with --dev?</> [<comment>yes</>]? ')) {
    $input->setOption('dev', true);
}
```

Similar to preventing adding require-dev dependencies to require, this helps to prevent user mistake of making something available beyond the scope. Especially in regards to onlyDebug, as some tools like DebugKit or my TestHelper plugin should never be loaded in prod mode.


Many plugins are already adjusted for it

onlyDebug
- https://github.com/cakephp/debug_kit/blob/0b0f6a74bef7be35bbb19e40f44d6ec814c28309/composer.json#L10
- https://github.com/cakephp/bake/blob/530d7c8c025833b01d57c6fc36d52dc6ea61113b/composer.json#L9
- https://github.com/dereuromark/cakephp-ide-helper/blob/494d8694f77625feeb173894d16976f5f92bc562/composer.json#L14
- https://github.com/dereuromark/cakephp-test-helper/blob/55a01e625d0f3e6b87594e325ed7d3bf7e1e2c99/composer.json#L13

onlyCli
- https://github.com/cakephp/migrations/blob/486b6cfe05f9fb07ab326ef42adff28514d3a032/composer.json#L9
- https://github.com/cakephp/bake/blob/91d32beebfc63acc15308b0663acf0e288d2a9d5/composer.json#L10
- https://github.com/dereuromark/cakephp-ide-helper/blob/fe66ea05bc5fa6cf5945dc005770cc1e75adff93/composer.json#L14

If not, we can quickly fix that.