### PR TITLE
Add lost DocBlock line to FileEngine.php

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -55,7 +55,8 @@ class FileEngine extends CacheEngine
      * - `path` Path to where cache files should be saved. Defaults to system's temp dir.
      * - `prefix` Prepended to all entries. Good for when you need to share a keyspace
      *    with either another cache config or another application.
-     *    cache::gc from ever being called automatically.
+     * - `probability` Probability of hitting a cache gc cleanup. Setting to 0 will disable
+     *    Cache::gc from ever being called automatically.
      * - `serialize` Should cache objects be serialized first.
      *
      * @var array<string, mixed>

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -55,8 +55,6 @@ class FileEngine extends CacheEngine
      * - `path` Path to where cache files should be saved. Defaults to system's temp dir.
      * - `prefix` Prepended to all entries. Good for when you need to share a keyspace
      *    with either another cache config or another application.
-     * - `probability` Probability of hitting a cache gc cleanup. Setting to 0 will disable
-     *    Cache::gc from ever being called automatically.
      * - `serialize` Should cache objects be serialized first.
      *
      * @var array<string, mixed>


### PR DESCRIPTION
Just adding a seemingly lost line to a DocBlock. Copied exact wording from [Cookbook](https://book.cakephp.org/5/en/core-libraries/caching.html#engine-options).

I have to mention though that I could not find any other usage of "probability" in the code, so it might be a unused remnant of the past, then it should be removed from code and cookbook as well.