### PR TITLE
Add Column from migrations

### DIFF
--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -423,7 +423,7 @@ class Column
     /**
      * Sets whether field should be unsigned.
      *
-     * @param bool $signed Signed
+     * @param bool $unsinged Signed
      * @return $this
      */
     public function setUnsigned(bool $unsigned)

--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -68,6 +68,11 @@ class Column
     /**
      * @var int|null
      */
+    protected ?int $precision = null;
+
+    /**
+     * @var int|null
+     */
     protected ?int $increment = null;
 
     /**
@@ -78,7 +83,7 @@ class Column
     /**
      * @var string|null
      */
-    protected ?string $update = null;
+    protected ?string $onUpdate = null;
 
     /**
      * @var string|null
@@ -98,7 +103,7 @@ class Column
     /**
      * @var string|null
      */
-    protected ?string $collation = null;
+    protected ?string $collate = null;
 
     /**
      * @var int|null
@@ -334,7 +339,7 @@ class Column
      */
     public function setOnUpdate(string $update)
     {
-        $this->update = $update;
+        $this->onUpdate = $update;
 
         return $this;
     }
@@ -346,7 +351,7 @@ class Column
      */
     public function getOnUpdate(): ?string
     {
-        return $this->update;
+        return $this->onUpdate;
     }
 
     /**
@@ -496,9 +501,9 @@ class Column
      * @param string $collation Collation
      * @return $this
      */
-    public function setCollation(string $collation)
+    public function setCollate(string $collation)
     {
-        $this->collation = $collation;
+        $this->collate = $collation;
 
         return $this;
     }
@@ -508,9 +513,9 @@ class Column
      *
      * @return string|null
      */
-    public function getCollation(): ?string
+    public function getCollate(): ?string
     {
-        return $this->collation;
+        return $this->collate;
     }
 
     /**
@@ -550,12 +555,12 @@ class Column
             'null',
             'identity',
             'after',
-            'update',
+            'onUpdate',
             'comment',
-            'signed',
+            'unsigned',
             'type',
             'properties',
-            'collation',
+            'collate',
             'srid',
             'increment',
             'generated',
@@ -613,9 +618,9 @@ class Column
             'length' => $length,
             'null' => $this->getNull(),
             'default' => $this->getDefault(),
-            'unsigned' => !$this->getSigned(),
+            'unsigned' => !$this->getUnsigned(),
             'onUpdate' => $this->getOnUpdate(),
-            'collate' => $this->getCollation(),
+            'collate' => $this->getCollate(),
             'precision' => $precision,
             'srid' => $this->getSrid(),
             'comment' => $this->getComment(),

--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -88,7 +88,7 @@ class Column
     /**
      * @var bool
      */
-    protected bool $signed = true;
+    protected bool $unsigned = true;
 
     /**
      * @var array
@@ -425,26 +425,26 @@ class Column
     }
 
     /**
-     * Sets whether field should be signed.
+     * Sets whether field should be unsigned.
      *
      * @param bool $signed Signed
      * @return $this
      */
-    public function setSigned(bool $signed)
+    public function setUnsigned(bool $unsigned)
     {
-        $this->signed = $signed;
+        $this->unsigned = $unsigned;
 
         return $this;
     }
 
     /**
-     * Gets whether field should be signed.
+     * Gets whether field should be unsigned.
      *
      * @return bool
      */
-    public function getSigned(): bool
+    public function getUnsigned(): bool
     {
-        return $this->signed;
+        return $this->unsigned;
     }
 
     /**
@@ -454,7 +454,17 @@ class Column
      */
     public function isSigned(): bool
     {
-        return $this->getSigned();
+        return !$this->getUnsigned();
+    }
+
+    /**
+     * Should the column be unsigned?
+     *
+     * @return bool
+     */
+    public function isUnsigned(): bool
+    {
+        return $this->getUnsigned();
     }
 
     /**

--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -559,25 +559,25 @@ class Column
     }
 
     /**
-     * Utility method that maps an array of column options to this object's methods.
+     * Utility method that maps an array of column attributes to this object's methods.
      *
-     * @param array<string, mixed> $options Options
+     * @param array<string, mixed> $attributes Attributes
      * @throws \RuntimeException
      * @return $this
      */
