### PR TITLE
Skip sequences when listing tables

### DIFF
--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -36,7 +36,10 @@ class MysqlSchemaDialect extends SchemaDialect
      */
     public function listTablesSql(array $config): array
     {
-        return ['SHOW FULL TABLES FROM ' . $this->_driver->quoteIdentifier($config['database']), []];
+        return [
+            'SHOW FULL TABLES FROM ' . $this->_driver->quoteIdentifier($config['database'])
+            . " WHERE TABLE_TYPE IN ('BASE TABLE', 'VIEW')"
+            , []];
     }
 
     /**


### PR DESCRIPTION
We are using MariaDb sequences and they show up when we are baking models creating various issues.

