### PR TITLE
Don't set query options with numeric keys.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2718,9 +2718,19 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
 
         if ($args) {
-            $query->applyOptions($args);
+            $unNamedArgs = [];
+            $namedArgs = [];
+            foreach ($args as $key => $value) {
+                if (is_int($key)) {
+                    $unNamedArgs[$key] = $value;
+                } else {
+                    $namedArgs[$key] = $value;
+                }
+            }
+
+            $query->applyOptions($namedArgs);
             // Fetch custom args without the query options.
-            $args = array_intersect_key($args, $query->getOptions());
+            $args = $unNamedArgs + array_intersect_key($args, $query->getOptions());
 
             unset($params[0]);
             $lastParam = end($params);

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -481,7 +481,7 @@ class AssociationTest extends TestCase
     {
         $this->association->setFinder('publishedWithArgOnly');
         $this->assertEquals(
-            ['custom', 'this' => 'custom'],
+            ['this' => 'custom'],
             $this->association->find(null, 'custom')->getOptions(),
         );
         $this->assertEquals(

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1323,7 +1323,7 @@ class TableTest extends TestCase
             ->find('withIdArgument', 2)
             ->find('custom', id: [1, 2], second: false);
 
-        $this->assertSame([2, 'id' => [1, 2], 'second' => false], $query->getOptions());
+        $this->assertSame(['id' => [1, 2], 'second' => false], $query->getOptions());
 
         $query = $this->getTableLocator()->get('Authors')
             ->find('withIdArgument', id: 2)


### PR DESCRIPTION
These values are meant to be positional arguments for finders.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
