### PR TITLE
Fix assertions against session when enableRetainFlashMessages() is true

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -512,7 +512,7 @@ trait IntegrationTestTrait
             $response = $dispatcher->execute($request);
             $this->_requestSession = $request['session'];
             if ($this->_retainFlashMessages && $this->_flashMessages) {
-                $this->_requestSession->write('Flash', $this->_flashMessages);
+                $_SESSION['Flash'] = $this->_flashMessages;
             }
             $this->_response = $response;
         } catch (PHPUnitException | DatabaseException $e) {

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -722,6 +722,19 @@ class IntegrationTestTraitTest extends TestCase
     }
 
     /**
+     * Test asserting session and flash messages.
+     */
+    public function testFlashAssertionsWithSession(): void
+    {
+        $this->enableRetainFlashMessages();
+        $this->get('/posts/flashWithSession');
+        $this->assertRedirect();
+
+        $this->assertFlashElement('flash/error');
+        $this->assertSession(true, 'test');
+    }
+
+    /**
      * Test flash assertions stored with enableRememberFlashMessages() even if
      * no view is rendered
      */

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -109,6 +109,19 @@ class PostsController extends AppController
     }
 
     /**
+     * Sets a session variable and flash message
+     *
+     * @return \Cake\Http\Response
+     */
+    public function flashWithSession()
+    {
+        $this->getRequest()->getSession()->write('test', true);
+        $this->Flash->error('An error message');
+
+        return $this->redirect(['action' => 'index']);
+    }
+
+    /**
      * Stub get method
      *
      * @return void


### PR DESCRIPTION
Replaces #18384 

Targets 5.x. The unused `$_requestSession` property is still on the trait. If anyone accesses this property during tests to read or write to the session, the global `$_SESSION` is destroyed and future assertions against session (all of which use `$_SESSION`) will fail. This property *should not* be used for anything, even debugging. Use `getSession()` instead.

The property is also still passed to `Cake\TestSuite\Constraint\Session\FlashParamEquals` despite being unused. Let me know if you'd like any of this to be cleaned up.