### PR TITLE
Add proper constructors to Index and Column

### DIFF
--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -32,9 +32,9 @@ class Column
      *
      * @param string $name Name of the column
      * @param string $type Type of the column
-     * @param int|null $length Length of the column
      * @param bool $null Whether the column allows null values
      * @param mixed $default Default value for the column
+     * @param int|null $length Length of the column
      * @param bool $identity Whether the column is an identity column
      * @param string|null $generated Postgres identity option (always|default)
      * @param int|null $precision Precision for decimal or float columns
@@ -47,11 +47,11 @@ class Column
      * @param string|null $srid SRID for geometry fields
      */
     public function __construct(
-        protected string $name = '',
-        protected string $type = TableSchemaInterface::TYPE_STRING,
-        protected ?int $length = null,
+        protected string $name,
+        protected string $type,
         protected bool $null = true,
         protected mixed $default = null,
+        protected ?int $length = null,
         protected bool $identity = false,
         protected ?string $generated = PostgresSchemaDialect::GENERATED_BY_DEFAULT,
         protected ?int $precision = null,

--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -44,7 +44,7 @@ class Column
      * @param string|null $comment Comment for the column
      * @param bool $unsigned Whether the column is unsigned
      * @param string|null $collate Collation for the column
-     * @param string|null $srid SRID for geometry fields
+     * @param int|null $srid SRID for geometry fields
      */
     public function __construct(
         protected string $name,
@@ -417,29 +417,6 @@ class Column
     public function isUnsigned(): bool
     {
         return $this->getUnsigned();
-    }
-
-    /**
-     * Sets field properties.
-     *
-     * @param array $properties Properties
-     * @return $this
-     */
-    public function setProperties(array $properties)
-    {
-        $this->properties = $properties;
-
-        return $this;
-    }
-
-    /**
-     * Gets field properties
-     *
-     * @return array
-     */
-    public function getProperties(): array
-    {
-        return $this->properties;
     }
 
     /**

--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -28,86 +28,42 @@ use RuntimeException;
 class Column
 {
     /**
-     * @var string
-     */
-    protected string $name = '';
-
-    /**
-     * @var string
-     */
-    protected string $type = TableSchemaInterface::TYPE_STRING;
-
-    /**
-     * @var int|null
-     */
-    protected ?int $length = null;
-
-    /**
-     * @var bool
-     */
-    protected bool $null = true;
-
-    /**
-     * @var mixed
-     */
-    protected mixed $default = null;
-
-    /**
-     * @var bool
-     */
-    protected bool $identity = false;
-
-    /**
-     * Postgres-only column option for identity (always|default)
+     * Constructor.
      *
-     * @var ?string
+     * @param string $name Name of the column
+     * @param string $type Type of the column
+     * @param int|null $length Length of the column
+     * @param bool $null Whether the column allows null values
+     * @param mixed $default Default value for the column
+     * @param bool $identity Whether the column is an identity column
+     * @param string|null $generated Postgres identity option (always|default)
+     * @param int|null $precision Precision for decimal or float columns
+     * @param int|null $increment Increment for identity columns
+     * @param string|null $after Name of the column to add this column after
+     * @param string|null $onUpdate MySQL 'ON UPDATE' function
+     * @param string|null $comment Comment for the column
+     * @param bool $unsigned Whether the column is unsigned
+     * @param string|null $collate Collation for the column
+     * @param string|null $srid SRID for geometry fields
      */
-    protected ?string $generated = PostgresSchemaDialect::GENERATED_BY_DEFAULT;
-
-    /**
-     * @var int|null
-     */
-    protected ?int $precision = null;
-
-    /**
-     * @var int|null
-     */
-    protected ?int $increment = null;
-
-    /**
-     * @var string|null
-     */
-    protected ?string $after = null;
-
-    /**
-     * @var string|null
-     */
-    protected ?string $onUpdate = null;
-
-    /**
-     * @var string|null
-     */
-    protected ?string $comment = null;
-
-    /**
-     * @var bool
-     */
-    protected bool $unsigned = true;
-
-    /**
-     * @var array
-     */
-    protected array $properties = [];
-
-    /**
-     * @var string|null
-     */
-    protected ?string $collate = null;
-
-    /**
-     * @var int|null
-     */
-    protected ?int $srid = null;
+    public function __construct(
+        protected string $name = '',
+        protected string $type = TableSchemaInterface::TYPE_STRING,
+        protected ?int $length = null,
+        protected bool $null = true,
+        protected mixed $default = null,
+        protected bool $identity = false,
+        protected ?string $generated = PostgresSchemaDialect::GENERATED_BY_DEFAULT,
+        protected ?int $precision = null,
+        protected ?int $increment = null,
+        protected ?string $after = null,
+        protected ?string $onUpdate = null,
+        protected ?string $comment = null,
+        protected bool $unsigned = true,
+        protected ?string $collate = null,
+        protected ?int $srid = null,
+    ) {
+    }
 
     /**
      * Sets the column name.

--- a/src/Database/Schema/Index.php
+++ b/src/Database/Schema/Index.php
@@ -38,44 +38,28 @@ class Index
     public const FULLTEXT = TableSchema::INDEX_FULLTEXT;
 
     /**
-     * @var ?array<string>
+     * Constructor
+     *
+     * @param array<string>|null $columns The columns to index.
+     * @param string $type The type of index, e.g. 'index', 'fulltext'.
+     * @param ?string $name The name of the index.
+     * @param array<string, int>|int|null $length The length of the index.
+     * @param array<string>|null $order The sort order of the index columns.
+     * @param array<string>|null $includedColumns The included columns for covering indexes.
+     * @param bool $concurrent Whether the index should be created concurrently.
+     * @param ?string $where The where clause for partial indexes.
      */
-    protected ?array $columns = null;
-
-    /**
-     * @var string
-     */
-    protected string $type = self::INDEX;
-
-    /**
-     * @var string|null
-     */
-    protected ?string $name = null;
-
-    /**
-     * @var array|int|null
-     */
-    protected int|array|null $length = null;
-
-    /**
-     * @var ?array<string>
-     */
-    protected ?array $order = null;
-
-    /**
-     * @var ?array<string>
-     */
-    protected ?array $includedColumns = null;
-
-    /**
-     * @var bool
-     */
-    protected bool $concurrent = false;
-
-    /**
-     * @var string|null The where clause for partial indexes.
-     */
-    protected ?string $where = null;
+    public function __construct(
+        protected ?array $columns = null,
+        protected string $type = self::INDEX,
+        protected ?string $name = null,
+        protected array|int|null $length = null,
+        protected ?array $order = null,
+        protected ?array $includedColumns = null,
+        protected bool $concurrent = false,
+        protected ?string $where = null,
+    ) {
+    }
 
     /**
      * Sets the index columns.

--- a/src/Database/Schema/Index.php
+++ b/src/Database/Schema/Index.php
@@ -40,9 +40,9 @@ class Index
     /**
      * Constructor
      *
-     * @param array<string>|null $columns The columns to index.
+     * @param string $name The name of the index.
+     * @param array<string> $columns The columns to index.
      * @param string $type The type of index, e.g. 'index', 'fulltext'.
-     * @param ?string $name The name of the index.
      * @param array<string, int>|int|null $length The length of the index.
      * @param array<string>|null $order The sort order of the index columns.
      * @param array<string>|null $includedColumns The included columns for covering indexes.
@@ -50,9 +50,9 @@ class Index
      * @param ?string $where The where clause for partial indexes.
      */
     public function __construct(
-        protected ?array $columns = null,
+        protected string $name,
+        protected array $columns,
         protected string $type = self::INDEX,
-        protected ?string $name = null,
         protected array|int|null $length = null,
         protected ?array $order = null,
         protected ?array $includedColumns = null,

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -410,7 +410,6 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             throw new DatabaseException($message);
         }
 
-        $column = new Column();
         $data['name'] = $name;
         $attrs = [];
         foreach ($data as $key => $value) {
@@ -423,7 +422,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             }
             $attrs[$key] = $value;
         }
-        $column->setAttributes($attrs);
+        $column = new Column(...$attrs);
 
         return $column;
     }
