### PR TITLE
6.x: rename conflicting underscored methods

### DIFF
--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -221,7 +221,7 @@ class ConsoleOutput
             $message = implode(static::LF, $message);
         }
 
-        return $this->_write($this->styleText($message . str_repeat(static::LF, $newlines)));
+        return $this->writeStream($this->styleText($message . str_repeat(static::LF, $newlines)));
     }
 
     /**
@@ -291,7 +291,7 @@ class ConsoleOutput
      * @param string $message Message to write.
      * @return int The number of bytes returned from writing to output.
      */
-    protected function _write(string $message): int
+    protected function writeStream(string $message): int
     {
         if (!isset($this->_output)) {
             return 0;

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -258,12 +258,12 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
         $options += ['validate' => true];
 
         if ($options['validate'] === false) {
-            return $this->_execute($data);
+            return $this->process($data);
         }
 
         $validator = $options['validate'] === true ? static::DEFAULT_VALIDATOR : $options['validate'];
 
-        return $this->validate($data, $validator) && $this->_execute($data);
+        return $this->validate($data, $validator) && $this->process($data);
     }
 
     /**
@@ -274,7 +274,7 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
      * @param array $data Form data.
      * @return bool
      */
-    protected function _execute(array $data): bool
+    protected function process(array $data): bool
     {
         return true;
     }

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -500,7 +500,7 @@ class Client implements EventDispatcherInterface, ClientInterface
             $requestSent = false;
             if ($response === null) {
                 $requestSent = true;
-                $response = $this->_sendRequest($request, $event->getAdapterOptions());
+                $response = $this->processRequest($request, $event->getAdapterOptions());
             }
 
             /** @var \Cake\Http\Client\ClientEvent $event */
@@ -582,7 +582,7 @@ class Client implements EventDispatcherInterface, ClientInterface
      * @param array<string, mixed> $options Additional options to use.
      * @return \Cake\Http\Client\Response
      */
-    protected function _sendRequest(RequestInterface $request, array $options): Response
+    protected function processRequest(RequestInterface $request, array $options): Response
     {
         $responses = [];
         if (static::$_mockAdapter) {

--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -79,7 +79,7 @@ class Stream implements AdapterInterface
 
         $this->buildContext($request, $options);
 
-        return $this->_send($request);
+        return $this->processRequest($request);
     }
 
     /**
@@ -238,7 +238,7 @@ class Stream implements AdapterInterface
      * @return array Array of populated Response objects
      * @throws \Psr\Http\Client\NetworkExceptionInterface
      */
-    protected function _send(RequestInterface $request): array
+    protected function processRequest(RequestInterface $request): array
     {
         $deadline = false;
         if (isset($this->_contextOptions['timeout']) && $this->_contextOptions['timeout'] > 0) {

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -511,10 +511,10 @@ class ServerRequest implements ServerRequestInterface
             throw new InvalidArgumentException(sprintf('No detector set for type `%s`.', $type));
         }
         if ($args) {
-            return $this->_is($type, $args);
+            return $this->isType($type, $args);
         }
 
-        return $this->_detectorCache[$type] ??= $this->_is($type, $args);
+        return $this->_detectorCache[$type] ??= $this->isType($type, $args);
     }
 
     /**
@@ -534,7 +534,7 @@ class ServerRequest implements ServerRequestInterface
      * @param array $args Array of custom detector arguments.
      * @return bool Whether the request is the type you are checking.
      */
-    protected function _is(string $type, array $args): bool
+    protected function isType(string $type, array $args): bool
     {
         $detect = static::$_detectors[$type];
         if ($detect instanceof Closure) {

--- a/src/I18n/Date.php
+++ b/src/I18n/Date.php
@@ -169,7 +169,7 @@ class Date extends ChronosDate implements JsonSerializable, Stringable
             $format = [$format, IntlDateFormatter::NONE];
         }
 
-        return static::_parseDateTime($date, $format);
+        return static::processDateTime($date, $format);
     }
 
     /**

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -130,7 +130,7 @@ trait DateFormatTrait
      * @param \DateTimeZone|string|null $tz The timezone for the instance
      * @return static|null
      */
-    protected static function _parseDateTime(
+    protected static function processDateTime(
         string $time,
         array|string $format,
         DateTimeZone|string|null $tz = null,

--- a/src/I18n/DateTime.php
+++ b/src/I18n/DateTime.php
@@ -284,7 +284,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
         $format ??= static::$_toStringFormat;
         $format = is_int($format) ? [$format, $format] : $format;
 
-        return static::_parseDateTime($time, $format, $tz);
+        return static::processDateTime($time, $format, $tz);
     }
 
     /**

--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -143,7 +143,7 @@ class Time extends ChronosTime implements JsonSerializable, Stringable
             $format = [IntlDateFormatter::NONE, $format];
         }
 
-        return static::_parseDateTime($time, $format);
+        return static::processDateTime($time, $format);
     }
 
     /**

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -122,7 +122,7 @@ class SmtpTransport extends AbstractTransport
     public function connect(): void
     {
         if (!$this->connected()) {
-            $this->_connect();
+            $this->connectSmtp();
             $this->auth();
         }
     }
@@ -151,7 +151,7 @@ class SmtpTransport extends AbstractTransport
             return;
         }
 
-        $this->_disconnect();
+        $this->disconnectSmtp();
     }
 
     /**
@@ -196,7 +196,7 @@ class SmtpTransport extends AbstractTransport
         $this->checkRecipient($message);
 
         if (!$this->connected()) {
-            $this->_connect();
+            $this->connectSmtp();
             $this->auth();
         } else {
             $this->smtpSend('RSET');
@@ -206,7 +206,7 @@ class SmtpTransport extends AbstractTransport
         $this->sendData($message);
 
         if (!$this->_config['keepAlive']) {
-            $this->_disconnect();
+            $this->disconnectSmtp();
         }
 
         /** @var array{headers: string, message: string} */
@@ -286,7 +286,7 @@ class SmtpTransport extends AbstractTransport
      * @return void
      * @throws \Cake\Network\Exception\SocketException
      */
-    protected function _connect(): void
+    protected function connectSmtp(): void
     {
         $this->generateSocket();
         if (!$this->_socket->connect()) {
@@ -565,7 +565,7 @@ class SmtpTransport extends AbstractTransport
      * @return void
      * @throws \Cake\Network\Exception\SocketException
      */
-    protected function _disconnect(): void
+    protected function disconnectSmtp(): void
     {
         $this->smtpSend('QUIT', false);
         $this->_socket->disconnect();

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -392,7 +392,7 @@ class HasMany extends Association
                 ->toList(),
         ];
 
-        $this->_unlink($foreignKey, $target, $conditions, $options);
+        $this->doUnlink($foreignKey, $target, $conditions, $options);
 
         $result = $sourceEntity->get($property);
         if ($options['cleanProperty'] && $result !== null) {
@@ -516,7 +516,7 @@ class HasMany extends Association
             ];
         }
 
-        return $this->_unlink(array_keys($foreignKeyReference), $target, $conditions, $options);
+        return $this->doUnlink(array_keys($foreignKeyReference), $target, $conditions, $options);
     }
 
     /**
@@ -531,7 +531,7 @@ class HasMany extends Association
      * @param array<string, mixed> $options list of options accepted by `Table::delete()`
      * @return bool success
      */
-    protected function _unlink(array $foreignKey, Table $target, array $conditions = [], array $options = []): bool
+    protected function doUnlink(array $foreignKey, Table $target, array $conditions = [], array $options = []): bool
     {
         $mustBeDependent = (!$this->foreignKeyAcceptsNull($target, $foreignKey) || $this->getDependent());
 

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -540,7 +540,7 @@ class TreeBehavior extends Behavior
         return $this->_table->getConnection()->transactional(function () use ($node) {
             $this->ensureFields($node);
 
-            return $this->_removeFromTree($node);
+            return $this->doRemoveFromTree($node);
         });
     }
 
@@ -551,7 +551,7 @@ class TreeBehavior extends Behavior
      * @return \Cake\Datasource\EntityInterface|false the node after being removed from the tree or
      * false on error
      */
-    protected function _removeFromTree(EntityInterface $node): EntityInterface|false
+    protected function doRemoveFromTree(EntityInterface $node): EntityInterface|false
     {
         $config = $this->getConfig();
         $left = $node->get($config['left']);
@@ -605,7 +605,7 @@ class TreeBehavior extends Behavior
         return $this->_table->getConnection()->transactional(function () use ($node, $number) {
             $this->ensureFields($node);
 
-            return $this->_moveUp($node, $number);
+            return $this->doMoveUp($node, $number);
         });
     }
 
@@ -617,7 +617,7 @@ class TreeBehavior extends Behavior
      * @return \Cake\Datasource\EntityInterface $node The node after being moved
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When node was not found
      */
-    protected function _moveUp(EntityInterface $node, int|bool $number): EntityInterface
+    protected function doMoveUp(EntityInterface $node, int|bool $number): EntityInterface
     {
         $config = $this->getConfig();
         [$parent, $left, $right] = [$config['parent'], $config['left'], $config['right']];
@@ -693,7 +693,7 @@ class TreeBehavior extends Behavior
         return $this->_table->getConnection()->transactional(function () use ($node, $number) {
             $this->ensureFields($node);
 
-            return $this->_moveDown($node, $number);
+            return $this->doMoveDown($node, $number);
         });
     }
 
@@ -705,7 +705,7 @@ class TreeBehavior extends Behavior
      * @return \Cake\Datasource\EntityInterface $node The node after being moved
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When node was not found
      */
-    protected function _moveDown(EntityInterface $node, int|bool $number): EntityInterface
+    protected function doMoveDown(EntityInterface $node, int|bool $number): EntityInterface
     {
         $config = $this->getConfig();
         [$parent, $left, $right] = [$config['parent'], $config['left'], $config['right']];

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -371,7 +371,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
     {
         if ($this->_results !== null) {
             if (!($this->_results instanceof ResultSetInterface)) {
-                $this->_results = $this->_decorateResults($this->_results);
+                $this->_results = $this->ormDecorateResults($this->_results);
             }
 
             return $this->_results;
@@ -379,7 +379,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
 
         $results = $this->_cache?->fetch($this);
         if ($results === null) {
-            $results = $this->_decorateResults($this->_execute());
+            $results = $this->ormDecorateResults($this->ormExecute());
             $this->_cache?->store($this, $results);
         }
         $this->_results = $results;
@@ -727,7 +727,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * @param iterable $result Original results
      * @return \Cake\Datasource\ResultSetInterface<\Cake\Datasource\EntityInterface|mixed>
      */
-    protected function _decorateResults(iterable $result): ResultSetInterface
+    protected function ormDecorateResults(iterable $result): ResultSetInterface
     {
         $resultSetClass = $this->resultSetFactory()->getResultSetClass();
 
@@ -1559,7 +1559,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @return iterable
      */
-    protected function _execute(): iterable
+    protected function ormExecute(): iterable
     {
         $this->triggerBeforeFind();
         if ($this->_results !== null) {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2246,7 +2246,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         array $options = [],
     ): iterable|false {
         try {
-            return $this->_saveMany($entities, $options);
+            return $this->doSaveMany($entities, $options);
         } catch (PersistenceFailedException) {
             return false;
         }
@@ -2267,7 +2267,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function saveManyOrFail(iterable $entities, array $options = []): iterable
     {
-        return $this->_saveMany($entities, $options);
+        return $this->doSaveMany($entities, $options);
     }
 
     /**
@@ -2277,7 +2277,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @throws \Exception If an entity couldn't be saved.
      * @return iterable<\Cake\Datasource\EntityInterface> Entities list.
      */
-    protected function _saveMany(
+    protected function doSaveMany(
         iterable $entities,
         array $options = [],
     ): iterable {
@@ -2427,7 +2427,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function deleteMany(iterable $entities, array $options = []): iterable|false
     {
-        $failed = $this->_deleteMany($entities, $options);
+        $failed = $this->doDeleteMany($entities, $options);
 
         if ($failed !== null) {
             return false;
@@ -2451,7 +2451,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function deleteManyOrFail(iterable $entities, array $options = []): iterable
     {
-        $failed = $this->_deleteMany($entities, $options);
+        $failed = $this->doDeleteMany($entities, $options);
 
         if ($failed !== null) {
             throw new PersistenceFailedException($failed, ['deleteMany']);
@@ -2465,7 +2465,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array<string, mixed> $options Options used.
      * @return \Cake\Datasource\EntityInterface|null
      */
-    protected function _deleteMany(iterable $entities, array $options = []): ?EntityInterface
+    protected function doDeleteMany(iterable $entities, array $options = []): ?EntityInterface
     {
         $options = new ArrayObject($options + [
                 'atomic' => true,

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -667,7 +667,7 @@ class Hash
             }
         }
 
-        return array_filter($data, $callback ?? static::_filter(...));
+        return array_filter($data, $callback ?? static::doFilter(...));
     }
 
     /**
@@ -676,7 +676,7 @@ class Hash
      * @param mixed $var Array to filter.
      * @return bool
      */
-    protected static function _filter(mixed $var): bool
+    protected static function doFilter(mixed $var): bool
     {
         return $var === 0 || $var === 0.0 || $var === '0' || !empty($var);
     }
@@ -786,7 +786,7 @@ class Hash
             $stack[] = [(array)$curArg, &$return];
         }
         unset($curArg);
-        static::_merge($stack, $return);
+        static::doMerge($stack, $return);
 
         return $return;
     }
@@ -798,7 +798,7 @@ class Hash
      * @param array $return The return value to operate on.
      * @return void
      */
-    protected static function _merge(array $stack, array &$return): void
+    protected static function doMerge(array $stack, array &$return): void
     {
         while ($stack !== []) {
             foreach ($stack as $curKey => &$curMerge) {

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -409,7 +409,7 @@ class Text
     {
         $paragraphs = explode($break, $text);
         foreach ($paragraphs as &$paragraph) {
-            $paragraph = static::_wordWrap($paragraph, $width, $break, $cut);
+            $paragraph = static::doWordWrap($paragraph, $width, $break, $cut);
         }
 
         return implode($break, $paragraphs);
@@ -424,7 +424,7 @@ class Text
      * @param bool $cut If the cut is set to true, the string is always wrapped at the specified width.
      * @return string Formatted text.
      */
-    protected static function _wordWrap(string $text, int $width = 72, string $break = "\n", bool $cut = false): string
+    protected static function doWordWrap(string $text, int $width = 72, string $break = "\n", bool $cut = false): string
     {
         $parts = [];
         if ($cut) {

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -294,7 +294,7 @@ class Xml
         if ($options['pretty']) {
             $dom->formatOutput = true;
         }
-        self::_fromArray($dom, $dom, $input, $options['format']);
+        self::doFromArray($dom, $dom, $input, $options['format']);
 
         $options['return'] = strtolower($options['return']);
         if ($options['return'] === 'simplexml' || $options['return'] === 'simplexmlelement') {
@@ -314,7 +314,7 @@ class Xml
      * @return void
      * @throws \Cake\Utility\Exception\XmlException
      */
-    protected static function _fromArray(
+    protected static function doFromArray(
         DOMDocument $dom,
         DOMDocument|DOMElement $node,
         mixed $data,
@@ -432,7 +432,7 @@ class Xml
             $child->setAttribute('xmlns', $childNS);
         }
 
-        static::_fromArray($dom, $child, $value, $format);
+        static::doFromArray($dom, $child, $value, $format);
         $node->appendChild($child);
     }
 
@@ -455,7 +455,7 @@ class Xml
 
         $result = [];
         $namespaces = array_merge(['' => ''], $obj->getNamespaces(true));
-        static::_toArray($obj, $result, '', array_keys($namespaces));
+        static::doToArray($obj, $result, '', array_keys($namespaces));
 
         return $result;
     }
@@ -469,7 +469,7 @@ class Xml
      * @param array<string> $namespaces List of namespaces in XML
      * @return void
      */
-    protected static function _toArray(SimpleXMLElement $xml, array &$parentData, string $ns, array $namespaces): void
+    protected static function doToArray(SimpleXMLElement $xml, array &$parentData, string $ns, array $namespaces): void
     {
         $data = [];
 
@@ -483,7 +483,7 @@ class Xml
             }
 
             foreach ($xml->children($namespace, true) as $child) {
-                static::_toArray($child, $data, $namespace, $namespaces);
+                static::doToArray($child, $data, $namespace, $namespaces);
             }
         }
 

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -709,7 +709,7 @@ class PaginatorHelper extends Helper
         if ($options['modulus'] !== false && $params['pageCount'] > $options['modulus']) {
             $out = $this->modulusNumbers($templater, $params, $options);
         } else {
-            $out = $this->_numbers($templater, $params, $options);
+            $out = $this->doNumbers($templater, $params, $options);
         }
 
         if (isset($options['templates'])) {
@@ -887,7 +887,7 @@ class PaginatorHelper extends Helper
      * @param array<string, mixed> $options Options from the numbers() method.
      * @return string Markup output.
      */
-    protected function _numbers(StringTemplate $templater, array $params, array $options): string
+    protected function doNumbers(StringTemplate $templater, array $params, array $options): string
     {
         $out = '';
         $out .= $options['before'];

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -709,7 +709,7 @@ class PaginatorHelper extends Helper
         if ($options['modulus'] !== false && $params['pageCount'] > $options['modulus']) {
             $out = $this->modulusNumbers($templater, $params, $options);
         } else {
-            $out = $this->doNumbers($templater, $params, $options);
+            $out = $this->buildNumbers($templater, $params, $options);
         }
 
         if (isset($options['templates'])) {
@@ -887,7 +887,7 @@ class PaginatorHelper extends Helper
      * @param array<string, mixed> $options Options from the numbers() method.
      * @return string Markup output.
      */
-    protected function doNumbers(StringTemplate $templater, array $params, array $options): string
+    protected function buildNumbers(StringTemplate $templater, array $params, array $options): string
     {
         $out = '';
         $out .= $options['before'];

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -782,7 +782,7 @@ class View implements EventDispatcherInterface
         $templateFileName = $this->getTemplateFileName($template);
         $this->_currentType = static::TYPE_TEMPLATE;
         $this->dispatchEvent('View.beforeRender', [$templateFileName]);
-        $this->Blocks->set('content', $this->_render($templateFileName));
+        $this->Blocks->set('content', $this->doRender($templateFileName));
         $this->dispatchEvent('View.afterRender', [$templateFileName]);
 
         if ($this->autoLayout) {
@@ -834,7 +834,7 @@ class View implements EventDispatcherInterface
         }
 
         $this->_currentType = static::TYPE_LAYOUT;
-        $this->Blocks->set('content', $this->_render($layoutFileName));
+        $this->Blocks->set('content', $this->doRender($layoutFileName));
 
         $this->dispatchEvent('View.afterLayout', [$layoutFileName]);
 
@@ -1131,7 +1131,7 @@ class View implements EventDispatcherInterface
      * @triggers View.beforeRenderFile $this, [$templateFile]
      * @triggers View.afterRenderFile $this, [$templateFile, $content]
      */
-    protected function _render(string $templateFile, array $data = []): string
+    protected function doRender(string $templateFile, array $data = []): string
     {
         if (!$data) {
             $data = $this->viewVars;
@@ -1152,7 +1152,7 @@ class View implements EventDispatcherInterface
             $this->_stack[] = $this->fetch('content');
             $this->assign('content', $content);
 
-            $content = $this->_render($this->_parents[$templateFile]);
+            $content = $this->doRender($this->_parents[$templateFile]);
             $this->assign('content', array_pop($this->_stack));
         }
 
@@ -1686,7 +1686,7 @@ class View implements EventDispatcherInterface
             $this->dispatchEvent('View.beforeRender', [$file]);
         }
 
-        $element = $this->_render($file, array_merge($this->viewVars, $data));
+        $element = $this->doRender($file, array_merge($this->viewVars, $data));
 
         if ($options['callbacks']) {
             $this->dispatchEvent('View.afterRender', [$file, $element]);

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -782,7 +782,7 @@ class View implements EventDispatcherInterface
         $templateFileName = $this->getTemplateFileName($template);
         $this->_currentType = static::TYPE_TEMPLATE;
         $this->dispatchEvent('View.beforeRender', [$templateFileName]);
-        $this->Blocks->set('content', $this->doRender($templateFileName));
+        $this->Blocks->set('content', $this->renderFile($templateFileName));
         $this->dispatchEvent('View.afterRender', [$templateFileName]);
 
         if ($this->autoLayout) {
@@ -834,7 +834,7 @@ class View implements EventDispatcherInterface
         }
 
         $this->_currentType = static::TYPE_LAYOUT;
-        $this->Blocks->set('content', $this->doRender($layoutFileName));
+        $this->Blocks->set('content', $this->renderFile($layoutFileName));
 
         $this->dispatchEvent('View.afterLayout', [$layoutFileName]);
 
@@ -1131,7 +1131,7 @@ class View implements EventDispatcherInterface
      * @triggers View.beforeRenderFile $this, [$templateFile]
      * @triggers View.afterRenderFile $this, [$templateFile, $content]
      */
-    protected function doRender(string $templateFile, array $data = []): string
+    protected function renderFile(string $templateFile, array $data = []): string
     {
         if (!$data) {
             $data = $this->viewVars;
@@ -1152,7 +1152,7 @@ class View implements EventDispatcherInterface
             $this->_stack[] = $this->fetch('content');
             $this->assign('content', $content);
 
-            $content = $this->doRender($this->_parents[$templateFile]);
+            $content = $this->renderFile($this->_parents[$templateFile]);
             $this->assign('content', array_pop($this->_stack));
         }
 
@@ -1686,7 +1686,7 @@ class View implements EventDispatcherInterface
             $this->dispatchEvent('View.beforeRender', [$file]);
         }
 
-        $element = $this->doRender($file, array_merge($this->viewVars, $data));
+        $element = $this->renderFile($file, array_merge($this->viewVars, $data));
 
         if ($options['callbacks']) {
             $this->dispatchEvent('View.afterRender', [$file, $element]);

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -39,7 +39,7 @@ class ConsoleOutputTest extends TestCase
     {
         parent::setUp();
         $this->output = $this->getMockBuilder(ConsoleOutput::class)
-            ->onlyMethods(['_write'])
+            ->onlyMethods(['writeStream'])
             ->getMock();
         $this->output->setOutputAs(ConsoleOutput::COLOR);
     }
@@ -67,7 +67,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testWriteNoNewLine(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeStream')
             ->with('Some output');
 
         $this->output->write('Some output', 0);
@@ -78,7 +78,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testWriteNewLine(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeStream')
             ->with('Some output' . PHP_EOL);
 
         $this->output->write('Some output');
@@ -89,7 +89,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testWriteMultipleNewLines(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeStream')
             ->with('Some output' . PHP_EOL . PHP_EOL . PHP_EOL . PHP_EOL);
 
         $this->output->write('Some output', 4);
@@ -100,7 +100,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testWriteArray(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeStream')
             ->with('Line' . PHP_EOL . 'Line' . PHP_EOL . 'Line' . PHP_EOL);
 
         $this->output->write(['Line', 'Line', 'Line']);
@@ -141,7 +141,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testFormattingSimple(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeStream')
             ->with("\033[31mError:\033[0m Something bad");
 
         $this->output->write('<error>Error:</error> Something bad', 0);
@@ -152,7 +152,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testFormattingNotEatingTags(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeStream')
             ->with('<red> Something bad');
 
         $this->output->write('<red> Something bad', 0);
@@ -170,7 +170,7 @@ class ConsoleOutputTest extends TestCase
             'underline' => true,
         ]);
 
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeStream')
             ->with("\033[35;46;5;4mAnnoy:\033[0m Something bad");
 
         $this->output->write('<annoying>Annoy:</annoying> Something bad', 0);
@@ -181,7 +181,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testFormattingMissingStyleName(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeStream')
             ->with('<not_there>Error:</not_there> Something bad');
 
         $this->output->write('<not_there>Error:</not_there> Something bad', 0);
@@ -192,7 +192,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testFormattingMultipleStylesName(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeStream')
             ->with("\033[31mBad\033[0m \033[33mWarning\033[0m Regular");
 
         $this->output->write('<error>Bad</error> <warning>Warning</warning> Regular', 0);
@@ -203,7 +203,7 @@ class ConsoleOutputTest extends TestCase
      */
     public function testFormattingMultipleSameTags(): void
     {
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeStream')
             ->with("\033[31mBad\033[0m \033[31mWarning\033[0m Regular");
 
         $this->output->write('<error>Bad</error> <error>Warning</error> Regular', 0);
@@ -215,7 +215,7 @@ class ConsoleOutputTest extends TestCase
     public function testSetOutputAsRaw(): void
     {
         $this->output->setOutputAs(ConsoleOutput::RAW);
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeStream')
             ->with('<error>Bad</error> Regular');
 
         $this->output->write('<error>Bad</error> Regular', 0);
@@ -228,7 +228,7 @@ class ConsoleOutputTest extends TestCase
     {
         $this->output->setOutputAs(ConsoleOutput::PLAIN);
         $this->assertSame(ConsoleOutput::PLAIN, $this->output->getOutputAs());
-        $this->output->expects($this->once())->method('_write')
+        $this->output->expects($this->once())->method('writeStream')
             ->with('Bad Regular');
 
         $this->output->write('<error>Bad</error> Regular', 0);
@@ -241,7 +241,7 @@ class ConsoleOutputTest extends TestCase
     {
         $this->output->setOutputAs(ConsoleOutput::PLAIN);
         $this->output->expects($this->once())
-            ->method('_write')
+            ->method('writeStream')
             ->with('Bad Regular <b>Left</b> <i>behind</i> <name>');
 
         $this->output->write('<error>Bad</error> Regular <b>Left</b> <i>behind</i> <name>', 0);

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -167,7 +167,7 @@ class FormTest extends TestCase
     {
         $form = new class extends Form {
             // phpcs:ignore CakePHP.NamingConventions.ValidFunctionName.PublicWithUnderscore
-            public function _execute(array $data): bool
+            public function process(array $data): bool
             {
                 throw new Exception('Should not be called');
             }

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -38,7 +38,7 @@ class StreamTest extends TestCase
     {
         parent::setUp();
         $this->stream = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['_send'])
+            ->onlyMethods(['processRequest'])
             ->getMock();
         stream_wrapper_unregister('http');
         stream_wrapper_register('http', CakeStreamWrapper::class);


### PR DESCRIPTION
Refs: https://github.com/cakephp/upgrade/pull/313 and https://github.com/cakephp/cakephp/pull/18687