### PR TITLE
Improving mockery integration

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -39,8 +39,8 @@ use Closure;
 use Exception;
 use LogicException;
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase as BaseTestCase;
 use ReflectionClass;
 use ReflectionException;
 use function Cake\Core\pluginSplit;
@@ -48,7 +48,7 @@ use function Cake\Core\pluginSplit;
 /**
  * Cake TestCase class
  */
-abstract class TestCase extends BaseTestCase
+abstract class TestCase extends MockeryTestCase
 {
     use LocatorAwareTrait;
     use PHPUnitConsecutiveTrait;

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -38,7 +38,6 @@ use Cake\Utility\Inflector;
 use Closure;
 use Exception;
 use LogicException;
-use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
@@ -258,9 +257,6 @@ abstract class TestCase extends MockeryTestCase
         $this->getTableLocator()->clear();
         $this->_configure = [];
         $this->_tableLocator = null;
-        if (class_exists(Mockery::class)) {
-            Mockery::close();
-        }
     }
 
     /**

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -38,8 +38,10 @@ use Cake\Utility\Inflector;
 use Closure;
 use Exception;
 use LogicException;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\Adapter\Phpunit\MockeryTestCaseSetUp;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 use ReflectionClass;
 use ReflectionException;
 use function Cake\Core\pluginSplit;
@@ -47,9 +49,11 @@ use function Cake\Core\pluginSplit;
 /**
  * Cake TestCase class
  */
-abstract class TestCase extends MockeryTestCase
+abstract class TestCase extends BaseTestCase
 {
     use LocatorAwareTrait;
+    use MockeryPHPUnitIntegration;
+    use MockeryTestCaseSetUp;
     use PHPUnitConsecutiveTrait;
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -25,7 +25,6 @@ use Cake\Controller\Exception\MissingActionException;
 use Cake\Core\Configure;
 use Cake\Core\Container;
 use Cake\Datasource\Paging\PaginatedInterface;
-use Cake\Event\Event;
 use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
 use Cake\Http\Exception\NotFoundException;
@@ -628,8 +627,7 @@ class ControllerTest extends TestCase
             ->shouldHaveReceived('dispatch')
             ->withArgs(function ($event) {
                 return $event->getName() === 'Controller.startup';
-            })
-        ;
+            });
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -614,24 +614,22 @@ class ControllerTest extends TestCase
      */
     public function testStartupProcess(): void
     {
-        $eventManager = Mockery::mock(EventManager::class)->makePartial();
-        $eventManager->shouldReceive('dispatch')
+        $eventManager = Mockery::spy(EventManager::class);
+        $controller = new Controller(new ServerRequest(), null, $eventManager);
+        $controller->startupProcess();
+
+        $eventManager
+            ->shouldHaveReceived('dispatch')
             ->withArgs(function ($event) {
                 return $event->getName() === 'Controller.initialize';
-            })
-            ->once()
-            ->andReturn(new Event('stub'));
+            });
 
-        $eventManager->shouldReceive('dispatch')
+        $eventManager
+            ->shouldHaveReceived('dispatch')
             ->withArgs(function ($event) {
                 return $event->getName() === 'Controller.startup';
             })
