### PR TITLE
Add Query::getDriver() helper to return driver for current role

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -199,6 +199,19 @@ abstract class Query implements ExpressionInterface, Stringable
     }
 
     /**
+     * Returns driver for current connection role by default.
+     *
+     * See `Query::getConnectionRole()` for role options.
+     *
+     * @param string|null $role Connection role
+     * @return \Cake\Database\Driver
+     */
+    public function getDriver(?string $role = null): Driver
+    {
+        return $this->_connection->getDriver($role ?? $this->connectionRole);
+    }
+
+    /**
      * Compiles the SQL representation of this query and executes it using the
      * configured connection object. Returns the resulting statement object.
      *

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -185,7 +185,7 @@ class QueryCompiler
      */
     protected function _buildSelectPart(array $parts, Query $query, ValueBinder $binder): string
     {
-        $driver = $query->getConnection()->getDriver($query->getConnectionRole());
+        $driver = $query->getDriver();
         $select = 'SELECT%s %s%s';
         if (
             ($query->clause('union') || $query->clause('intersect')) &&


### PR DESCRIPTION
Connection::getDriver() currently defaults to ROLE_WRITE and doesn't have access to the query role, but it probably shouldn't default and this helper should be the default.