### PR TITLE
Fix up bonkers PHPUnit deprecation handling.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
          colors="true"
          bootstrap="tests/bootstrap.php"
          backupGlobals="true"
+         failOnDeprecation="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="cakephp">

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -249,6 +249,13 @@ class ConsoleOptionParser
             $this->addArguments($spec['arguments']);
         }
         if (!empty($spec['options'])) {
+            foreach ($spec['options'] as $name => $params) {
+                if ($params instanceof ConsoleInputOption) {
+                    $name = $params->name();
+                }
+                $this->removeOption($name);
+            }
+
             $this->addOptions($spec['options']);
         }
         if (!empty($spec['description'])) {

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -164,7 +164,7 @@ abstract class TestCase extends BaseTestCase
      * @param \Closure $callable callable function that will receive asserts
      * @return void
      */
-    #[WithoutErrorHandler]
+    #
     public function deprecated(Closure $callable): void
     {
         $duplicate = Configure::read('Error.allowDuplicateDeprecations');

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -217,6 +217,8 @@ abstract class TestCase extends BaseTestCase
         }
 
         EventManager::instance(new EventManager());
+
+        error_reporting(E_ALL);
     }
 
     /**

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -234,7 +234,7 @@ abstract class TestCase extends BaseTestCase
 
         EventManager::instance(new EventManager());
 
-        error_reporting(E_ALL);
+        error_reporting(Configure::read('TestSuite.errorLevel', E_ALL));
     }
 
     /**

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -234,7 +234,10 @@ abstract class TestCase extends BaseTestCase
 
         EventManager::instance(new EventManager());
 
-        error_reporting(Configure::read('TestSuite.errorLevel', E_ALL));
+        $errorLevelOverwrite = Configure::read('TestSuite.errorLevel', E_ALL);
+        if ($errorLevelOverwrite !== false) {
+            error_reporting($errorLevelOverwrite);
+        }
     }
 
     /**

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -39,7 +39,6 @@ use Closure;
 use Exception;
 use LogicException;
 use Mockery;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use ReflectionClass;
@@ -161,20 +160,37 @@ abstract class TestCase extends BaseTestCase
     /**
      * Helper method for check deprecation methods
      *
-     * @param \Closure $callable callable function that will receive asserts
+     * @param \Closure $callable callable function that will receive asserts.
+     * @param int $type Error level to expect, E_DEPRECATED or E_USER_DEPRECATED.
+     * @param string|null $phpVersion If set, only applies to this version forward, e.g. `8.4`.
      * @return void
      */