-    public function setOptions(array $options)
+    public function setAttributes(array $attributes)
     {
         $validOptions = $this->getValidOptions();
-        if (isset($options['identity']) && $options['identity'] && !isset($options['null'])) {
-            $options['null'] = false;
+        if (isset($attributes['identity']) && $attributes['identity'] && !isset($attributes['null'])) {
+            $attributes['null'] = false;
         }
 
-        foreach ($options as $option => $value) {
-            if (!in_array($option, $validOptions, true)) {
-                throw new RuntimeException(sprintf('"%s" is not a valid column option.', $option));
+        foreach ($attributes as $attribute => $value) {
+            if (!in_array($attribute, $validOptions, true)) {
+                throw new RuntimeException(sprintf('"%s" is not a valid column option.', $attribute));
             }
 
-            $method = 'set' . ucfirst($option);
+            $method = 'set' . ucfirst($attribute);
             $this->$method($value);
         }
 

--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -36,7 +36,7 @@ class Column
     /**
      * @var string
      */
-    protected string $type;
+    protected string $type = TableSchemaInterface::TYPE_STRING;
 
     /**
      * @var int|null
@@ -71,11 +71,6 @@ class Column
     protected ?int $increment = null;
 
     /**
-     * @var int|null
-     */
-    protected ?int $scale = null;
-
-    /**
      * @var string|null
      */
     protected ?string $after = null;
@@ -96,11 +91,6 @@ class Column
     protected bool $signed = true;
 
     /**
-     * @var bool
-     */
-    protected bool $timezone = false;
-
-    /**
      * @var array
      */
     protected array $properties = [];
@@ -114,11 +104,6 @@ class Column
      * @var int|null
      */
     protected ?int $srid = null;
-
-    /**
-     * @var array|null
-     */
-    protected ?array $values = null;
 
     /**
      * Column constructor
@@ -153,6 +138,11 @@ class Column
 
     /**
      * Sets the column type.
+     *
+     * Type names are not validated, as drivers and dialects may implement
+     * platform specific types that are not known by cakephp.
+     *
+     * Drivers are expected to handle unknown types gracefully.
      *
      * @param string $type Column type
      * @return $this
@@ -544,7 +534,7 @@ class Column
     protected function getValidOptions(): array
     {
         return [
-            'limit',
+            'length',
             'default',
             'null',
             'identity',
@@ -552,9 +542,8 @@ class Column
             'update',
             'comment',
             'signed',
-            'timezone',
+            'type',
             'properties',
-            'values',
             'collation',
             'srid',
             'increment',

--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -535,6 +535,7 @@ class Column
     {
         return [
             'length',
+            'precision',
             'default',
             'null',
             'identity',

--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -625,6 +625,7 @@ class Column
             'srid' => $this->getSrid(),
             'comment' => $this->getComment(),
             'autoIncrement' => $this->getIdentity(),
+            'identity' => $this->getIdentity(),
         ];
     }
 }

--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -1,0 +1,625 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @copyright     Copyright (c) Cake Software Foundation, Inc.
+ *                (https://github.com/cakephp/migrations/tree/master/LICENSE.txt)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Schema;
+
+use Cake\Core\Configure;
+use RuntimeException;
+
+/**
+ * Schema metadata for a single column
+ *
+ * Used by `TableSchema` when reflecting schema or creating tables.
+ */
+class Column
+{
+    /**
+     * @var string
+     */
+    protected string $name = '';
+
+    /**
+     * @var string
+     */
+    protected string $type;
+
+    /**
+     * @var int|null
+     */
+    protected ?int $length = null;
+
+    /**
+     * @var bool
+     */
+    protected bool $null = true;
+
+    /**
+     * @var mixed
+     */
+    protected mixed $default = null;
+
+    /**
+     * @var bool
+     */
+    protected bool $identity = false;
+
+    /**
+     * Postgres-only column option for identity (always|default)
+     *
+     * @var ?string
+     */
+    protected ?string $generated = PostgresSchemaDialect::GENERATED_BY_DEFAULT;
+
+    /**
+     * @var int|null
+     */
+    protected ?int $increment = null;
+
+    /**
+     * @var int|null
+     */
+    protected ?int $scale = null;
+
+    /**
+     * @var string|null
+     */
+    protected ?string $after = null;
+
+    /**
+     * @var string|null
+     */
+    protected ?string $update = null;
+
+    /**
+     * @var string|null
+     */
+    protected ?string $comment = null;
+
+    /**
+     * @var bool
+     */
+    protected bool $signed = true;
+
+    /**
+     * @var bool
+     */
+    protected bool $timezone = false;
+
+    /**
+     * @var array
+     */
+    protected array $properties = [];
+
+    /**
+     * @var string|null
+     */
+    protected ?string $collation = null;
+
+    /**
+     * @var int|null
+     */
+    protected ?int $srid = null;
+
+    /**
+     * @var array|null
+     */
+    protected ?array $values = null;
+
+    /**
+     * Column constructor
+     */
+    public function __construct()
+    {
+        $this->null = (bool)Configure::read('Migrations.column_null_default');
+    }
+
+    /**
+     * Sets the column name.
+     *
+     * @param string $name Name
+     * @return $this
+     */
+    public function setName(string $name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Gets the column name.
+     *
+     * @return string|null
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Sets the column type.
+     *
+     * @param string $type Column type
+     * @return $this
+     */
+    public function setType(string $type)
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * Gets the column type.
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * Sets the column length.
+     *
+     * @param int|null $length Length
+     * @return $this
+     */
+    public function setLength(?int $length)
+    {
+        $this->length = $length;
+
+        return $this;
+    }
+
+    /**
+     * Gets the column length.
+     *
+     * @return int|null
+     */
+    public function getLength(): ?int
+    {
+        return $this->length;
+    }
+
+    /**
+     * Sets whether the column allows nulls.
+     *
+     * @param bool $null Null
+     * @return $this
+     */
+    public function setNull(bool $null)
+    {
+        $this->null = $null;
+
+        return $this;
+    }
+
+    /**
+     * Gets whether the column allows nulls.
+     *
+     * @return bool
+     */
+    public function getNull(): bool
+    {
+        return $this->null;
+    }
+
+    /**
+     * Does the column allow nulls?
+     *
+     * @return bool
+     */
+    public function isNull(): bool
+    {
+        return $this->getNull();
+    }
+
+    /**
+     * Sets the default column value.
+     *
+     * @param mixed $default Default
+     * @return $this
+     */
+    public function setDefault(mixed $default)
+    {
+        $this->default = $default;
+
+        return $this;
+    }
+
+    /**
+     * Gets the default column value.
+     *
+     * @return mixed
+     */
+    public function getDefault(): mixed
+    {
+        return $this->default;
+    }
+
+    /**
+     * Sets generated option for identity columns. Ignored otherwise.
+     *
+     * @param string|null $generated Generated option
+     * @return $this
+     */
+    public function setGenerated(?string $generated)
+    {
+        $this->generated = $generated;
+
+        return $this;
+    }
+
+    /**
+     * Gets generated option for identity columns. Null otherwise
+     *
+     * @return string|null
+     */
+    public function getGenerated(): ?string
+    {
+        return $this->generated;
+    }
+
+    /**
+     * Sets whether the column is an identity column.
+     *
+     * @param bool $identity Identity
+     * @return $this
+     */
+    public function setIdentity(bool $identity)
+    {
+        $this->identity = $identity;
+
+        return $this;
+    }
+
+    /**
+     * Gets whether the column is an identity column.
+     *
+     * @return bool
+     */
+    public function getIdentity(): bool
+    {
+        return $this->identity;
+    }
+
+    /**
+     * Is the column an identity column?
+     *
+     * @return bool
+     */
+    public function isIdentity(): bool
+    {
+        return $this->getIdentity();
+    }
+
+    /**
+     * Sets the name of the column to add this column after.
+     *
+     * @param string $after After
+     * @return $this
+     */
+    public function setAfter(string $after)
+    {
+        $this->after = $after;
+
+        return $this;
+    }
+
+    /**
+     * Returns the name of the column to add this column after.
+     *
+     * Used by MySQL and MariaDB in ALTER TABLE statements.
+     *
+     * @return string|null
+     */
+    public function getAfter(): ?string
+    {
+        return $this->after;
+    }
+
+    /**
+     * Sets the 'ON UPDATE' mysql column function.
+     *
+     * Used by MySQL and MariaDB in ALTER TABLE statements.
+     *
+     * @param string $update On Update function
+     * @return $this
+     */
+    public function setOnUpdate(string $update)
+    {
+        $this->update = $update;
+
+        return $this;
+    }
+
+    /**
+     * Returns the value of the ON UPDATE column function.
+     *
+     * @return string|null
+     */
+    public function getOnUpdate(): ?string
+    {
+        return $this->update;
+    }
+
+    /**
+     * Sets the number precision for decimal or float column.
+     *
+     * For example `DECIMAL(5,2)`, 5 is the length and 2 is the precision,
+     * and the column could store value from -999.99 to 999.99.
+     *
+     * @param int|null $precision Number precision
+     * @return $this
+     */
+    public function setPrecision(?int $precision)
+    {
+        $this->precision = $precision;
+
+        return $this;
+    }
+
+    /**
+     * Gets the number precision for decimal or float column.
+     *
+     * For example `DECIMAL(5,2)`, 5 is the length and 2 is the precision,
+     * and the column could store value from -999.99 to 999.99.
+     *
+     * @return int|null
+     */
+    public function getPrecision(): ?int
+    {
+        return $this->precision;
+    }
+
+    /**
+     * Sets the column identity increment.
+     *
+     * @param int $increment Number increment
+     * @return $this
+     */
+    public function setIncrement(int $increment)
+    {
+        $this->increment = $increment;
+
+        return $this;
+    }
+
+    /**
+     * Gets the column identity increment.
+     *
+     * @return int|null
+     */
+    public function getIncrement(): ?int
+    {
+        return $this->increment;
+    }
+
+    /**
+     * Sets the column comment.
+     *
+     * @param string|null $comment Comment
+     * @return $this
+     */
+    public function setComment(?string $comment)
+    {
+        $this->comment = $comment;
+
+        return $this;
+    }
+
+    /**
+     * Gets the column comment.
+     *
+     * @return string
+     */
+    public function getComment(): ?string
+    {
+        return $this->comment;
+    }
+
+    /**
+     * Sets whether field should be signed.
+     *
+     * @param bool $signed Signed
+     * @return $this
+     */
+    public function setSigned(bool $signed)
+    {
+        $this->signed = $signed;
+
+        return $this;
+    }
+
+    /**
+     * Gets whether field should be signed.
+     *
+     * @return bool
+     */
+    public function getSigned(): bool
+    {
+        return $this->signed;
+    }
+
+    /**
+     * Should the column be signed?
+     *
+     * @return bool
+     */
+    public function isSigned(): bool
+    {
+        return $this->getSigned();
+    }
+
+    /**
+     * Sets field properties.
+     *
+     * @param array $properties Properties
+     * @return $this
+     */
+    public function setProperties(array $properties)
+    {
+        $this->properties = $properties;
+
+        return $this;
+    }
+
+    /**
+     * Gets field properties
+     *
+     * @return array
+     */
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+
+    /**
+     * Sets the column collation.
+     *
+     * @param string $collation Collation
+     * @return $this
+     */
+    public function setCollation(string $collation)
+    {
+        $this->collation = $collation;
+
+        return $this;
+    }
+
+    /**
+     * Gets the column collation.
+     *
+     * @return string|null
+     */
+    public function getCollation(): ?string
+    {
+        return $this->collation;
+    }
+
+    /**
+     * Sets the column SRID for geometry fields.
+     *
+     * @param int $srid SRID
+     * @return $this
+     */
+    public function setSrid(int $srid)
+    {
+        $this->srid = $srid;
+
+        return $this;
+    }
+
+    /**
+     * Gets the column SRID from geometry fields.
+     *
+     * @return int|null
+     */
+    public function getSrid(): ?int
+    {
+        return $this->srid;
+    }
+
+    /**
+     * Gets all allowed options. Each option must have a corresponding `setFoo` method.
+     *
+     * @return array
+     */
+    protected function getValidOptions(): array
+    {
+        return [
+            'limit',
+            'default',
+            'null',
+            'identity',
+            'after',
+            'update',
+            'comment',
+            'signed',
+            'timezone',
+            'properties',
+            'values',
+            'collation',
+            'srid',
+            'increment',
+            'generated',
+        ];
+    }
+
+    /**
+     * Utility method that maps an array of column options to this object's methods.
+     *
+     * @param array<string, mixed> $options Options
+     * @throws \RuntimeException
+     * @return $this
+     */
+    public function setOptions(array $options)
+    {
+        $validOptions = $this->getValidOptions();
+        if (isset($options['identity']) && $options['identity'] && !isset($options['null'])) {
+            $options['null'] = false;
+        }
+
+        foreach ($options as $option => $value) {
+            if (!in_array($option, $validOptions, true)) {
+                throw new RuntimeException(sprintf('"%s" is not a valid column option.', $option));
+            }
+
+            $method = 'set' . ucfirst($option);
+            $this->$method($value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Convert the column into the array shape
+     * used by cakephp/database.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        $type = $this->getType();
+        $length = $this->getLength();
+        $precision = $this->getPrecision();
+        if ($precision !== null) {
+            if ($type === TableSchemaInterface::TYPE_TIMESTAMP) {
+                $type = 'timestampfractional';
+            } elseif ($type === TableSchemaInterface::TYPE_DATETIME) {
+                $type = 'datetimefractional';
+            }
+        }
+
+        return [
+            'name' => $this->getName(),
+            'type' => $type,
+            'length' => $length,
+            'null' => $this->getNull(),
+            'default' => $this->getDefault(),
+            'unsigned' => !$this->getSigned(),
+            'onUpdate' => $this->getOnUpdate(),
+            'collate' => $this->getCollation(),
+            'precision' => $precision,
+            'srid' => $this->getSrid(),
+            'comment' => $this->getComment(),
+            'autoIncrement' => $this->getIdentity(),
+        ];
+    }
+}

--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -18,7 +18,6 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Schema;
 
-use Cake\Core\Configure;
 use RuntimeException;
 
 /**
@@ -109,14 +108,6 @@ class Column
      * @var int|null
      */
     protected ?int $srid = null;
-
-    /**
-     * Column constructor
-     */
-    public function __construct()
-    {
-        $this->null = (bool)Configure::read('Migrations.column_null_default');
-    }
 
     /**
      * Sets the column name.

--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -423,7 +423,7 @@ class Column
     /**
      * Sets whether field should be unsigned.
      *
-     * @param bool $unsinged Signed
+     * @param bool $unsigned Signed
      * @return $this
      */
     public function setUnsigned(bool $unsigned)

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -31,6 +31,11 @@ class PostgresSchemaDialect extends SchemaDialect
     public const DEFAULT_SRID = 4326;
 
     /**
+     * @const string
+     */
+    public const GENERATED_BY_DEFAULT = 'BY DEFAULT';
+
+    /**
      * Generate the SQL to list the tables and views.
      *
      * @param array<string, mixed> $config The connection configuration to use for
@@ -769,7 +774,7 @@ class PostgresSchemaDialect extends SchemaDialect
         }
 
         if ($isAutoincrement && $identityVersion) {
-            $generated = $column['generated'] ?? 'BY DEFAULT';
+            $generated = $column['generated'] ?? static::GENERATED_BY_DEFAULT;
             $out .= ' GENERATED ' . $generated . ' AS IDENTITY';
         }
 

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -391,6 +391,38 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     }
 
     /**
+     * Get a column object for a given column name.
+     *
+     * Will raise an exception if the column does not exist.
+     *
+     * @param string $name The name of the column to get.
+     * @return \Cake\Database\Schema\Column
+     */
+    public function column(string $name): Column
+    {
+        if (!isset($this->_columns[$name])) {
+            $message = sprintf(
+                'Column `%s` of table `%s` does not exist.',
+                $name,
+                $this->_table,
+            );
+            throw new DatabaseException($message);
+        }
+
+        $column = new Column($name, $this->_columns[$name]['type']);
+        $attrs = [];
+        foreach ($this->_columns[$name] as $key => $value) {
+            if ($key === 'baseType' || $value === null) {
+                continue;
+            }
+            $attrs[$key] = $value;
+        }
+        $column->setOptions($attrs);
+
+        return $column;
+    }
+
+    /**
      * @inheritDoc
      */
     public function getColumnType(string $name): ?string

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -421,7 +421,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             }
             $attrs[$key] = $value;
         }
-        $column->setOptions($attrs);
+        $column->setAttributes($attrs);
 
         return $column;
     }

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -409,7 +409,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             throw new DatabaseException($message);
         }
 
-        $column = new Column($name, $this->_columns[$name]['type']);
+        $column = new Column();
         $attrs = [];
         foreach ($this->_columns[$name] as $key => $value) {
             if ($key === 'baseType' || $value === null) {

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -402,9 +402,9 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     {
         if (!isset($this->_columns[$name])) {
             $message = sprintf(
-                'Column `%s` of table `%s` does not exist.',
-                $name,
+                'Table `%s` does not contain a column named `%s`.',
                 $this->_table,
+                $name,
             );
             throw new DatabaseException($message);
         }

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -416,7 +416,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
                 continue;
             }
             if ($key === 'autoIncrement') {
-                // TODO what to do with this?
+                $attrs['identity'] = true;
                 continue;
             }
             $attrs[$key] = $value;

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -415,6 +415,10 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             if ($key === 'baseType' || $value === null) {
                 continue;
             }
+            if ($key === 'autoIncrement') {
+                // TODO what to do with this?
+                continue;
+            }
             $attrs[$key] = $value;
         }
         $column->setOptions($attrs);

--- a/tests/TestCase/Database/Schema/ColumnTest.php
+++ b/tests/TestCase/Database/Schema/ColumnTest.php
@@ -156,10 +156,10 @@ class ColumnTest extends TestCase
     public function testSetCollation(): void
     {
         $column = new Column();
-        $this->assertNull($column->getCollation());
+        $this->assertNull($column->getCollate());
 
-        $column->setCollation('utf8mb4_general_ci');
-        $this->assertSame('utf8mb4_general_ci', $column->getCollation());
+        $column->setCollate('utf8mb4_general_ci');
+        $this->assertSame('utf8mb4_general_ci', $column->getCollate());
     }
 
     public function testSetSrid(): void
@@ -189,13 +189,13 @@ class ColumnTest extends TestCase
             'length' => 255,
             'null' => false,
             'default' => 'default_value',
-            'collation' => 'utf8mb4_general_ci',
+            'collate' => 'utf8mb4_general_ci',
         ];
         $column->setOptions($options);
 
         $this->assertSame(255, $column->getLength());
         $this->assertFalse($column->isNull());
         $this->assertSame('default_value', $column->getDefault());
-        $this->assertSame('utf8mb4_general_ci', $column->getCollation());
+        $this->assertSame('utf8mb4_general_ci', $column->getCollate());
     }
 }

--- a/tests/TestCase/Database/Schema/ColumnTest.php
+++ b/tests/TestCase/Database/Schema/ColumnTest.php
@@ -100,14 +100,14 @@ class ColumnTest extends TestCase
         $this->assertSame('CURRENT_TIMESTAMP', $column->getOnUpdate());
     }
 
