### PR TITLE
Fix reflection of primary keys

### DIFF
--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -703,6 +703,7 @@ SQL;
 
     public function testDescribeIndexesTextPrimaryKey(): void
     {
+        $this->_needsConnection();
         $connection = ConnectionManager::get('test');
         $dialect = $connection->getDriver()->schemaDialect();
 


### PR DESCRIPTION
When a primary key exists on a string column type without a default, sqlite will return that primary key in index_info(). When we get that primary key, we don't need to scan the columns.

This improves efficency and fixes regressions that would occur in migrations.