-    #
-    public function deprecated(Closure $callable): void
+    public function deprecated(Closure $callable, int $type = E_USER_DEPRECATED, ?string $phpVersion = null): void
     {
+        if ($phpVersion !== null && version_compare(PHP_VERSION, $phpVersion, '<')) {
+            $callable();
+
+            return;
+        }
+
         $duplicate = Configure::read('Error.allowDuplicateDeprecations');
         Configure::write('Error.allowDuplicateDeprecations', true);
         /** @var bool $deprecation Expand type for psalm */
         $deprecation = false;
 
         $previousHandler = set_error_handler(
-            function ($code, $message, $file, $line, $context = null) use (&$previousHandler, &$deprecation): bool {
-                if ($code == E_USER_DEPRECATED) {
+            function (
+                $code,
+                $message,
+                $file,
+                $line,
+                $context = null,
+            ) use (
+                &$previousHandler,
+                &$deprecation,
+                $type,
+            ): bool {
+                if ($code == $type) {
                     $deprecation = true;
 
                     return true;

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -234,6 +234,7 @@ abstract class TestCase extends BaseTestCase
 
         EventManager::instance(new EventManager());
 
+        /** @var int|false $errorLevelOverwrite */
         $errorLevelOverwrite = Configure::read('TestSuite.errorLevel', E_ALL);
         if ($errorLevelOverwrite !== false) {
             error_reporting($errorLevelOverwrite);

--- a/tests/TestCase/Console/ArgumentsTest.php
+++ b/tests/TestCase/Console/ArgumentsTest.php
@@ -252,12 +252,14 @@ class ArgumentsTest extends TestCase
 
     public function testGetMultipleOption(): void
     {
-        $options = [
-            'types' => ['one', 'two', 'three'],
-        ];
-        $args = new Arguments([], $options, []);
-        $this->assertSame(['one', 'two', 'three'], $args->getMultipleOption('types'));
-        $this->assertNull($args->getMultipleOption('missing'));
+        $this->deprecated(function (): void {
+            $options = [
+                'types' => ['one', 'two', 'three'],
+            ];
+            $args = new Arguments([], $options, []);
+            $this->assertSame(['one', 'two', 'three'], $args->getMultipleOption('types'));
+            $this->assertNull($args->getMultipleOption('missing'));
+        });
     }
 
     /**

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -201,7 +201,7 @@ class ConsoleOptionParserTest extends TestCase
     /**
      * test adding an option and using the short value for parsing throws deprecation if conflicting.
      */
-    #[WithoutErrorHandler]
+    #
     public function testAddOptionShortConflict(): void
     {
         $parser = new ConsoleOptionParser('test', false);

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -201,7 +201,6 @@ class ConsoleOptionParserTest extends TestCase
     /**
      * test adding an option and using the short value for parsing throws deprecation if conflicting.
      */
-    #
     public function testAddOptionShortConflict(): void
     {
         $parser = new ConsoleOptionParser('test', false);

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -908,7 +908,7 @@ class ControllerTest extends TestCase
         ]);
         $Controller = new AdminPostsController($request);
         $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $e) {
-            return $e->getSubject()->getResponse();
+            $e->setResult($e->getSubject()->getResponse());
         });
         $Controller->render();
         $this->assertSame('Admin' . DS . 'Posts', $Controller->viewBuilder()->getTemplatePath());
@@ -916,7 +916,7 @@ class ControllerTest extends TestCase
         $request = $request->withParam('prefix', 'admin/super');
         $Controller = new AdminPostsController($request);
         $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $e) {
-            return $e->getSubject()->getResponse();
+            $e->setResult($e->getSubject()->getResponse());
         });
         $Controller->render();
         $this->assertSame('Admin' . DS . 'Super' . DS . 'Posts', $Controller->viewBuilder()->getTemplatePath());
@@ -929,7 +929,7 @@ class ControllerTest extends TestCase
         ]);
         $Controller = new PagesController($request);
         $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $e) {
-            return $e->getSubject()->getResponse();
+            $e->setResult($e->getSubject()->getResponse());
         });
         $Controller->render();
         $this->assertSame('Pages', $Controller->viewBuilder()->getTemplatePath());

--- a/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
@@ -37,7 +37,9 @@ class AuthSecurityExceptionTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->authSecurityException = new AuthSecurityException();
+        $this->deprecated(function (): void {
+            $this->authSecurityException = new AuthSecurityException();
+        });
     }
 
     /**

--- a/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
@@ -37,7 +37,9 @@ class SecurityExceptionTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->securityException = new SecurityException();
+        $this->deprecated(function (): void {
+            $this->securityException = new SecurityException();
+        });
     }
 
     /**
@@ -45,9 +47,10 @@ class SecurityExceptionTest extends TestCase
      */
     public function testGetType(): void
     {
+        $type = $this->securityException->getType();
         $this->assertSame(
             'secure',
-            $this->securityException->getType(),
+            $type,
             '::getType should always return the type of `secure`.',
         );
     }

--- a/tests/TestCase/Core/FunctionsGlobalTest.php
+++ b/tests/TestCase/Core/FunctionsGlobalTest.php
@@ -20,7 +20,6 @@ use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use stdClass;
 
 require_once CAKE . 'Core/functions_global.php';
@@ -333,7 +332,6 @@ class FunctionsGlobalTest extends TestCase
     /**
      * Test no error when warning level is off.
      */
