### PR TITLE
Fix API doc example

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1486,7 +1486,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * Get an article and some relationships:
      *
      * ```
-     * $article = $articles->get(1, ['contain' => ['Users', 'Comments']]);
+     * $article = $articles->get(1, contain: ['Users', 'Comments']]);
      * ```
      *
      * @param mixed $primaryKey primary key value to find


### PR DESCRIPTION
This example should use named parameters instead of the deprecated options array.