### PR TITLE
Add more clear error source

### DIFF
--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -17,7 +17,9 @@ declare(strict_types=1);
 namespace Cake\Event;
 
 use Cake\Core\Exception\CakeException;
+use Closure;
 use InvalidArgumentException;
+use ReflectionFunction;
 use function Cake\Core\deprecationWarning;
 
 /**
@@ -335,14 +337,16 @@ class EventManager implements EventManagerInterface
             } catch (CakeException) {
                 $class = 'unknown subject';
             }
-            
-            $ref = new \ReflectionFunction($listener);
-            $closureClass = $ref->getClosureScopeClass();
-            $clousereMethod = $ref->getName();
-            if ($closureClass && $closureClass->name && $clousereMethod) {
-                $class = $closureClass->name . '::' . $clousereMethod;
+
+            if ($listener instanceof Closure) {
+                $ref = new ReflectionFunction($listener);
+                $closureClass = $ref->getClosureScopeClass();
+                $closureMethod = $ref->getName();
+                if ($closureClass && $closureClass->name && $closureMethod) {
+                    $class = $closureClass->name . '::' . $closureMethod . '()';
+                }
             }
-            
+
             deprecationWarning(
                 '5.2.0',
                 'Returning a value from event listeners is deprecated. ' .

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -335,6 +335,14 @@ class EventManager implements EventManagerInterface
             } catch (CakeException) {
                 $class = 'unknown subject';
             }
+            
+            $ref = new \ReflectionFunction($listener);
+            $closureClass = $ref->getClosureScopeClass();
+            $clousereMethod = $ref->getName();
+            if ($closureClass && $closureClass->name && $clousereMethod) {
+                $class = $closureClass->name . '::' . $clousereMethod;
+            }
+            
             deprecationWarning(
                 '5.2.0',
                 'Returning a value from event listeners is deprecated. ' .


### PR DESCRIPTION
Sometimes, there are nested components in controllers. There could be the case were a controller uses a component X that actually runs the event with a invalid return. It would be helpful to see what is the component and function that actually triggers the warning (instead of the name of the event subject, that is most often just the controller name)

This is just a sketch, to be considered in the future as a potential help for developers