-            ->once()
-            ->andReturn(new Event('stub'));
-
-        $controller = new Controller(new ServerRequest(), null, $eventManager);
-
-        $this->assertNull($controller->startupProcess());
+        ;
     }
 
     /**
@@ -639,16 +637,15 @@ class ControllerTest extends TestCase
      */
     public function testShutdownProcess(): void
     {
-        $eventManager = Mockery::mock(EventManager::class)->makePartial();
-        $eventManager->shouldReceive('dispatch')
+        $eventManager = Mockery::spy(EventManager::class);
+        $controller = new Controller(new ServerRequest(), null, $eventManager);
+        $controller->shutdownProcess();
+
+        $eventManager->shouldHaveReceived('dispatch')
+            ->once()
             ->withArgs(function ($event) {
                 return $event->getName() === 'Controller.shutdown';
-            })
-            ->once()
-            ->andReturn(new Event('stub'));
-        $controller = new Controller(new ServerRequest(), null, $eventManager);
-
-        $this->assertNull($controller->shutdownProcess());
+            });
     }
 
     /**

--- a/tests/TestCase/Database/Type/StringTypeTest.php
+++ b/tests/TestCase/Database/Type/StringTypeTest.php
@@ -63,13 +63,14 @@ class StringTypeTest extends TestCase
      */
     public function testToDatabase(): void
     {
-        $obj = Mockery::mock('StdClass')->shouldAllowMockingMethod('__toString');
-        $obj->shouldReceive('__toString')->andReturn('toString called');
+        $obj = Mockery::spy('StdClass');
 
         $this->assertNull($this->type->toDatabase(null, $this->driver));
         $this->assertSame('word', $this->type->toDatabase('word', $this->driver));
         $this->assertSame('2.123', $this->type->toDatabase(2.123, $this->driver));
-        $this->assertSame('toString called', $this->type->toDatabase($obj, $this->driver));
+        $this->assertSame((string)$obj, $this->type->toDatabase($obj, $this->driver));
+
+        $obj->shouldHaveReceived('__toString');
     }
 
     /**

--- a/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
+++ b/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
@@ -49,11 +49,12 @@ class PaginatedResultSetTest extends TestCase
 
     public function testCall(): void
     {
-        $resultSet = Mockery::mock(ResultSet::class);
-        $resultSet->shouldReceive('extract')
-            ->once()
+        $resultSet = Mockery::mock(ResultSet::class)
+            ->shouldReceive('extract')
             ->with('foo')
-            ->andReturn(collection(['bar']));
+            ->once()
+            ->andReturn(collection(['bar']))
+            ->getMock();
 
         $paginatedResults = new PaginatedResultSet(
             $resultSet,

--- a/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
+++ b/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
@@ -51,8 +51,8 @@ class PaginatedResultSetTest extends TestCase
     {
         $resultSet = Mockery::mock(ResultSet::class);
         $resultSet->shouldReceive('extract')
-            ->with('foo')
             ->once()
+            ->with('foo')
             ->andReturn(collection(['bar']));
 
         $paginatedResults = new PaginatedResultSet(

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -150,8 +150,8 @@ class ServerTest extends TestCase
         $app->shouldHaveReceived('pluginBootstrap')
             ->once();
         $app->shouldHaveReceived('pluginMiddleware')
-            ->once()
-            ->with(Mockery::type(MiddlewareQueue::class));
+            ->with(Mockery::type(MiddlewareQueue::class))
+            ->once();
     }
 
     /**

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -131,14 +131,8 @@ class ServerTest extends TestCase
         $request = $request->withHeader('X-pass', 'request header');
 
         /** @var \TestApp\Http\MiddlewareApplication|\Mockery\MockInterface $app */
-        $app = Mockery::mock(MiddlewareApplication::class, [$this->config])
-            ->shouldAllowMockingMethod('pluginEvents')
+        $app = Mockery::spy(MiddlewareApplication::class, [$this->config])
             ->makePartial();
-        $app->shouldReceive('pluginBootstrap', 'pluginMiddleware')
-            ->with(Mockery::type(MiddlewareQueue::class))
-            ->andReturnUsing(function ($middleware) {
-                return $middleware;
-            });
 
         $server = new Server($app);
         $res = $server->run($request);
@@ -152,6 +146,12 @@ class ServerTest extends TestCase
             $res->getHeaderLine('X-pass'),
             'Request is used in middleware',
         );
