### PR TITLE
Add Message::addAttachment()

### DIFF
--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -126,6 +126,7 @@ use function Cake\Core\deprecationWarning;
  * @method string getDomain() Gets domain. {@see \Cake\Mailer\Message::getDomain()}
  * @method $this setAttachments($attachments) Add attachments to the email message. {@see \Cake\Mailer\Message::setAttachments()}
  * @method array getAttachments() Gets attachments to the email message. {@see \Cake\Mailer\Message::getAttachments()}
+ * @method $this addAttachment(\Psr\Http\Message\UploadedFileInterface|string $path, ?string $name, ?string $mimetype, ?string $contentId, ?bool $contentDisposition) Add an attachment. {@see \Cake\Mailer\Message::addAttachment()}
  * @method $this addAttachments($attachments) Add attachments. {@see \Cake\Mailer\Message::addAttachments()}
  * @method array|string getBody(?string $type = null) Get generated message body as array.
  *   {@see \Cake\Mailer\Message::getBody()}

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -1234,6 +1234,35 @@ class Message implements JsonSerializable
     }
 
     /**
+     * Add attachment.
+     *
+     * @param \Psr\Http\Message\UploadedFileInterface|string $path Path to the file or UploadedFileInterface instance.
+     * @param string|null $name Overrides the attachment name.
+     * @param string|null $mimetype Mimetype of the file.
+     * @param string|null $contentId Content ID for inline attachments.
+     * @param bool|null $contentDisposition Allows you to disable the `Content-Disposition` header
+     * @return $this
+     */
+    public function addAttachment(
+        UploadedFileInterface|string $path,
+        ?string $name = null,
+        ?string $mimetype = null,
+        ?string $contentId = null,
+        ?bool $contentDisposition = null,
+    ) {
+        $name ??= 0;
+
+        $this->addAttachments([$name => [
+            'file' => $path,
+            'mimetype' => $mimetype,
+            'contentId' => $contentId,
+            'contentDisposition' => $contentDisposition,
+        ]]);
+
+        return $this;
+    }
+
+    /**
      * Add attachments
      *
      * @param array $attachments Array of filenames.

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -933,6 +933,36 @@ HTML;
         $this->assertSame($expected, $this->message->getAttachments());
     }
 
+    public function testAddAttachment(): void
+    {
+        $uploadedFile = new UploadedFile(
+            __FILE__,
+            filesize(__FILE__),
+            UPLOAD_ERR_OK,
+            'MessageTest.php',
+            'text/x-php',
+        );
+
+        $this->message->addAttachment(CAKE . 'Mailer' . DS . 'Message.php', mimetype: 'text/plain', contentId: 'attached');
+        $this->message->addAttachment($uploadedFile, contentDisposition: false);
+
+        $expected = [
+            'Message.php' => [
+                'file' => CAKE . 'Mailer' . DS . 'Message.php',
+                'mimetype' => 'text/plain',
+                'contentId' => 'attached',
+                'contentDisposition' => null,
+            ],
+            'MessageTest.php' => [
+                'file' => $uploadedFile,
+                'mimetype' => 'text/x-php',
+                'contentId' => null,
+                'contentDisposition' => false,
+            ],
+        ];
+        $this->assertSame($expected, $this->message->getAttachments());
+    }
+
     public function testSetAttachmentInvalidFile(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
This provides a more user friendly API than the array based methods addAttachments() and setAttachments()

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
