### PR TITLE
Improve console help

### DIFF
--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -26,6 +26,7 @@ use Cake\Console\ConsoleOptionParser;
 use Cake\Console\ConsoleOutput;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
+use Cake\Utility\Inflector;
 use SimpleXMLElement;
 
 /**
@@ -101,11 +102,11 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
                 continue;
             }
             $namespace = str_replace('\\', '/', $matches[1]);
-            $prefix = 'App';
+            $prefix = 'app';
             if ($namespace === 'Cake') {
-                $prefix = 'CakePHP';
+                $prefix = 'cakephp';
             } elseif (in_array($namespace, $plugins, true)) {
-                $prefix = $namespace;
+                $prefix = Inflector::underscore($namespace);
             }
             $shortestName = $this->getShortestName($names);
             if (str_contains($shortestName, '.')) {

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -264,6 +264,14 @@ class CommandRunner implements EventDispatcherInterface
             if ($commands->has($name)) {
                 return [$name, array_slice($argv, $i)];
             }
+
+            $firstChar = $name[0] ?? '';
+            if ($firstChar == strtoupper($firstChar) && str_contains($name, '.')) {
+                $underName = Inflector::underscore($name);
+                if ($commands->has($underName)) {
+                    return [$underName, array_slice($argv, $i)];
+                }
+            }
         }
         $name = array_shift($argv);
 

--- a/src/Event/Decorator/AbstractDecorator.php
+++ b/src/Event/Decorator/AbstractDecorator.php
@@ -26,7 +26,7 @@ abstract class AbstractDecorator
      *
      * @var callable
      */
-    protected $_callable;
+    protected mixed $_callable;
 
     /**
      * Decorator options

--- a/tests/TestCase/Console/Command/HelpCommandTest.php
+++ b/tests/TestCase/Console/Command/HelpCommandTest.php
@@ -72,7 +72,7 @@ class HelpCommandTest extends TestCase
      */
     protected function assertCommandList(): void
     {
-        $this->assertOutputContains('<info>TestPlugin</info>', 'plugin header should appear');
+        $this->assertOutputContains('<info>test_plugin</info>', 'plugin header should appear');
         $this->assertOutputContains('- sample', 'plugin command should appear');
         $this->assertOutputNotContains(
             '- test_plugin.sample',
@@ -82,9 +82,9 @@ class HelpCommandTest extends TestCase
             ' - abstract',
             'Abstract command classes should not appear.',
         );
-        $this->assertOutputContains('<info>App</info>', 'app header should appear');
+        $this->assertOutputContains('<info>app</info>', 'app header should appear');
         $this->assertOutputContains('- sample', 'app shell');
-        $this->assertOutputContains('<info>CakePHP</info>', 'cakephp header should appear');
+        $this->assertOutputContains('<info>cakephp</info>', 'cakephp header should appear');
         $this->assertOutputContains('- routes', 'core shell');
         $this->assertOutputContains('- sample', 'short plugin name');
         $this->assertOutputContains('- abort', 'command object');

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -311,6 +311,34 @@ class CommandRunnerTest extends TestCase
     }
 
     /**
+     * Test running a valid command with spaces in the name
+     */
+    public function testRunSubcommandNameInflection(): void
+    {
+        // Simulate typical plugin command registration.
+        $app = $this->makeAppWithCommands([
+            'my_plugin.tool demo' => DemoCommand::class,
+            'tool demo' => DemoCommand::class,
+        ]);
+        $runner = new CommandRunner($app, 'cake');
+
+        // With underscore inflection
+        $output = new StubConsoleOutput();
+        $result = $runner->run(['cake', 'my_plugin.tool', 'demo'], $this->getMockIo($output));
+        $this->assertSame(CommandInterface::CODE_SUCCESS, $result);
+
+        // Unprefixed
+        $output = new StubConsoleOutput();
+        $result = $runner->run(['cake', 'tool', 'demo'], $this->getMockIo($output));
+        $this->assertSame(CommandInterface::CODE_SUCCESS, $result);
+
+        // Inflected in typical plugin casing
+        $output = new StubConsoleOutput();
+        $result = $runner->run(['cake', 'MyPlugin.tool', 'demo'], $this->getMockIo($output));
+        $this->assertSame(CommandInterface::CODE_SUCCESS, $result);
+    }
+
+    /**
      * Test using a custom factory
      */
     public function testRunWithCustomFactory(): void


### PR DESCRIPTION
- Align the casing of plugin names in console help to be the same as how commands are documented as being called.
- Also fix incomplete support for camelCase plugin prefixes. Now `MyPlugin.command subcommand` works just like `MyPlugin.command` does.

Fixes #17728