### PR TITLE
Add optimizer hint query api

### DIFF
--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -255,6 +255,7 @@ class Mysql extends Driver
             DriverFeatureEnum::INTERSECT => $versionCompare(),
             DriverFeatureEnum::INTERSECT_ALL => $versionCompare(),
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => true,
+            DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => true,
         };
     }
 

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -210,6 +210,7 @@ class Postgres extends Driver
             DriverFeatureEnum::INTERSECT_ALL => true,
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => true,
             DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION => false,
+            DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => true,
         };
     }
 

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -207,6 +207,7 @@ class Sqlite extends Driver
             DriverFeatureEnum::INTERSECT => true,
             DriverFeatureEnum::INTERSECT_ALL => false,
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => false,
+            DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => false,
         };
     }
 

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -280,6 +280,7 @@ class Sqlserver extends Driver
             DriverFeatureEnum::INTERSECT_ALL => false,
             DriverFeatureEnum::JSON => false,
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => false,
+            DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => false,
         };
     }
 

--- a/src/Database/DriverFeatureEnum.php
+++ b/src/Database/DriverFeatureEnum.php
@@ -62,4 +62,9 @@ enum DriverFeatureEnum: string
      * Support for order by in set operations (union, intersect)
      */
     case SET_OPERATIONS_ORDER_BY = 'set-operations-order-by';
+
+    /**
+     * Support for optimizer hints in comment form after statement keyword (SELECT <hint>, etc)
+     */
+    case OPTIMIZER_HINT_COMMENT = 'optimizer-hint-comment';
 }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -107,6 +107,7 @@ abstract class Query implements ExpressionInterface, Stringable
         'insert' => [],
         'values' => [],
         'with' => [],
+        'optimizerHint' => [],
         'select' => [],
         'distinct' => false,
         'modifier' => [],
@@ -421,6 +422,22 @@ abstract class Query implements ExpressionInterface, Stringable
         }
 
         $this->_parts['with'][] = $cte;
