### PR TITLE
Add an option to Plugin Assets Symlink for a relative path. Has testcase.

### DIFF
--- a/src/Command/PluginAssetsSymlinkCommand.php
+++ b/src/Command/PluginAssetsSymlinkCommand.php
@@ -61,7 +61,8 @@ class PluginAssetsSymlinkCommand extends Command
 
         $name = $args->getArgument('name');
         $overwrite = (bool)$args->getOption('overwrite');
-        $this->_process($this->_list($name), false, $overwrite);
+        $relative = (bool)$args->getOption('relative');
+        $this->_process($this->_list($name), false, $overwrite, $relative);
 
         return static::CODE_SUCCESS;
     }
@@ -81,6 +82,10 @@ class PluginAssetsSymlinkCommand extends Command
             'required' => false,
         ])->addOption('overwrite', [
             'help' => 'Overwrite existing symlink / folder / files.',
+            'default' => false,
+            'boolean' => true,
+        ])->addOption('relative', [
+            'help' => 'If symlink should be relative.',
             'default' => false,
             'boolean' => true,
         ]);

--- a/src/Command/PluginAssetsTrait.php
+++ b/src/Command/PluginAssetsTrait.php
@@ -104,12 +104,11 @@ trait PluginAssetsTrait
      * @return void
      */
     protected function _process(
-        array $plugins, 
-        bool $copy = false, 
-        bool $overwrite = false, 
+        array $plugins,
+        bool $copy = false,
+        bool $overwrite = false,
         bool $relative = false,
-    ): void
-    {
+    ): void {
         foreach ($plugins as $plugin => $config) {
             $this->io->out();
             $this->io->out('For plugin: ' . $plugin);

--- a/src/Command/PluginAssetsTrait.php
+++ b/src/Command/PluginAssetsTrait.php
@@ -103,7 +103,12 @@ trait PluginAssetsTrait
      * @param bool $relative Relative. Default false.
      * @return void
      */
-    protected function _process(array $plugins, bool $copy = false, bool $overwrite = false, bool $relative = false): void
+    protected function _process(
+        array $plugins, 
+        bool $copy = false, 
+        bool $overwrite = false, 
+        bool $relative = false,
+    ): void
     {
         foreach ($plugins as $plugin => $config) {
             $this->io->out();
@@ -274,13 +279,18 @@ trait PluginAssetsTrait
         $fromParts = explode(DIRECTORY_SEPARATOR, $from);
         $toParts = explode(DIRECTORY_SEPARATOR, $to);
 
+        $fromCount = count($fromParts);
+        $toCount = count($toParts);
+
         // Remove common parts
-        while (count($fromParts) && count($toParts) && $fromParts[0] === $toParts[0]) {
+        while ($fromCount && $toCount && $fromParts[0] === $toParts[0]) {
             array_shift($fromParts);
             array_shift($toParts);
+            $fromCount--;
+            $toCount--;
         }
 
-        return str_repeat('..' . DIRECTORY_SEPARATOR, count($fromParts)) . implode(DIRECTORY_SEPARATOR, $toParts);
+        return str_repeat('..' . DIRECTORY_SEPARATOR, $fromCount) . implode(DIRECTORY_SEPARATOR, $toParts);
     }
 
     /**

--- a/src/Command/PluginAssetsTrait.php
+++ b/src/Command/PluginAssetsTrait.php
@@ -100,9 +100,10 @@ trait PluginAssetsTrait
      * @param array<string, mixed> $plugins List of plugins to process
      * @param bool $copy Force copy mode. Default false.
      * @param bool $overwrite Overwrite existing files.
+     * @param bool $relative Relative. Default false.
      * @return void
      */
-    protected function _process(array $plugins, bool $copy = false, bool $overwrite = false): void
+    protected function _process(array $plugins, bool $copy = false, bool $overwrite = false, bool $relative = false): void
     {
         foreach ($plugins as $plugin => $config) {
             $this->io->out();
@@ -136,6 +137,7 @@ trait PluginAssetsTrait
                 $result = $this->_createSymlink(
                     $config['srcPath'],
                     $dest,
+                    $relative,
                 );
                 if ($result) {
                     continue;
@@ -234,10 +236,15 @@ trait PluginAssetsTrait
      *
      * @param string $target Target directory
      * @param string $link Link name
+     * @param bool $relative Relative (true) or Absolute (false)
      * @return bool
      */
-    protected function _createSymlink(string $target, string $link): bool
+    protected function _createSymlink(string $target, string $link, bool $relative = false): bool
     {
+        if ($relative) {
+            $target = $this->_makeRelativePath($link, $target);
+        }
+
         // phpcs:disable
         $result = @symlink($target, $link);
         // phpcs:enable
@@ -249,6 +256,31 @@ trait PluginAssetsTrait
         }
 
         return false;
+    }
+
+    /**
+     * Generate a relative path from one directory to another.
+     *
+     * @param string $from The symlink path
+     * @param string $to The target path
+     * @return string Relative path
+     */
+    protected function _makeRelativePath(string $from, string $to): string
+    {
+        $from = is_dir($from) ? rtrim($from, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR : dirname($from);
+        $from = realpath($from);
+        $to = realpath($to);
+
+        $fromParts = explode(DIRECTORY_SEPARATOR, $from);
+        $toParts = explode(DIRECTORY_SEPARATOR, $to);
+
+        // Remove common parts
+        while (count($fromParts) && count($toParts) && $fromParts[0] === $toParts[0]) {
+            array_shift($fromParts);
+            array_shift($toParts);
+        }
+
+        return str_repeat('..' . DIRECTORY_SEPARATOR, count($fromParts)) . implode(DIRECTORY_SEPARATOR, $toParts);
     }
 
     /**

--- a/src/Command/PluginAssetsTrait.php
+++ b/src/Command/PluginAssetsTrait.php
@@ -275,6 +275,10 @@ trait PluginAssetsTrait
         $from = realpath($from);
         $to = realpath($to);
 
+        if ($from === false || $to === false) {
+            throw new \InvalidArgumentException('Invalid path provided to _makeRelativePath.');
+        }
+
         $fromParts = explode(DIRECTORY_SEPARATOR, $from);
         $toParts = explode(DIRECTORY_SEPARATOR, $to);
 

--- a/src/Command/PluginAssetsTrait.php
+++ b/src/Command/PluginAssetsTrait.php
@@ -22,6 +22,7 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Utility\Filesystem;
 use Cake\Utility\Inflector;
+use InvalidArgumentException;
 
 /**
  * trait for symlinking / copying plugin assets to app's webroot.
@@ -276,7 +277,7 @@ trait PluginAssetsTrait
         $to = realpath($to);
 
         if ($from === false || $to === false) {
-            throw new \InvalidArgumentException('Invalid path provided to _makeRelativePath.');
+            throw new InvalidArgumentException('Invalid path provided to _makeRelativePath.');
         }
 
         $fromParts = explode(DIRECTORY_SEPARATOR, $from);

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -91,6 +91,29 @@ class PluginAssetsCommandsTest extends TestCase
         $this->assertTrue(is_link($path));
     }
 
+    /**
+     * testRelativeSymlink method
+     */
+    public function testRelativeSymlink(): void
+    {
+        $this->loadPlugins(['TestPlugin' => ['routes' => false], 'Company/TestPluginThree']);
+
+        $this->exec('plugin assets symlink --relative');
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+
+        $path = $this->wwwRoot . 'test_plugin';
+        $this->assertFileExists($path . DS . 'root.js');
+        $this->assertTrue(is_link($path));
+
+        $path = $this->wwwRoot . 'company' . DS . 'test_plugin_three';
+        $this->assertFileExists($path . DS . 'css' . DS . 'company.css');
+        $this->assertTrue(is_link($path));
+
+        // Verify that the symlink is relative
+        $target = readlink($path);
+        $this->assertStringStartsWith('../', $target);
+    }
+
     public function testSymlinkWhenVendorDirectoryExists(): void
     {
         $this->loadPlugins(['Company/TestPluginThree']);

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -96,6 +96,7 @@ class PluginAssetsCommandsTest extends TestCase
      */
     public function testRelativeSymlink(): void
     {
+        $this->skipIf(DS === '\\', 'Cant perform operations with symlinks windows.');
         $this->loadPlugins(['TestPlugin' => ['routes' => false], 'Company/TestPluginThree']);
 
         $this->exec('plugin assets symlink --relative');


### PR DESCRIPTION
I needed this for cases where asset symlinks become wrong if they were generated inside a container but it's volume mounted as well as when I move an application between systems. 