### PR TITLE
Fix up test warnings.

### DIFF
--- a/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
@@ -1930,7 +1930,7 @@ class CaseStatementExpressionTest extends TestCase
                 function (): void {
                 },
             ],
-            [$res, 'resource (closed)'],
+            [$res], // resource (closed)
         ];
     }
 
@@ -1992,11 +1992,13 @@ class CaseStatementExpressionTest extends TestCase
             [1.0],
             [new stdClass()],
             [
+                // Closure
                 function (): void {
                 },
-                'Closure',
             ],
-            [$res, 'resource (closed)'],
+            [
+                $res, //resource (closed)
+            ],
         ];
     }
 

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -206,7 +206,7 @@ class ClientTest extends TestCase
     }
 
     #[DataProvider('urlProvider')]
-    public function testBuildUrl(string $expected, string $url, array $query, ?array $opts): void
+    public function testBuildUrl(string $expected, string $url, array $query, ?array $opts, string $type): void
     {
         $http = new Client();
 


### PR DESCRIPTION
Fixed up some obvious issues for test data providers

The remaining issues I opened as ticket in
https://github.com/sebastianbergmann/phpunit/pull/6213#issuecomment-2948961394

I do wonder if we need to those ...$rest
or if we could just rewrite it to clean method arguments instead.
```
2 tests triggered 18 PHPUnit warnings:

1) Cake\Test\TestCase\TestSuite\IntegrationTestTraitTest::testAssertionFailureMessages
* Data set "assertCookie" has more arguments (5) than the test method accepts (4)

* Data set "assertCookieVerbose" has more arguments (5) than the test method accepts (4)

* Data set "assertCookieEncrypted" has more arguments (5) than the test method accepts (4)

* Data set "assertCookieEncryptedVerbose" has more arguments (5) than the test method accepts (4)

* Data set "assertHeader" has more arguments (5) than the test method accepts (4)

* Data set "assertHeaderContains" has more arguments (5) than the test method accepts (4)

* Data set "assertHeaderNotContains" has more arguments (5) than the test method accepts (4)

* Data set "assertHeaderContainsVerbose" has more arguments (5) than the test method accepts (4)

* Data set "assertHeaderNotContainsVerbose" has more arguments (5) than the test method accepts (4)

* Data set "assertSession" has more arguments (5) than the test method accepts (4)

* Data set "assertFlashMessageWithKey" has more arguments (5) than the test method accepts (4)

* Data set "assertFlashMessageAt" has more arguments (5) than the test method accepts (4)

* Data set "assertFlashMessageAtWithKey" has more arguments (6) than the test method accepts (4)

* Data set "assertFlashElementWithKey" has more arguments (5) than the test method accepts (4)

* Data set "assertFlashElementAt" has more arguments (5) than the test method accepts (4)

* Data set "assertFlashElementAtWithKey" has more arguments (6) than the test method accepts (4)

/home/runner/work/cakephp/cakephp/tests/TestCase/TestSuite/IntegrationTestTraitTest.php:1573

2) Cake\Test\TestCase\TestSuite\IntegrationTestTraitTest::testAssertSessionRelatedVerboseMessages
* Data set "assertFlashMessageAtVerbose" has more arguments (3) than the test method accepts (2)

* Data set "assertSessionVerbose" has more arguments (3) than the test method accepts (2)

/home/runner/work/cakephp/cakephp/tests/TestCase/TestSuite/IntegrationTestTraitTest.php:1745
```