-    public function testSetOptionThrowsExceptionIfOptionIsNotString(): void
+    public function testSetAttributesThrowsExceptionIfOptionIsNotString(): void
     {
         $column = new Column();
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('"0" is not a valid column option.');
 
-        $column->setOptions(['identity']);
+        $column->setAttributes(['identity']);
     }
 
     public function testSetAfter(): void
@@ -142,13 +142,13 @@ class ColumnTest extends TestCase
         $this->assertFalse($column->isSigned());
     }
 
-    public function testSetOptionsIdentity(): void
+    public function testSetAttributesIdentity(): void
     {
         $column = new Column();
         $this->assertTrue($column->isNull());
         $this->assertFalse($column->isIdentity());
 
-        $column->setOptions(['identity' => true]);
+        $column->setAttributes(['identity' => true]);
         $this->assertFalse($column->isNull());
         $this->assertTrue($column->isIdentity());
     }
@@ -171,7 +171,7 @@ class ColumnTest extends TestCase
         $this->assertSame(4326, $column->getSrid());
     }
 
-    public function testSetOptions(): void
+    public function testSetAttributes(): void
     {
         $column = new Column();
         $options = [
@@ -181,7 +181,7 @@ class ColumnTest extends TestCase
             'default' => 'default_value',
             'collate' => 'utf8mb4_general_ci',
         ];
-        $column->setOptions($options);
+        $column->setAttributes($options);
 
         $this->assertSame(255, $column->getLength());
         $this->assertFalse($column->isNull());

--- a/tests/TestCase/Database/Schema/ColumnTest.php
+++ b/tests/TestCase/Database/Schema/ColumnTest.php
@@ -47,16 +47,16 @@ class ColumnTest extends TestCase
     public function testSetNull(): void
     {
         $column = new Column();
-        $this->assertFalse($column->isNull());
-        $this->assertFalse($column->getNull());
-
-        $column->setNull(true);
         $this->assertTrue($column->isNull());
         $this->assertTrue($column->getNull());
 
         $column->setNull(false);
         $this->assertFalse($column->isNull());
         $this->assertFalse($column->getNull());
+
+        $column->setNull(true);
+        $this->assertTrue($column->isNull());
+        $this->assertTrue($column->getNull());
     }
 
     public function testSetDefault(): void
@@ -145,7 +145,7 @@ class ColumnTest extends TestCase
     public function testSetOptionsIdentity(): void
     {
         $column = new Column();
-        $this->assertFalse($column->isNull());
+        $this->assertTrue($column->isNull());
         $this->assertFalse($column->isIdentity());
 
         $column->setOptions(['identity' => true]);
@@ -169,16 +169,6 @@ class ColumnTest extends TestCase
 
         $column->setSrid(4326);
         $this->assertSame(4326, $column->getSrid());
-    }
-
-    public function testColumnNullFeatureFlag(): void
-    {
-        $column = new Column();
-        $this->assertFalse($column->isNull());
-
-        Configure::write('Migrations.column_null_default', true);
-        $column = new Column();
-        $this->assertTrue($column->isNull());
     }
 
     public function testSetOptions(): void

--- a/tests/TestCase/Database/Schema/ColumnTest.php
+++ b/tests/TestCase/Database/Schema/ColumnTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Cake\Test\TestCase\Database\Schema;
 
-use Cake\Core\Configure;
 use Cake\Database\Schema\Column;
 use Cake\Database\Schema\PostgresSchemaDialect;
 use Cake\Database\Schema\TableSchemaInterface;

--- a/tests/TestCase/Database/Schema/ColumnTest.php
+++ b/tests/TestCase/Database/Schema/ColumnTest.php
@@ -1,0 +1,204 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Database\Schema;
+
+use Cake\Core\Configure;
+use Cake\Database\Schema\Column;
+use Cake\TestSuite\TestCase;
+use RuntimeException;
+
+class ColumnTest extends TestCase
+{
+    public function testSetName(): void
+    {
+        $column = new Column();
+        $this->assertNull($column->getName());
+
+        $column->setName('id');
+        $this->assertSame('id', $column->getName());
+    }
+
+    public function testSetType(): void
+    {
+        $column = new Column();
+        $this->assertNull($column->getType());
+
+        $column->setType('integer');
+        $this->assertSame('integer', $column->getType());
+    }
+
+    public function testSetTypeInvalid(): void
+    {
+        $column = new Column();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('"invalid" is not a valid column type.');
+
+        $column->setType('invalid');
+    }
+
+    public function testSetLength(): void
+    {
+        $column = new Column();
+        $this->assertNull($column->getLength());
+
+        $column->setLength(255);
+        $this->assertSame(255, $column->getLength());
+    }
+
+    public function testSetNull(): void
+    {
+        $column = new Column();
+        $this->assertTrue($column->isNull());
+        $this->assertNull($column->getNull());
+
+        $column->setNull(false);
+        $this->assertFalse($column->isNull());
+        $this->assertFalse($column->getNull());
+
+        $column->setNull(true);
+        $this->assertTrue($column->isNull());
+        $this->assertTrue($column->getNull());
+    }
+
+    public function testSetDefault(): void
+    {
+        $column = new Column();
+        $this->assertNull($column->getDefault());
+
+        $column->setDefault('default_value');
+        $this->assertSame('default_value', $column->getDefault());
+
+        // TODO literal values?
+    }
+
+    public function testSetGenerated(): void
+    {
+        $column = new Column();
+        $this->assertNull($column->getGenerated());
+
+        $column->setGenerated('by default');
+        $this->assertEquals('by default', $column->getGenerated());
+    }
+
+    public function testSetIdentity(): void
+    {
+        $column = new Column();
+        $this->assertFalse($column->isIdentity());
+
+        $column->setIdentity(true);
+        $this->assertTrue($column->isIdentity());
+        $this->assertTrue($column->getIdentity());
+
+        $column->setIdentity(false);
+        $this->assertFalse($column->isIdentity());
+        $this->assertFalse($column->getIdentity());
+    }
+
+    public function testSetOnUpdate(): void
+    {
+        $column = new Column();
+        $this->assertNull($column->getOnUpdate());
+
+        $column->setOnUpdate('CURRENT_TIMESTAMP');
+        $this->assertSame('CURRENT_TIMESTAMP', $column->getOnUpdate());
+    }
+
+    public function testSetOptionThrowsExceptionIfOptionIsNotString(): void
+    {
+        $column = new Column();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('"0" is not a valid column option.');
+
+        $column->setOptions(['identity']);
+    }
+
+    public function testSetAfter(): void
+    {
+        $column = new Column();
+        $this->assertNull($column->getAfter());
+
+        $column->setAfter('previous_column');
+        $this->assertSame('previous_column', $column->getAfter());
+    }
+
+    public function testSetComment(): void
+    {
+        $column = new Column();
+        $this->assertNull($column->getComment());
+
+        $column->setComment('This is a comment');
+        $this->assertSame('This is a comment', $column->getComment());
+    }
+
+    public function testSetSigned(): void
+    {
+        $column = new Column();
+        $this->assertNull($column->getSigned());
+
+        $column->setSigned(true);
+        $this->assertTrue($column->getSigned());
+
+        $column->setSigned(false);
+        $this->assertFalse($column->getSigned());
+    }
+
+    public function testSetOptionsIdentity(): void
+    {
+        $column = new Column();
+        $this->assertTrue($column->isNull());
+        $this->assertFalse($column->isIdentity());
+
+        $column->setOptions(['identity' => true]);
+        $this->assertFalse($column->isNull());
+        $this->assertTrue($column->isIdentity());
+    }
+
+    public function testSetCollation(): void
+    {
+        $column = new Column();
+        $this->assertNull($column->getCollation());
+
+        $column->setCollation('utf8mb4_general_ci');
+        $this->assertSame('utf8mb4_general_ci', $column->getCollation());
+    }
+
+    public function testSetSrid(): void
+    {
+        $column = new Column();
+        $this->assertNull($column->getSrid());
+
+        $column->setSrid(4326);
+        $this->assertSame(4326, $column->getSrid());
+    }
+
+    public function testColumnNullFeatureFlag(): void
+    {
+        $column = new Column();
+        $this->assertTrue($column->isNull());
+
+        Configure::write('Migrations.column_null_default', false);
+        $column = new Column();
+        $this->assertFalse($column->isNull());
+    }
+
+    public function testSetOptions(): void
+    {
+        $column = new Column();
+        $options = [
+            'type' => 'string',
+            'length' => 255,
+            'null' => false,
+            'default' => 'default_value',
+            'collation' => 'utf8mb4_general_ci',
+        ];
+        $column->setOptions($options);
+
+        $this->assertSame(255, $column->getLength());
+        $this->assertFalse($column->isNull());
+        $this->assertSame('default_value', $column->getDefault());
+        $this->assertSame('utf8mb4_general_ci', $column->getCollation());
+    }
+}

--- a/tests/TestCase/Database/Schema/ColumnTest.php
+++ b/tests/TestCase/Database/Schema/ColumnTest.php
@@ -128,16 +128,18 @@ class ColumnTest extends TestCase
         $this->assertSame('This is a comment', $column->getComment());
     }
 
