### PR TITLE
5.3 Add citext and interval types for postgres

### DIFF
--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -673,6 +673,7 @@ class PostgresSchemaDialect extends SchemaDialect
             TableSchemaInterface::TYPE_CHAR => ' CHAR',
             TableSchemaInterface::TYPE_CITEXT => ' CITEXT',
             TableSchemaInterface::TYPE_JSON => ' JSONB',
+            TableSchemaInterface::TYPE_INTERVAL => ' INTERVAL',
             TableSchemaInterface::TYPE_GEOMETRY => ' GEOGRAPHY(GEOMETRY, %s)',
             TableSchemaInterface::TYPE_POINT => ' GEOGRAPHY(POINT, %s)',
             TableSchemaInterface::TYPE_LINESTRING => ' GEOGRAPHY(LINESTRING, %s)',

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -708,10 +708,7 @@ class PostgresSchemaDialect extends SchemaDialect
             $out .= ' BYTEA';
         }
 
-        if (
-            $column['type'] === TableSchemaInterface::TYPE_CHAR ||
-            $column['type'] === TableSchemaInterface::TYPE_CITEXT
-        ) {
+        if ($column['type'] === TableSchemaInterface::TYPE_CHAR) {
             $out .= '(' . $column['length'] . ')';
         }
 

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -139,7 +139,7 @@ class PostgresSchemaDialect extends SchemaDialect
             return $type;
         }
 
