### PR TITLE
Add network types for postgres

### DIFF
--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -672,6 +672,9 @@ class PostgresSchemaDialect extends SchemaDialect
             TableSchemaInterface::TYPE_POINT => ' GEOGRAPHY(POINT, %s)',
             TableSchemaInterface::TYPE_LINESTRING => ' GEOGRAPHY(LINESTRING, %s)',
             TableSchemaInterface::TYPE_POLYGON => ' GEOGRAPHY(POLYGON, %s)',
+            TableSchemaInterface::TYPE_CIDR => ' CIDR',
+            TableSchemaInterface::TYPE_INET => ' INET',
+            TableSchemaInterface::TYPE_MACADDR => ' MACADDR',
         ];
 
         $autoIncrementTypes = [

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -139,7 +139,7 @@ class PostgresSchemaDialect extends SchemaDialect
             return $type;
         }
 
-        if (in_array($col, ['date', 'time', 'boolean'], true)) {
+        if (in_array($col, ['date', 'time', 'boolean', 'inet', 'cidr', 'macaddr'], true)) {
             return ['type' => $col, 'length' => null];
         }
         if (in_array($col, ['timestamptz', 'timestamp with time zone'], true)) {

--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -215,6 +215,27 @@ interface TableSchemaInterface extends SchemaInterface
     public const TYPE_POLYGON = 'polygon';
 
     /**
+     * INET type. Only implemented in postgres.
+     *
+     * @var string
+     */
+    public const TYPE_INET = 'inet';
+
+    /**
+     * CIDR type. Only implemented in postgres.
+     *
+     * @var string
+     */
+    public const TYPE_CIDR = 'cidr';
+
+    /**
+     * Macaddr type. Only implemented in postgres.
+     *
+     * @var string
+     */
+    public const TYPE_MACADDR = 'macaddr';
+
+    /**
      * Geospatial column types
      *
      * @var array

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -109,7 +109,6 @@ SQL;
     {
         return [
             // Timestamp
-            //
             [
                 ['type' => 'TIMESTAMP', 'datetime_precision' => 6],
                 ['type' => 'timestampfractional', 'length' => null, 'precision' => 6],

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -1116,6 +1116,22 @@ SQL;
                 ['type' => 'polygon', 'null' => false, 'srid' => 4326],
                 '"p" GEOGRAPHY(POLYGON, 4326) NOT NULL',
             ],
+            // Network address types
+            [
+                'network',
+                ['type' => 'cidr', 'null' => false],
+                '"network" CIDR NOT NULL',
+            ],
+            [
+                'network',
+                ['type' => 'inet', 'null' => false],
+                '"network" INET NOT NULL',
+            ],
+            [
+                'network',
+                ['type' => 'macaddr', 'null' => false],
+                '"network" MACADDR NOT NULL',
+            ],
         ];
     }
 

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -109,6 +109,7 @@ SQL;
     {
         return [
             // Timestamp
+            //
             [
                 ['type' => 'TIMESTAMP', 'datetime_precision' => 6],
                 ['type' => 'timestampfractional', 'length' => null, 'precision' => 6],
@@ -218,10 +219,6 @@ SQL;
                 ['type' => 'UUID'],
                 ['type' => 'uuid', 'length' => null],
             ],
-            [
-                ['type' => 'INET'],
-                ['type' => 'string', 'length' => 39],
-            ],
             // Text
             [
                 ['type' => 'TEXT'],
@@ -266,6 +263,19 @@ SQL;
             [
                 ['type' => 'GEOGRAPHY(POLYGON, 4326)'],
                 ['type' => 'polygon', 'length' => null, 'srid' => 4326],
+            ],
+            // network addresses
+            [
+                ['type' => 'CIDR'],
+                ['type' => 'cidr', 'length' => null],
+            ],
+            [
+                ['type' => 'inet'],
+                ['type' => 'inet', 'length' => null],
+            ],
+            [
+                ['type' => 'macaddr'],
+                ['type' => 'macaddr', 'length' => null],
             ],
         ];
     }


### PR DESCRIPTION
Add the inet, cidr, and macaddr types to postgres schema dialect. This helps improve compatibility with the ORM and provides support for the ORM to use these data types when portability is not a concern.

Refs #18362