+        $this->_dirty();
+
+        return $this;
+    }
+
+    /**
+     * Add engine-specific optimizer hint.
+     *
+     * @param array<string>|string $hint Optimizer hint
+     * @param bool $overwrite Whether to replace existing hints
+     * @return $this
+     */
+    public function optimizerHint(array|string $hint, bool $overwrite = false)
+    {
+        $hints = array_values((array)$hint);
+        $this->_parts['optimizerHint'] = $overwrite ? $hints : array_merge($this->_parts['optimizerHint'], $hints);
         $this->_dirty();
 
         return $this;

--- a/src/Database/Query/DeleteQuery.php
+++ b/src/Database/Query/DeleteQuery.php
@@ -39,6 +39,7 @@ class DeleteQuery extends Query
         'comment' => null,
         'with' => [],
         'delete' => true,
+        'optimizerHint' => [],
         'modifier' => [],
         'from' => [],
         'join' => [],

--- a/src/Database/Query/InsertQuery.php
+++ b/src/Database/Query/InsertQuery.php
@@ -42,6 +42,7 @@ class InsertQuery extends Query
         'comment' => null,
         'with' => [],
         'insert' => [],
+        'optimizerHint' => [],
         'modifier' => [],
         'values' => [],
         'epilog' => null,

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -53,9 +53,10 @@ class SelectQuery extends Query implements IteratorAggregate
      */
     protected array $_parts = [
         'comment' => null,
-        'modifier' => [],
         'with' => [],
         'select' => [],
+        'optimizerHint' => [],
+        'modifier' => [],
         'distinct' => false,
         'from' => [],
         'join' => [],

--- a/src/Database/Query/UpdateQuery.php
+++ b/src/Database/Query/UpdateQuery.php
@@ -43,6 +43,7 @@ class UpdateQuery extends Query
         'comment' => null,
         'with' => [],
         'update' => [],
+        'optimizerHint' => [],
         'modifier' => [],
         'join' => [],
         'set' => [],

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -68,7 +68,8 @@ class QueryCompiler
      *
      * @var array<string>
      */
-    protected array $_deleteParts = ['comment', 'with', 'delete', 'modifier', 'from', 'where', 'epilog'];
+    protected array $_deleteParts = ['comment', 'with', 'delete', 'optimizerHint', 'modifier', 'from', 'where',
+        'epilog'];
 
     /**
      * The list of query clauses to traverse for generating an INSERT statement
@@ -186,14 +187,15 @@ class QueryCompiler
     protected function _buildSelectPart(array $parts, Query $query, ValueBinder $binder): string
     {
         $driver = $query->getDriver();
-        $select = 'SELECT%s %s%s';
+        $select = 'SELECT%s%s %s%s';
         if (
             ($query->clause('union') || $query->clause('intersect')) &&
             $driver->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY)
         ) {
-            $select = '(SELECT%s %s%s';
+            $select = '(SELECT%s%s %s%s';
         }
-        $distinct = $query->clause('distinct');
+
+        $hint = $this->_buildOptimizerHintPart($query->clause('optimizerHint'), $query, $binder);
         $modifiers = $this->_buildModifierPart($query->clause('modifier'), $query, $binder);
 
         $quoteIdentifiers = $driver->isAutoQuotingEnabled() || $this->_quotedSelectAliases;
@@ -211,16 +213,15 @@ class QueryCompiler
             $normalized[] = $p;
         }
 
+        $distinct = $query->clause('distinct');
         if ($distinct === true) {
             $distinct = 'DISTINCT ';
-        }
-
-        if (is_array($distinct)) {
+        } elseif (is_array($distinct)) {
             $distinct = $this->_stringifyExpressions($distinct, $binder);
             $distinct = sprintf('DISTINCT ON (%s) ', implode(', ', $distinct));
         }
 
-        return sprintf($select, $modifiers, $distinct, implode(', ', $normalized));
+        return sprintf($select, $hint, $modifiers, $distinct, implode(', ', $normalized));
     }
 
     /**
@@ -426,9 +427,10 @@ class QueryCompiler
         }
         $table = $parts[0];
         $columns = $this->_stringifyExpressions($parts[1], $binder);
+        $hint = $this->_buildOptimizerHintPart($query->clause('optimizerHint'), $query, $binder);
         $modifiers = $this->_buildModifierPart($query->clause('modifier'), $query, $binder);
 
-        return sprintf('INSERT%s INTO %s (%s)', $modifiers, $table, implode(', ', $columns));
+        return sprintf('INSERT%s%s INTO %s (%s)', $hint, $modifiers, $table, implode(', ', $columns));
     }
 
     /**
@@ -455,9 +457,27 @@ class QueryCompiler
     protected function _buildUpdatePart(array $parts, Query $query, ValueBinder $binder): string
     {
         $table = $this->_stringifyExpressions($parts, $binder);
+        $hint = $this->_buildOptimizerHintPart($query->clause('optimizerHint'), $query, $binder);
         $modifiers = $this->_buildModifierPart($query->clause('modifier'), $query, $binder);
 
-        return sprintf('UPDATE%s %s', $modifiers, implode(',', $table));
+        return sprintf('UPDATE%s%s %s', $hint, $modifiers, implode(',', $table));
+    }
+
+    /**
+     * Builds the optimizer hint comment part.
+     *
+     * @param list<string> $parts The optmizer hints
+     * @param \Cake\Database\Query $query The query that is being compiled
+     * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
+     * @return string Optimizer hint comment
+     */
+    protected function _buildOptimizerHintPart(array $parts, Query $query, ValueBinder $binder): string
+    {
+        if ($parts === [] || !$query->getDriver()->supports(DriverFeatureEnum::OPTIMIZER_HINT_COMMENT)) {
+            return '';
+        }
+
+        return sprintf(' /*+ %s */', implode(' ', $parts));
     }
 
     /**

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -319,4 +319,19 @@ class QueryTest extends TestCase
         $this->assertEmpty($this->query->clause('where'));
         $this->query->clause('nope');
     }
+
+    public function testOptimizerHintClause(): void
+    {
+        $this->query->optimizerHint('single_hint()');
+        $this->assertSame(['single_hint()'], $this->query->clause('optimizerHint'));
+
+        $this->query->optimizerHint(['array_hint()', 'array_hint()']);
+        $this->assertSame(['single_hint()', 'array_hint()', 'array_hint()'], $this->query->clause('optimizerHint'));
+
+        $this->query->optimizerHint('single_hint()', true);
+        $this->assertSame(['single_hint()'], $this->query->clause('optimizerHint'));
+
+        $this->query->optimizerHint(['array_hint()', 'array_hint()'], true);
+        $this->assertSame(['array_hint()', 'array_hint()'], $this->query->clause('optimizerHint'));
+    }
 }


### PR DESCRIPTION
refs https://github.com/cakephp/cakephp/issues/18140

Example mysql index hint:
https://dev.mysql.com/doc/refman/8.4/en/index-hints.html
```php
$query->index('USE', ['my_index1', 'my_index2']);
$query->index('IGNORE', 'my_index3');
```
```sql
select * from table USE INDEX (my_index1, my_index2) IGNORE INDEX (my_index3)
```


Example mysql optimizer hint (added in 8.4 with plans to warning to deprecate index hint but not done so):
https://dev.mysql.com/doc/refman/8.4/en/optimizer-hints.html
```php
$query->hint('INDEX', 'my_index');
``` 
```sql
select /*+ INDEX(my_index) */ from table
```

The postgresql extension has syntax compatible with mysql hint syntax so the api should work for both:
https://github.com/ossc-db/pg_hint_plan/blob/master/docs/hint_details.md