### PR TITLE
Fixed regression for `EntityTrait::isModified()`

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -353,6 +353,10 @@ trait EntityTrait
      */
     protected function isModified(string $field, mixed $value): bool
     {
+        if (!array_key_exists($field, $this->_fields)) {
+            return true;
+        }
+
         $existing = $this->_fields[$field] ?? null;
 
         if (($value === null || is_scalar($value)) && $existing === $value) {

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -486,7 +486,9 @@ class EntityTest extends TestCase
      */
     public function testHas(): void
     {
-        $entity = new Entity(['id' => 1, 'name' => 'Juan', 'foo' => null]);
+        $entity = new Entity(['id' => 1]);
+        $entity->name = 'Juan';
+        $entity->foo = null;
         $this->assertTrue($entity->has('id'));
         $this->assertTrue($entity->has('name'));
         $this->assertTrue($entity->has('foo'));


### PR DESCRIPTION
See issue https://github.com/cakephp/cakephp/issues/18380

Waiting to know if it is necessary and possible to extend the tests (and possibly directly involve `isModified()` or `patch()`).