-    public function testSetSigned(): void
+    public function testSetUnsigned(): void
     {
         $column = new Column();
-        $this->assertTrue($column->getSigned());
+        $this->assertTrue($column->getUnsigned());
 
-        $column->setSigned(false);
-        $this->assertFalse($column->getSigned());
+        $column->setUnsigned(false);
+        $this->assertFalse($column->getUnsigned());
 
-        $column->setSigned(true);
-        $this->assertTrue($column->getSigned());
+        $column->setUnsigned(true);
+        $this->assertTrue($column->getUnsigned());
+        $this->assertTrue($column->isUnsigned());
+        $this->assertFalse($column->isSigned());
     }
 
     public function testSetOptionsIdentity(): void

--- a/tests/TestCase/Database/Schema/ColumnTest.php
+++ b/tests/TestCase/Database/Schema/ColumnTest.php
@@ -5,6 +5,8 @@ namespace Cake\Test\TestCase\Database\Schema;
 
 use Cake\Core\Configure;
 use Cake\Database\Schema\Column;
+use Cake\Database\Schema\PostgresSchemaDialect;
+use Cake\Database\Schema\TableSchemaInterface;
 use Cake\TestSuite\TestCase;
 use RuntimeException;
 
@@ -13,7 +15,7 @@ class ColumnTest extends TestCase
     public function testSetName(): void
     {
         $column = new Column();
-        $this->assertNull($column->getName());
+        $this->assertEquals('', $column->getName());
 
         $column->setName('id');
         $this->assertSame('id', $column->getName());
@@ -22,20 +24,15 @@ class ColumnTest extends TestCase
     public function testSetType(): void
     {
         $column = new Column();
-        $this->assertNull($column->getType());
+        $this->assertEquals(TableSchemaInterface::TYPE_STRING, $column->getType());
 
         $column->setType('integer');
         $this->assertSame('integer', $column->getType());
-    }
 
-    public function testSetTypeInvalid(): void
-    {
-        $column = new Column();
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('"invalid" is not a valid column type.');
-
-        $column->setType('invalid');
+        // Types are not validated, so that we can preserve types we don't have specific handling
+        // for, as drivers and dialects can implement their own types.
+        $column->setType('imaginary');
+        $this->assertSame('imaginary', $column->getType());
     }
 
     public function testSetLength(): void
@@ -50,16 +47,16 @@ class ColumnTest extends TestCase
     public function testSetNull(): void
     {
         $column = new Column();
-        $this->assertTrue($column->isNull());
-        $this->assertNull($column->getNull());
-
-        $column->setNull(false);
         $this->assertFalse($column->isNull());
         $this->assertFalse($column->getNull());
 
         $column->setNull(true);
         $this->assertTrue($column->isNull());
         $this->assertTrue($column->getNull());
+
+        $column->setNull(false);
+        $this->assertFalse($column->isNull());
+        $this->assertFalse($column->getNull());
     }
 
     public function testSetDefault(): void
@@ -69,14 +66,12 @@ class ColumnTest extends TestCase
 
         $column->setDefault('default_value');
         $this->assertSame('default_value', $column->getDefault());
-
-        // TODO literal values?
     }
 
     public function testSetGenerated(): void
     {
         $column = new Column();
-        $this->assertNull($column->getGenerated());
+        $this->assertEquals(PostgresSchemaDialect::GENERATED_BY_DEFAULT, $column->getGenerated());
 
         $column->setGenerated('by default');
         $this->assertEquals('by default', $column->getGenerated());
@@ -136,19 +131,19 @@ class ColumnTest extends TestCase
     public function testSetSigned(): void
     {
         $column = new Column();
-        $this->assertNull($column->getSigned());
-
-        $column->setSigned(true);
         $this->assertTrue($column->getSigned());
 
         $column->setSigned(false);
         $this->assertFalse($column->getSigned());
+
+        $column->setSigned(true);
+        $this->assertTrue($column->getSigned());
     }
 
     public function testSetOptionsIdentity(): void
     {
         $column = new Column();
-        $this->assertTrue($column->isNull());
+        $this->assertFalse($column->isNull());
         $this->assertFalse($column->isIdentity());
 
         $column->setOptions(['identity' => true]);
@@ -177,11 +172,11 @@ class ColumnTest extends TestCase
     public function testColumnNullFeatureFlag(): void
     {
         $column = new Column();
-        $this->assertTrue($column->isNull());
-
-        Configure::write('Migrations.column_null_default', false);
-        $column = new Column();
         $this->assertFalse($column->isNull());
+
+        Configure::write('Migrations.column_null_default', true);
+        $column = new Column();
+        $this->assertTrue($column->isNull());
     }
 
     public function testSetOptions(): void

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -544,6 +544,18 @@ SQL;
                 $result->getColumn($field),
                 'Field definition does not match for ' . $field,
             );
+            $col = $result->column($field);
+            $this->assertEquals($definition['type'], $col->getType());
+            $this->assertEquals($definition['null'], $col->getNull());
+            $this->assertEquals($definition['length'], $col->getLength());
+            $this->assertEquals($definition['precision'], $col->getPrecision());
+            $this->assertEquals($definition['comment'], $col->getComment());
+            if (isset($definition['onUpdate'])) {
+                $this->assertEquals($definition['onUpdate'], $col->getOnUpdate());
+            }
+            if (isset($definition['collate'])) {
+                $this->assertEquals($definition['collate'], $col->getCollate());
+            }
         }
 
         $columns = $dialect->describeColumns('schema_articles');

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -544,17 +544,29 @@ SQL;
                 $result->getColumn($field),
                 'Field definition does not match for ' . $field,
             );
