### PR TITLE
Fix(Database): Ensure read/write settings correctly inherit shared config

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -163,8 +163,8 @@ class Connection implements ConnectionInterface
             'write',
         ]));
 
-        $writeConfig = $config['write'] ?? [] + $sharedConfig;
-        $readConfig = $config['read'] ?? [] + $sharedConfig;
+        $writeConfig = ($config['write'] ?? []) + $sharedConfig;
+        $readConfig = ($config['read'] ?? []) + $sharedConfig;
         if (array_key_exists('write', $config) || array_key_exists('read', $config)) {
             $readDriver = new $driverClass(['_role' => self::ROLE_READ] + $readConfig);
             $writeDriver = new $driverClass(['_role' => self::ROLE_WRITE] + $writeConfig);


### PR DESCRIPTION
### Description of Changes

Currently, in the `Database\Connection::createDrivers()` method, if a configuration array is provided for the `read` or `write` roles, it does not correctly inherit the values from the shared (default) configuration.

For instance, if a user only specifies the `port` for the `read` connection, other essential parameters like `host`, `username`, and `database` are not carried over from the shared config. This leads to a connection failure, contrary to the behavior described in the documentation.

This issue stems from PHP's operator precedence, where the array union operator (`+`) is evaluated before the null coalescing operator (`??`).

### Proposed Changes

This PR corrects this behavior by adding parentheses to the configuration merging logic.

The line is changed from:
`$readConfig = $config['read'] ?? [] + $sharedConfig;`

To:
`$readConfig = ($config['read'] ?? []) + $sharedConfig;`

This small but critical change ensures that the `read` or `write` specific configuration is resolved first, and then the shared configuration is correctly applied as a fallback for any keys that were not specified.

With this fix, users can define only the parameters they wish to override in the `read` and `write` configurations, making the feature work as intended and documented.