### PR TITLE
remove underscores from cache package methods via rector

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -137,7 +137,7 @@ class Cache
      * @throws \RuntimeException If loading of the engine failed.
      * @return void
      */
-    protected static function _buildEngine(string $name): void
+    protected static function buildEngine(string $name): void
     {
         $registry = static::getRegistry();
 
@@ -213,7 +213,7 @@ class Cache
             return $registry->{$config};
         }
 
-        static::_buildEngine($config);
+        static::buildEngine($config);
 
         return $registry->{$config};
     }

--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -335,7 +335,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      * @return string Prefixed key with potentially unsafe characters replaced.
      * @throws \Cake\Cache\Exception\InvalidArgumentException If key's value is invalid.
      */
-    protected function _key(string $key): string
+    protected function key(string $key): string
     {
         $this->ensureValidKey($key);
 

--- a/src/Cache/Engine/ApcuEngine.php
+++ b/src/Cache/Engine/ApcuEngine.php
@@ -64,7 +64,7 @@ class ApcuEngine extends CacheEngine
      */
     public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $duration = $this->duration($ttl);
 
         return apcu_store($key, $value, $duration);
@@ -81,7 +81,7 @@ class ApcuEngine extends CacheEngine
      */
     public function get(string $key, mixed $default = null): mixed
     {
-        $value = apcu_fetch($this->_key($key), $success);
+        $value = apcu_fetch($this->key($key), $success);
         if ($success === false) {
             return $default;
         }
@@ -99,7 +99,7 @@ class ApcuEngine extends CacheEngine
      */
     public function increment(string $key, int $offset = 1): int|false
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         return apcu_inc($key, $offset);
     }
@@ -114,7 +114,7 @@ class ApcuEngine extends CacheEngine
      */
     public function decrement(string $key, int $offset = 1): int|false
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         return apcu_dec($key, $offset);
     }
@@ -128,7 +128,7 @@ class ApcuEngine extends CacheEngine
      */
     public function delete(string $key): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         return apcu_delete($key);
     }
@@ -173,7 +173,7 @@ class ApcuEngine extends CacheEngine
      */
     public function add(string $key, mixed $value): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $duration = $this->_config['duration'];
 
         return apcu_add($key, $value, $duration);

--- a/src/Cache/Engine/ArrayEngine.php
+++ b/src/Cache/Engine/ArrayEngine.php
@@ -52,7 +52,7 @@ class ArrayEngine extends CacheEngine
      */
     public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $expires = time() + $this->duration($ttl);
         $this->data[$key] = ['exp' => $expires, 'val' => $value];
 
@@ -69,7 +69,7 @@ class ArrayEngine extends CacheEngine
      */
     public function get(string $key, mixed $default = null): mixed
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
         if (!isset($this->data[$key])) {
             return $default;
         }
@@ -98,7 +98,7 @@ class ArrayEngine extends CacheEngine
         if ($this->get($key) === null) {
             $this->set($key, 0);
         }
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $this->data[$key]['val'] += $offset;
 
         return $this->data[$key]['val'];
@@ -116,7 +116,7 @@ class ArrayEngine extends CacheEngine
         if ($this->get($key) === null) {
             $this->set($key, 0);
         }
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $this->data[$key]['val'] -= $offset;
 
         return $this->data[$key]['val'];
@@ -130,7 +130,7 @@ class ArrayEngine extends CacheEngine
      */
     public function delete(string $key): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
         unset($this->data[$key]);
 
         return true;

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -98,7 +98,7 @@ class FileEngine extends CacheEngine
             $this->_groupPrefix = str_replace('_', DIRECTORY_SEPARATOR, $this->_groupPrefix);
         }
 
