### PR TITLE
Use the cloned query to get count instead of actual records in paginate()

### DIFF
--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -222,9 +222,10 @@ class NumericPaginator implements PaginatorInterface
         $data = $this->extractData($target, $params, $settings);
         $query = $this->getQuery($target, $query, $data);
 
-        $items = $this->getItems(clone $query, $data);
+        $countQuery = clone $query;
+        $items = $this->getItems($query, $data);
         $this->pagingParams['count'] = count($items);
-        $this->pagingParams['totalCount'] = $this->getCount($query, $data);
+        $this->pagingParams['totalCount'] = $this->getCount($countQuery, $data);
 
         $pagingParams = $this->buildParams($data);
         if ($pagingParams['requestedPage'] > $pagingParams['currentPage']) {


### PR DESCRIPTION
This avoids duplicate queries issue when users do weird things like call `all()` again on the query instance passed to `paginate()`.

Refs #18755

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