+
+            // Integration test for column() method.
             $col = $result->column($field);
             $this->assertEquals($definition['type'], $col->getType());
             $this->assertEquals($definition['null'], $col->getNull());
             $this->assertEquals($definition['length'], $col->getLength());
+            $this->assertEquals($definition['default'], $col->getDefault());
             $this->assertEquals($definition['precision'], $col->getPrecision());
             $this->assertEquals($definition['comment'], $col->getComment());
             if (isset($definition['onUpdate'])) {
                 $this->assertEquals($definition['onUpdate'], $col->getOnUpdate());
+            } else {
+                $this->assertNull($col->getOnUpdate());
             }
             if (isset($definition['collate'])) {
                 $this->assertEquals($definition['collate'], $col->getCollate());
+            } else {
+                $this->assertNull($col->getCollate());
+            }
+            if (isset($definition['autoIncrement'])) {
+                $this->assertEquals($definition['autoIncrement'], $col->getIdentity());
+            } else {
+                $this->assertFalse($col->getIdentity());
             }
         }
 

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -529,7 +529,7 @@ SQL;
             // https://mariadb.com/kb/en/json/
             $expected['config']['type'] = 'text';
             $expected['config']['length'] = 4294967295;
-            $expected['comment'] = '';
+            $expected['config']['comment'] = '';
             $expected['config']['collate'] = 'utf8mb4_bin';
         }
         if ($driver->isMariaDb() || version_compare($driver->version(), '8.0.30', '>=')) {

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -529,6 +529,33 @@ SQL;
             $expectedFields = array_intersect_key($expectedItem, $column);
             $resultFields = array_intersect_key($column, $expectedFields);
             $this->assertEquals($expectedFields, $resultFields, 'difference in ' . $column['name']);
+
+            // Integration test for column() method.
+            $col = $result->column($column['name']);
+            $this->assertEquals($column['type'], $col->getType());
+            $this->assertEquals($column['null'], $col->getNull());
+            $this->assertEquals($column['length'], $col->getLength());
+            $this->assertEquals($column['default'], $col->getDefault());
+            $this->assertEquals($column['comment'], $col->getComment());
+
+            if (isset($column['precision'])) {
+                $this->assertEquals($column['precision'], $col->getPrecision());
+            }
+            if (isset($column['onUpdate'])) {
+                $this->assertEquals($column['onUpdate'], $col->getOnUpdate());
+            } else {
+                $this->assertNull($col->getOnUpdate());
+            }
+            if (isset($column['collate'])) {
+                $this->assertEquals($column['collate'], $col->getCollate());
+            } else {
+                $this->assertNull($col->getCollate());
+            }
+            if (isset($column['autoIncrement'])) {
+                $this->assertEquals($column['autoIncrement'], $col->getIdentity());
+            } else {
+                $this->assertFalse($col->getIdentity());
+            }
         }
     }
 

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -886,7 +886,21 @@ SQL;
             $schemaAttrs = array_intersect_key($schemaField, $field);
             $expectedAttrs = array_intersect_key($field, $schemaAttrs);
             $this->assertEquals($expectedAttrs, $schemaAttrs);
