### PR TITLE
fixed tests after PR #18668

### DIFF
--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -65,10 +65,11 @@ class PostgresTest extends TestCase
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
         ];
 
-        $connection = Mockery::mock('PDO');
+        $connection = Mockery::mock(PDO::class);
 
         $connection->shouldReceive('quote')
-            ->andReturnArg(0);
+            ->andReturnArg(0)
+            ->twice();
 
         $connection->shouldReceive('exec')->with('SET NAMES utf8')->once();
         $connection->shouldReceive('exec')->with('SET search_path TO public')->once();
@@ -117,10 +118,11 @@ class PostgresTest extends TestCase
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
         ];
 
-        $connection = Mockery::mock('PDO');
+        $connection = Mockery::mock(PDO::class);
 
         $connection->shouldReceive('quote')
-            ->andReturnArg(0);
+            ->andReturnArg(0)
+            ->times(3);
 
         $connection->shouldReceive('exec')->with('SET NAMES a-language')->once();
         $connection->shouldReceive('exec')->with('SET search_path TO fooblic')->once();


### PR DESCRIPTION
In the end the problem was due to this line:

https://github.com/cakephp/cakephp/pull/18675/files#diff-6fbd0b31ae5c4af026805cee0a785090b0d5e9fed3ba4154a015493461e680afR125

I got there through debugging, exclusions and... unorthodox methods and it makes no sense to me.

Now, why the lack of an expectation counter in a mock of `PostgresTest::testConnectionConfigCustom()` causes another test in another class to fail is a mystery to me.
