### PR TITLE
Fixes InvalidArgumentException (#16362)

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -62,6 +62,7 @@ class EagerLoader
         'joinType' => 1,
         'strategy' => 1,
         'negateMatch' => 1,
+        'includeFields' => 1,
     ];
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6370,12 +6370,12 @@ class TableTest extends TestCase
 
         $entity = $table->get(2);
         $result = $table->loadInto($entity, [
-            'Articles' => function(SelectQuery $q) {
+            'Articles' => function (SelectQuery $q) {
                 return $q->innerJoinWith('Authors', function ($q) {
                     return $q->where(['Authors.name' => 'mariano']);
                 });
             },
-            'Articles.Authors'
+            'Articles.Authors',
         ]);
         $this->assertSame($entity, $result);
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6361,6 +6361,29 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests loadInto() with a belongsTo association with a join and contain on the same table
+     */
+    public function testLoadBelongsToDoubleJoin(): void
+    {
+        $table = $this->getTableLocator()->get('Comments');
+        $table->belongsTo('Articles');
+
+        $entity = $table->get(2);
+        $result = $table->loadInto($entity, [
+            'Articles' => function(SelectQuery $q) {
+                return $q->innerJoinWith('Authors', function ($q) {
+                    return $q->where(['Authors.name' => 'mariano']);
+                });
+            },
+            'Articles.Authors'
+        ]);
+        $this->assertSame($entity, $result);
+
+        $expected = $table->get(2, contain: ['Articles.Authors']);
+        $this->assertEquals($expected, $entity);
+    }
+
+    /**
      * Tests that it is possible to post-load associations for many entities at
      * the same time
      */

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6377,10 +6377,13 @@ class TableTest extends TestCase
             },
             'Articles.Authors',
         ]);
+
         $this->assertSame($entity, $result);
 
         $expected = $table->get(2, contain: ['Articles.Authors']);
         $this->assertEquals($expected, $entity);
+        $this->assertEquals($expected->article, $entity->article);
+        $this->assertEquals($expected->article->author, $entity->article->author);
     }
 
     /**


### PR DESCRIPTION
I also came across the issue described in #16362

The error happens when you contain a table that was joined earlier on.
In my case the join was added in the findAll method and performed a check on deleted items.
E.g. When an article is set to deleted I want to prevent it's comments from being loaded as well. 
And later on, when I used loadInto, it gave the exception.

It also happens when you add a join in the contain options, so that's how I decided to test it.
