### PR TITLE
Fix up allowMethod() signature.

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1423,19 +1423,19 @@ class ServerRequest implements ServerRequestInterface
      * or
      * $this->request->allowMethod(['post', 'delete']);
      *
-     * If the request would be GET, response header "Allow: POST, DELETE" will be set
+     * If the request is GET, the response header "Allow: POST, DELETE" will be set
      * and a 405 error will be returned.
      *
      * @param array<string>|string $methods Allowed HTTP request methods.
-     * @return true
+     * @return void
      * @throws \Cake\Http\Exception\MethodNotAllowedException
      */
-    public function allowMethod(array|string $methods): bool
+    public function allowMethod(array|string $methods): void
     {
         $methods = (array)$methods;
         foreach ($methods as $method) {
             if ($this->is($method)) {
-                return true;
+                return;
             }
         }
         $allowed = strtoupper(implode(', ', $methods));

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -29,6 +29,7 @@ use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use Laminas\Diactoros\Uri;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -1543,6 +1544,7 @@ class ServerRequestTest extends TestCase
     /**
      * TestAllowMethod
      */
+    #[DoesNotPerformAssertions]
     public function testAllowMethod(): void
     {
         $request = new ServerRequest(['environment' => [

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -1550,10 +1550,10 @@ class ServerRequestTest extends TestCase
             'REQUEST_METHOD' => 'PUT',
         ]]);
 
-        $this->assertTrue($request->allowMethod('put'));
+        $request->allowMethod('put');
 
         $request = $request->withEnv('REQUEST_METHOD', 'DELETE');
-        $this->assertTrue($request->allowMethod(['post', 'delete']));
+        $request->allowMethod(['post', 'delete']);
     }
 
     /**


### PR DESCRIPTION
Given that this method throws an exception in the failure case, a return type seems non-functional and not useful.