### PR TITLE
fix subjectless events throw before deprecation message is being display

### DIFF
--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -330,7 +330,11 @@ class EventManager implements EventManagerInterface
         $result = $listener($event, ...array_values($event->getData()));
 
         if ($result !== null) {
-            $class = get_class($event->getSubject());
+            try {
+                $class = get_class($event->getSubject());
+            } catch (CakeException) {
+                $class = 'unknown subject';
+            }
             deprecationWarning(
                 '5.2.0',
                 'Returning a value from event listeners is deprecated. ' .

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -912,4 +912,21 @@ class EventManagerTest extends TestCase
         $returnValue = $eventManager->unsetEventList();
         $this->assertSame($eventManager, $returnValue);
     }
+
+    /**
+     * Test that an event without a subject can be dispatched and
+     * displays a deprecation warning if the listener returns a value.
+     */
+    public function testEventWithoutSubjectWorksWithReturningListener(): void
+    {
+        $eventManager = new EventManager();
+        $eventManager->on('example', function (): string {
+            return 'example event called';
+        });
+        $result = '';
+        $this->deprecated(function () use (&$eventManager, &$result) {
+            $result = $eventManager->dispatch(new Event('example'));
+        });
+        $this->assertEquals('example event called', $result->getResult());
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/18692