### PR TITLE
Fixed up chaotic addClass() docblock types.

### DIFF
--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -346,7 +346,7 @@ class StringTemplate
     /**
      * Adds a class and returns a unique list either in array or space separated
      *
-     * @param mixed $input The array or string to add the class to
+     * @param array<string, mixed>|string|null $input The array or string to add the class to
      * @param array<string>|string|false|null $newClass the new class or classes to add
      * @param string $useIndex if you are inputting an array with an element other than default of 'class'.
      * @return array<string, string>|string|null


### PR DESCRIPTION
In the future maybe we can split those based on array vs string.
And the input type wouldnt need to be mixed IMO, but array|string.