### PR TITLE
Expand tests for float datatypes

### DIFF
--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -190,6 +190,10 @@ class MysqlSchemaDialectTest extends TestCase
                 ['type' => 'float', 'length' => null, 'precision' => null, 'unsigned' => false],
             ],
             [
+                'FLOAT(24)',
+                ['type' => 'float', 'length' => 24, 'precision' => 0, 'unsigned' => false],
+            ],
+            [
                 'DOUBLE',
                 ['type' => 'float', 'length' => null, 'precision' => null, 'unsigned' => false],
             ],


### PR DESCRIPTION
I came across this working on migrations and it didn't have test coverage.
