### PR TITLE
Fix primary key reflection in sqlserver

### DIFF
--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -430,7 +430,9 @@ class SqlserverSchemaDialect extends SchemaDialect
         foreach ($statement->fetchAll('assoc') as $row) {
             $type = TableSchema::INDEX_INDEX;
             $name = $row['index_name'];
+            $constraint = null;
             if ($row['is_primary_key']) {
+                $constraint = $name;
                 $name = TableSchema::CONSTRAINT_PRIMARY;
                 $type = TableSchema::CONSTRAINT_PRIMARY;
             }
@@ -447,6 +449,9 @@ class SqlserverSchemaDialect extends SchemaDialect
                 ];
             }
             $indexes[$name]['columns'][] = $row['column_name'];
+            if ($constraint) {
+                $indexes[$name]['constraint'] = $constraint;
+            }
         }
 
         return array_values($indexes);

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -662,6 +662,7 @@ SQL;
 
         // Compare with describeIndexes() which includes indexes + uniques
         $expected['author_idx'] = $authorIdx;
+
         $indexes = $dialect->describeIndexes('schema_articles');
         $this->assertCount(4, $indexes);
         foreach ($indexes as $index) {
@@ -670,6 +671,10 @@ SQL;
             $expectedItem = $expected[$name];
             $expectedFields = array_intersect_key($expectedItem, $index);
             $resultFields = array_intersect_key($index, $expectedFields);
+
+            if (isset($index['constraint'])) {
+                $this->assertStringStartsWith('PK__schema', $index['constraint']);
+            }
 
             $this->assertNotEmpty($resultFields);
             $this->assertEquals($expectedFields, $resultFields);


### PR DESCRIPTION
Migrations requires primary key names to be preserved in sqlserver. Follow the pattern used in postgres to retain backwards compatibility with cakephp/database (name = primary) and preserve the key's actual name.
