### PR TITLE
fix: removeOption() does not clear _shortOptions in ConsoleOptionParser

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -418,6 +418,11 @@ class ConsoleOptionParser
     {
         unset($this->_options[$name]);
 
+        $key = array_search($name, $this->_shortOptions, true);
+        if ($key !== false) {
+            unset($this->_shortOptions[$key]);
+        }
+
         return $this;
     }
 

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -97,6 +97,20 @@ class ConsoleOptionParserTest extends TestCase
     }
 
     /**
+     * test removing an option clears also shortOption.
+     */
+    #[WithoutErrorHandler]
+    public function testRemoveOptionAlsoClearsShort(): void
+    {
+        $parser = new ConsoleOptionParser('test', false);
+        $result = $parser->addOption('test', ['short' => 't'])
+            ->removeOption('test')
+            ->removeOption('help')
+            ->addOption('test', ['short' => 't']);
+        $this->assertSame($parser, $result, 'Did not return $this from removeOption');
+    }
+
+    /**
      * test adding an option and using the long value for parsing.
      */
     public function testAddOptionLong(): void


### PR DESCRIPTION
https://github.com/cakephp/cakephp/pull/18376 + test case