### PR TITLE
fix PHPUnit 12 problem in tests

### DIFF
--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -4811,7 +4811,7 @@ class TableTest extends TestCase
 
         $this->assertTrue($authors->Articles->replace($author, $newArticles));
         $this->assertCount(count($newArticles), $author->articles);
-        $this->assertEquals((new Collection($newArticles))->extract('title'), (new Collection($author->articles))->extract('title'));
+        $this->assertEquals((new Collection($newArticles))->extract('title')->toArray(), (new Collection($author->articles))->extract('title')->toArray());
     }
 
     /**


### PR DESCRIPTION
For some reason, those 2 collection instances are not "equal" any more in PHPUnit 12...

Refs: https://github.com/cakephp/cakephp/pull/17982