### PR TITLE
Allow flushDb() usage

### DIFF
--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -360,7 +360,7 @@ class RedisEngine extends CacheEngine
     public function clearBlocking(): bool
     {
         if ($this->getConfig('flushDb')) {
-            $this->_Redis->flushDB(false);
+            $this->_Redis->flushDB(true);
 
             return true;
         }

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -53,7 +53,9 @@ class RedisEngine extends CacheEngine
      * - `server` URL or IP to the Redis server host.
      * - `timeout` timeout in seconds (float).
      * - `unix_socket` Path to the unix socket file (default: false)
-     * - `flushDb` Allow to flush DB in atomic operation, ignoring the prefix
+     * - `clearUsesFlushDb` Enable clear() and clearBlocking() to use FLUSHDB. This will be
+     *   faster than standard clear()/clearBlocking() but will ignore prefixes and will
+     *   cause dataloss if other applications are sharing a redis database.
      *
      * @var array<string, mixed>
      */
@@ -71,7 +73,7 @@ class RedisEngine extends CacheEngine
         'timeout' => 0,
         'unix_socket' => false,
         'scanCount' => 10,
-        'flushDb' => false,
+        'clearUsesFlushDb' => false,
     ];
 
     /**
@@ -322,7 +324,7 @@ class RedisEngine extends CacheEngine
      */
     public function clear(): bool
     {
-        if ($this->getConfig('flushDb')) {
+        if ($this->getConfig('clearUsesFlushDb')) {
             $this->_Redis->flushDB(false);
 
             return true;
@@ -359,7 +361,7 @@ class RedisEngine extends CacheEngine
      */
     public function clearBlocking(): bool
     {
-        if ($this->getConfig('flushDb')) {
+        if ($this->getConfig('clearUsesFlushDb')) {
             $this->_Redis->flushDB(true);
 
             return true;

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -53,6 +53,7 @@ class RedisEngine extends CacheEngine
      * - `server` URL or IP to the Redis server host.
      * - `timeout` timeout in seconds (float).
      * - `unix_socket` Path to the unix socket file (default: false)
+     * - `flushDb` Allow to flush DB in atomic operation, ignoring the prefix
      *
      * @var array<string, mixed>
      */
@@ -70,6 +71,7 @@ class RedisEngine extends CacheEngine
         'timeout' => 0,
         'unix_socket' => false,
         'scanCount' => 10,
+        'flushDb' => false,
     ];
 
     /**
@@ -320,6 +322,12 @@ class RedisEngine extends CacheEngine
      */
     public function clear(): bool
     {
+        if ($this->getConfig('flushDb')) {
+            $this->_Redis->flushDB(false);
+
+            return true;
+        }
+
         $this->_Redis->setOption(Redis::OPT_SCAN, (string)Redis::SCAN_RETRY);
 
         $isAllDeleted = true;
@@ -351,6 +359,12 @@ class RedisEngine extends CacheEngine
      */
     public function clearBlocking(): bool
     {
+        if ($this->getConfig('flushDb')) {
+            $this->_Redis->flushDB(false);
+
+            return true;
+        }
+
         $this->_Redis->setOption(Redis::OPT_SCAN, (string)Redis::SCAN_RETRY);
 
         $isAllDeleted = true;

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -745,13 +745,13 @@ class RedisEngineTest extends TestCase
             'clearUsesFlushDb' => true,
         ]);
 
-        Cache::write('some_value', 'cache1', 'redis');
-        $result = Cache::clear('redis');
+        Cache::write('some_value', 'cache1', 'redis2');
+        $result = Cache::clear('redis2');
         $this->assertTrue($result);
-        $this->assertNull(Cache::read('some_value', 'redis'));
+        $this->assertNull(Cache::read('some_value', 'redis2'));
 
-        Cache::write('some_value', 'cache2', 'redis2');
-        $result = Cache::clear('redis');
+        Cache::write('some_value', 'cache2', 'redis');
+        $result = Cache::clear('redis2');
         $this->assertTrue($result);
 
         // Both cache prefixes are cleared
@@ -771,18 +771,16 @@ class RedisEngineTest extends TestCase
             'port' => $this->port,
         ]);
 
-        Cache::write('some_value', 'cache1', 'redis');
-        $result = Cache::pool('redis')->clearBlocking();
+        Cache::write('some_value', 'cache1', 'redis_clear_blocking');
+        $result = Cache::pool('redis_clear_blocking')->clearBlocking();
+        $this->assertTrue($result);
+        $this->assertNull(Cache::read('some_value', 'redis_clear_blocking'));
+
+        Cache::write('some_value', 'cache2', 'redis');
+        $result = Cache::pool('redis_clear_blocking')->clearBlocking();
         $this->assertTrue($result);
         $this->assertNull(Cache::read('some_value', 'redis'));
-
-        Cache::write('some_value', 'cache2', 'redis_clear_blocking');
-        $result = Cache::pool('redis')->clearBlocking();
-        $this->assertTrue($result);
-        $this->assertNull(Cache::read('some_value', 'redis'));
-        $this->assertSame('cache2', Cache::read('some_value', 'redis_clear_blocking'));
-
-        Cache::pool('redis_clear_blocking')->clearBlocking();
+        $this->assertNull(Cache::read('some_value', 'redis_clear_blocking'));
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -60,6 +60,8 @@ class RedisEngineTest extends TestCase
     {
         parent::tearDown();
         Cache::drop('redis');
+        Cache::drop('redis2');
+        Cache::drop('redis_clear_blocking');
         Cache::drop('redis_groups');
         Cache::drop('redis_helper');
     }

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -131,7 +131,7 @@ class RedisEngineTest extends TestCase
             'host' => 'localhost',
             'scheme' => 'redis',
             'scanCount' => 10,
-            'flushDb' => false,
+            'clearUsesFlushDb' => false,
         ];
         $this->assertEquals($expecting, $config);
 
@@ -170,6 +170,7 @@ class RedisEngineTest extends TestCase
             'ssl_ca' => '/tmp/cert.crt',
             'ssl_key' => '/tmp/local.key',
             'ssl_cert' => '/tmp/local.crt',
+            'clearUsesFlushDb' => false,
         ];
         $this->assertEquals($expecting, $config);
 

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -731,6 +731,33 @@ class RedisEngineTest extends TestCase
     }
 
     /**
+     * test clearing redis.
+     */
+    public function testClearWithFlush(): void
+    {
+        Cache::setConfig('redis2', [
+            'engine' => 'Redis',
+            'prefix' => 'cake2_',
+            'duration' => 3600,
+            'port' => $this->port,
+            'clearUsesFlushDb' => true,
+        ]);
+
+        Cache::write('some_value', 'cache1', 'redis');
+        $result = Cache::clear('redis');
+        $this->assertTrue($result);
+        $this->assertNull(Cache::read('some_value', 'redis'));
+
+        Cache::write('some_value', 'cache2', 'redis2');
+        $result = Cache::clear('redis');
+        $this->assertTrue($result);
+
+        // Both cache prefixes are cleared
+        $this->assertNull(Cache::read('some_value', 'redis'));
+        $this->assertNull(Cache::read('some_value', 'redis2'));
+    }
+
+    /**
      * testClearBlocking method
      */
     public function testClearBlocking(): void
