### PR TITLE
Add deferrable constraints

### DIFF
--- a/src/Database/Schema/ForeignKey.php
+++ b/src/Database/Schema/ForeignKey.php
@@ -31,6 +31,9 @@ class ForeignKey extends Constraint
     public const RESTRICT = TableSchema::ACTION_RESTRICT;
     public const SET_NULL = TableSchema::ACTION_SET_NULL;
     public const NO_ACTION = TableSchema::ACTION_NO_ACTION;
+    public const DEFERRED = 'DEFERRABLE INITIALLY DEFERRED';
+    public const IMMEDIATE = 'DEFERRABLE INITIALLY IMMEDIATE';
+    public const NOT_DEFERRED = 'NOT DEFERRABLE';
 
     /**
      * An allow list of valid actions
@@ -55,6 +58,11 @@ class ForeignKey extends Constraint
     protected ?string $update = null;
 
     /**
+     * @var string|null
+     */
+    protected ?string $deferrable = null;
+
+    /**
      * Constructor
      *
      * @param string $name The name of the index.
@@ -71,11 +79,12 @@ class ForeignKey extends Constraint
         protected array $referencedColumns = [],
         ?string $delete = null,
         ?string $update = null,
+        ?string $deferrable = null,
     ) {
-        // TODO add deferrable
         $this->type = self::FOREIGN;
         $this->delete = $this->normalizeAction($delete ?? self::NO_ACTION);
         $this->update = $this->normalizeAction($update ?? self::NO_ACTION);
+        $this->deferrable = $this->normalizeDeferrable($deferrable ?? self::IMMEDIATE);
     }
 
     /**
@@ -184,5 +193,51 @@ class ForeignKey extends Constraint
             return $action;
         }
         throw new InvalidArgumentException('Unknown action passed: ' . $action);
+    }
+
+    /**
+     * Sets deferrable mode for the foreign key.
+     *
+     * @param string $deferrable Constraint
+     * @return $this
+     */
+    public function setDeferrable(string $deferrable)
+    {
+        $this->deferrable= $this->normalizeDeferrable($deferrable);
+
+        return $this;
+    }
+
+    /**
+     * Gets deferrable mode for the foreign key.
+     */
+    public function getDeferrable(): ?string
+    {
+        return $this->deferrable;
+    }
+
+    /**
+     * From passed value checks if it's correct and fixes if needed
+     *
+     * @param string $deferrable Deferrable
+     * @throws \InvalidArgumentException
+     * @return string
+     */
+    protected function normalizeDeferrable(string $deferrable): string
+    {
+        $mapping = [
+            'DEFERRED' => ForeignKey::DEFERRED,
+            'IMMEDIATE' => ForeignKey::IMMEDIATE,
+            'NOT DEFERRED' => ForeignKey::NOT_DEFERRED,
+            ForeignKey::DEFERRED => ForeignKey::DEFERRED,
+            ForeignKey::IMMEDIATE => ForeignKey::IMMEDIATE,
+            ForeignKey::NOT_DEFERRED => ForeignKey::NOT_DEFERRED,
+        ];
+        $normalized = strtoupper(str_replace('_', ' ', $deferrable));
+        if (array_key_exists($normalized, $mapping)) {
+            return $mapping[$normalized];
+        }
+
+        throw new InvalidArgumentException('Unknown deferrable passed: ' . $deferrable);
     }
 }

--- a/src/Database/Schema/ForeignKey.php
+++ b/src/Database/Schema/ForeignKey.php
@@ -205,7 +205,7 @@ class ForeignKey extends Constraint
      */
     public function setDeferrable(string $deferrable)
     {
-        $this->deferrable= $this->normalizeDeferrable($deferrable);
+        $this->deferrable = $this->normalizeDeferrable($deferrable);
 
         return $this;
     }

--- a/src/Database/Schema/ForeignKey.php
+++ b/src/Database/Schema/ForeignKey.php
@@ -84,7 +84,9 @@ class ForeignKey extends Constraint
         $this->type = self::FOREIGN;
         $this->delete = $this->normalizeAction($delete ?? self::NO_ACTION);
         $this->update = $this->normalizeAction($update ?? self::NO_ACTION);
