### PR TITLE
Reword exception message.

### DIFF
--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -746,7 +746,7 @@ class QueryExpression implements ExpressionInterface, Countable
         if ($value === null && $this->_conjunction !== ',') {
             throw new InvalidArgumentException(
                 sprintf(
-                    'Expression `%s` with invalid `null` value.'
+                    'Expression `%s` has invalid `null` value.'
                     . ' If `null` is a valid value, operator (IS, IS NOT) is missing.',
                     $expression,
                 ),

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -745,7 +745,11 @@ class QueryExpression implements ExpressionInterface, Countable
 
         if ($value === null && $this->_conjunction !== ',') {
             throw new InvalidArgumentException(
-                sprintf('Expression `%s` is missing operator (IS, IS NOT) with `null` value.', $expression),
+                sprintf(
+                    'Expression `%s` with invalid `null` value.'
+                    . ' If `null` is a valid value, operator (IS, IS NOT) is missing.',
+                    $expression,
+                ),
             );
         }
 

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -3486,7 +3486,7 @@ class SelectQueryTest extends TestCase
     public function testIsNullInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expression `%s` has invalid `null` value. If `null` is a valid value, operator (IS, IS NOT) is missing.');
+        $this->expectExceptionMessage('Expression `name` has invalid `null` value. If `null` is a valid value, operator (IS, IS NOT) is missing.');
 
         (new SelectQuery($this->connection))
             ->select(['name'])

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -3486,7 +3486,7 @@ class SelectQueryTest extends TestCase
     public function testIsNullInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expression `%s` with invalid `null` value. If `null` is a valid value, operator (IS, IS NOT) is missing.');
+        $this->expectExceptionMessage('Expression `%s` has invalid `null` value. If `null` is a valid value, operator (IS, IS NOT) is missing.');
 
         (new SelectQuery($this->connection))
             ->select(['name'])

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -3486,7 +3486,7 @@ class SelectQueryTest extends TestCase
     public function testIsNullInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expression `name` is missing operator (IS, IS NOT) with `null` value.');
+        $this->expectExceptionMessage('Expression `%s` with invalid `null` value. If `null` is a valid value, operator (IS, IS NOT) is missing.');
 
         (new SelectQuery($this->connection))
             ->select(['name'])


### PR DESCRIPTION
For some newer (cake>3) devs the message isnt too clear:

    Expression `account_id` is missing operator (IS, IS NOT) with `null` value. 

They are confused on what to do.

Maybe we can rephrase to the actual meaning of this in default case?
When the value was not passed, but expected to be there.

And add the solution to a valid nullable as 2nd sentence maybe?