### PR TITLE
Update return type of EventInterface::getSubject().

### DIFF
--- a/src/Event/Decorator/SubjectFilterDecorator.php
+++ b/src/Event/Decorator/SubjectFilterDecorator.php
@@ -58,12 +58,8 @@ class SubjectFilterDecorator extends AbstractDecorator
             $this->_options['allowedSubject'] = [$this->_options['allowedSubject']];
         }
 
-        try {
-            $subject = $event->getSubject();
-        } catch (CakeException) {
-            return false;
-        }
+        $subject = $event->getSubject();
 
-        return in_array($subject::class, $this->_options['allowedSubject'], true);
+        return $subject !== null && in_array($subject::class, $this->_options['allowedSubject'], true);
     }
 }

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -16,8 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Event;
 
-use Cake\Core\Exception\CakeException;
-
 /**
  * Class Event
  *
@@ -101,18 +99,11 @@ class Event implements EventInterface
     /**
      * Returns the subject of this event
      *
-     * If the event has no subject an exception will be raised.
-     *
-     * @return object
-     * @throws \Cake\Core\Exception\CakeException
-     * @phpstan-return TSubject
+     * @return object|null
+     * @phpstan-return TSubject|null
      */
-    public function getSubject(): object
+    public function getSubject(): ?object
     {
-        if ($this->_subject === null) {
-            throw new CakeException('No subject set for this event');
-        }
-
         return $this->_subject;
     }
 

--- a/src/Event/EventInterface.php
+++ b/src/Event/EventInterface.php
@@ -35,10 +35,10 @@ interface EventInterface
     /**
      * Returns the subject of this event.
      *
-     * @return object
-     * @phpstan-return TSubject
+     * @return object|null
+     * @phpstan-return TSubject|null
      */
-    public function getSubject(): object;
+    public function getSubject(): ?object;
 
     /**
      * Stops the event from being used anymore.

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Event;
 
-use Cake\Core\Exception\CakeException;
 use InvalidArgumentException;
 
 /**
@@ -491,10 +490,10 @@ class EventManager implements EventManagerInterface
                 assert(!empty($this->_eventList[$i]), 'Given event item not present');
 
                 $event = $this->_eventList[$i];
-                try {
-                    $subject = $event->getSubject();
+                $subject = $event->getSubject();
+                if ($subject) {
                     $properties['_dispatchedEvents'][] = $event->getName() . ' with subject ' . $subject::class;
-                } catch (CakeException) {
+                } else {
                     $properties['_dispatchedEvents'][] = $event->getName() . ' with no subject';
                 }
             }

--- a/tests/TestCase/Event/EventTest.php
+++ b/tests/TestCase/Event/EventTest.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Event;
 
-use Cake\Core\Exception\CakeException;
 use Cake\Event\Event;
 use Cake\TestSuite\TestCase;
 
@@ -50,9 +49,6 @@ class EventTest extends TestCase
     {
         $event = new Event('fake.event', $this);
         $this->assertSame($this, $event->getSubject());
-
-        $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('No subject set for this event');
 
         $event = new Event('fake.event');
         $this->assertNull($event->getSubject());


### PR DESCRIPTION
Since the event subject is optional making the return of getSubject() nullable makes more sense.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