-        return $this->_active();
+        return $this->active();
     }
 
     /**
@@ -117,9 +117,9 @@ class FileEngine extends CacheEngine
             return false;
         }
 
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
-        if ($this->_setKey($key, true) === false) {
+        if ($this->setKey($key, true) === false) {
             return false;
         }
 
@@ -157,9 +157,9 @@ class FileEngine extends CacheEngine
      */
     public function get(string $key, mixed $default = null): mixed
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
-        if (!$this->_init || $this->_setKey($key) === false) {
+        if (!$this->_init || $this->setKey($key) === false) {
             return $default;
         }
 
@@ -208,9 +208,9 @@ class FileEngine extends CacheEngine
      */
     public function delete(string $key): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
-        if ($this->_setKey($key) === false || !$this->_init) {
+        if ($this->setKey($key) === false || !$this->_init) {
             return false;
         }
 
@@ -238,7 +238,7 @@ class FileEngine extends CacheEngine
         }
         unset($this->_File);
 
-        $this->_clearDirectory($this->_config['path']);
+        $this->clearDirectory($this->_config['path']);
 
         $directory = new RecursiveDirectoryIterator(
             $this->_config['path'],
@@ -264,7 +264,7 @@ class FileEngine extends CacheEngine
 
             $path = $realPath . DIRECTORY_SEPARATOR;
             if (!in_array($path, $cleared, true)) {
-                $this->_clearDirectory($path);
+                $this->clearDirectory($path);
                 $cleared[] = $path;
             }
 
@@ -285,7 +285,7 @@ class FileEngine extends CacheEngine
      * @param string $path The path to search.
      * @return void
      */
-    protected function _clearDirectory(string $path): void
+    protected function clearDirectory(string $path): void
     {
         if (!is_dir($path)) {
             return;
@@ -356,7 +356,7 @@ class FileEngine extends CacheEngine
      * @param bool $createKey Whether the key should be created if it doesn't exists, or not
      * @return bool true if the cache key could be set, false otherwise
      */
-    protected function _setKey(string $key, bool $createKey = false): bool
+    protected function setKey(string $key, bool $createKey = false): bool
     {
         $groups = null;
         if ($this->_groupPrefix) {
@@ -405,7 +405,7 @@ class FileEngine extends CacheEngine
      *
      * @return bool
      */
-    protected function _active(): bool
+    protected function active(): bool
     {
         $dir = new SplFileInfo($this->_config['path']);
         $path = $dir->getPathname();
@@ -431,9 +431,9 @@ class FileEngine extends CacheEngine
     /**
      * @inheritDoc
      */
-    protected function _key(string $key): string
+    protected function key(string $key): string
     {
-        $key = parent::_key($key);
+        $key = parent::key($key);
 
         return rawurlencode($key);
     }

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -144,7 +144,7 @@ class MemcachedEngine extends CacheEngine
         } else {
             $this->_Memcached = new Memcached();
         }
-        $this->_setOptions();
+        $this->setOptions();
 
         $serverList = $this->_Memcached->getServerList();
         if ($serverList) {
@@ -207,7 +207,7 @@ class MemcachedEngine extends CacheEngine
      * @throws \Cake\Cache\Exception\InvalidArgumentException When the Memcached extension is not built
      *   with the desired serializer engine.
      */
-    protected function _setOptions(): void
+    protected function setOptions(): void
     {
         $this->_Memcached->setOption(Memcached::OPT_LIBKETAMA_COMPATIBLE, true);
 
@@ -307,7 +307,7 @@ class MemcachedEngine extends CacheEngine
     {
         $duration = $this->duration($ttl);
 
-        return $this->_Memcached->set($this->_key($key), $value, $duration);
+        return $this->_Memcached->set($this->key($key), $value, $duration);
     }
 
     /**
@@ -323,7 +323,7 @@ class MemcachedEngine extends CacheEngine
     {
         $cacheData = [];
         foreach ($values as $key => $value) {
-            $cacheData[$this->_key($key)] = $value;
+            $cacheData[$this->key($key)] = $value;
         }
         $duration = $this->duration($ttl);
 
@@ -340,7 +340,7 @@ class MemcachedEngine extends CacheEngine
      */
     public function get(string $key, mixed $default = null): mixed
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $value = $this->_Memcached->get($key);
         if ($this->_Memcached->getResultCode() == Memcached::RES_NOTFOUND) {
             return $default;
@@ -361,7 +361,7 @@ class MemcachedEngine extends CacheEngine
     {
         $cacheKeys = [];
         foreach ($keys as $key) {
-            $cacheKeys[$key] = $this->_key($key);
+            $cacheKeys[$key] = $this->key($key);
         }
 
         $values = $this->_Memcached->getMulti($cacheKeys);
@@ -386,7 +386,7 @@ class MemcachedEngine extends CacheEngine
      */
     public function increment(string $key, int $offset = 1): int|false
     {
-        return $this->_Memcached->increment($this->_key($key), $offset);
+        return $this->_Memcached->increment($this->key($key), $offset);
     }
 
     /**
@@ -398,7 +398,7 @@ class MemcachedEngine extends CacheEngine
      */
     public function decrement(string $key, int $offset = 1): int|false
     {
-        return $this->_Memcached->decrement($this->_key($key), $offset);
+        return $this->_Memcached->decrement($this->key($key), $offset);
     }
 
     /**
@@ -410,7 +410,7 @@ class MemcachedEngine extends CacheEngine
      */
     public function delete(string $key): bool
     {
-        return $this->_Memcached->delete($this->_key($key));
+        return $this->_Memcached->delete($this->key($key));
     }
 
     /**
@@ -424,7 +424,7 @@ class MemcachedEngine extends CacheEngine
     {
         $cacheKeys = [];
         foreach ($keys as $key) {
-            $cacheKeys[] = $this->_key($key);
+            $cacheKeys[] = $this->key($key);
         }
 
         return (bool)$this->_Memcached->deleteMulti($cacheKeys);
@@ -461,7 +461,7 @@ class MemcachedEngine extends CacheEngine
     public function add(string $key, mixed $value): bool
     {
         $duration = $this->_config['duration'];
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         return $this->_Memcached->add($key, $value, $duration);
     }

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -96,7 +96,7 @@ class RedisEngine extends CacheEngine
 
         parent::init($config);
 
-        return $this->_connect();
+        return $this->connect();
     }
 
     /**
@@ -104,7 +104,7 @@ class RedisEngine extends CacheEngine
      *
      * @return bool True if Redis server was connected
      */
-    protected function _connect(): bool
+    protected function connect(): bool
     {
         $tls = $this->_config['tls'] === true ? 'tls://' : '';
 
@@ -122,13 +122,13 @@ class RedisEngine extends CacheEngine
         }
 
         try {
-            $this->_Redis = $this->_createRedisInstance();
+            $this->_Redis = $this->createRedisInstance();
             if (!empty($this->_config['unix_socket'])) {
                 $return = $this->_Redis->connect($this->_config['unix_socket']);
             } elseif (empty($this->_config['persistent'])) {
-                $return = $this->_connectTransient($tls . $this->_config['server'], $ssl);
+                $return = $this->connectTransient($tls . $this->_config['server'], $ssl);
             } else {
-                $return = $this->_connectPersistent($tls . $this->_config['server'], $ssl);
+                $return = $this->connectPersistent($tls . $this->_config['server'], $ssl);
             }
         } catch (RedisException $e) {
             if (class_exists(Log::class)) {
@@ -155,7 +155,7 @@ class RedisEngine extends CacheEngine
      * @throws \RedisException
      * @return bool True if Redis server was connected
      */
-    protected function _connectTransient(string $server, array $ssl): bool
+    protected function connectTransient(string $server, array $ssl): bool
     {
         if ($ssl === []) {
             return $this->_Redis->connect(
@@ -184,7 +184,7 @@ class RedisEngine extends CacheEngine
      * @throws \RedisException
      * @return bool True if Redis server was connected
      */
-    protected function _connectPersistent(string $server, array $ssl): bool
+    protected function connectPersistent(string $server, array $ssl): bool
     {
         $persistentId = $this->_config['port'] . $this->_config['timeout'] . $this->_config['database'];
 
@@ -220,7 +220,7 @@ class RedisEngine extends CacheEngine
      */
     public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $value = $this->serialize($value);
 
         $duration = $this->duration($ttl);
@@ -241,7 +241,7 @@ class RedisEngine extends CacheEngine
      */
     public function get(string $key, mixed $default = null): mixed
     {
-        $value = $this->_Redis->get($this->_key($key));
+        $value = $this->_Redis->get($this->key($key));
         if ($value === false) {
             return $default;
         }
@@ -259,7 +259,7 @@ class RedisEngine extends CacheEngine
     public function increment(string $key, int $offset = 1): int|false
     {
         $duration = $this->_config['duration'];
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         $value = $this->_Redis->incrBy($key, $offset);
         if ($duration > 0) {
@@ -279,7 +279,7 @@ class RedisEngine extends CacheEngine
     public function decrement(string $key, int $offset = 1): int|false
     {
         $duration = $this->_config['duration'];
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         $value = $this->_Redis->decrBy($key, $offset);
         if ($duration > 0) {
@@ -297,7 +297,7 @@ class RedisEngine extends CacheEngine
      */
     public function delete(string $key): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         return (int)$this->_Redis->del($key) > 0;
     }
@@ -312,7 +312,7 @@ class RedisEngine extends CacheEngine
      */
     public function deleteAsync(string $key): bool
     {
-        $key = $this->_key($key);
+        $key = $this->key($key);
 
         return (int)$this->_Redis->unlink($key) > 0;
     }
@@ -401,7 +401,7 @@ class RedisEngine extends CacheEngine
     public function add(string $key, mixed $value): bool
     {
         $duration = $this->_config['duration'];
-        $key = $this->_key($key);
+        $key = $this->key($key);
         $value = $this->serialize($value);
 
         if ($this->_Redis->set($key, $value, ['nx', 'ex' => $duration])) {
@@ -484,7 +484,7 @@ class RedisEngine extends CacheEngine
      *
      * @return \Redis
      */
-    protected function _createRedisInstance(): Redis
+    protected function createRedisInstance(): Redis
     {
         return new Redis();
     }

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -193,7 +193,7 @@ class RedisEngineTest extends TestCase
      */
     public function testConnectTransient(): void
     {
-        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $Redis = $this->createPartialMock(RedisEngine::class, ['createRedisInstance']);
         $phpredis = $this->createMock(Redis::class);
 
         $phpredis->expects($this->once())
@@ -211,7 +211,7 @@ class RedisEngineTest extends TestCase
             ->willReturn(true);
 
         $Redis->expects($this->once())
-            ->method('_createRedisInstance')
+            ->method('createRedisInstance')
             ->willReturn($phpredis);
 
         $config = [
@@ -220,7 +220,7 @@ class RedisEngineTest extends TestCase
         ];
         $this->assertTrue($Redis->init($config + Cache::pool('redis')->getConfig()));
 
-        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $Redis = $this->createPartialMock(RedisEngine::class, ['createRedisInstance']);
         $phpredis = $this->createMock(Redis::class);
 
         $phpredis->expects($this->once())
@@ -238,7 +238,7 @@ class RedisEngineTest extends TestCase
             ->willReturn(true);
 
         $Redis->expects($this->once())
-            ->method('_createRedisInstance')
+            ->method('createRedisInstance')
             ->willReturn($phpredis);
 
         $config = [
@@ -254,7 +254,7 @@ class RedisEngineTest extends TestCase
      */
     public function testConnectTransientContext(): void
     {
-        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $Redis = $this->createPartialMock(RedisEngine::class, ['createRedisInstance']);
         $phpredis = $this->createMock(Redis::class);
 
         $cafile = ROOT . DS . 'vendor' . DS . 'composer' . DS . 'ca-bundle' . DS . 'res' . DS . 'cacert.pem';
@@ -284,7 +284,7 @@ class RedisEngineTest extends TestCase
             ->willReturn(true);
 
         $Redis->expects($this->once())
-            ->method('_createRedisInstance')
+            ->method('createRedisInstance')
             ->willReturn($phpredis);
 
         $config = [
@@ -301,7 +301,7 @@ class RedisEngineTest extends TestCase
      */
     public function testConnectPersistent(): void
     {
-        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $Redis = $this->createPartialMock(RedisEngine::class, ['createRedisInstance']);
         $phpredis = $this->createMock(Redis::class);
 
         $expectedPersistentId = $this->port . $Redis->getConfig('timeout') . $Redis->getConfig('database');
@@ -322,7 +322,7 @@ class RedisEngineTest extends TestCase
             ->willReturn(true);
 
         $Redis->expects($this->once())
-            ->method('_createRedisInstance')
+            ->method('createRedisInstance')
             ->willReturn($phpredis);
 
         $config = [
@@ -330,7 +330,7 @@ class RedisEngineTest extends TestCase
         ];
         $this->assertTrue($Redis->init($config + Cache::pool('redis')->getConfig()));
 
-        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $Redis = $this->createPartialMock(RedisEngine::class, ['createRedisInstance']);
         $phpredis = $this->createMock(Redis::class);
 
         $phpredis->expects($this->once())
@@ -349,7 +349,7 @@ class RedisEngineTest extends TestCase
             ->willReturn(true);
 
         $Redis->expects($this->once())
-            ->method('_createRedisInstance')
+            ->method('createRedisInstance')
             ->willReturn($phpredis);
 
         $config = [
@@ -364,7 +364,7 @@ class RedisEngineTest extends TestCase
      */
     public function testConnectPersistentContext(): void
     {
-        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $Redis = $this->createPartialMock(RedisEngine::class, ['createRedisInstance']);
         $phpredis = $this->createMock(Redis::class);
 
         $expectedPersistentId = $this->port . $Redis->getConfig('timeout') . $Redis->getConfig('database');
@@ -396,7 +396,7 @@ class RedisEngineTest extends TestCase
             ->willReturn(true);
 
         $Redis->expects($this->once())
-            ->method('_createRedisInstance')
+            ->method('createRedisInstance')
             ->willReturn($phpredis);
 
         $config = [


### PR DESCRIPTION
See https://github.com/cakephp/upgrade/pull/309

The changes from the first commit are what gets automatically applied via
```
bin/cake upgrade rector --rules cakephp60 /my/abs/path/to/app
```

all commits after that are to fix tests/CS etc.