-        $this->deferrable = $this->normalizeDeferrable($deferrable ?? self::IMMEDIATE);
+        if ($deferrable) {
+            $this->deferrable = $this->normalizeDeferrable($deferrable);
+        }
     }
 
     /**

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -515,6 +515,7 @@ class PostgresSchemaDialect extends SchemaDialect
             'references' => [$row['references_table'], $row['references_field']],
             'update' => $this->_convertOnClause($row['on_update']),
             'delete' => $this->_convertOnClause($row['on_delete']),
+            'deferrable' => $this->convertDeferrable($row),
         ];
         $schema->addConstraint($row['name'], $data);
     }
@@ -538,6 +539,7 @@ class PostgresSchemaDialect extends SchemaDialect
                     'references' => [$row['references_table'], []],
                     'update' => $this->_convertOnClause($row['on_update']),
                     'delete' => $this->_convertOnClause($row['on_delete']),
+                    'deferrable' => $this->convertDeferrable($row),
                 ];
             }
             // column indexes start at 1
@@ -576,7 +578,9 @@ class PostgresSchemaDialect extends SchemaDialect
         c.confdeltype AS on_delete,
         c.confrelid::regclass AS references_table,
         ab.attname AS references_field,
-        array_position(c.confkey, ab.attnum) AS references_field_order
+        array_position(c.confkey, ab.attnum) AS references_field_order,
+        c.condeferrable AS deferrable,
+        c.condeferred AS initially_deferred
         FROM pg_catalog.pg_namespace n
         INNER JOIN pg_catalog.pg_class cl ON (n.oid = cl.relnamespace)
         INNER JOIN pg_catalog.pg_constraint c ON (n.oid = c.connamespace)
@@ -614,6 +618,27 @@ class PostgresSchemaDialect extends SchemaDialect
         }
 
         return TableSchema::ACTION_SET_NULL;
+    }
+
+    /**
+     * Convert deferrable option from the postgres metadata into a string
+     *
+     * @param array $row The row to convert.
+     * @return string|null The deferrable value or null if not deferrable.
+     */
+    protected function convertDeferrable(array $row): ?string
+    {
+        if (!isset($row['deferrable'])) {
+            return null;
+        }
+        if (!$row['deferrable']) {
+            return ForeignKey::NOT_DEFERRED;
+        }
+        if (isset($row['initially_deferred']) && $row['initially_deferred']) {
+            return ForeignKey::DEFERRED;
+        }
+
+        return ForeignKey::IMMEDIATE;
     }
 
     /**

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -898,12 +898,14 @@ class PostgresSchemaDialect extends SchemaDialect
         );
         if ($data['type'] === TableSchema::CONSTRAINT_FOREIGN) {
             return $prefix . sprintf(
-                ' FOREIGN KEY (%s) REFERENCES %s (%s) ON UPDATE %s ON DELETE %s DEFERRABLE INITIALLY IMMEDIATE',
+                ' FOREIGN KEY (%s) REFERENCES %s (%s) ON UPDATE %s ON DELETE %s %s',
                 implode(', ', $columns),
                 $this->_driver->quoteIdentifier($data['references'][0]),
                 $this->_convertConstraintColumns($data['references'][1]),
                 $this->_foreignOnClause($data['update']),
                 $this->_foreignOnClause($data['delete']),
+                // Historically CakePHP used 'DEFERRABLE INITIALLY IMEDIATE, and this maintains backwards compat.
+                $data['deferrable'] ?? ForeignKey::IMMEDIATE,
             );
         }
 

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -212,6 +212,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         'update' => 'restrict',
         'delete' => 'restrict',
         'constraint' => null,
+        'deferrable' => null,
     ];
 
     /**
@@ -544,7 +545,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         }
         $attrs = array_intersect_key($attrs, static::$_indexKeys);
         $attrs += static::$_indexKeys;
-        unset($attrs['references'], $attrs['update'], $attrs['delete'], $attrs['constraint']);
+        unset($attrs['references'], $attrs['update'], $attrs['delete'], $attrs['constraint'], $attrs['deferrable']);
 
         if (!in_array($attrs['type'], static::$_validIndexTypes, true)) {
             throw new DatabaseException(sprintf(
@@ -698,7 +699,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
                 return $this;
             }
         } else {
-            unset($attrs['references'], $attrs['update'], $attrs['delete']);
+            unset($attrs['references'], $attrs['update'], $attrs['delete'], $attrs['deferrable']);
         }
 
         $this->_constraints[$name] = $attrs;
@@ -818,6 +819,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
                 'referencedColumns' => (array)$attrs['references'][1],
                 'update' => $attrs['update'],
                 'delete' => $attrs['delete'],
+                'deferrable' => $attrs['deferrable'] ?? null,
             ];
         } elseif ($type === static::CONSTRAINT_PRIMARY) {
             $attrs = [

--- a/tests/TestCase/Database/Schema/ForeignKeyTest.php
+++ b/tests/TestCase/Database/Schema/ForeignKeyTest.php
@@ -104,11 +104,25 @@ class ForeignKeyTest extends TestCase
         $key->setDelete('invalid');
     }
 
-    public function setDefaultLength(): void
+    public function testSetDeferrable(): void
     {
-        // capture the current behavior.
-        // TODO: This method shouldn't exist. Separate UniqueKey from Constraint.
         $key = new ForeignKey('title_idx', ['title'], 'users', ['id']);
-        $this->assertSame([], $key->getLength());
+        $this->assertEquals(ForeignKey::IMMEDIATE, $key->getDeferrable());
+
+        $key->setDeferrable(ForeignKey::DEFERRED);
+        $this->assertEquals(ForeignKey::DEFERRED, $key->getDeferrable());
+
+        $key->setDeferrable(ForeignKey::IMMEDIATE);
+        $this->assertEquals(ForeignKey::IMMEDIATE, $key->getDeferrable());
+
+        $key->setDeferrable(ForeignKey::NOT_DEFERRED);
+        $this->assertEquals(ForeignKey::NOT_DEFERRED, $key->getDeferrable());
+    }
+
+    public function testSetDeferrableInvalid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $key = new ForeignKey('title_idx', ['title'], 'users', ['id']);
+        $key->setDeferrable('invalid');
     }
 }

--- a/tests/TestCase/Database/Schema/ForeignKeyTest.php
+++ b/tests/TestCase/Database/Schema/ForeignKeyTest.php
@@ -107,7 +107,7 @@ class ForeignKeyTest extends TestCase
     public function testSetDeferrable(): void
     {
         $key = new ForeignKey('title_idx', ['title'], 'users', ['id']);
-        $this->assertEquals(ForeignKey::IMMEDIATE, $key->getDeferrable());
+        $this->assertNull($key->getDeferrable());
 
         $key->setDeferrable(ForeignKey::DEFERRED);
         $this->assertEquals(ForeignKey::DEFERRED, $key->getDeferrable());

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -715,6 +715,7 @@ SQL;
                 'length' => [],
                 'update' => 'cascade',
                 'delete' => 'restrict',
+                'deferrable' => null,
             ],
             'unique_id_idx' => [
                 'type' => 'unique',

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -88,7 +88,15 @@ created_without_precision TIMESTAMP(0),
 created_with_precision TIMESTAMP(3),
 created_with_timezone timestamp with time zone,
 CONSTRAINT "content_idx" UNIQUE ("title", "body"),
-CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+CONSTRAINT "author_idx" FOREIGN KEY ("author_id")
+    REFERENCES "schema_authors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+    DEFERRABLE INITIALLY DEFERRED,
+CONSTRAINT "author_idx_immediate" FOREIGN KEY ("author_id")
+    REFERENCES "schema_authors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+    DEFERRABLE INITIALLY IMMEDIATE,
+CONSTRAINT "author_idx_not" FOREIGN KEY ("author_id")
+    REFERENCES "schema_authors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+    NOT DEFERRABLE
 )
 SQL;
         $connection->execute($table);
@@ -788,7 +796,7 @@ SQL;
         $result = $dialect->describe('schema_articles');
         $this->assertInstanceOf(TableSchema::class, $result);
 
-        $this->assertCount(4, $result->constraints());
+        $this->assertCount(6, $result->constraints());
         $expected = [
             'primary' => [
                 'type' => 'primary',
@@ -808,7 +816,25 @@ SQL;
                 'length' => [],
                 'update' => 'cascade',
                 'delete' => 'restrict',
-                'deferrable' => null,
+                'deferrable' => ForeignKey::DEFERRED,
+            ],
+            'author_idx_immediate' => [
+                'type' => 'foreign',
+                'columns' => ['author_id'],
+                'references' => ['schema_authors', 'id'],
+                'length' => [],
+                'update' => 'cascade',
+                'delete' => 'restrict',
+                'deferrable' => ForeignKey::IMMEDIATE,
+            ],
+            'author_idx_not' => [
+                'type' => 'foreign',
+                'columns' => ['author_id'],
+                'references' => ['schema_authors', 'id'],
+                'length' => [],
+                'update' => 'cascade',
+                'delete' => 'restrict',
+                'deferrable' => ForeignKey::NOT_DEFERRED,
             ],
             'unique_id_idx' => [
                 'type' => 'unique',
@@ -820,7 +846,7 @@ SQL;
         ];
         foreach ($expected as $name => $expectedItem) {
             // Compare both the array API and the Schema\Constraint API.
-            $this->assertEquals($expectedItem, $result->getConstraint($name));
+            $this->assertEquals($expectedItem, $result->getConstraint($name), "mismatch in {$name} constraint");
             $this->assertConstraint($expectedItem, $name, $result);
         }
 

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -808,6 +808,7 @@ SQL;
                 'length' => [],
                 'update' => 'cascade',
                 'delete' => 'restrict',
+                'deferrable' => null,
             ],
             'unique_id_idx' => [
                 'type' => 'unique',
@@ -1361,6 +1362,18 @@ SQL;
                 ['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'noAction'],
                 'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
                 'REFERENCES "authors" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT DEFERRABLE INITIALLY IMMEDIATE',
+            ],
+            [
+                'author_id_idx',
+                [
+                    'type' => 'foreign',
+                    'columns' => ['author_id'],
+                    'references' => ['authors', 'id'],
+                    'update' => 'noAction',
+                    'deferrable' => ForeignKey::DEFERRED,
+                ],
+                'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
+                'REFERENCES "authors" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED',
             ],
         ];
     }

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -814,7 +814,7 @@ SQL;
             ],
         ];
         foreach ($expected as $name => $constraint) {
-            $this->assertSame($constraint, $result->getConstraint($name), "does not match $name constraint");
+            $this->assertSame($constraint, $result->getConstraint($name), "does not match {$name} constraint");
         }
         $this->assertCount(3, $result->constraints());
 

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -588,6 +588,7 @@ SQL;
                 'length' => [],
                 'update' => 'cascade',
                 'delete' => 'restrict',
+                'deferrable' => null,
             ],
             'unique_id_idx' => [
                 'type' => 'unique',
@@ -795,6 +796,7 @@ SQL;
                 'update' => 'cascade',
                 'delete' => 'noAction',
                 'length' => [],
+                'deferrable' => null,
             ],
             'author_fk' => [
                 'type' => 'foreign',
@@ -808,10 +810,11 @@ SQL;
                 'update' => 'cascade',
                 'delete' => 'restrict',
                 'length' => [],
+                'deferrable' => null,
             ],
         ];
         foreach ($expected as $name => $constraint) {
-            $this->assertSame($constraint, $result->getConstraint($name));
+            $this->assertSame($constraint, $result->getConstraint($name), "does not match $name constraint");
         }
         $this->assertCount(3, $result->constraints());
 
@@ -1326,6 +1329,18 @@ SQL;
                 ['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'noAction'],
                 'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
                 'REFERENCES "authors" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT',
+            ],
+            [
+                'author_id_idx',
+                [
+                    'type' => 'foreign',
+                    'columns' => ['author_id'],
+                    'references' => ['authors', 'id'],
+                    'update' => 'noAction',
+                    'deferrable' => ForeignKey::DEFERRED,
+                ],
+                'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
+                'REFERENCES "authors" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED',
             ],
         ];
     }

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -627,6 +627,7 @@ SQL;
                 'length' => [],
                 'update' => 'cascade',
                 'delete' => 'cascade',
+                'deferrable' => null,
             ],
             'unique_id_idx' => [
                 'type' => 'unique',

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -563,6 +563,7 @@ class TableSchemaTest extends TestCase
             'update' => 'cascade',
             'delete' => 'cascade',
             'length' => [],
+            'deferrable' => null,
         ];
         $this->assertEquals($expected, $compositeConstraint);
 

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Database\Schema;
 
 use Cake\Database\Driver\Postgres;
 use Cake\Database\Exception\DatabaseException;
+use Cake\Database\Schema\ForeignKey;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionManager;
@@ -553,6 +554,7 @@ class TableSchemaTest extends TestCase
     public function testConstraintForeignKey(): void
     {
         $table = $this->getTableLocator()->get('ArticlesTags');
+        $driver = $table->getConnection()->getDriver();
 
         $name = 'tag_id_fk';
         $compositeConstraint = $table->getSchema()->getConstraint($name);
@@ -565,6 +567,10 @@ class TableSchemaTest extends TestCase
             'length' => [],
             'deferrable' => null,
         ];
+        // Postgres reflection always includes deferrable state.
+        if ($driver instanceof Postgres) {
+            $expected['deferrable'] = ForeignKey::IMMEDIATE;
+        }
         $this->assertEquals($expected, $compositeConstraint);
 
         $expectedSubstring = "CONSTRAINT <{$name}> FOREIGN KEY \\(<tag_id>\\) REFERENCES <tags> \\(<id>\\)";

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -613,6 +613,7 @@ class TableSchemaTest extends TestCase
             'update' => 'cascade',
             'delete' => 'cascade',
             'length' => [],
+            'deferrable' => null,
         ];
         $this->assertEquals($expected, $compositeConstraint);
 


### PR DESCRIPTION
Port behavior from migrations/phinx to support deferrable foreign keys. I've implemented it so far for sqlite and postgres. MySQL doesn't support this behavior to my knowledge. Sqlserver also does not support deferrable constraints :melting_face: 

### TODO

- [x] schema reflection for postgres