+
+            // Integration test for column() method.
+            $col = $schema->column($field['name']);
+            $this->assertEquals($field['type'], $col->getType());
+            $this->assertEquals($field['null'], $col->getNull());
+            $this->assertEquals($field['length'], $col->getLength());
+            $this->assertEquals($field['default'], $col->getDefault());
+            $this->assertEquals($field['comment'], $col->getComment());
+            if (isset($field['autoIncrement'])) {
+                $this->assertEquals($field['autoIncrement'], $col->getIdentity());
+            } else {
+                $this->assertFalse($col->getIdentity());
+            }
         }
+
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -900,7 +900,6 @@ SQL;
                 $this->assertFalse($col->getIdentity());
             }
         }
-
     }
 
     /**

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -228,6 +228,8 @@ class TableSchemaTest extends TestCase
             'collate' => null,
         ];
         $this->assertEquals($expected, $result);
+        $column = $table->column('title');
+        $this->assertSame($expected['type'], $column->getType());
 
         $table->addColumn('author_id', [
             'type' => 'integer',
@@ -245,21 +247,29 @@ class TableSchemaTest extends TestCase
             'generated' => null,
         ];
         $this->assertEquals($expected, $result);
+        $column = $table->column('author_id');
+        $this->assertSame($expected['type'], $column->getType());
 
         $table->addColumn('amount', [
             'type' => 'decimal',
+            'length' => 10,
+            'precision' => 3,
         ]);
         $result = $table->getColumn('amount');
         $expected = [
             'type' => 'decimal',
-            'length' => null,
-            'precision' => null,
+            'length' => 10,
+            'precision' => 3,
             'default' => null,
             'null' => null,
             'unsigned' => null,
             'comment' => null,
         ];
         $this->assertEquals($expected, $result);
+        $column = $table->column('amount');
+        $this->assertSame($expected['type'], $column->getType());
+        $this->assertSame($expected['length'], $column->getLength());
+        $this->assertSame($expected['precision'], $column->getPrecision());
     }
 
     /**


### PR DESCRIPTION
Part of #18362. Import the `Column` object from migrations into cakephp. I think having an object based API for schema metadata would be a better API in the future. Having `Column` will help simplify migrations further (minus some deprecations in migrations).