### PR TITLE
fix: removeOption() does not clear _shortOptions in ConsoleOptionParser

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -418,6 +418,11 @@ class ConsoleOptionParser
     {
         unset($this->_options[$name]);
 
+        $key = array_search($name, $this->_shortOptions, true);
+        if ($key !== false) {
+            unset($this->_shortOptions[$key]);
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
https://github.com/cakephp/cakephp/issues/18375
