### PR TITLE
Fixed Cache tests

### DIFF
--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -103,16 +103,19 @@ class CacheTest extends TestCase
      */
     public function testCachePoolFallbackDisabled(): void
     {
-        $filename = tempnam(CACHE, 'tmp_');
+        $engine = new class extends TestAppCacheEngine {
+            public function init(array $config = []): bool
+            {
+                return false;
+            }
+        };
 
         Cache::setConfig('tests', [
-            'engine' => 'File',
-            'path' => $filename,
-            'prefix' => 'test_',
+            'engine' => $engine,
             'fallback' => false,
         ]);
 
-        $this->expectErrorMessageMatches('/^Cache engine `.*FileEngine` is not properly configured/', function (): void {
+        $this->expectErrorMessageMatches('/^Cache engine `.*TestAppCacheEngine.*` is not properly configured/', function (): void {
             Cache::pool('tests');
         });
     }


### PR DESCRIPTION
Fixed warning in all tests:
```
PHP Warning:  /tmp/cache/tmp_JwayM1/ is not writable in /home/runner/work/cakephp/cakephp/src/Cache/Engine/FileEngine.php on line 425
.
Warning: /tmp/cache/tmp_JwayM1/ is not writable in /home/runner/work/cakephp/cakephp/src/Cache/Engine/FileEngine.php on line 425
```

Removed useless call to `tempnam()`
