### PR TITLE
update stan

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpstan" version="2.1.14" installed="2.1.14" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="2.1.17" installed="2.1.17" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,6 +17,8 @@ parameters:
 			identifier: missingType.generics
 		-
 			identifier: include.fileNotFound
+		-
+			identifier: method.internalClass
 
 services:
 	-

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -25,6 +25,7 @@ use Closure;
 use InvalidArgumentException;
 use JsonSerializable;
 use Psr\Http\Message\UploadedFileInterface;
+use RuntimeException;
 use SimpleXMLElement;
 use function Cake\Core\env;
 
@@ -1593,10 +1594,20 @@ class Message implements JsonSerializable
         }
 
         if ($this->appCharset === null) {
-            return mb_convert_encoding($text, $charset);
+            $encoded = mb_convert_encoding($text, $charset);
+            if ($encoded === false) {
+                throw new RuntimeException('mb_convert_encoding failed.');
+            }
+
+            return $encoded;
         }
 
-        return mb_convert_encoding($text, $charset, $this->appCharset);
+        $encoded = mb_convert_encoding($text, $charset, $this->appCharset);
+        if ($encoded === false) {
+            throw new RuntimeException('mb_convert_encoding failed.');
+        }
+
+        return $encoded;
     }
 
     /**


### PR DESCRIPTION
unset possibly hooked property reported this:
```
 ------ ------------------------------------------------------------------------------------------------------- 
  Line   Cache/Engine/FileEngine.php                                                                            
 ------ ------------------------------------------------------------------------------------------------------- 
  145    Cannot unset property Cake\Cache\Engine\FileEngine::$_File because it might have hooks in a subclass.  
         🪪 unset.possiblyHookedProperty                                                                        
  218    Cannot unset property Cake\Cache\Engine\FileEngine::$_File because it might have hooks in a subclass.  
         🪪 unset.possiblyHookedProperty                                                                        
  239    Cannot unset property Cake\Cache\Engine\FileEngine::$_File because it might have hooks in a subclass.  
         🪪 unset.possiblyHookedProperty                                                                        
  449    Cannot unset property Cake\Cache\Engine\FileEngine::$_File because it might have hooks in a subclass.  
         🪪 unset.possiblyHookedProperty                                                                        
 ------ ------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------- 
  Line   Console/ConsoleInput.php                                                                             
 ------ ----------------------------------------------------------------------------------------------------- 
  71     Cannot unset property Cake\Console\ConsoleInput::$_input because it might have hooks in a subclass.  
         🪪 unset.possiblyHookedProperty                                                                      
 ------ ----------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------- 
  Line   Console/ConsoleOutput.php                                                                              
 ------ ------------------------------------------------------------------------------------------------------- 
  388    Cannot unset property Cake\Console\ConsoleOutput::$_output because it might have hooks in a subclass.  
         🪪 unset.possiblyHookedProperty                                                                        
 ------ ------------------------------------------------------------------------------------------------------- 


 ------ ---------------------------------------------------------------------------------------------------------------- 
  Line   Mailer/Transport/SmtpTransport.php                                                                              
 ------ ---------------------------------------------------------------------------------------------------------------- 
  111    Cannot unset property Cake\Mailer\Transport\SmtpTransport::$_socket because it might have hooks in a subclass.  
         🪪 unset.possiblyHookedProperty                                                                                 
 ------ ---------------------------------------------------------------------------------------------------------------- 
```

and internalClass was
```

 ------ --------------------------------------------------------------------------------------------------------------------- 
  Line   TestSuite/Constraint/EventFired.php                                                                                  
 ------ --------------------------------------------------------------------------------------------------------------------- 
  46     Call to method __construct() of internal class PHPUnit\Framework\Exception from outside its root namespace PHPUnit.  
         🪪 method.internalClass                                                                                              
 ------ --------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------- 
  Line   TestSuite/Constraint/EventFiredWith.php                                                                              
 ------ --------------------------------------------------------------------------------------------------------------------- 
  54     Call to method __construct() of internal class PHPUnit\Framework\Exception from outside its root namespace PHPUnit.  
         🪪 method.internalClass                                                                                              
  92     Call to method __construct() of internal class PHPUnit\Framework\Exception from outside its root namespace PHPUnit.  
         🪪 method.internalClass                                                                                              
 ------ --------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------- 
  Line   TestSuite/Constraint/Response/ResponseBase.php                                                                       
 ------ --------------------------------------------------------------------------------------------------------------------- 
  43     Call to method __construct() of internal class PHPUnit\Framework\Exception from outside its root namespace PHPUnit.  
         🪪 method.internalClass                                                                                              
 ------ --------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------- 
  Line   TestSuite/Constraint/Session/FlashParamEquals.php                                                                    
 ------ --------------------------------------------------------------------------------------------------------------------- 
  63     Call to method __construct() of internal class PHPUnit\Framework\Exception from outside its root namespace PHPUnit.  
         🪪 method.internalClass                                                                                              
 ------ --------------------------------------------------------------------------------------------------------------------- 
```