### PR TITLE
Fix up missing string cast.

### DIFF
--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -99,7 +99,7 @@ class ResultSetFactory
 
         $fields = [];
         foreach ($query->clause('select') as $key => $field) {
-            $key = trim($key, '"`[]');
+            $key = trim((string)$key, '"`[]');
 
             if (strpos($key, '__') <= 0) {
                 $fields[$data['primaryAlias']][$key] = $key;


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/18352

I checked the other places, there they use is_string() checks.
So this seems to be the only place where the key is always expected to be a string.

I wasn't able to find a simple test case with disableAutoAliasing() to reproduce, though.
It looks simple enough to manually verify in this case maybe.