### PR TITLE
Fix problem with chained find() calls and overlapping argument names.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2722,7 +2722,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if ($args) {
             $query->applyOptions($args);
             // Fetch custom args without the query options.
-            $args = $query->getOptions();
+            $args = array_intersect_key($args, $query->getOptions());
 
             unset($params[0]);
             $lastParam = end($params);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1314,6 +1314,30 @@ class TableTest extends TestCase
         $this->assertSame(2, $author->id);
     }
 
+    /**
+     * https://github.com/cakephp/cakephp/issues/18716
+     */
+    public function testChangedFindWithOverlappingArgs(): void
+    {
+        $query = $this->getTableLocator()->get('Authors')
+            ->find('withIdArgument', 2)
+            ->find('custom', id: [1, 2], second: false);
+
+        $this->assertSame([2, 'id' => [1, 2], 'second' => false], $query->getOptions());
+
+        $query = $this->getTableLocator()->get('Authors')
+            ->find('withIdArgument', id: 2)
+            ->find('custom', second: true);
+
+        $this->assertSame(['id' => 2, 'second' => true], $query->getOptions());
+
+        $query = $this->getTableLocator()->get('Authors')
+            ->find('withIdArgument', id: 2)
+            ->find('custom2', id: [2, 3], second: true);
+
+        $this->assertSame(['id' => [2, 3], 'second' => true], $query->getOptions());
+    }
+
     public function testFindTypedParameterCompatibility(): void
     {
         $articles = $this->fetchTable('Articles');

--- a/tests/test_app/TestApp/Model/Table/AuthorsTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthorsTable.php
@@ -74,4 +74,14 @@ class AuthorsTable extends Table
     {
         return $query->where(['id' => $id]);
     }
+
+    public function findCustom(SelectQuery $query, array $id = [], bool $second = true): SelectQuery
+    {
+        return $query;
+    }
+
+    public function findCustom2(SelectQuery $query, array $id, bool $second): SelectQuery
+    {
+        return $query;
+    }
 }


### PR DESCRIPTION
Closes #18716

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