+
+        $app->shouldHaveReceived('pluginBootstrap')
+            ->once();
+        $app->shouldHaveReceived('pluginMiddleware')
+            ->once()
+            ->with(Mockery::type(MiddlewareQueue::class));
     }
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -316,10 +316,10 @@ class BelongsToTest extends TestCase
      */
     public function testSaveAssociatedOnlyEntities(): void
     {
-        $mock = Mockery::spy(Table::class);
+        $spy = Mockery::spy(Table::class);
         $config = [
             'sourceTable' => $this->client,
-            'targetTable' => $mock,
+            'targetTable' => $spy,
         ];
 
         $entity = new Entity([
@@ -333,7 +333,7 @@ class BelongsToTest extends TestCase
         $this->assertSame($result, $entity);
         $this->assertNull($entity->author_id);
 
-        $mock->shouldNotHaveReceived('saveAssociated');
+        $spy->shouldNotHaveReceived('saveAssociated');
     }
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -316,14 +316,11 @@ class BelongsToTest extends TestCase
      */
     public function testSaveAssociatedOnlyEntities(): void
     {
-        $mock = Mockery::mock(Table::class)
-            ->shouldAllowMockingMethod('saveAssociated')
-            ->makePartial();
+        $mock = Mockery::spy(Table::class);
         $config = [
             'sourceTable' => $this->client,
             'targetTable' => $mock,
         ];
-        $mock->shouldNotReceive('saveAssociated');
 
         $entity = new Entity([
             'title' => 'A Title',
@@ -335,6 +332,8 @@ class BelongsToTest extends TestCase
         $result = $association->saveAssociated($entity);
         $this->assertSame($result, $entity);
         $this->assertNull($entity->author_id);
+
+        $mock->shouldNotHaveReceived('saveAssociated');
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -636,10 +636,10 @@ class HasManyTest extends TestCase
      */
     public function testSaveAssociatedOnlyEntities(): void
     {
-        $mock = Mockery::spy(Table::class);
+        $spy = Mockery::spy(Table::class);
         $config = [
             'sourceTable' => $this->author,
-            'targetTable' => $mock,
+            'targetTable' => $spy,
         ];
 
         $entity = new Entity([
@@ -655,7 +655,7 @@ class HasManyTest extends TestCase
         $result = $association->saveAssociated($entity);
         $this->assertSame($result, $entity);
 
-        $mock->shouldNotHaveReceived('saveAssociated');
+        $spy->shouldNotHaveReceived('saveAssociated');
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -636,9 +636,7 @@ class HasManyTest extends TestCase
      */
     public function testSaveAssociatedOnlyEntities(): void
     {
-        $mock = Mockery::mock(Table::class)
-            ->shouldAllowMockingMethod('saveAssociated')
-            ->makePartial();
+        $mock = Mockery::spy(Table::class);
         $config = [
             'sourceTable' => $this->author,
             'targetTable' => $mock,
@@ -653,11 +651,11 @@ class HasManyTest extends TestCase
             ],
         ]);
 
-        $mock->shouldNotReceive('saveAssociated');
-
         $association = new HasMany('Articles', $config);
         $result = $association->saveAssociated($entity);
         $this->assertSame($result, $entity);
+
+        $mock->shouldNotHaveReceived('saveAssociated');
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -229,14 +229,11 @@ class HasOneTest extends TestCase
      */
     public function testSaveAssociatedOnlyEntities(): void
     {
-        $mock = Mockery::mock(Table::class)
-            ->shouldAllowMockingMethod('saveAssociated')
-            ->makePartial();
+        $mock = Mockery::spy(Table::class);
         $config = [
             'sourceTable' => $this->user,
             'targetTable' => $mock,
         ];
-        $mock->shouldNotReceive('saveAssociated');
 
         $entity = new Entity([
             'username' => 'Mark',
@@ -248,6 +245,7 @@ class HasOneTest extends TestCase
         $result = $association->saveAssociated($entity);
 
         $this->assertSame($result, $entity);
+        $mock->shouldNotHaveReceived('saveAssociated');
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -229,10 +229,10 @@ class HasOneTest extends TestCase
      */
     public function testSaveAssociatedOnlyEntities(): void
     {
-        $mock = Mockery::spy(Table::class);
+        $spy = Mockery::spy(Table::class);
         $config = [
             'sourceTable' => $this->user,
-            'targetTable' => $mock,
+            'targetTable' => $spy,
         ];
 
         $entity = new Entity([
@@ -245,7 +245,7 @@ class HasOneTest extends TestCase
         $result = $association->saveAssociated($entity);
 
         $this->assertSame($result, $entity);
-        $mock->shouldNotHaveReceived('saveAssociated');
+        $spy->shouldNotHaveReceived('saveAssociated');
     }
 
     /**

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -161,14 +161,14 @@ class AssociationProxyTest extends TestCase
     public function testAssociationMethodProxy(): void
     {
         $articles = $this->getTableLocator()->get('articles');
-        $mock = Mockery::spy(Table::class);
+        $spy = Mockery::spy(Table::class);
         $articles->belongsTo('authors', [
-            'targetTable' => $mock,
+            'targetTable' => $spy,
         ]);
 
         $articles->authors->crazy('a', 'b');
 
-        $mock
+        $spy
             ->shouldHaveReceived('crazy')
             ->once()
             ->with('a', 'b');

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -161,15 +161,16 @@ class AssociationProxyTest extends TestCase
     public function testAssociationMethodProxy(): void
     {
         $articles = $this->getTableLocator()->get('articles');
-        $mock = Mockery::mock(Table::class)
-            ->shouldAllowMockingMethod('crazy');
+        $mock = Mockery::spy(Table::class);
         $articles->belongsTo('authors', [
             'targetTable' => $mock,
         ]);
 
-        $mock->shouldReceive('crazy')
-            ->with('a', 'b')
-            ->andReturn('thing');
-        $this->assertSame('thing', $articles->authors->crazy('a', 'b'));
+        $articles->authors->crazy('a', 'b');
+
+        $mock
+            ->shouldHaveReceived('crazy')
+            ->once()
+            ->with('a', 'b');
     }
 }

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -170,7 +170,7 @@ class AssociationProxyTest extends TestCase
 
         $spy
             ->shouldHaveReceived('crazy')
-            ->once()
-            ->with('a', 'b');
+            ->with('a', 'b')
+            ->once();
     }
 }

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -302,14 +302,8 @@ class BehaviorRegistryTest extends TestCase
     public function testCallFinder(): void
     {
         $this->Behaviors->load('Sluggable');
-        $mockedBehavior = Mockery::mock(Behavior::class)
-            ->shouldAllowMockingMethod('findNoSlug', 'implementedFinders')
-            ->makePartial();
-        $mockedBehavior->shouldReceive('implementedFinders')
-            ->once()
-            ->andReturn([
-                'noslug' => 'findNoSlug',
-            ]);
+        $mockedBehavior = Mockery::mock(Behavior::class)->makePartial();
+        $mockedBehavior->shouldReceive(['implementedFinders' => ['noslug' => 'findNoSlug']]);
         $this->Behaviors->set('Sluggable', $mockedBehavior);
 
         $query = new SelectQuery($this->Table);

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -202,7 +202,7 @@ class LinkConstraintTest extends TestCase
             ]],
         );
         $Articles->shouldReceive('buildRules')
-            ->atLeast()->once()
+            ->between(1, 2)
             ->andReturn($rulesChecker);
 
         $rulesChecker->addDelete(

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1039,11 +1039,7 @@ class RouteTest extends TestCase
      */
     public function testParseRequestDelegates(): void
     {
-        $route = Mockery::mock(Route::class)->makePartial();
-        $route->shouldReceive('parse')
-            ->once()
-            ->with('/forward', 'GET')
-            ->andReturn(['works!']);
+        $route = Mockery::spy(Route::class)->makePartial();
 
         $request = new ServerRequest([
             'environment' => [
@@ -1051,8 +1047,11 @@ class RouteTest extends TestCase
                 'REQUEST_URI' => '/forward',
             ],
         ]);
-        $result = $route->parseRequest($request);
-        $this->assertNotEmpty($result);
+        $route->parseRequest($request);
+
+        $route->shouldHaveReceived('parse')
+            ->once()
+            ->with('/forward', 'GET');
     }
 
     /**

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1050,8 +1050,8 @@ class RouteTest extends TestCase
         $route->parseRequest($request);
 
         $route->shouldHaveReceived('parse')
-            ->once()
-            ->with('/forward', 'GET');
+            ->with('/forward', 'GET')
+            ->once();
     }
 
     /**

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -30,6 +30,7 @@ use Cake\Test\Fixture\FixturizedTestCase;
 use Cake\TestSuite\TestCase;
 use Exception;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestStatus\Skipped;
 use PHPUnit\Framework\TestStatus\Success;
 use PHPUnit\Runner\Version;
@@ -123,6 +124,7 @@ class TestCaseTest extends TestCase
     /**
      * testSkipIf
      */
+    #[WithoutErrorHandler]
     public function testSkipIf(): void
     {
         $test = new FixturizedTestCase('testSkipIfTrue');

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -226,10 +226,10 @@ class FormHelperTest extends TestCase
         $this->Form->widget('test', ['val' => 1]);
 
         $widget->shouldHaveReceived('render')
-            ->once()
             ->withArgs(function (array $data) {
                 return $data === ['val' => 1];
-            });
+            })
+            ->once();
     }
 
     /**
@@ -249,13 +249,13 @@ class FormHelperTest extends TestCase
         $this->Form->widget('test', ['val' => 1, 'name' => 'test', 'secure' => true]);
 
         $widget->shouldHaveReceived('render')
-            ->once()
             ->withArgs(function (array $data) {
                 return $data === ['val' => 1, 'name' => 'test'];
-            });
+            })
+            ->once();
         $widget->shouldHaveReceived('secureFields')
-            ->once()
-            ->with(['val' => 1, 'name' => 'test']);
+            ->with(['val' => 1, 'name' => 'test'])
+            ->once();
     }
 
     /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -221,15 +221,15 @@ class FormHelperTest extends TestCase
      */
     public function testAddWidgetAndRenderWidget(): void
     {
-        $data = ['val' => 1];
-        $widget = Mockery::mock(WidgetInterface::class);
-        $widget->shouldReceive('render')
-            ->withSomeOfArgs($data)
-            ->once()
-            ->andReturn('HTML');
+        $widget = Mockery::spy(WidgetInterface::class)->makePartial();
         $this->Form->addWidget('test', $widget);
-        $result = $this->Form->widget('test', $data);
-        $this->assertSame('HTML', $result);
+        $this->Form->widget('test', ['val' => 1]);
+
+        $widget->shouldHaveReceived('render')
+            ->once()
+            ->withArgs(function (array $data) {
+                return $data === ['val' => 1];
+            });
     }
 
     /**
@@ -242,20 +242,20 @@ class FormHelperTest extends TestCase
             'unlockedFields' => [],
         ]));
 
-        $data = ['val' => 1, 'name' => 'test'];
-        $widget = Mockery::mock(WidgetInterface::class);
-        $widget->shouldReceive('render')
-            ->withSomeOfArgs($data)
-            ->once()
-            ->andReturn('HTML');
-        $widget->shouldReceive('secureFields')
-            ->with($data)
-            ->once()
-            ->andReturn(['test']);
+        $widget = Mockery::spy(WidgetInterface::class);
+
         $this->Form->addWidget('test', $widget);
         $this->Form->create();
-        $result = $this->Form->widget('test', ['val' => 1, 'name' => 'test', 'secure' => true]);
-        $this->assertSame('HTML', $result);
+        $this->Form->widget('test', ['val' => 1, 'name' => 'test', 'secure' => true]);
+
+        $widget->shouldHaveReceived('render')
+            ->once()
+            ->withArgs(function (array $data) {
+                return $data === ['val' => 1, 'name' => 'test'];
+            });
+        $widget->shouldHaveReceived('secureFields')
+            ->once()
+            ->with(['val' => 1, 'name' => 'test']);
     }
 
     /**


### PR DESCRIPTION
For now, this is meant as a draft. See https://github.com/cakephp/cakephp/issues/18633.

I'll add some comments to the code soon.

Some general observations.

- We should try to use spy instead of mock whenever possible and we want to make an assertion about the methods involved (rather than making these methods return a dummy value and making the assertion about the return value). See [here](https://adamwathan.me/2016/10/12/replacing-mocks-with-spies).
This, in addition to making the tests more fluid and more readable, allows us to maintain the "Arrange, Act, and Assert" pattern (the assertion goes at the end, with the other assertions. Using mocks, the assertion must necessarily be together with the mock definition)
- ~~Just as a good practice, the various `once()` (and similar) methods should come before the various `with()` (and similar) methods.~~ EDIT: at least for spies, the `once()` method (and similar ones) can only be called at the end (see https://github.com/mockery/mockery/issues/1462#issuecomment-2863955735). So, contrary to what I suggested, even for mocks and for consistency it is better to always use this order.
- An interesting thing about Mockery is overloading (see [Mocking Hard Dependencies](https://docs.mockery.io/en/latest/cookbook/mocking_hard_dependencies.html)).
We could start using it in some cases, for example now I see that tests generate warnings for some methods of the `Cache` class.
This could solve several problems and also improve the quality of the tests. It requires that the tests run in separate processes.
Possibly to be integrated with this PR.
- The `PHPUnitConsecutiveTrait::withConsecutive()` method can now always be solved with Mockery features.
I think we could proceed for now by replacing the tests that use it, but leaving the method for those who already use it in their plugins.
I don't see why CakePHP should bother integrating this feature (with all that it entails).
Possibly additional PR needed.
- I have seen that sometimes the the `shouldAllowMockingMethod()` method is called with more than one argument (it only takes one)
To check.
- I see that this code is widely recurring in tests:
```php
$output = new StubConsoleOutput();
$io = Mockery::mock(ConsoleIo::class, [$output, $output, null, null])->makePartial();
```
Can we think of a DRY solution?
Possibly additional PR needed.

