### PR TITLE
5.x - Fix dependencies, mockery is always required now

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "laminas/laminas-diactoros": "^3.3",
         "laminas/laminas-httphandlerrunner": "^2.6",
         "league/container": "^4.2",
+        "mockery/mockery": "^1.6",
         "psr/container": "^1.1 || ^2.0",
         "psr/http-client": "^1.0.2",
         "psr/http-factory": "^1.1",
@@ -60,7 +61,6 @@
         "cakephp/cakephp-codesniffer": "^5.2",
         "http-interop/http-factory-tests": "dev-main",
         "mikey179/vfsstream": "^1.6.10",
-        "mockery/mockery": "^1.6",
         "paragonie/csp-builder": "^2.3 || ^3.0",
         "phpunit/phpunit": "^10.5.5 || ^11.1.3 || ^12.0.9"
     },


### PR DESCRIPTION
Because `Cake\TestSuite\TestCase` includes the mockery trait, application and plugin tests will also need mockery available, making mockery a hard dependency for cakephp.

If we don't want this, we'll need another solution to Mockery integration.