### PR TITLE
Fix regression in MissingAction exception

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -485,8 +485,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
 
         if (!$this->isAction($action)) {
             throw new MissingActionException([
-                $controller,
-                $action,
+                'controller' => $controller,
+                'action' => $action,
             ]);
         }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -736,15 +736,24 @@ class ControllerTest extends TestCase
      */
     public function testGetActionMissingAction(): void
     {
-        $this->expectException(MissingActionException::class);
-        $this->expectExceptionMessage('Action `TestController::missing()` could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/missing',
             'params' => ['controller' => 'Test', 'action' => 'missing'],
         ]);
 
         $Controller = new TestController($url);
-        $Controller->getAction();
+        try {
+            $Controller->getAction();
+        } catch (MissingActionException $e) {
+            $this->assertEquals(
+                'Action `TestController::missing()` could not be found, or is not accessible.',
+                $e->getMessage(),
+            );
+            $this->assertEquals(
+                ['controller' => 'TestController', 'action' => 'missing'],
+                $e->getAttributes(),
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Restore the attribute names to the MissingActionException so that templates render.

Fixes #18617