@@ -754,6 +781,32 @@ class RedisEngineTest extends TestCase
         $this->assertSame('cache2', Cache::read('some_value', 'redis_clear_blocking'));
 
         Cache::pool('redis_clear_blocking')->clearBlocking();
+    }
+
+    /**
+     * testClearBlocking method
+     */
+    public function testClearBlockingWithFlush(): void
+    {
+        Cache::setConfig('redis_clear_blocking', [
+            'engine' => 'Redis',
+            'prefix' => 'cake2_',
+            'duration' => 3600,
+            'port' => $this->port,
+            'clearUsesFlushDb' => true,
+        ]);
+
+        Cache::write('some_value', 'cache1', 'redis');
+        $result = Cache::pool('redis')->clearBlocking();
+        $this->assertTrue($result);
+        $this->assertNull(Cache::read('some_value', 'redis'));
+
+        Cache::write('some_value', 'cache2', 'redis_clear_blocking');
+        $result = Cache::pool('redis')->clearBlocking();
+        $this->assertTrue($result);
+        // Both cache prefixes are cleared
+        $this->assertNull(Cache::read('some_value', 'redis'));
+        $this->assertNull(Cache::read('some_value', 'redis_clear_blocking'));
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -779,7 +779,7 @@ class RedisEngineTest extends TestCase
         Cache::write('some_value', 'cache2', 'redis');
         $result = Cache::pool('redis_clear_blocking')->clearBlocking();
         $this->assertTrue($result);
-        $this->assertNull(Cache::read('some_value', 'redis'));
+        $this->assertSame('cache2', Cache::read('some_value', 'redis'));
         $this->assertNull(Cache::read('some_value', 'redis_clear_blocking'));
     }
 
@@ -797,13 +797,14 @@ class RedisEngineTest extends TestCase
         ]);
 
         Cache::write('some_value', 'cache1', 'redis');
-        $result = Cache::pool('redis')->clearBlocking();
+        $result = Cache::pool('redis_clear_blocking')->clearBlocking();
         $this->assertTrue($result);
         $this->assertNull(Cache::read('some_value', 'redis'));
 
         Cache::write('some_value', 'cache2', 'redis_clear_blocking');
-        $result = Cache::pool('redis')->clearBlocking();
+        $result = Cache::pool('redis_clear_blocking')->clearBlocking();
         $this->assertTrue($result);
+
         // Both cache prefixes are cleared
         $this->assertNull(Cache::read('some_value', 'redis'));
         $this->assertNull(Cache::read('some_value', 'redis_clear_blocking'));

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -101,6 +101,7 @@ class RedisEngineTest extends TestCase
             'unix_socket' => false,
             'host' => null,
             'scanCount' => 10,
+            'flushDb' => false,
         ];
         $this->assertEquals($expecting, $config);
     }
@@ -130,6 +131,7 @@ class RedisEngineTest extends TestCase
             'host' => 'localhost',
             'scheme' => 'redis',
             'scanCount' => 10,
+            'flushDb' => false,
         ];
         $this->assertEquals($expecting, $config);
 

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -101,7 +101,7 @@ class RedisEngineTest extends TestCase
             'unix_socket' => false,
             'host' => null,
             'scanCount' => 10,
-            'flushDb' => false,
+            'clearUsesFlushDb' => false,
         ];
         $this->assertEquals($expecting, $config);
     }


### PR DESCRIPTION
I have issues with flushing the normal way, using all keys etc.

Is there a reason not to have the option availavble to fully flush()?
especially if you are only using one "prefix" per db, so it is essentually the same, but probably much faster.

This is opt-in, so fully BC.

I targeted 5.x as I would need this asap to be able to use redis functionally.