### PR TITLE
Created a new cache engine for redis cluster. 

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -83,6 +83,7 @@ class Cache
         'memcached' => Engine\MemcachedEngine::class,
         'null' => Engine\NullEngine::class,
         'redis' => Engine\RedisEngine::class,
+        'rediscluster' => Engine\RedisClusterEngine::class,
     ];
 
     /**

--- a/src/Cache/Engine/RedisClusterEngine.php
+++ b/src/Cache/Engine/RedisClusterEngine.php
@@ -98,7 +98,7 @@ class RedisClusterEngine extends CacheEngine
      */
     public function connect(): RedisCluster
     {
-       return new RedisCluster(
+        return new RedisCluster(
             $this->_config['cluster'],
             $this->_config['seeds'],
             $this->_config['timeout'],

--- a/src/Cache/Engine/RedisClusterEngine.php
+++ b/src/Cache/Engine/RedisClusterEngine.php
@@ -92,6 +92,25 @@ class RedisClusterEngine extends CacheEngine
     }
 
     /**
+     * Creates a connection to the cluster
+     * This is public for mocking in tests and it should be considered
+     * internal otherwise.
+     */
+    public function connect(): RedisCluster
+    {
+       return new RedisCluster(
+            $this->_config['cluster'],
+            $this->_config['seeds'],
+            $this->_config['timeout'],
+            $this->_config['read_timeout'],
+            $this->_config['persistent'],
+            $this->_config['auth'],
+            // See: https://github.com/phpredis/phpredis/commit/8144db374338006a316beb11549f37926bd40c5d
+            $this->_config['tls'] === true ? [] : null,
+        );
+    }
+
+    /**
      * Connects to a Redis server
      *
      * @return bool True if Redis server was connected
@@ -99,16 +118,7 @@ class RedisClusterEngine extends CacheEngine
     protected function _connect(): bool
     {
         try {
-            $this->_Redis = new RedisCluster(
-                $this->_config['cluster'],
-                $this->_config['seeds'],
-                $this->_config['timeout'],
-                $this->_config['read_timeout'],
-                $this->_config['persistent'],
-                $this->_config['auth'],
-                // See: https://github.com/phpredis/phpredis/commit/8144db374338006a316beb11549f37926bd40c5d
-                $this->_config['tls'] === true ? [] : null,
-            );
+            $this->_Redis = $this->connect();
         } catch (RedisClusterException $e) {
             if (class_exists(Log::class)) {
                 Log::error('RedisEngine could not connect. Got error: ' . $e->getMessage());

--- a/src/Cache/Engine/RedisClusterEngine.php
+++ b/src/Cache/Engine/RedisClusterEngine.php
@@ -1,0 +1,166 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Cache\Engine;
+
+use Cake\Cache\CacheEngine;
+use Cake\Core\Exception\CakeException;
+use Cake\Log\Log;
+use Generator;
+use RedisCluster;
+use RedisClusterException;
+
+/**
+ * Redis Cluster storage engine for cache.
+ */
+class RedisClusterEngine extends CacheEngine
+{
+    use RedisEngineTrait;
+
+    /**
+     * Redis wrapper.
+     */
+    protected RedisCluster $_Redis;
+
+    /**
+     * The default config used unless overridden by runtime configuration
+     * - `cluster` Redis cluster name (must be defined in redis.ini)
+     * - `seeds` An array with the seed nodes to connect to. Only use seeds or cluster, not both.
+     * - `read_timeout` Read timeout.
+     * - `tls` Whether to use TLS
+     * - `duration` Specify how long items in this cache configuration last.
+     * - `groups` List of groups or 'tags' associated to every key stored in this config.
+     *    handy for deleting a complete group from cache.
+     * - `persistent` Connect to the Redis server with a persistent connection
+     * - `prefix` Prefix appended to all entries. Good for when you need to share a keyspace
+     *    with either another cache config or another application.
+     * - `scanCount` Number of keys to ask for each scan (default: 10)
+     * - `server` URL or IP to the Redis server host.
+     * - `timeout` timeout in seconds (float).
+     * - `clearUsesFlushDb` Enable clear() and clearBlocking() to use FLUSHDB. This will be
+     *   faster than standard clear()/clearBlocking() but will ignore prefixes and will
+     *   cause data loss if other applications are sharing a redis database.
+     *
+     * @var array<string, mixed>
+     */
+    protected array $_defaultConfig = [
+        'cluster' => null,
+        'seeds' => [],
+        'read_timeout' => 0,
+        'auth' => null,
+        'persistent' => true,
+        'duration' => 3600,
+        'groups' => [],
+        'tls' => false,
+        'prefix' => 'cake_',
+        'timeout' => 0,
+        'scanCount' => 10,
+        'clearUsesFlushDb' => false,
+    ];
+
+    /**
+     * Initialize the Cache Engine
+     *
+     * Called automatically by the cache frontend
+     *
+     * @param array<string, mixed> $config array of setting for the engine
+     * @return bool True if the engine has been successfully initialized, false if not
+     */
+    public function init(array $config = []): bool
+    {
+        if (!class_exists('RedisCluster')) {
+            throw new CakeException('The `redis` extension must be enabled to use RedisClusterEngine.');
+        }
+
+        parent::init($config);
+
+        return $this->_connect();
+    }
+
+    /**
+     * Connects to a Redis server
+     *
+     * @return bool True if Redis server was connected
+     */
+    protected function _connect(): bool
+    {
+        try {
+            $this->_Redis = new RedisCluster(
+                $this->_config['cluster'],
+                $this->_config['seeds'],
+                $this->_config['timeout'],
+                $this->_config['read_timeout'],
+                $this->_config['persistent'],
+                $this->_config['auth'],
+                // See: https://github.com/phpredis/phpredis/commit/8144db374338006a316beb11549f37926bd40c5d
+                $this->_config['tls'] === true ? [] : null,
+            );
+        } catch (RedisClusterException $e) {
+            if (class_exists(Log::class)) {
+                Log::error('RedisEngine could not connect. Got error: ' . $e->getMessage());
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string $pattern Pattern to scaen
+     * @return \Generator<array>
+     */
+    protected function scan(string $pattern): Generator
+    {
+        $iterator = null;
+        foreach ($this->_Redis->_masters() as $node) {
+            while (true) {
+                // @phpstan-ignore arguments.count, argument.type
+                $keys = $this->_Redis->scan($iterator, $node, $pattern, (int)$this->_config['scanCount']);
+                if ($keys === false) {
+                    break;
+                }
+
+                yield $keys;
+            }
+        }
+    }
+
+    /**
+     * Flushes DB
+     *
+     * @param bool $async Whether to use asynchronous mode
+     * @return void
+     */
+    protected function flushDB(bool $async = true): void
+    {
+        foreach ($this->_Redis->_masters() as $node) {
+            // @phpstan-ignore arguments.count
+            $this->_Redis->flushDB($node, $async);
+        }
+    }
+
+    /**
+     * Disconnects from the redis server
+     */
+    public function __destruct()
+    {
+        if (empty($this->_config['persistent']) && isset($this->_Redis)) {
+            $this->_Redis->close();
+        }
+    }
+}

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -20,7 +20,7 @@ namespace Cake\Cache\Engine;
 use Cake\Cache\CacheEngine;
 use Cake\Core\Exception\CakeException;
 use Cake\Log\Log;
-use DateInterval;
+use Generator;
 use Redis;
 use RedisException;
 
@@ -29,6 +29,8 @@ use RedisException;
  */
 class RedisEngine extends CacheEngine
 {
+    use RedisEngineTrait;
+
     /**
      * Redis wrapper.
      *
@@ -55,7 +57,7 @@ class RedisEngine extends CacheEngine
      * - `unix_socket` Path to the unix socket file (default: false)
      * - `clearUsesFlushDb` Enable clear() and clearBlocking() to use FLUSHDB. This will be
      *   faster than standard clear()/clearBlocking() but will ignore prefixes and will
-     *   cause dataloss if other applications are sharing a redis database.
+     *   cause data loss if other applications are sharing a redis database.
      *
      * @var array<string, mixed>
      */
@@ -209,274 +211,31 @@ class RedisEngine extends CacheEngine
     }
 
     /**
-     * Write data for key into cache.
-     *
-     * @param string $key Identifier for the data
-     * @param mixed $value Data to be cached
-     * @param \DateInterval|int|null $ttl Optional. The TTL value of this item. If no value is sent and
-     *   the driver supports TTL then the library may set a default value
-     *   for it or let the driver take care of that.
-     * @return bool True if the data was successfully cached, false on failure
+     * @param string $pattern Pattern to scaen
+     * @return \Generator<array>
      */
-    public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
+    protected function scan(string $pattern): Generator
     {
-        $key = $this->_key($key);
-        $value = $this->serialize($value);
-
-        $duration = $this->duration($ttl);
-        if ($duration === 0) {
-            return $this->_Redis->set($key, $value);
-        }
-
-        return $this->_Redis->setEx($key, $duration, $value);
-    }
-
-    /**
-     * Read a key from the cache
-     *
-     * @param string $key Identifier for the data
-     * @param mixed $default Default value to return if the key does not exist.
-     * @return mixed The cached data, or the default if the data doesn't exist, has
-     *   expired, or if there was an error fetching it
-     */
-    public function get(string $key, mixed $default = null): mixed
-    {
-        $value = $this->_Redis->get($this->_key($key));
-        if ($value === false) {
-            return $default;
-        }
-
-        return $this->unserialize($value);
-    }
-
-    /**
-     * Increments the value of an integer cached key & update the expiry time
-     *
-     * @param string $key Identifier for the data
-     * @param int $offset How much to increment
-     * @return int|false New incremented value, false otherwise
-     */
-    public function increment(string $key, int $offset = 1): int|false
-    {
-        $duration = $this->_config['duration'];
-        $key = $this->_key($key);
-
-        $value = $this->_Redis->incrBy($key, $offset);
-        if ($duration > 0) {
-            $this->_Redis->expire($key, $duration);
-        }
-
-        return $value;
-    }
-
-    /**
-     * Decrements the value of an integer cached key & update the expiry time
-     *
-     * @param string $key Identifier for the data
-     * @param int $offset How much to subtract
-     * @return int|false New decremented value, false otherwise
-     */
-    public function decrement(string $key, int $offset = 1): int|false
-    {
-        $duration = $this->_config['duration'];
-        $key = $this->_key($key);
-
-        $value = $this->_Redis->decrBy($key, $offset);
-        if ($duration > 0) {
-            $this->_Redis->expire($key, $duration);
-        }
-
-        return $value;
-    }
-
-    /**
-     * Delete a key from the cache
-     *
-     * @param string $key Identifier for the data
-     * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
-     */
-    public function delete(string $key): bool
-    {
-        $key = $this->_key($key);
-
-        return (int)$this->_Redis->del($key) > 0;
-    }
-
-    /**
-     * Delete a key from the cache asynchronously
-     *
-     * Just unlink a key from the cache. The actual removal will happen later asynchronously.
-     *
-     * @param string $key Identifier for the data
-     * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
-     */
-    public function deleteAsync(string $key): bool
-    {
-        $key = $this->_key($key);
-
-        return (int)$this->_Redis->unlink($key) > 0;
-    }
-
-    /**
-     * Delete all keys from the cache
-     *
-     * @return bool True if the cache was successfully cleared, false otherwise
-     */
-    public function clear(): bool
-    {
-        if ($this->getConfig('clearUsesFlushDb')) {
-            $this->_Redis->flushDB(false);
-
-            return true;
-        }
-
-        $this->_Redis->setOption(Redis::OPT_SCAN, (string)Redis::SCAN_RETRY);
-
-        $isAllDeleted = true;
         $iterator = null;
-        $pattern = $this->_config['prefix'] . '*';
-
         while (true) {
             $keys = $this->_Redis->scan($iterator, $pattern, (int)$this->_config['scanCount']);
-
             if ($keys === false) {
                 break;
             }
 
-            foreach ($keys as $key) {
-                $isDeleted = ((int)$this->_Redis->del($key) > 0);
-                $isAllDeleted = $isAllDeleted && $isDeleted;
-            }
+            yield $keys;
         }
-
-        return $isAllDeleted;
     }
 
     /**
-     * Delete all keys from the cache by a blocking operation
+     * Flushes DB
      *
-     * Faster than clear() using unlink method.
-     *
-     * @return bool True if the cache was successfully cleared, false otherwise
+     * @param bool $async Whether to use asynchronous mode
+     * @return void
      */
-    public function clearBlocking(): bool
+    protected function flushDB(bool $async = true): void
     {
-        if ($this->getConfig('clearUsesFlushDb')) {
-            $this->_Redis->flushDB(true);
-
-            return true;
-        }
-
-        $this->_Redis->setOption(Redis::OPT_SCAN, (string)Redis::SCAN_RETRY);
-
-        $isAllDeleted = true;
-        $iterator = null;
-        $pattern = $this->_config['prefix'] . '*';
-
-        while (true) {
-            $keys = $this->_Redis->scan($iterator, $pattern, (int)$this->_config['scanCount']);
-
-            if ($keys === false) {
-                break;
-            }
-
-            foreach ($keys as $key) {
-                $isDeleted = ((int)$this->_Redis->unlink($key) > 0);
-                $isAllDeleted = $isAllDeleted && $isDeleted;
-            }
-        }
-
-        return $isAllDeleted;
-    }
-
-    /**
-     * Write data for key into cache if it doesn't exist already.
-     * If it already exists, it fails and returns false.
-     *
-     * @param string $key Identifier for the data.
-     * @param mixed $value Data to be cached.
-     * @return bool True if the data was successfully cached, false on failure.
-     * @link https://github.com/phpredis/phpredis#set
-     */
-    public function add(string $key, mixed $value): bool
-    {
-        $duration = $this->_config['duration'];
-        $key = $this->_key($key);
-        $value = $this->serialize($value);
-
-        if ($this->_Redis->set($key, $value, ['nx', 'ex' => $duration])) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Returns the `group value` for each of the configured groups
-     * If the group initial value was not found, then it initializes
-     * the group accordingly.
-     *
-     * @return array<string>
-     */
-    public function groups(): array
-    {
-        $result = [];
-        foreach ($this->_config['groups'] as $group) {
-            $value = $this->_Redis->get($this->_config['prefix'] . $group);
-            if (!$value) {
-                $value = $this->serialize(1);
-                $this->_Redis->set($this->_config['prefix'] . $group, $value);
-            }
-            $result[] = $group . $value;
-        }
-
-        return $result;
-    }
-
-    /**
-     * Increments the group value to simulate deletion of all keys under a group
-     * old values will remain in storage until they expire.
-     *
-     * @param string $group name of the group to be cleared
-     * @return bool success
-     */
-    public function clearGroup(string $group): bool
-    {
-        return (bool)$this->_Redis->incr($this->_config['prefix'] . $group);
-    }
-
-    /**
-     * Serialize value for saving to Redis.
-     *
-     * This is needed instead of using Redis' in built serialization feature
-     * as it creates problems incrementing/decrementing initially set integer value.
-     *
-     * @param mixed $value Value to serialize.
-     * @return string
-     * @link https://github.com/phpredis/phpredis/issues/81
-     */
-    protected function serialize(mixed $value): string
-    {
-        if (is_int($value)) {
-            return (string)$value;
-        }
-
-        return serialize($value);
-    }
-
-    /**
-     * Unserialize string value fetched from Redis.
-     *
-     * @param string $value Value to unserialize.
-     * @return mixed
-     */
-    protected function unserialize(string $value): mixed
-    {
-        if (preg_match('/^[-]?\d+$/', $value)) {
-            return (int)$value;
-        }
-
-        return unserialize($value);
+        $this->_Redis->flushDB($async);
     }
 
     /**
@@ -494,7 +253,7 @@ class RedisEngine extends CacheEngine
      */
     public function __destruct()
     {
-        if (empty($this->_config['persistent'])) {
+        if (empty($this->_config['persistent']) && isset($this->_Redis)) {
             $this->_Redis->close();
         }
     }

--- a/src/Cache/Engine/RedisEngineTrait.php
+++ b/src/Cache/Engine/RedisEngineTrait.php
@@ -1,0 +1,301 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Cache\Engine;
+
+use DateInterval;
+use Redis;
+
+/**
+ * Common functions shared between Redis cache engines
+ * Note: The classes do not have a common ancestor so any differences
+ * are handled with functions in the corresponding engine classes.
+ *
+ * Examples:
+ *  - scan()
+ *  - flushDB()
+ */
+trait RedisEngineTrait
+{
+    /**
+     * Write data for key into cache.
+     *
+     * @param string $key Identifier for the data
+     * @param mixed $value Data to be cached
+     * @param \DateInterval|int|null $ttl Optional. The TTL value of this item. If no value is sent and
+     *   the driver supports TTL then the library may set a default value
+     *   for it or let the driver take care of that.
+     * @return bool True if the data was successfully cached, false on failure
+     */
+    public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
+    {
+        $key = $this->_key($key);
+        $value = $this->serialize($value);
+
+        $duration = $this->duration($ttl);
+        if ($duration === 0) {
+            return $this->_Redis->set($key, $value);
+        }
+
+        return $this->_Redis->setex($key, $duration, $value);
+    }
+
+    /**
+     * Read a key from the cache
+     *
+     * @param string $key Identifier for the data
+     * @param mixed $default Default value to return if the key does not exist.
+     * @return mixed The cached data, or the default if the data doesn't exist, has
+     *   expired, or if there was an error fetching it
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        $value = $this->_Redis->get($this->_key($key));
+        if ($value === false) {
+            return $default;
+        }
+
+        return $this->unserialize($value);
+    }
+
+    /**
+     * Increments the value of an integer cached key & update the expiry time
+     *
+     * @param string $key Identifier for the data
+     * @param int $offset How much to increment
+     * @return int|false New incremented value, false otherwise
+     */
+    public function increment(string $key, int $offset = 1): int|false
+    {
+        $duration = $this->_config['duration'];
+        $key = $this->_key($key);
+
+        $value = $this->_Redis->incrBy($key, $offset);
+        if ($duration > 0) {
+            $this->_Redis->expire($key, $duration);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Decrements the value of an integer cached key & update the expiry time
+     *
+     * @param string $key Identifier for the data
+     * @param int $offset How much to subtract
+     * @return int|false New decremented value, false otherwise
+     */
+    public function decrement(string $key, int $offset = 1): int|false
+    {
+        $duration = $this->_config['duration'];
+        $key = $this->_key($key);
+
+        $value = $this->_Redis->decrBy($key, $offset);
+        if ($duration > 0) {
+            $this->_Redis->expire($key, $duration);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Delete a key from the cache
+     *
+     * @param string $key Identifier for the data
+     * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
+     */
+    public function delete(string $key): bool
+    {
+        $key = $this->_key($key);
+
+        return (int)$this->_Redis->del($key) > 0;
+    }
+
+    /**
+     * Delete a key from the cache asynchronously
+     *
+     * Just unlink a key from the cache. The actual removal will happen later asynchronously.
+     *
+     * @param string $key Identifier for the data
+     * @return bool True if the value was successfully deleted, false if it didn't exist or couldn't be removed
+     */
+    public function deleteAsync(string $key): bool
+    {
+        $key = $this->_key($key);
+
+        return $this->unlink($key);
+    }
+
+    /**
+     * Delete all keys from the cache
+     *
+     * @return bool True if the cache was successfully cleared, false otherwise
+     */
+    public function clear(): bool
+    {
+        if ($this->getConfig('clearUsesFlushDb')) {
+            $this->flushDB(false);
+
+            return true;
+        }
+
+        $this->_Redis->setOption(Redis::OPT_SCAN, (string)Redis::SCAN_RETRY);
+
+        $isAllDeleted = true;
+        $pattern = $this->_config['prefix'] . '*';
+
+        foreach ($this->scan($pattern) as $keys) {
+            foreach ($keys as $key) {
+                $isDeleted = $this->unlink($key);
+                $isAllDeleted = $isAllDeleted && $isDeleted;
+            }
+        }
+
+        return $isAllDeleted;
+    }
+
+    /**
+     * Wrapper for unlink to improve type safety
+     */
+    protected function unlink(array|string $key): bool
+    {
+        // @phpstan-ignore-next-line method.notFound Fixes phpstan with older stubs
+        $res = $this->_Redis->unlink($key);
+
+        return is_int($res) && $res > 0;
+    }
+
+    /**
+     * Delete all keys from the cache by a blocking operation
+     *
+     * Faster than clear() using unlink method.
+     *
+     * @return bool True if the cache was successfully cleared, false otherwise
+     */
+    public function clearBlocking(): bool
+    {
+        if ($this->getConfig('clearUsesFlushDb')) {
+            $this->flushDB(false);
+
+            return true;
+        }
+
+        $this->_Redis->setOption(Redis::OPT_SCAN, (string)Redis::SCAN_RETRY);
+
+        $isAllDeleted = true;
+        $pattern = $this->_config['prefix'] . '*';
+
+        foreach ($this->scan($pattern) as $keys) {
+            foreach ($keys as $key) {
+                $isDeleted = ((int)$this->_Redis->del($key) > 0);
+                $isAllDeleted = $isAllDeleted && $isDeleted;
+            }
+        }
+
+        return $isAllDeleted;
+    }
+
+    /**
+     * Write data for key into cache if it doesn't exist already.
+     * If it already exists, it fails and returns false.
+     *
+     * @param string $key Identifier for the data.
+     * @param mixed $value Data to be cached.
+     * @return bool True if the data was successfully cached, false on failure.
+     * @link https://github.com/phpredis/phpredis#set
+     */
+    public function add(string $key, mixed $value): bool
+    {
+        $duration = $this->_config['duration'];
+        $key = $this->_key($key);
+        $value = $this->serialize($value);
+
+        if ($this->_Redis->set($key, $value, ['nx', 'ex' => $duration])) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the `group value` for each of the configured groups
+     * If the group initial value was not found, then it initializes
+     * the group accordingly.
+     *
+     * @return array<string>
+     */
+    public function groups(): array
+    {
+        $result = [];
+        foreach ($this->_config['groups'] as $group) {
+            $value = $this->_Redis->get($this->_config['prefix'] . $group);
+            if (!$value) {
+                $value = $this->serialize(1);
+                $this->_Redis->set($this->_config['prefix'] . $group, $value);
+            }
+            $result[] = $group . $value;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Increments the group value to simulate deletion of all keys under a group
+     * old values will remain in storage until they expire.
+     *
+     * @param string $group name of the group to be cleared
+     * @return bool success
+     */
+    public function clearGroup(string $group): bool
+    {
+        return (bool)$this->_Redis->incr($this->_config['prefix'] . $group);
+    }
+
+    /**
+     * Serialize value for saving to Redis.
+     *
+     * This is needed instead of using Redis' in built serialization feature
+     * as it creates problems incrementing/decrementing initially set integer value.
+     *
+     * @param mixed $value Value to serialize.
+     * @return string
+     * @link https://github.com/phpredis/phpredis/issues/81
+     */
+    protected function serialize(mixed $value): string
+    {
+        if (is_int($value)) {
+            return (string)$value;
+        }
+
+        return serialize($value);
+    }
+
+    /**
+     * Unserialize string value fetched from Redis.
+     *
+     * @param string $value Value to unserialize.
+     * @return mixed
+     */
+    protected function unserialize(string $value): mixed
+    {
+        if (preg_match('/^-?\d+$/', $value)) {
+            return (int)$value;
+        }
+
+        return unserialize($value);
+    }
+}

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -47,72 +47,144 @@ class RedisClusterEngineTest extends TestCase
         unset($this->engine);
     }
 
-    public function testClearEmpty(): void
+    protected function mockCluster(array $data): RedisCluster
     {
-        $cluster = new class() extends RedisCluster {
-            private array $data = [
-                'node-1' => [
-                    'key_1',
-                ],
-                'node-2' => [
-                    'key_2',
-                ],
-                'node-3' => [
-                    'key_3',
-                ],
-            ];
-
-            public function __construct()
+        return new class ($data) extends RedisCluster {
+            public function __construct(private array $data)
             {
             }
 
+            /**
+             * @phpcs:disable CakePHP.NamingConventions.ValidFunctionName.PublicWithUnderscore
+             */
             public function _masters(): array
             {
+                // @phpcs:enable CakePHP.NamingConventions.ValidFunctionName.PublicWithUnderscore
+
                 return array_keys($this->data);
             }
 
+            public function get($key)
+            {
+                foreach ($this->data as $nodeData) {
+                    if (array_key_exists($key, $nodeData)) {
+                        return serialize($nodeData[$key]);
+                    }
+                }
+
+                return false;
+            }
+
+            /**
+             * Emulates scan and returns one key at a time, to ensure we properly handle
+             * the iteration.
+             */
             public function scan(&$iterator, $str_node, $pattern = null, $count = 0): bool|array
             {
                 if (!isset($this->data[$str_node])) {
                     return false;
                 }
 
-                $keys = $this->data[$str_node];
+                $keys = array_keys($this->data[$str_node]);
 
-                if ($iterator === null) {
-                    $iterator = 0;
+                if ($iterator === null || $iterator['node'] !== $str_node) {
+                    $iterator = [
+                        'node' => $str_node,
+                        'count' => 0,
+                    ];
                 } else {
-                    $iterator++;
+                    $iterator['count'] = $iterator['count'] + 1;
                 }
 
-                if (!isset($keys[$iterator])) {
+                $index = $iterator['count'];
+
+                if (!isset($keys[$index])) {
                     return false;
                 }
 
-                return [ $keys[$iterator] ];
+                return [ $keys[$index] ];
             }
 
             public function unlink($key, ...$other_keys): int
             {
                 $count = 0;
                 foreach ($this->data as &$nodeData) {
-                    $index = array_search($key, $nodeData, true);
-
-                    if (is_int($index)) {
+                    if (array_key_exists($key, $nodeData)) {
                         $count++;
-                        unset($nodeData[$index]);
+                        unset($nodeData[$key]);
                     }
                 }
 
                 return $count;
             }
+
+            public function del($key, ...$other_keys): int
+            {
+                return $this->unlink($key, ...$other_keys);
+            }
+
+            public function flushdb($key_or_address, $async = false)
+            {
+                $this->data = [];
+
+                return true;
+            }
         };
+    }
+
+    public function testClearEmpty(): void
+    {
+        $cluster = $this->mockCluster([
+            'node-1' => [
+                'cake_key_1' => 'value_1',
+            ],
+            'node-2' => [
+                'cake_key_2' => 'value_2',
+            ],
+            'node-3' => [
+                'cake_key_3' => 'value_3',
+            ],
+        ]);
 
         $this->engine->expects($this->atLeastOnce())
             ->method('connect')
             ->willReturn($cluster);
 
         $this->assertTrue($this->engine->init());
+        $this->assertSame('value_1', $this->engine->get('key_1'));
+
         $this->assertTrue($this->engine->clear());
+        $this->assertNull($this->engine->get('key_1'));
+        $this->assertNull($this->engine->get('key_2'));
+        $this->assertNull($this->engine->get('key_3'));
+    }
+
+    public function testClearEmptyFlushDb(): void
+    {
+        $cluster = $this->mockCluster([
+            'node-1' => [
+                'cake_key_1' => 'value_1',
+            ],
+            'node-2' => [
+                'cake_key_2' => 'value_2',
+            ],
+            'node-3' => [
+                'cake_key_3' => 'value_3',
+            ],
+        ]);
+
+        $this->engine->expects($this->atLeastOnce())
+            ->method('connect')
+            ->willReturn($cluster);
+
+        $this->assertTrue($this->engine->init());
+        $this->assertSame('value_1', $this->engine->get('key_1'));
+
+        // Test flushDB
+        $this->engine->setConfig('clearUsesFlushDb', true);
+        $this->assertTrue($this->engine->clear());
+        $this->assertNull($this->engine->get('key_1'));
+        $this->assertNull($this->engine->get('key_2'));
+        $this->assertNull($this->engine->get('key_3'));
     }
 }

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://book.cakephp.org/view/1196/Testing CakePHP(tm) Tests
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Cache\Engine;
+
+use Cake\Cache\Engine\RedisClusterEngine;
+use Cake\TestSuite\TestCase;
+use RedisCluster;
+
+/**
+ * RedisClusterEngineTest class
+ */
+class RedisClusterEngineTest extends TestCase
+{
+    /**
+     * @var \Cake\Cache\Engine\RedisClusterEngine&\PHPUnit\Framework\MockObject\MockObject $engine
+     */
+    private RedisClusterEngine $engine;
+
+    /**
+     * setUp method
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->engine = $this->getMockBuilder(RedisClusterEngine::class)
+            ->onlyMethods(['connect'])
+            ->getMock();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->engine);
+    }
+
+    public function testClearEmpty(): void
+    {
+        $cluster = new class() extends RedisCluster {
+            private array $data = [
+                'node-1' => [
+                    'key_1',
+                ],
+                'node-2' => [
+                    'key_2',
+                ],
+                'node-3' => [
+                    'key_3',
+                ],
+            ];
+
+            public function __construct()
+            {
+            }
+
+            public function _masters(): array
+            {
+                return array_keys($this->data);
+            }
+
+            public function scan(&$iterator, $str_node, $pattern = null, $count = 0): bool|array
+            {
+                if (!isset($this->data[$str_node])) {
+                    return false;
+                }
+
+                $keys = $this->data[$str_node];
+
+                if ($iterator === null) {
+                    $iterator = 0;
+                } else {
+                    $iterator++;
+                }
+
+                if (!isset($keys[$iterator])) {
+                    return false;
+                }
+
+                return [ $keys[$iterator] ];
+            }
+
+            public function unlink($key, ...$other_keys): int
+            {
+                $count = 0;
+                foreach ($this->data as &$nodeData) {
+                    $index = array_search($key, $nodeData, true);
+
+                    if (is_int($index)) {
+                        $count++;
+                        unset($nodeData[$index]);
+                    }
+                }
+
+                return $count;
+            }
+        };
+
+        $this->engine->expects($this->atLeastOnce())
+            ->method('connect')
+            ->willReturn($cluster);
+
+        $this->assertTrue($this->engine->init());
+        $this->assertTrue($this->engine->clear());
+    }
+}

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Cache\Engine;
 use Cake\Cache\Engine\RedisClusterEngine;
 use Cake\TestSuite\TestCase;
 use RedisCluster;
+use ReflectionClass;
 
 /**
  * RedisClusterEngineTest class
@@ -48,6 +49,98 @@ class RedisClusterEngineTest extends TestCase
     }
 
     protected function mockCluster(array $data): RedisCluster
+    {
+        $class = new ReflectionClass(RedisCluster::class);
+
+        /* Old version of the extension without return types */
+        if ($class->getMethod('flushdb')?->getReturnType() === null) {
+            return $this->mockClusterOld($data);
+        }
+
+        return new class ($data) extends RedisCluster {
+            public function __construct(private array $data)
+            {
+            }
+
+            /**
+             * @phpcs:disable CakePHP.NamingConventions.ValidFunctionName.PublicWithUnderscore
+             */
+            public function _masters(): array
+            {
+                // @phpcs:enable CakePHP.NamingConventions.ValidFunctionName.PublicWithUnderscore
+
+                return array_keys($this->data);
+            }
+
+            public function get(string $key): mixed
+            {
+                foreach ($this->data as $nodeData) {
+                    if (array_key_exists($key, $nodeData)) {
+                        return serialize($nodeData[$key]);
+                    }
+                }
+
+                return false;
+            }
+
+            /**
+             * Emulates scan and returns one key at a time, to ensure we properly handle
+             * the iteration.
+             */
+            public function scan(&$iterator, $str_node, $pattern = null, $count = 0): bool|array
+            {
+                if (!isset($this->data[$str_node])) {
+                    return false;
+                }
+
+                $keys = array_keys($this->data[$str_node]);
+
+                if ($iterator === null || $iterator['node'] !== $str_node) {
+                    $iterator = [
+                        'node' => $str_node,
+                        'count' => 0,
+                    ];
+                } else {
+                    $iterator['count'] = $iterator['count'] + 1;
+                }
+
+                $index = $iterator['count'];
+
+                if (!isset($keys[$index])) {
+                    return false;
+                }
+
+                return [ $keys[$index] ];
+            }
+
+            public function unlink(array|string $key, string ...$other_keys): RedisCluster|int|false
+            {
+                $count = 0;
+                foreach ($this->data as &$nodeData) {
+                    if (array_key_exists($key, $nodeData)) {
+                        $count++;
+                        unset($nodeData[$key]);
+                    }
+                }
+
+                return $count;
+            }
+
+            public function del(array|string $key, string ...$other_keys): RedisCluster|int|false
+            {
+                return $this->unlink($key, ...$other_keys);
+            }
+
+            public function flushdb(array|string $key_or_address, bool $async = false): RedisCluster|bool
+            {
+                $this->data = [];
+
+                return true;
+            }
+        };
+    }
+
+    protected function mockClusterOld(array $data): RedisCluster
     {
         return new class ($data) extends RedisCluster {
             public function __construct(private array $data)

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -53,7 +53,7 @@ class RedisClusterEngineTest extends TestCase
         $class = new ReflectionClass(RedisCluster::class);
 
         /* Old version of the extension without return types */
-        if ($class->getMethod('flushdb')?->getReturnType() === null) {
+        if ($class->getMethod('flushdb')->getReturnType() === null) {
             return $this->mockClusterOld($data);
         }
 
@@ -101,7 +101,7 @@ class RedisClusterEngineTest extends TestCase
                         'count' => 0,
                     ];
                 } else {
-                    $iterator['count'] = $iterator['count'] + 1;
+                    $iterator['count'] += 1;
                 }
 
                 $index = $iterator['count'];
@@ -186,7 +186,7 @@ class RedisClusterEngineTest extends TestCase
                         'count' => 0,
                     ];
                 } else {
-                    $iterator['count'] = $iterator['count'] + 1;
+                    $iterator['count'] += 1;
                 }
 
                 $index = $iterator['count'];


### PR DESCRIPTION
We have a variant of this running in production for a while now.

Even though there is another PR for RedisCluster, I think this implementation is better in terms of
maintainability because:

- The existing cache engine for redis is not affected and has its own options that make sense.
- The RedisCluster engine has options that make sense for cluster mode and it's own initialiazation.
- Common functionality is moved into a trait and the few operations that work differently are wrapped.

## TODO
- Test cases