### PR TITLE
5.x - Mockery is not a hard dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         "laminas/laminas-diactoros": "^3.3",
         "laminas/laminas-httphandlerrunner": "^2.6",
         "league/container": "^4.2",
-        "mockery/mockery": "^1.6",
         "psr/container": "^1.1 || ^2.0",
         "psr/http-client": "^1.0.2",
         "psr/http-factory": "^1.1",
@@ -61,6 +60,7 @@
         "cakephp/cakephp-codesniffer": "^5.2",
         "http-interop/http-factory-tests": "dev-main",
         "mikey179/vfsstream": "^1.6.10",
+        "mockery/mockery": "^1.6",
         "paragonie/csp-builder": "^2.3 || ^3.0",
         "phpunit/phpunit": "^10.5.5 || ^11.1.3 || ^12.0.9"
     },

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -225,6 +225,7 @@ abstract class TestCase extends BaseTestCase
         parent::assertPostConditions();
 
         if (class_exists(Mockery::class)) {
+            // @phpstan-ignore method.internal
             $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
         }
     }

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -38,8 +38,7 @@ use Cake\Utility\Inflector;
 use Closure;
 use Exception;
 use LogicException;
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
-use Mockery\Adapter\Phpunit\MockeryTestCaseSetUp;
+use Mockery;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use ReflectionClass;
@@ -52,8 +51,6 @@ use function Cake\Core\pluginSplit;
 abstract class TestCase extends BaseTestCase
 {
     use LocatorAwareTrait;
-    use MockeryPHPUnitIntegration;
-    use MockeryTestCaseSetUp;
     use PHPUnitConsecutiveTrait;
 
     /**
@@ -217,6 +214,22 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
+     * This method is called between test and tearDown().
+     *
+     * Gets the count of expectations on the mocks produced through Mockery.
+     *
+     * @return void
+     */
+    protected function assertPostConditions(): void
+    {
+        parent::assertPostConditions();
+
+        if (class_exists(Mockery::class)) {
+            $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
+        }
+    }
+
+    /**
      * Setup the test case, backup the static object values so they can be restored.
      * Specifically backs up the contents of Configure and paths in App if they have
      * not already been backed up.
@@ -261,6 +274,9 @@ abstract class TestCase extends BaseTestCase
         $this->getTableLocator()->clear();
         $this->_configure = [];
         $this->_tableLocator = null;
+        if (class_exists(Mockery::class)) {
+            Mockery::close();
+        }
     }
 
     /**


### PR DESCRIPTION
This should be enough for it not to require Mockery as hard dependency.

Fix https://github.com/cakephp/cakephp/pull/18669.
Reset https://github.com/cakephp/cakephp/pull/17255

To be tested with plugins.