-    #
     public function testTriggerWarningLevelDisabled(): void
     {
         $this->withErrorReporting(E_ALL ^ E_USER_WARNING, function (): void {

--- a/tests/TestCase/Core/FunctionsGlobalTest.php
+++ b/tests/TestCase/Core/FunctionsGlobalTest.php
@@ -333,7 +333,7 @@ class FunctionsGlobalTest extends TestCase
     /**
      * Test no error when warning level is off.
      */
-    #[WithoutErrorHandler]
+    #
     public function testTriggerWarningLevelDisabled(): void
     {
         $this->withErrorReporting(E_ALL ^ E_USER_WARNING, function (): void {

--- a/tests/TestCase/Database/Expression/WindowExpressionTest.php
+++ b/tests/TestCase/Database/Expression/WindowExpressionTest.php
@@ -110,7 +110,7 @@ class WindowExpressionTest extends TestCase
         );
     }
 
-    #[WithoutErrorHandler]
+    #
     public function testOrderDeprecated(): void
     {
         $this->deprecated(function () {

--- a/tests/TestCase/Database/Expression/WindowExpressionTest.php
+++ b/tests/TestCase/Database/Expression/WindowExpressionTest.php
@@ -111,7 +111,7 @@ class WindowExpressionTest extends TestCase
 
     public function testOrderDeprecated(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $w = (new WindowExpression())->order('test');
             $this->assertEqualsSql(
                 'ORDER BY test',

--- a/tests/TestCase/Database/Expression/WindowExpressionTest.php
+++ b/tests/TestCase/Database/Expression/WindowExpressionTest.php
@@ -23,7 +23,6 @@ use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\WindowExpression;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 
 /**
  * Tests WindowExpression class
@@ -110,7 +109,6 @@ class WindowExpressionTest extends TestCase
         );
     }
 
-    #
     public function testOrderDeprecated(): void
     {
         $this->deprecated(function () {

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -42,7 +42,6 @@ use Cake\I18n\DateTime;
 use Cake\Test\TestCase\Database\QueryAssertsTrait;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use ReflectionProperty;
 use stdClass;
 use TestApp\Database\Type\BarType;
@@ -1761,7 +1760,6 @@ class SelectQueryTest extends TestCase
         $result->closeCursor();
     }
 
-    #
     public function testSelectOrderDeprecated(): void
     {
         $this->deprecated(function () {
@@ -2047,7 +2045,6 @@ class SelectQueryTest extends TestCase
         $this->assertCount(3, $result->fetchAll());
     }
 
-    #
     public function testSelectGroupDeprecated(): void
     {
         $this->deprecated(function () {

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -1761,7 +1761,7 @@ class SelectQueryTest extends TestCase
         $result->closeCursor();
     }
 
-    #[WithoutErrorHandler]
+    #
     public function testSelectOrderDeprecated(): void
     {
         $this->deprecated(function () {
@@ -2047,7 +2047,7 @@ class SelectQueryTest extends TestCase
         $this->assertCount(3, $result->fetchAll());
     }
 
-    #[WithoutErrorHandler]
+    #
     public function testSelectGroupDeprecated(): void
     {
         $this->deprecated(function () {

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -1762,7 +1762,7 @@ class SelectQueryTest extends TestCase
 
     public function testSelectOrderDeprecated(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $query = new SelectQuery($this->connection);
             $result = $query
                 ->select(['id'])
@@ -2047,7 +2047,7 @@ class SelectQueryTest extends TestCase
 
     public function testSelectGroupDeprecated(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $query = new SelectQuery($this->connection);
             $result = $query
                 ->select(['total' => 'count(author_id)', 'author_id'])

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -230,7 +230,7 @@ class SchemaDialectTest extends TestCase
      * Test that SchemaDialect implementations without describeColumns etc
      * implemented still work with describe().
      */
-    #[WithoutErrorHandler]
+    #
     public function testBackwardsCompatibility(): void
     {
         $this->deprecated(function () {

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -231,7 +231,7 @@ class SchemaDialectTest extends TestCase
      */
     public function testBackwardsCompatibility(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             /** @var \Cake\Database\Driver $driver */
             $driver = ConnectionManager::get('test')->getDriver();
             $this->skipIf(!($driver instanceof Sqlite), 'requires sqlite connection');

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -21,7 +21,6 @@ use Cake\Database\Driver\Sqlite;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use TestApp\Database\Schema\CompatDialect;
 
 /**
@@ -230,7 +229,6 @@ class SchemaDialectTest extends TestCase
      * Test that SchemaDialect implementations without describeColumns etc
      * implemented still work with describe().
      */
-    #
     public function testBackwardsCompatibility(): void
     {
         $this->deprecated(function () {

--- a/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
+++ b/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
@@ -23,7 +23,6 @@ use Cake\Datasource\ResultSetInterface;
 use Cake\ORM\ResultSet;
 use Cake\TestSuite\TestCase;
 use Mockery;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use function Cake\Collection\collection;
 
 class PaginatedResultSetTest extends TestCase
@@ -48,7 +47,6 @@ class PaginatedResultSetTest extends TestCase
         $this->assertSame([1, 2, 3], $out);
     }
 
-    #
     public function testCall(): void
     {
         $resultSet = Mockery::mock(ResultSet::class);

--- a/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
+++ b/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
@@ -48,7 +48,7 @@ class PaginatedResultSetTest extends TestCase
         $this->assertSame([1, 2, 3], $out);
     }
 
-    #[WithoutErrorHandler]
+    #
     public function testCall(): void
     {
         $resultSet = Mockery::mock(ResultSet::class);

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -88,7 +88,7 @@ class ErrorTrapTest extends TestCase
     {
         $trap = new ErrorTrap(['errorRenderer' => TextErrorRenderer::class]);
         $trap->register();
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             try {
                 trigger_error('Oh no it was bad', E_USER_ERROR);
                 $this->fail('Should raise a fatal error');

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -88,15 +88,17 @@ class ErrorTrapTest extends TestCase
     {
         $trap = new ErrorTrap(['errorRenderer' => TextErrorRenderer::class]);
         $trap->register();
-        try {
-            trigger_error('Oh no it was bad', E_USER_ERROR);
-            $this->fail('Should raise a fatal error');
-        } catch (FatalErrorException $e) {
-            $this->assertEquals('Oh no it was bad', $e->getMessage());
-            $this->assertEquals(E_USER_ERROR, $e->getCode());
-        } finally {
-            restore_error_handler();
-        }
+        $this->deprecated(function () {
+            try {
+                trigger_error('Oh no it was bad', E_USER_ERROR);
+                $this->fail('Should raise a fatal error');
+            } catch (FatalErrorException $e) {
+                $this->assertEquals('Oh no it was bad', $e->getMessage());
+                $this->assertEquals(E_USER_ERROR, $e->getCode());
+            } finally {
+                restore_error_handler();
+            }
+        }, E_DEPRECATED, '8.4');
     }
 
     public static function logLevelProvider(): array

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -22,6 +22,7 @@ use Cake\Error\ExceptionTrap;
 use Cake\Error\Renderer\ConsoleExceptionRenderer;
 use Cake\Error\Renderer\TextExceptionRenderer;
 use Cake\Error\Renderer\WebExceptionRenderer;
+use Cake\Event\EventInterface;
 use Cake\Http\Exception\MissingControllerException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\ServerRequest;
@@ -316,8 +317,8 @@ class ExceptionTrapTest extends TestCase
     public function testBeforeRenderEventReturnResponse(): void
     {
         $trap = new ExceptionTrap(['exceptionRenderer' => TextExceptionRenderer::class]);
-        $trap->getEventManager()->on('Exception.beforeRender', function ($event, Throwable $error, ?ServerRequest $req) {
-            return 'Here B Erroz';
+        $trap->getEventManager()->on('Exception.beforeRender', function (EventInterface $event, Throwable $error, ?ServerRequest $req) {
+            $event->setResult('Here B Erroz');
         });
 
         ob_start();

--- a/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
+++ b/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
@@ -993,7 +993,6 @@ class WebExceptionRendererTest extends TestCase
         $this->assertStringContainsString('<xml>rendered xml exception</xml>', $result);
     }
 
-    #[WithoutErrorHandler]
     public function testDeprecatedHttpErrorCodeMapping(): void
     {
         $this->deprecated(function () {

--- a/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
+++ b/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
@@ -52,7 +52,6 @@ use Mockery;
 use OutOfBoundsException;
 use PDOException;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use ReflectionMethod;
 use RuntimeException;
 use TestApp\Controller\Admin\ErrorController as PrefixErrorController;
@@ -682,17 +681,19 @@ class WebExceptionRendererTest extends TestCase
      */
     public function testExceptionNameMangling(): void
     {
-        $exceptionRenderer = new MyCustomExceptionRenderer(new MissingWidgetThing());
+        $this->deprecated(function () {
+            $exceptionRenderer = new MyCustomExceptionRenderer(new MissingWidgetThing());
 
-        $result = (string)$exceptionRenderer->render()->getBody();
-        $this->assertStringContainsString('widget thing is missing', $result);
+            $result = (string)$exceptionRenderer->render()->getBody();
+            $this->assertStringContainsString('widget thing is missing', $result);
 
-        // Custom method should be called even when debug is off.
-        Configure::write('debug', false);
-        $exceptionRenderer = new MyCustomExceptionRenderer(new MissingWidgetThing());
+            // Custom method should be called even when debug is off.
+            Configure::write('debug', false);
+            $exceptionRenderer = new MyCustomExceptionRenderer(new MissingWidgetThing());
 
-        $result = (string)$exceptionRenderer->render()->getBody();
-        $this->assertStringContainsString('widget thing is missing', $result);
+            $result = (string)$exceptionRenderer->render()->getBody();
+            $this->assertStringContainsString('widget thing is missing', $result);
+        });
     }
 
     /**

--- a/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
+++ b/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
@@ -681,7 +681,7 @@ class WebExceptionRendererTest extends TestCase
      */
     public function testExceptionNameMangling(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $exceptionRenderer = new MyCustomExceptionRenderer(new MissingWidgetThing());
 
             $result = (string)$exceptionRenderer->render()->getBody();
@@ -996,7 +996,7 @@ class WebExceptionRendererTest extends TestCase
 
     public function testDeprecatedHttpErrorCodeMapping(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $exception = new MissingWidgetThing();
             $exceptionRenderer = new MyCustomExceptionRenderer($exception);
 

--- a/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
+++ b/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
@@ -75,8 +75,7 @@ class ConditionDecoratorTest extends TestCase
 
         $listener2 = function (EventInterface $event) {
             $event->setData('counter', $event->getData('counter') + 1);
-
-            return $event;
+            $event->setResult(false);
         };
 
         EventManager::instance()->on('decorator.test2', $listener1);

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -961,7 +961,7 @@ class ClientTest extends TestCase
         $client->getEventManager()->on(
             'HttpClient.beforeSend',
             function (ClientEvent $event, Request $request, array $adapterOptions, int $redirects) {
-                return new Response(body: 'short circuit');
+                $event->setResult(new Response(body: 'short circuit'));
             },
         );
 
@@ -983,7 +983,7 @@ class ClientTest extends TestCase
         $client->getEventManager()->on(
             'HttpClient.afterSend',
             function (ClientEvent $event, Request $request, array $adapterOptions, int $redirects) {
-                return new Response(body: 'modified response');
+                $event->setResult(new Response(body: 'modified response'));
             },
         );
 

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -634,7 +634,7 @@ class SessionTest extends TestCase
         $_COOKIE = [];
         $_GET[session_name()] = '123abc';
 
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $session = new TestWebSession([
                 'ini' => [
                     'session.use_cookies' => 1,

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -58,17 +58,20 @@ class SessionTest extends TestCase
     {
         $_SESSION = null;
 
-        $config = [
-            'cookie' => 'test',
-            'checkAgent' => false,
-            'timeout' => 86400,
-            'ini' => [
-                'session.referer_check' => 'example.com',
-                'session.use_trans_sid' => false,
-            ],
-        ];
+        $this->deprecated(function (): void {
+            $config = [
+                'cookie' => 'test',
+                'checkAgent' => false,
+                'timeout' => 86400,
+                'ini' => [
+                    'session.referer_check' => 'example.com',
+                    'session.use_trans_sid' => false,
+                ],
+            ];
 
-        Session::create($config);
+            Session::create($config);
+        }, E_DEPRECATED, '8.4');
+
         $this->assertSame('', ini_get('session.use_trans_sid'), 'Ini value is incorrect');
         $this->assertSame('example.com', ini_get('session.referer_check'), 'Ini value is incorrect');
         $this->assertSame('test', ini_get('session.name'), 'Ini value is incorrect');
@@ -631,16 +634,18 @@ class SessionTest extends TestCase
         $_COOKIE = [];
         $_GET[session_name()] = '123abc';
 
-        $session = new TestWebSession([
-            'ini' => [
-                'session.use_cookies' => 1,
-                'session.use_trans_sid' => 1,
-            ],
-        ]);
+        $this->deprecated(function () {
+            $session = new TestWebSession([
+                'ini' => [
+                    'session.use_cookies' => 1,
+                    'session.use_trans_sid' => 1,
+                ],
+            ]);
 
-        $this->assertFalse($session->started());
-        $session->check('something');
-        $this->assertTrue($session->started());
+            $this->assertFalse($session->started());
+            $session->check('something');
+            $this->assertTrue($session->started());
+        }, E_DEPRECATED, '8.4');
     }
 
     /**

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -22,7 +22,6 @@ use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use TestApp\Log\Engine\TestAppLog;
 use TestPlugin\Log\Engine\TestPluginLog;
 
@@ -404,7 +403,6 @@ class LogTest extends TestCase
     /**
      * Test scoped logging backwards compat
      */
-    #
     public function testScopedLoggingBackwardsCompat(): void
     {
         $this->_deleteLogs();

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -404,7 +404,7 @@ class LogTest extends TestCase
     /**
      * Test scoped logging backwards compat
      */
-    #[WithoutErrorHandler]
+    #
     public function testScopedLoggingBackwardsCompat(): void
     {
         $this->_deleteLogs();

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -27,7 +27,6 @@ use Cake\TestSuite\TestCase;
 use Cake\View\Exception\MissingTemplateException;
 use DateTime;
 use InvalidArgumentException;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use TestApp\Mailer\TestMailer;
 use function Cake\Core\env;
 
@@ -110,7 +109,6 @@ class MailerTest extends TestCase
      *
      * @deprecated
      */
-    #
     public function testSetMessage(): void
     {
         $message = $this->mailer->getMessage();

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -110,7 +110,7 @@ class MailerTest extends TestCase
      *
      * @deprecated
      */
-    #[WithoutErrorHandler]
+    #
     public function testSetMessage(): void
     {
         $message = $this->mailer->getMessage();

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -23,7 +23,6 @@ use Cake\ORM\Locator\LocatorInterface;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use TestApp\Model\Table\AuthorsTable;
 use TestApp\Model\Table\TestTable;
 use TestPlugin\Model\Table\CommentsTable;
@@ -495,7 +494,6 @@ class AssociationTest extends TestCase
         );
     }
 
-    #
     public function testCustomFinderWithOptions(): void
     {
         $this->association->setFinder('withOptions');

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -495,7 +495,7 @@ class AssociationTest extends TestCase
         );
     }
 
-    #[WithoutErrorHandler]
+    #
     public function testCustomFinderWithOptions(): void
     {
         $this->association->setFinder('withOptions');

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -54,7 +54,7 @@ class EntityTest extends TestCase
         $this->assertSame('bar', $entity->getOriginal('foo'));
     }
 
-    #[WithoutErrorHandler]
+    #
     public function testEntitySetDeprecated(): void
     {
         $this->deprecated(function () {
@@ -1459,7 +1459,7 @@ class EntityTest extends TestCase
      *
      * @deprecated
      */
-    #[WithoutErrorHandler]
+    #
     public function testToString(): void
     {
         $this->deprecated(function () {

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -21,7 +21,6 @@ use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use Exception;
 use InvalidArgumentException;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use stdClass;
 use TestApp\Model\Entity\Extending;
 use TestApp\Model\Entity\NonExtending;
@@ -54,7 +53,6 @@ class EntityTest extends TestCase
         $this->assertSame('bar', $entity->getOriginal('foo'));
     }
 
-    #
     public function testEntitySetDeprecated(): void
     {
         $this->deprecated(function () {
@@ -1459,7 +1457,6 @@ class EntityTest extends TestCase
      *
      * @deprecated
      */
-    #
     public function testToString(): void
     {
         $this->deprecated(function () {

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -55,7 +55,7 @@ class EntityTest extends TestCase
 
     public function testEntitySetDeprecated(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $entity = new Entity();
             $entity->set(['foo' => 'bar']);
         });
@@ -1459,7 +1459,7 @@ class EntityTest extends TestCase
      */
     public function testToString(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $entity = new Entity(['foo' => 1, 'bar' => 2]);
             $this->assertEquals(json_encode($entity, JSON_PRETTY_PRINT), (string)$entity);
         });

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -625,7 +625,7 @@ class TableTest extends TestCase
      * @return void
      * @deprecated
      */
-    #[WithoutErrorHandler]
+    #
     public function testFindAllOldStyleOptionsArray(): void
     {
         $this->deprecated(function (): void {
@@ -1315,7 +1315,7 @@ class TableTest extends TestCase
         $this->assertSame(2, $author->id);
     }
 
-    #[WithoutErrorHandler]
+    #
     public function testFindTypedParameterCompatibility(): void
     {
         $articles = $this->fetchTable('Articles');
@@ -1625,7 +1625,7 @@ class TableTest extends TestCase
     /**
      * Tests find(list) with backwards compatibile options
      */
-    #[WithoutErrorHandler]
+    #
     public function testFindListArrayOptions(): void
     {
         $table = new Table([
@@ -1706,7 +1706,7 @@ class TableTest extends TestCase
      * @return void
      * @deprecated
      */
-    #[WithoutErrorHandler]
+    #
     public function testFindListWithArray(): void
     {
         $this->deprecated(function (): void {
@@ -5443,7 +5443,7 @@ class TableTest extends TestCase
      *
      * @return void
      */
-    #[WithoutErrorHandler]
+    #
     public function testGetBackwardsCompatibility(): void
     {
         $this->deprecated(function (): void {

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -62,7 +62,6 @@ use Exception;
 use InvalidArgumentException;
 use PDOException;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use RuntimeException;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Entity\ArticlesTag;
@@ -625,7 +624,6 @@ class TableTest extends TestCase
      * @return void
      * @deprecated
      */
-    #
     public function testFindAllOldStyleOptionsArray(): void
     {
         $this->deprecated(function (): void {
@@ -1315,7 +1313,6 @@ class TableTest extends TestCase
         $this->assertSame(2, $author->id);
     }
 
-    #
     public function testFindTypedParameterCompatibility(): void
     {
         $articles = $this->fetchTable('Articles');
@@ -1625,7 +1622,6 @@ class TableTest extends TestCase
     /**
      * Tests find(list) with backwards compatibile options
      */
-    #
     public function testFindListArrayOptions(): void
     {
         $table = new Table([
@@ -1706,7 +1702,6 @@ class TableTest extends TestCase
      * @return void
      * @deprecated
      */
-    #
     public function testFindListWithArray(): void
     {
         $this->deprecated(function (): void {
@@ -5443,7 +5438,6 @@ class TableTest extends TestCase
      *
      * @return void
      */
-    #
     public function testGetBackwardsCompatibility(): void
     {
         $this->deprecated(function (): void {

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -236,7 +236,7 @@ class TestCaseTest extends TestCase
     /**
      * test deprecated() with duplicate deprecation with same messsage and line
      */
-    #[WithoutErrorHandler]
+    #
     public function testDeprecatedWithDuplicatedDeprecation(): void
     {
         /**

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -30,7 +30,6 @@ use Cake\Test\Fixture\FixturizedTestCase;
 use Cake\TestSuite\TestCase;
 use Exception;
 use PHPUnit\Framework\AssertionFailedError;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestStatus\Skipped;
 use PHPUnit\Framework\TestStatus\Success;
 use PHPUnit\Runner\Version;
@@ -236,7 +235,6 @@ class TestCaseTest extends TestCase
     /**
      * test deprecated() with duplicate deprecation with same messsage and line
      */
-    #
     public function testDeprecatedWithDuplicatedDeprecation(): void
     {
         /**

--- a/tests/TestCase/Validation/RulesProviderTest.php
+++ b/tests/TestCase/Validation/RulesProviderTest.php
@@ -34,7 +34,7 @@ class RulesProviderTest extends TestCase
      */
     public function testProxyToValidation(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $provider = new RulesProvider();
             $this->assertTrue($provider->extension('foo.jpg', compact('provider')));
             $this->assertFalse($provider->extension('foo.jpg', ['png'], compact('provider')));
@@ -47,7 +47,7 @@ class RulesProviderTest extends TestCase
      */
     public function testCustomObject(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $object = new CustomProvider();
 
             /** @var \TestApp\Validation\CustomProvider|\Cake\Validation\RulesProvider $provider */

--- a/tests/TestCase/Validation/RulesProviderTest.php
+++ b/tests/TestCase/Validation/RulesProviderTest.php
@@ -33,7 +33,7 @@ class RulesProviderTest extends TestCase
      * extra arguments that are passed according to the signature of validation
      * methods.
      */
-    #[WithoutErrorHandler]
+    #
     public function testProxyToValidation(): void
     {
         $this->deprecated(function () {
@@ -47,7 +47,7 @@ class RulesProviderTest extends TestCase
      * Tests that it is possible to use a custom object as the provider to
      * be decorated
      */
-    #[WithoutErrorHandler]
+    #
     public function testCustomObject(): void
     {
         $this->deprecated(function () {

--- a/tests/TestCase/Validation/RulesProviderTest.php
+++ b/tests/TestCase/Validation/RulesProviderTest.php
@@ -18,7 +18,6 @@ namespace Cake\Test\TestCase\Validation;
 
 use Cake\TestSuite\TestCase;
 use Cake\Validation\RulesProvider;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use TestApp\Validation\CustomProvider;
 
 /**
@@ -33,7 +32,6 @@ class RulesProviderTest extends TestCase
      * extra arguments that are passed according to the signature of validation
      * methods.
      */
-    #
     public function testProxyToValidation(): void
     {
         $this->deprecated(function () {
@@ -47,7 +45,6 @@ class RulesProviderTest extends TestCase
      * Tests that it is possible to use a custom object as the provider to
      * be decorated
      */
-    #
     public function testCustomObject(): void
     {
         $this->deprecated(function () {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2618,7 +2618,7 @@ class FormHelperTest extends TestCase
     /**
      * @deprecated
      */
-    #[WithoutErrorHandler]
+    #
     public function testWarningForDeprecatedErrorClassConfig(): void
     {
         $this->Form->setConfig('errorClass', 'danger');
@@ -3913,7 +3913,7 @@ class FormHelperTest extends TestCase
     /**
      * @deprecated
      */
-    #[WithoutErrorHandler]
+    #
     public function testEnumOptionsDeprecationMessage(): void
     {
         $this->deprecated(function () {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -48,7 +48,6 @@ use DOMXPath;
 use InvalidArgumentException;
 use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use ReflectionProperty;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Enum\ArticleStatus;
@@ -2618,7 +2617,6 @@ class FormHelperTest extends TestCase
     /**
      * @deprecated
      */
-    #
     public function testWarningForDeprecatedErrorClassConfig(): void
     {
         $this->Form->setConfig('errorClass', 'danger');
@@ -3913,7 +3911,6 @@ class FormHelperTest extends TestCase
     /**
      * @deprecated
      */
-    #
     public function testEnumOptionsDeprecationMessage(): void
     {
         $this->deprecated(function () {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3913,7 +3913,7 @@ class FormHelperTest extends TestCase
      */
     public function testEnumOptionsDeprecationMessage(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $articlesTable = $this->getTableLocator()->get('Articles');
             $articlesTable->getSchema()->setColumnType(
                 'published',


### PR DESCRIPTION
Testing if this works to make them displayed by default.

For me it was:
```
2 tests triggered 2 deprecations:

1) /app/vendor/cakephp/cakephp/src/Core/functions.php:373
Since 5.2.0: You cannot redefine short options. This will throw an error in 5.3.0+.
/app/vendor/cakephp/cakephp/tests/TestCase/Console/ConsoleOptionParserTest.php, line: 108
You can disable all deprecation warnings by setting `Error.errorLevel` to `E_ALL & ~E_USER_DEPRECATED`. Adding `tests/TestCase/Console/ConsoleOptionParserTest.php` to `Error.ignoredDeprecationPaths` in your `config/app.php` config will mute deprecations from that file only.

Triggered by:

* Cake\Test\TestCase\Console\ConsoleOptionParserTest::testRemoveOptionAlsoClearsShort
  /app/vendor/cakephp/cakephp/tests/TestCase/Console/ConsoleOptionParserTest.php:102

2) /app/vendor/cakephp/cakephp/src/Core/functions.php:373
Since 5.2.0: You cannot redefine short options. This will throw an error in 5.3.0+.
/app/vendor/cakephp/cakephp/src/Console/ConsoleOptionParser.php, line: 517
You can disable all deprecation warnings by setting `Error.errorLevel` to `E_ALL & ~E_USER_DEPRECATED`. Adding `src/Console/ConsoleOptionParser.php` to `Error.ignoredDeprecationPaths` in your `config/app.php` config will mute deprecations from that file only.

Triggered by:

* Cake\Test\TestCase\Console\ConsoleOptionParserTest::testMerge
  /app/vendor/cakephp/cakephp/tests/TestCase/Console/ConsoleOptionParserTest.php:1036
```