### PR TITLE
5.next assert redirect back to referer

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -960,6 +960,34 @@ trait IntegrationTestTrait
     }
 
     /**
+     * Assert whether the response is redirecting back to the referer.
+     *
+     * @param string $message The failure message that will be appended to the generated message.
+     * @return void
+     */
+    public function assertRedirectBackToReferer(string $message = ''): void
+    {
+        if (!$this->_response) {
+            $this->fail('No response set, cannot assert header.');
+        }
+
+        $verboseMessage = $this->extractVerboseMessage($message);
+        $this->assertThat(null, new HeaderSet($this->_response, 'Location'), $verboseMessage);
+        $this->assertThat(null, new StatusSuccess($this->_response), $verboseMessage);
+
+        $referer = $this->_request['environment']['HTTP_REFERER'] ?? null;
+        if (!$referer) {
+            $this->fail('No `HTTP_REFERER` set in request environment, cannot assert header.');
+        }
+
+        $this->assertThat(
+            Router::url($referer, true),
+            new HeaderEquals($this->_response, 'Location'),
+            $verboseMessage,
+        );
+    }
+
+    /**
      * Asserts that the Location header is correct. Comparison is made against exactly the URL provided.
      *
      * @param array|string|null $url The URL you expected the client to go to. This

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -962,10 +962,11 @@ trait IntegrationTestTrait
     /**
      * Assert whether the response is redirecting back to the referer.
      *
+     * @param int|null $code Specific status code to validate against, defaults to success (2xx-3xx) range.
      * @param string $message The failure message that will be appended to the generated message.
      * @return void
      */
-    public function assertRedirectBackToReferer(string $message = ''): void
+    public function assertRedirectBackToReferer(?int $code = null, string $message = ''): void
     {
         if (!$this->_response) {
             $this->fail('No response set, cannot assert header.');
@@ -973,7 +974,11 @@ trait IntegrationTestTrait
 
         $verboseMessage = $this->extractVerboseMessage($message);
         $this->assertThat(null, new HeaderSet($this->_response, 'Location'), $verboseMessage);
-        $this->assertThat(null, new StatusSuccess($this->_response), $verboseMessage);
+        if ($code !== null) {
+            $this->assertThat($code, new StatusCode($this->_response), $message);
+        } else {
+            $this->assertThat(null, new StatusSuccess($this->_response), $verboseMessage);
+        }
 
         $referer = $this->_request['environment']['HTTP_REFERER'] ?? null;
         if (!$referer) {

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -1250,6 +1250,44 @@ class IntegrationTestTraitTest extends TestCase
     /**
      * Test the location header assertion.
      */
+    public function testAssertRedirectBackToRefererSpecificCode(): void
+    {
+        $this->_response = new Response();
+        $this->_request = [
+            'environment' => [
+                'HTTP_REFERER' => 'http://localhost/get/tasks/index',
+            ],
+        ];
+        $this->_response = $this->_response
+            ->withStatus(301)
+            ->withHeader('Location', 'http://localhost/get/tasks/index');
+
+        $this->assertRedirectBackToReferer(301);
+    }
+
+    /**
+     * Test the location header assertion.
+     */
+    public function testAssertRedirectBackToRefererInvalid(): void
+    {
+        $this->_response = new Response();
+        $this->_request = [
+            'environment' => [
+                'HTTP_REFERER' => 'http://localhost/get/tasks/index',
+            ],
+        ];
+        $this->_response = $this->_response
+            ->withStatus(302)
+            ->withHeader('Location', 'http://localhost/get/tasks/view/1');
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertRedirectBackToReferer();
+    }
+
+    /**
+     * Test the location header assertion.
+     */
     public function testAssertRedirectEquals(): void
     {
         $this->_response = new Response();

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -1232,6 +1232,24 @@ class IntegrationTestTraitTest extends TestCase
     /**
      * Test the location header assertion.
      */
+    public function testAssertRedirectBackToReferer(): void
+    {
+        $this->_response = new Response();
+        $this->_request = [
+            'environment' => [
+                'HTTP_REFERER' => 'http://localhost/get/tasks/index',
+            ],
+        ];
+        $this->_response = $this->_response
+            ->withStatus(302)
+            ->withHeader('Location', 'http://localhost/get/tasks/index');
+
+        $this->assertRedirectBackToReferer();
+    }
+
+    /**
+     * Test the location header assertion.
+     */
     public function testAssertRedirectEquals(): void
     {
         $this->_response = new Response();


### PR DESCRIPTION
Follow and complete https://github.com/cakephp/cakephp/pull/18628

This is a common pattern with postLinks() and posting to an action to redirect back to where you came from.
Anything but "deleting" actions at least, so adding and modifying actions.