### PR TITLE
Fix up data provider usage tests.

### DIFF
--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -271,7 +271,10 @@ class Xml
             $input = $input->toArray();
         }
         if (!is_array($input) || count($input) !== 1) {
-            throw new XmlException('Invalid input.');
+            throw new XmlException(
+                'Invalid input of type `' . gettype($input) . '`'
+                . (is_array($input) ? ' (Count of ' . count($input) . ')' : '') . '.',
+            );
         }
         $key = key($input);
         if (is_int($key)) {

--- a/tests/TestCase/View/XmlViewTest.php
+++ b/tests/TestCase/View/XmlViewTest.php
@@ -279,10 +279,10 @@ class XmlViewTest extends TestCase
     public static function falseyValues(): array
     {
         return [
-            [0, 0],
-            ['0', 0],
-            [false, 0],
-            ['', null],
+            [0, '<testing>0</testing>'],
+            ['0', '<testing>0</testing>'],
+            [false, '<testing>0</testing>'],
+            ['', '<testing/>'],
         ];
     }
 
@@ -290,7 +290,7 @@ class XmlViewTest extends TestCase
      * Test that rendering with _serialize can work with a single falsey value
      */
     #[DataProvider('falseyValues')]
-    public function testRenderSerializeWithFalseyValue($value, $expectedValue): void
+    public function testRenderSerializeWithFalseyValue($value, $expectedString): void
     {
         $Request = new ServerRequest();
         $Controller = new Controller($Request);
@@ -306,7 +306,6 @@ class XmlViewTest extends TestCase
 
         $expected = Xml::build(['response' => $data])->asXML();
         $this->assertSame($expected, $result);
-        $expectedString = $expectedValue === null ? '<testing/>' : '<testing>' . $expectedValue . '</testing>';
         $this->assertStringContainsString($expectedString, $result);
     }
 

--- a/tests/TestCase/View/XmlViewTest.php
+++ b/tests/TestCase/View/XmlViewTest.php
@@ -279,11 +279,10 @@ class XmlViewTest extends TestCase
     public static function falseyValues(): array
     {
         return [
-            [0],
-            ['0'],
-            [false],
-            [''],
-            [[]],
+            [0, 0],
+            ['0', 0],
+            [false, 0],
+            ['', null],
         ];
     }
 
@@ -291,12 +290,12 @@ class XmlViewTest extends TestCase
      * Test that rendering with _serialize can work with a single falsey value
      */
     #[DataProvider('falseyValues')]
-    public function testRenderSerializeWithFalseyValue(): void
+    public function testRenderSerializeWithFalseyValue($value, $expectedValue): void
     {
         $Request = new ServerRequest();
         $Controller = new Controller($Request);
         $data = [
-            'testing' => 0,
+            'testing' => $value,
         ];
         $Controller->set($data);
         $Controller->viewBuilder()
@@ -307,7 +306,8 @@ class XmlViewTest extends TestCase
 
         $expected = Xml::build(['response' => $data])->asXML();
         $this->assertSame($expected, $result);
-        $this->assertStringContainsString('<testing>0</testing>', $result);
+        $expectedString = $expectedValue === null ? '<testing/>' : '<testing>' . $expectedValue . '</testing>';
+        $this->assertStringContainsString($expectedString, $result);
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/18673 in a way that it actually tests the values.

The `[]` (empty array) case I dont know how to handle, it throws an actual error.
In the process I improved the exception message from

> Cake\Utility\Exception\XmlException: Invalid input.

to

> Cake\Utility\Exception\XmlException: Invalid input of type `array` (Count of 0).
