### PR TITLE
Use the correct operations for clear and clearBlocking

### DIFF
--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -355,8 +355,6 @@ class RedisEngine extends CacheEngine
     /**
      * Delete all keys from the cache by a blocking operation
      *
-     * Faster than clear() using unlink method.
-     *
      * @return bool True if the cache was successfully cleared, false otherwise
      */
     public function clearBlocking(): bool

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -381,7 +381,7 @@ class RedisEngine extends CacheEngine
             }
 
             foreach ($keys as $key) {
-                $isDeleted = ((int)$this->_Redis->delete($key) > 0);
+                $isDeleted = ((int)$this->_Redis->del($key) > 0);
                 $isAllDeleted = $isAllDeleted && $isDeleted;
             }
         }

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -344,7 +344,7 @@ class RedisEngine extends CacheEngine
             }
 
             foreach ($keys as $key) {
-                $isDeleted = ((int)$this->_Redis->del($key) > 0);
+                $isDeleted = ((int)$this->_Redis->unlink($key) > 0);
                 $isAllDeleted = $isAllDeleted && $isDeleted;
             }
         }
@@ -381,7 +381,7 @@ class RedisEngine extends CacheEngine
             }
 
             foreach ($keys as $key) {
-                $isDeleted = ((int)$this->_Redis->unlink($key) > 0);
+                $isDeleted = ((int)$this->_Redis->delete($key) > 0);
                 $isAllDeleted = $isAllDeleted && $isDeleted;
             }
         }


### PR DESCRIPTION
Fix Redis cache use of blocking and non-blocking operations.

Fixes: #18720