-        if (in_array($col, ['date', 'time', 'boolean', 'inet', 'cidr', 'macaddr', 'citext'], true)) {
+        if (in_array($col, ['date', 'time', 'boolean', 'inet', 'cidr', 'macaddr', 'citext', 'interval'], true)) {
             return ['type' => $col, 'length' => null];
         }
         if (in_array($col, ['timestamptz', 'timestamp with time zone'], true)) {

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -139,7 +139,7 @@ class PostgresSchemaDialect extends SchemaDialect
             return $type;
         }
 
-        if (in_array($col, ['date', 'time', 'boolean', 'inet', 'cidr', 'macaddr'], true)) {
+        if (in_array($col, ['date', 'time', 'boolean', 'inet', 'cidr', 'macaddr', 'citext'], true)) {
             return ['type' => $col, 'length' => null];
         }
         if (in_array($col, ['timestamptz', 'timestamp with time zone'], true)) {
@@ -282,7 +282,11 @@ class PostgresSchemaDialect extends SchemaDialect
         $statement = $this->_driver->execute($sql, [$name, $schema, $config['database']]);
         $columns = [];
         foreach ($statement->fetchAll('assoc') as $row) {
-            $field = $this->_convertColumn($row['type']);
+            $type = $row['type'];
+            if ($type === 'USER-DEFINED') {
+                $type = $row['udt_name'];
+            }
+            $field = $this->_convertColumn($type);
             if ($field['type'] === TableSchemaInterface::TYPE_BOOLEAN) {
                 if ($row['default'] === 'true') {
                     $row['default'] = 1;
@@ -667,6 +671,7 @@ class PostgresSchemaDialect extends SchemaDialect
             TableSchemaInterface::TYPE_UUID => ' UUID',
             TableSchemaInterface::TYPE_NATIVE_UUID => ' UUID',
             TableSchemaInterface::TYPE_CHAR => ' CHAR',
+            TableSchemaInterface::TYPE_CITEXT => ' CITEXT',
             TableSchemaInterface::TYPE_JSON => ' JSONB',
             TableSchemaInterface::TYPE_GEOMETRY => ' GEOGRAPHY(GEOMETRY, %s)',
             TableSchemaInterface::TYPE_POINT => ' GEOGRAPHY(POINT, %s)',
@@ -703,7 +708,10 @@ class PostgresSchemaDialect extends SchemaDialect
             $out .= ' BYTEA';
         }
 
-        if ($column['type'] === TableSchemaInterface::TYPE_CHAR) {
+        if (
+            $column['type'] === TableSchemaInterface::TYPE_CHAR ||
+            $column['type'] === TableSchemaInterface::TYPE_CITEXT
+        ) {
             $out .= '(' . $column['length'] . ')';
         }
 

--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -117,6 +117,15 @@ interface TableSchemaInterface extends SchemaInterface
     public const TYPE_CHAR = 'char';
 
     /**
+     * Case-insensitive text column type.
+     *
+     * Only implemented in postgres
+     *
+     * @var string
+     */
+    public const TYPE_CITEXT = 'citext';
+
+    /**
      * Text column type
      *
      * @var string

--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -96,6 +96,13 @@ interface TableSchemaInterface extends SchemaInterface
     public const TYPE_TIMESTAMP_TIMEZONE = 'timestamptimezone';
 
     /**
+     * Datetime interval. Only implemted in postgres.
+     *
+     * @var string
+     */
+    public const TYPE_INTERVAL = 'interval';
+
+    /**
      * JSON column type
      *
      * @var string

--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -96,7 +96,7 @@ interface TableSchemaInterface extends SchemaInterface
     public const TYPE_TIMESTAMP_TIMEZONE = 'timestamptimezone';
 
     /**
-     * Datetime interval. Only implemted in postgres.
+     * Datetime interval. Only implemented in postgres.
      *
      * @var string
      */

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -78,6 +78,7 @@ published BOOLEAN DEFAULT false,
 views SMALLINT DEFAULT 0,
 readingtime TIME,
 data JSONB,
+valid_period INTERVAL,
 average_note DECIMAL(4,2),
 average_income NUMERIC(10,2),
 created TIMESTAMP,
@@ -141,6 +142,10 @@ SQL;
             [
                 ['type' => 'TIME WITHOUT TIME ZONE'],
                 ['type' => 'time', 'length' => null],
+            ],
+            [
+                ['type' => 'INTERVAL'],
+                ['type' => 'interval', 'length' => null],
             ],
             // Integer
             [
@@ -436,6 +441,14 @@ SQL;
             ],
             'data' => [
                 'type' => 'json',
+                'null' => true,
+                'default' => null,
+                'length' => null,
+                'precision' => null,
+                'comment' => null,
+            ],
+            'valid_period' => [
+                'type' => 'interval',
                 'null' => true,
                 'default' => null,
                 'length' => null,

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -542,6 +542,41 @@ SQL;
     }
 
     /**
+     * Test describing a table with citext columns
+     */
+    public function testDescribeTableCiText(): void
+    {
+        $this->_needsConnection();
+        $connection = ConnectionManager::get('test');
+
+        $sql = 'CREATE EXTENSION IF NOT EXISTS citext';
+        $connection->execute($sql);
+
+        $sql = <<<SQL
+CREATE TABLE schema_citext (
+    "id" SERIAL,
+    "slug" CITEXT NOT NULL,
+    "name" VARCHAR(255),
+    PRIMARY KEY("id")
+);
+SQL;
+        $connection->execute($sql);
+        $schema = new SchemaCollection($connection);
+        $result = $schema->describe('schema_citext');
+        $connection->execute('DROP TABLE schema_citext');
+
+        $expected = [
+            'type' => 'citext',
+            'null' => false,
+            'default' => null,
+            'comment' => null,
+            'length' => null,
+            'precision' => null,
+        ];
+        $this->assertEquals($expected, $result->getColumn('slug'));
+    }
+
+    /**
      * Test describing a table containing defaults with Postgres
      */
     public function testDescribeTableWithDefaults(): void
@@ -889,6 +924,11 @@ SQL;
                 'title',
                 ['type' => 'string', 'length' => 255, 'null' => false, 'collate' => 'C'],
                 '"title" VARCHAR(255) COLLATE "C" NOT NULL',
+            ],
+            [
+                'slug',
+                ['type' => 'citext', 'length' => 36],
+                '"slug" CITEXT(36)',
             ],
             // Text
             [

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -940,8 +940,8 @@ SQL;
             ],
             [
                 'slug',
-                ['type' => 'citext', 'length' => 36],
-                '"slug" CITEXT(36)',
+                ['type' => 'citext', 'length' => null],
+                '"slug" CITEXT',
             ],
             // Text
             [


### PR DESCRIPTION
Add more types to postgres dialect that were supported in phinx/migrations.

Refs #18362