### PR TITLE
Clean up finder invokation.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2611,7 +2611,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
 
         if ($this->_behaviors->hasFinder($type)) {
-            return $this->_behaviors->callFinder($type, $query, ...$args);
+            return $this->invokeFinder($this->_behaviors->getFinder($type), $query, $args);
         }
 
         throw new BadMethodCallException(sprintf(
@@ -2622,14 +2622,15 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * @internal
+     * Invokes the finder callable with appropriate arguments.
+     *
      * @template TSubject of \Cake\Datasource\EntityInterface|array
      * @param \Closure $callable Callable.
      * @param \Cake\ORM\Query\SelectQuery<TSubject> $query The query object.
      * @param array $args Arguments for the callable.
      * @return \Cake\ORM\Query\SelectQuery<TSubject>
      */
-    public function invokeFinder(Closure $callable, SelectQuery $query, array $args): SelectQuery
+    protected function invokeFinder(Closure $callable, SelectQuery $query, array $args): SelectQuery
     {
         $reflected = new ReflectionFunction($callable);
         $params = $reflected->getParameters();


### PR DESCRIPTION
Finder invokation should not be part of the public API. BehaviorRegistry now only provides the finder callable.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
