### PR TITLE
Deprecate string usage on getTemplates().

### DIFF
--- a/src/View/StringTemplateTrait.php
+++ b/src/View/StringTemplateTrait.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\View;
 
+use function Cake\Core\deprecationWarning;
+
 /**
  * Adds string template functionality to any class by providing methods to
  * load and parse string templates.
@@ -49,10 +51,30 @@ trait StringTemplateTrait
     /**
      * Gets templates to use or a specific template.
      *
+     * Deprecated: Getting a specific template is deprecated. Use getTemplate() instead.
+     *
      * @param string|null $template String for reading a specific template, null for all.
      * @return array|string
      */
     public function getTemplates(?string $template = null): array|string
+    {
+        if ($template !== null) {
+            deprecationWarning(
+                '5.3.0',
+                'Returning a concrete template from getTemplates() is deprecated. Use getTemplate() instead.',
+            );
+        }
+
+        return $this->templater()->get($template);
+    }
+
+    /**
+     * Gets templates to use or a specific template.
+     *
+     * @param string $template String for reading a specific template.
+     * @return string
+     */
+    public function getTemplate(string $template): string
     {
         return $this->templater()->get($template);
     }

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -134,6 +134,19 @@ class PaginatorHelperTest extends TestCase
     }
 
     /**
+     * Test the getTemplate() method.
+     */
+    public function testGetTemplate(): void
+    {
+        $this->Paginator->setTemplates([
+            'test' => 'val',
+        ]);
+
+        $result = $this->Paginator->getTemplate('test');
+        $this->assertSame('val', $result);
+    }
+
+    /**
      * testHasPrevious method
      */
     public function testHasPrevious(): void


### PR DESCRIPTION
In 6.x we can the clean this up.