### PR TITLE
Backport #18763 to 4.x - Fixes InvalidArgumentException

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -64,6 +64,7 @@ class EagerLoader
         'joinType' => 1,
         'strategy' => 1,
         'negateMatch' => 1,
+        'includeFields' => 1,
     ];
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6377,7 +6377,7 @@ class TableTest extends TestCase
 
         $this->assertSame($entity, $result);
 
-        $expected = $table->get(2, contain: ['Articles.Authors']);
+        $expected = $table->get(2, ['contain' => ['Articles.Authors']]);
         $this->assertEquals($expected, $entity);
         $this->assertEquals($expected->article, $entity->article);
         $this->assertEquals($expected->article->author, $entity->article->author);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6358,6 +6358,32 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests loadInto() with a belongsTo association with a join and contain on the same table
+     */
+    public function testLoadBelongsToDoubleJoin(): void
+    {
+        $table = $this->getTableLocator()->get('Comments');
+        $table->belongsTo('Articles');
+
+        $entity = $table->get(2);
+        $result = $table->loadInto($entity, [
+            'Articles' => function (SelectQuery $q) {
+                return $q->innerJoinWith('Authors', function ($q) {
+                    return $q->where(['Authors.name' => 'mariano']);
+                });
+            },
+            'Articles.Authors',
+        ]);
+
+        $this->assertSame($entity, $result);
+
+        $expected = $table->get(2, contain: ['Articles.Authors']);
+        $this->assertEquals($expected, $entity);
+        $this->assertEquals($expected->article, $entity->article);
+        $this->assertEquals($expected->article->author, $entity->article->author);
+    }
+
+    /**
      * Tests that it is possible to post-load associations for many entities at
      * the same time
      */


### PR DESCRIPTION
* Fixes InvalidArgumentException when joining and containing the same table in a loadInto call
* Fix phpcs Errors
* Add assertions on article and author in TableTest::testloadBelongsToDoubleJoin

Backport #18763 to 4.x