### PR TITLE
Fix assertions against session when enableRetainFlashMessages() is true

### DIFF
--- a/src/TestSuite/Constraint/Session/FlashParamEquals.php
+++ b/src/TestSuite/Constraint/Session/FlashParamEquals.php
@@ -28,11 +28,6 @@ use PHPUnit\Framework\Constraint\Constraint;
 class FlashParamEquals extends Constraint
 {
     /**
-     * @var \Cake\Http\Session
-     */
-    protected $session;
-
-    /**
      * @var string
      */
     protected $key;
@@ -55,15 +50,14 @@ class FlashParamEquals extends Constraint
      * @param string $param Param to check
      * @param int|null $at Expected index
      */
-    public function __construct(?Session $session, string $key, string $param, ?int $at = null)
+    public function __construct(string $key, string $param, ?int $at = null)
     {
-        if (!$session) {
+        if (empty($_SESSION)) {
             $message = 'There is no stored session data. Perhaps you need to run a request?';
             $message .= ' Additionally, ensure `$this->enableRetainFlashMessages()` has been enabled for the test.';
             throw new AssertionFailedError($message);
         }
 
-        $this->session = $session;
         $this->key = $key;
         $this->param = $param;
         $this->at = $at;

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -136,13 +136,6 @@ trait IntegrationTestTrait
     protected $_layoutName;
 
     /**
-     * The session instance from the last request
-     *
-     * @var \Cake\Http\Session
-     */
-    protected $_requestSession;
-
-    /**
      * Boolean flag for whether the request should have
      * a SecurityComponent token added.
      *
@@ -209,7 +202,6 @@ trait IntegrationTestTrait
         $this->_controller = null;
         $this->_viewName = null;
         $this->_layoutName = null;
-        $this->_requestSession = null;
         $this->_securityToken = false;
         $this->_csrfToken = false;
         $this->_retainFlashMessages = false;
@@ -476,7 +468,6 @@ trait IntegrationTestTrait
         try {
             $request = $this->_buildRequest($url, $method, $data);
             $response = $dispatcher->execute($request);
-            $this->_requestSession = $request['session'];
             if ($this->_retainFlashMessages && $this->_flashMessages) {
                 $_SESSION['Flash'] = $this->_flashMessages;
             }
@@ -1174,7 +1165,7 @@ trait IntegrationTestTrait
     public function assertFlashMessage(string $expected, string $key = 'flash', string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat($expected, new FlashParamEquals($this->_requestSession, $key, 'message'), $verboseMessage);
+        $this->assertThat($expected, new FlashParamEquals($key, 'message'), $verboseMessage);
     }
 
     /**
@@ -1191,7 +1182,7 @@ trait IntegrationTestTrait
         $verboseMessage = $this->extractVerboseMessage($message);
         $this->assertThat(
             $expected,
-            new FlashParamEquals($this->_requestSession, $key, 'message', $at),
+            new FlashParamEquals($key, 'message', $at),
             $verboseMessage
         );
     }
@@ -1209,7 +1200,7 @@ trait IntegrationTestTrait
         $verboseMessage = $this->extractVerboseMessage($message);
         $this->assertThat(
             $expected,
-            new FlashParamEquals($this->_requestSession, $key, 'element'),
+            new FlashParamEquals($key, 'element'),
             $verboseMessage
         );
     }
@@ -1228,7 +1219,7 @@ trait IntegrationTestTrait
         $verboseMessage = $this->extractVerboseMessage($message);
         $this->assertThat(
             $expected,
-            new FlashParamEquals($this->_requestSession, $key, 'element', $at),
+            new FlashParamEquals($key, 'element', $at),
             $verboseMessage
         );
     }

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -478,7 +478,7 @@ trait IntegrationTestTrait
             $response = $dispatcher->execute($request);
             $this->_requestSession = $request['session'];
             if ($this->_retainFlashMessages && $this->_flashMessages) {
-                $this->_requestSession->write('Flash', $this->_flashMessages);
+                $_SESSION['Flash'] = $this->_flashMessages;
             }
             $this->_response = $response;
         } catch (PHPUnitException | DatabaseException $e) {

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -691,6 +691,19 @@ class IntegrationTestTraitTest extends TestCase
     }
 
     /**
+     * Test asserting session and flash messages.
+     */
+    public function testFlashAssertionsWithSession(): void
+    {
+        $this->enableRetainFlashMessages();
+        $this->get('/posts/flashWithSession');
+        $this->assertRedirect();
+
+        $this->assertFlashElement('flash/error');
+        $this->assertSession(true, 'test');
+    }
+
+    /**
      * Test flash assertions stored with enableRememberFlashMessages() even if
      * no view is rendered
      */

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -103,6 +103,19 @@ class PostsController extends AppController
     }
 
     /**
+     * Sets a session variable and flash message
+     *
+     * @return \Cake\Http\Response
+     */
+    public function flashWithSession()
+    {
+        $this->getRequest()->getSession()->write('test', true);
+        $this->Flash->error('An error message');
+
+        return $this->redirect(['action' => 'index']);
+    }
+
+    /**
      * Stub get method
      *
      * @return void


### PR DESCRIPTION
Between 4.1 and 4.2 some changes were introduced to `IntegrationTestTrait` that broke existing sessions assertions when `enableRetainFlashMessages()` was true. For some reason the original request session was reset and only the flash messages persisted.

This PR fixes that, once again allowing assertions against the session *and* flash messages. It also contains some cleanup for unused variables to ensure `$_SESSION` (or the TestSession via `getSession()`) is used for future assertions.

This bug likely affects 5.x as well, but I only took a cursory look (all the apps I maintain are far behind). Let me know if you'd like me to open a PR for 5.x as well.

Question: if merged, will this fix be backported to 4.2 when the bug was introduced? If not it makes upgrading old apps difficult due to the failures.