### PR TITLE
Fix stream errors in child processes

### DIFF
--- a/src/Console/TestSuite/StubConsoleInput.php
+++ b/src/Console/TestSuite/StubConsoleInput.php
@@ -47,10 +47,10 @@ class StubConsoleInput extends ConsoleInput
      */
     public function __construct(array $replies)
     {
-        parent::__construct();
-
-        unset($this->_input);
+        // Don't call parent on purpose as it opens php://stdin which doesn't
+        // always exist in RunInSeparateProcess tests.
         $this->replies = $replies;
+        $this->_canReadline = false;
     }
 
     /**

--- a/src/Console/TestSuite/StubConsoleOutput.php
+++ b/src/Console/TestSuite/StubConsoleOutput.php
@@ -42,15 +42,12 @@ class StubConsoleOutput extends ConsoleOutput
 
     /**
      * Constructor
-     *
-     * Closes and unsets the file handle created in the parent constructor to
-     * prevent 'too many open files' errors.
      */
     public function __construct()
     {
-        parent::__construct();
-        fclose($this->_output);
-        unset($this->_output);
+        // Don't call parent on purpose as it opens php://stdin which doesn't
+        // always exist in RunInSeparateProcess tests.
+        $this->_outputAs = self::PLAIN;
     }
 
     /**


### PR DESCRIPTION
In trying to reproduce #18733 I ran into a few stream operation errors that seem to come from PHPUnit's `RunInSeparateProcess` I was getting errors like

```
PHPUnit\Framework\Exception: warning: 2 :: fopen(php://stdout): Failed to open stream: operation failed on line 181 of /home/mark/code/cake-app-tailwind/vendor/cakephp/cakephp/src/Console/ConsoleOutput.php
Stack Trace:

Cake\Error\ErrorTrap->handleError() [internal], line ??
APP/vendor/cakephp/cakephp/src/Console/ConsoleOutput.php APP/vendor/cakephp/cakephp/src/Console/ConsoleOutput.php, line 181
Cake\Console\ConsoleOutput->__construct() APP/vendor/cakephp/cakephp/src/Console/TestSuite/StubConsoleOutput.php, line 51
Cake\Console\TestSuite\StubConsoleOutput->__construct() APP/vendor/cakephp/migrations/src/Migration/BuiltinBackend.php, line 177
Migrations\Migration\BuiltinBackend->getManager() APP/vendor/cakephp/migrations/src/Migration/BuiltinBackend.php, line 76
Migrations\Migration\BuiltinBackend->status() APP/vendor/cakephp/migrations/src/Migrations.php, line 165
Migrations\Migrations->status() APP/vendor/cakephp/migrations/src/TestSuite/Migrator.php, line 181
Migrations\TestSuite\Migrator->shouldDropTables() APP/vendor/cakephp/migrations/src/TestSuite/Migrator.php, line 103
Migrations\TestSuite\Migrator->runMany() APP/vendor/cakephp/migrations/src/TestSuite/Migrator.php, line 59
Migrations\TestSuite\Migrator->run() APP/tests/bootstrap.php, line 75
Standard input code Standard input code, line 114
[main]
[Cake\Console\Exception\ConsoleException] Invalid stream in constructor. It is not a valid resource. in APP/vendor/cakephp/cakephp/src/Console/ConsoleOutput.php on line 185
```

With these changes those errors are resolved.