@@ -620,8 +619,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             }
             $attrs[$key] = $value;
         }
-        $index = new Index();
-        $index->setAttributes($attrs);
+        $index = new Index(...$attrs);
 
         return $index;
     }

--- a/tests/TestCase/Database/Schema/ColumnTest.php
+++ b/tests/TestCase/Database/Schema/ColumnTest.php
@@ -13,8 +13,8 @@ class ColumnTest extends TestCase
 {
     public function testSetName(): void
     {
-        $column = new Column();
-        $this->assertEquals('', $column->getName());
+        $column = new Column('body', 'string');
+        $this->assertEquals('body', $column->getName());
 
         $column->setName('id');
         $this->assertSame('id', $column->getName());
@@ -22,7 +22,7 @@ class ColumnTest extends TestCase
 
     public function testSetType(): void
     {
-        $column = new Column();
+        $column = new Column('body', 'string');
         $this->assertEquals(TableSchemaInterface::TYPE_STRING, $column->getType());
 
         $column->setType('integer');
@@ -36,7 +36,7 @@ class ColumnTest extends TestCase
 
     public function testSetLength(): void
     {
-        $column = new Column();
+        $column = new Column('body', 'string');
         $this->assertNull($column->getLength());
 
         $column->setLength(255);
@@ -45,7 +45,7 @@ class ColumnTest extends TestCase
 
     public function testSetNull(): void
     {
-        $column = new Column();
+        $column = new Column('body', 'string');
         $this->assertTrue($column->isNull());
         $this->assertTrue($column->getNull());
 
@@ -60,7 +60,7 @@ class ColumnTest extends TestCase
 
     public function testSetDefault(): void
     {
-        $column = new Column();
+        $column = new Column('body', 'string');
         $this->assertNull($column->getDefault());
 
         $column->setDefault('default_value');
@@ -69,7 +69,7 @@ class ColumnTest extends TestCase
 
     public function testSetGenerated(): void
     {
-        $column = new Column();
+        $column = new Column('body', 'string');
         $this->assertEquals(PostgresSchemaDialect::GENERATED_BY_DEFAULT, $column->getGenerated());
 
         $column->setGenerated('by default');
@@ -78,7 +78,7 @@ class ColumnTest extends TestCase
 
     public function testSetIdentity(): void
     {
-        $column = new Column();
+        $column = new Column('body', 'string');
         $this->assertFalse($column->isIdentity());
 
         $column->setIdentity(true);
@@ -92,7 +92,7 @@ class ColumnTest extends TestCase
 
     public function testSetOnUpdate(): void
     {
-        $column = new Column();
+        $column = new Column('body', 'string');
         $this->assertNull($column->getOnUpdate());
 
         $column->setOnUpdate('CURRENT_TIMESTAMP');
@@ -101,7 +101,7 @@ class ColumnTest extends TestCase
 
     public function testSetAttributesThrowsExceptionIfOptionIsNotString(): void
     {
-        $column = new Column();
+        $column = new Column('body', 'string');
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('"0" is not a valid column option.');
@@ -111,7 +111,7 @@ class ColumnTest extends TestCase
 
     public function testSetAfter(): void
     {
-        $column = new Column();
+        $column = new Column('body', 'string');
         $this->assertNull($column->getAfter());
 
         $column->setAfter('previous_column');
@@ -120,7 +120,7 @@ class ColumnTest extends TestCase
 
     public function testSetComment(): void
     {
-        $column = new Column();
+        $column = new Column('body', 'string');
         $this->assertNull($column->getComment());
 
         $column->setComment('This is a comment');
@@ -129,7 +129,7 @@ class ColumnTest extends TestCase
 
     public function testSetUnsigned(): void
     {
-        $column = new Column();
+        $column = new Column('body', 'string');
         $this->assertTrue($column->getUnsigned());
 
         $column->setUnsigned(false);
@@ -143,7 +143,7 @@ class ColumnTest extends TestCase
 
     public function testSetAttributesIdentity(): void
     {
-        $column = new Column();
+        $column = new Column('body', 'string');
         $this->assertTrue($column->isNull());
         $this->assertFalse($column->isIdentity());
 
@@ -154,7 +154,7 @@ class ColumnTest extends TestCase
 
     public function testSetCollation(): void
     {
-        $column = new Column();
+        $column = new Column('body', 'string');
         $this->assertNull($column->getCollate());
 
         $column->setCollate('utf8mb4_general_ci');
@@ -163,7 +163,7 @@ class ColumnTest extends TestCase
 
     public function testSetSrid(): void
     {
-        $column = new Column();
+        $column = new Column('body', 'string');
         $this->assertNull($column->getSrid());
 
         $column->setSrid(4326);
@@ -172,7 +172,7 @@ class ColumnTest extends TestCase
 
     public function testSetAttributes(): void
     {
-        $column = new Column();
+        $column = new Column('body', 'string');
         $options = [
             'type' => 'string',
             'length' => 255,

--- a/tests/TestCase/Database/Schema/IndexTest.php
+++ b/tests/TestCase/Database/Schema/IndexTest.php
@@ -13,7 +13,7 @@ class IndexTest extends TestCase
 {
     public function testSetType(): void
     {
-        $index = new Index();
+        $index = new Index('title_idx', ['title']);
         $this->assertSame(Index::INDEX, $index->getType());
 
         $index->setType(Index::FULLTEXT);
@@ -25,8 +25,8 @@ class IndexTest extends TestCase
 
     public function testSetColumns(): void
     {
-        $index = new Index();
-        $this->assertNull($index->getColumns());
+        $index = new Index('title_idx', []);
+        $this->assertSame([], $index->getColumns());
 
         $index->setColumns(['title']);
         $this->assertSame(['title'], $index->getColumns());
@@ -37,8 +37,8 @@ class IndexTest extends TestCase
 
     public function testSetName(): void
     {
-        $index = new Index();
-        $this->assertNull($index->getName());
+        $index = new Index('title_idx', ['title']);
+        $this->assertSame('title_idx', $index->getName());
 
         $index->setName('my_index');
         $this->assertSame('my_index', $index->getName());
@@ -46,7 +46,7 @@ class IndexTest extends TestCase
 
     public function testSetLength(): void
     {
-        $index = new Index();
+        $index = new Index('title_idx', ['title']);
         $this->assertNull($index->getLength());
 
         $index->setLength(255);
@@ -59,7 +59,7 @@ class IndexTest extends TestCase
 
     public function testSetOrder(): void
     {
-        $index = new Index();
+        $index = new Index('title_idx', ['title']);
         $this->assertNull($index->getOrder());
 
         $index->setOrder(['title' => 'ASC']);
@@ -71,7 +71,7 @@ class IndexTest extends TestCase
 
     public function testSetInclude(): void
     {
-        $index = new Index();
+        $index = new Index('title_idx', ['title']);
         $this->assertNull($index->getInclude());
 
         $index->setInclude(['title']);
@@ -86,7 +86,7 @@ class IndexTest extends TestCase
 
     public function testSetConcurrently(): void
     {
-        $index = new Index();
+        $index = new Index('title_idx', ['title']);
         $this->assertFalse($index->getConcurrently());
 
         $index->setConcurrently(true);
@@ -98,7 +98,7 @@ class IndexTest extends TestCase
 
     public function testSetWhere(): void
     {
-        $index = new Index();
+        $index = new Index('title_idx', ['title']);
         $this->assertNull($index->getWhere());
 
         $index->setWhere('status = 1');
@@ -110,7 +110,7 @@ class IndexTest extends TestCase
 
     public function testSetAttributes(): void
     {
-        $index = new Index();
+        $index = new Index('title_idx', ['title']);
         $attrs = [
             'name' => 'index-name',
             'columns' => ['title', 'name'],


### PR DESCRIPTION
Having proper constructors seems reasonable now that we have named parameters and spread operators.
