### PR TITLE
Deprecate returning a callable from i18n package loader.

### DIFF
--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -18,6 +18,7 @@ namespace Cake\I18n;
 
 use Cake\Cache\CacheEngineInterface;
 use Psr\SimpleCache\CacheInterface;
+use function Cake\Core\deprecationWarning;
 
 /**
  * Constructs and stores instances of translators that can be
@@ -234,6 +235,12 @@ class TranslatorRegistry
 
         // Support __invoke() wrapper classes
         if (!$package instanceof Package && is_callable($package)) {
+            deprecationWarning(
+                '5.3.0',
+                'Using a callable as a package loader is deprecated. ' .
+                'Please return an instance of \Cake\I18n\Package instead.',
+            );
+
             $package = $package();
         }
 

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -179,7 +179,7 @@ class I18nTest extends TestCase
             );
         });
 
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $translator = I18n::getTranslator('custom', 'fr_FR');
             $this->assertSame('Le moo', $translator->translate('Cow'));
         });

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -155,6 +155,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests that custom translation loaders can be created on the fly and used later on
+     *
+     * @deprecated
      */
     public function testCreateCustomTranslationInvokable(): void
     {
@@ -177,8 +179,10 @@ class I18nTest extends TestCase
             );
         });
 
-        $translator = I18n::getTranslator('custom', 'fr_FR');
-        $this->assertSame('Le moo', $translator->translate('Cow'));
+        $this->deprecated(function () {
+            $translator = I18n::getTranslator('custom', 'fr_FR');
+            $this->assertSame('Le moo', $translator->translate('Cow'));
+        });
     }
 
     /**


### PR DESCRIPTION
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
