### PR TITLE
Auto coerce ints to strings when creating Options

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -391,7 +391,7 @@ class ConsoleOptionParser
             $options += $defaults;
 
             // If a default value is provided and it is not a string, do a cast
-            if ($options['default'] && !is_string($options['default'])) {
+            if ($options['default'] && is_int($options['default'])) {
                 $options['default'] = (string)$options['default'];
             }
 

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -390,8 +390,7 @@ class ConsoleOptionParser
 
             $options += $defaults;
 
-            // If a default value is provided and it is not a string, do a cast
-            if ($options['default'] && is_int($options['default'])) {
+            if ($options['default'] && (is_int($options['default']) || is_float($options['default']))) {
                 $options['default'] = (string)$options['default'];
             }
 

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -387,7 +387,14 @@ class ConsoleOptionParser
                 'required' => false,
                 'prompt' => null,
             ];
+
             $options += $defaults;
+
+            // If a default value is provided and it is not a string, do a cast
+            if ($options['default'] && !is_string($options['default'])) {
+                $options['default'] = (string)$options['default'];
+            }
+
             $option = new ConsoleInputOption(
                 $name,
                 $options['short'],

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -186,6 +186,60 @@ class ConsoleOptionParserTest extends TestCase
     }
 
     /**
+     * test adding an option with a non-string default.
+     */
+    public function testAddOptionIntegerDefault(): void
+    {
+        $parser = new ConsoleOptionParser('test', false);
+        $parser
+            ->addOption('test', [
+                'default' => 1,
+            ])
+            ->addOption('no-default', []);
+
+        $result = $parser->parse(['--test'], $this->io);
+        $this->assertSame(
+            ['test' => '1', 'help' => false],
+            $result[0],
+            'Default value did not parse out',
+        );
+
+        $parser = new ConsoleOptionParser('test', false);
+        $parser->addOption('test', [
+            'default' => 1,
+        ]);
+        $result = $parser->parse([], $this->io);
+        $this->assertEquals(['test' => '1', 'help' => false], $result[0], 'Default value did not parse out');
+    }
+
+     /**
+     * test adding an option with a non-string default.
+     */
+    public function testAddOptionBooleanDefault(): void
+    {
+        $parser = new ConsoleOptionParser('test', false);
+        $parser
+            ->addOption('test', [
+                'default' => true,
+            ])
+            ->addOption('no-default', []);
+
+        $result = $parser->parse(['--test'], $this->io);
+        $this->assertSame(
+            ['test' => 'true', 'help' => false],
+            $result[0],
+            'Default value did not parse out',
+        );
+
+        $parser = new ConsoleOptionParser('test', false);
+        $parser->addOption('test', [
+            'default' => true,
+        ]);
+        $result = $parser->parse([], $this->io);
+        $this->assertEquals(['test' => 'true', 'help' => false], $result[0], 'Default value did not parse out');
+    }
+
+    /**
      * test adding an option and using the short value for parsing.
      */
     public function testAddOptionShort(): void

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -212,33 +212,6 @@ class ConsoleOptionParserTest extends TestCase
         $this->assertEquals(['test' => '1', 'help' => false], $result[0], 'Default value did not parse out');
     }
 
-     /**
-     * test adding an option with a non-string default.
-     */
-    public function testAddOptionBooleanDefault(): void
-    {
-        $parser = new ConsoleOptionParser('test', false);
-        $parser
-            ->addOption('test', [
-                'default' => true,
-            ])
-            ->addOption('no-default', []);
-
-        $result = $parser->parse(['--test'], $this->io);
-        $this->assertSame(
-            ['test' => 'true', 'help' => false],
-            $result[0],
-            'Default value did not parse out',
-        );
-
-        $parser = new ConsoleOptionParser('test', false);
-        $parser->addOption('test', [
-            'default' => true,
-        ]);
-        $result = $parser->parse([], $this->io);
-        $this->assertEquals(['test' => 'true', 'help' => false], $result[0], 'Default value did not parse out');
-    }
-
     /**
      * test adding an option and using the short value for parsing.
      */

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -188,28 +188,24 @@ class ConsoleOptionParserTest extends TestCase
     /**
      * test adding an option with a non-string default.
      */
-    public function testAddOptionIntegerDefault(): void
+    public function testAddOptionNonStringDefault(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser
-            ->addOption('test', [
+            ->addOption('test_int', [
                 'default' => 1,
+            ])
+            ->addOption('test_float', [
+                'default' => 1.5,
             ])
             ->addOption('no-default', []);
 
-        $result = $parser->parse(['--test'], $this->io);
-        $this->assertSame(
-            ['test' => '1', 'help' => false],
+        $result = $parser->parse([], $this->io);
+        $this->assertEquals(
+            ['test_int' => '1', 'test_float' => '1.5', 'help' => false],
             $result[0],
             'Default value did not parse out',
         );
-
-        $parser = new ConsoleOptionParser('test', false);
-        $parser->addOption('test', [
-            'default' => 1,
-        ]);
-        $result = $parser->parse([], $this->io);
-        $this->assertEquals(['test' => '1', 'help' => false], $result[0], 'Default value did not parse out');
     }
 
     /**


### PR DESCRIPTION
Resolves [#18397 ](https://github.com/cakephp/cakephp/issues/18397)