### PR TITLE
Fix up custom MessagesFileLoader.

### DIFF
--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -232,6 +232,11 @@ class TranslatorRegistry
             $package = $this->_loaders[static::FALLBACK_LOADER]($name, $locale);
         }
 
+        // Support __invoke() wrapper classes
+        if (!$package instanceof Package && is_callable($package)) {
+            $package = $package();
+        }
+
         $package = $this->setFallbackPackage($name, $package);
         $this->packages->set($name, $locale, $package);
 

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -154,6 +154,34 @@ class I18nTest extends TestCase
     }
 
     /**
+     * Tests that custom translation loaders can be created on the fly and used later on
+     */
+    public function testCreateCustomTranslationInvokable(): void
+    {
+        $loader = new class {
+            public function __invoke(): Package
+            {
+                $package = new Package('default');
+                $package->setMessages([
+                    'Cow' => 'Le moo',
+                ]);
+
+                return $package;
+            }
+        };
+
+        I18n::config('custom', function ($domain, $locale) use ($loader) {
+            return new $loader(
+                $domain,
+                $locale,
+            );
+        });
+
+        $translator = I18n::getTranslator('custom', 'fr_FR');
+        $this->assertSame('Le moo', $translator->translate('Cow'));
+    }
+
+    /**
      * Tests that messages can also be loaded from plugins by using the
      * domain = plugin_name convention
      */


### PR DESCRIPTION
Seems to resolve https://github.com/cakephp/cakephp/issues/18395 and allows this former working approach again.

Makes https://github.com/dereuromark/cakephp-translate/blob/317c2c8f793191414c266d8f98a21849e8cdcd8e/src/I18n/MessagesDbLoader.php#L77
work

But not sure if thats the correct approach.
After all MessagesFileLoader seems to be the same __invoke() style and seems to work.