### PR TITLE
5.3 - Use new schema objects in TableSchema 

### DIFF
--- a/src/Database/Schema/Constraint.php
+++ b/src/Database/Schema/Constraint.php
@@ -122,4 +122,19 @@ class Constraint
     {
         return $this->name;
     }
+
+    /**
+     * Converts a constraint to an array that is compatible
+     * with the constructor.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'type' => $this->type,
+            'columns' => $this->columns,
+        ];
+    }
 }

--- a/src/Database/Schema/ForeignKey.php
+++ b/src/Database/Schema/ForeignKey.php
@@ -128,6 +128,27 @@ class ForeignKey extends Constraint
     }
 
     /**
+     * Converts the foreign key to an array that is compatible
+     * with the constructor.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $data = [
+            'name' => $this->name,
+            'type' => $this->type,
+            'columns' => $this->columns,
+            'referencedTable' => $this->referencedTable,
+            'referencedColumns' => $this->referencedColumns,
+            'delete' => $this->delete,
+            'update' => $this->update,
+        ];
+
+        return $data;
+    }
+
+    /**
      * Sets ON DELETE action for the foreign key.
      *
      * @param string $delete On Delete

--- a/src/Database/Schema/ForeignKey.php
+++ b/src/Database/Schema/ForeignKey.php
@@ -135,7 +135,7 @@ class ForeignKey extends Constraint
      */
     public function toArray(): array
     {
-        $data = [
+        return [
             'name' => $this->name,
             'type' => $this->type,
             'columns' => $this->columns,
@@ -144,8 +144,6 @@ class ForeignKey extends Constraint
             'delete' => $this->delete,
             'update' => $this->update,
         ];
-
-        return $data;
     }
 
     /**

--- a/src/Database/Schema/ForeignKey.php
+++ b/src/Database/Schema/ForeignKey.php
@@ -27,10 +27,11 @@ use InvalidArgumentException;
  */
 class ForeignKey extends Constraint
 {
-    public const CASCADE = TableSchema::ACTION_CASCADE;
-    public const RESTRICT = TableSchema::ACTION_RESTRICT;
-    public const SET_NULL = TableSchema::ACTION_SET_NULL;
-    public const NO_ACTION = TableSchema::ACTION_NO_ACTION;
+    public const CASCADE = 'cascade';
+    public const RESTRICT = 'restrict';
+    public const SET_NULL = 'setNull';
+    public const NO_ACTION = 'noAction';
+    public const SET_DEFAULT = 'setDefault';
 
     /**
      * An allow list of valid actions
@@ -42,6 +43,7 @@ class ForeignKey extends Constraint
         self::RESTRICT,
         self::SET_NULL,
         self::NO_ACTION,
+        self::SET_DEFAULT,
     ];
 
     /**

--- a/src/Database/Schema/Index.php
+++ b/src/Database/Schema/Index.php
@@ -27,6 +27,7 @@ use RuntimeException;
  */
 class Index
 {
+    // TODO change the direction of these.
     /**
      * @var string
      */

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -631,7 +631,6 @@ class SqliteSchemaDialect extends SchemaDialect
                     'references' => [$row['table'], []],
                     'update' => $this->_convertOnClause($row['on_update'] ?? ''),
                     'delete' => $this->_convertOnClause($row['on_delete'] ?? ''),
-                    'length' => [],
                 ];
             }
             $keys[$id]['columns'][$row['seq']] = $row['from'];

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -820,8 +820,17 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
                 $constraint->getReferencedTable(),
                 $constraint->getReferencedColumns(),
             ];
+            // If there is only one referenced column, we return it as a string.
+            // TODO this should be deprecated, but I don't know how to warn about it.
+            if (count($data['references'][1]) === 1) {
+                $data['references'][1] = $data['references'][1][0];
+            }
             unset($data['referencedTable'], $data['referencedColumns']);
         }
+        if ($constraint->getType() === static::CONSTRAINT_PRIMARY && $name === 'primary') {
+            $data['constraint'] = $constraint->getName();
+        }
+        unset($data['name']);
 
         return $data;
     }

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -683,31 +683,12 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             }
         }
 
-        /// start copy-paste
-        $data['name'] = $data['constraint'] ?? $name;
-        unset($data['constraint']);
-
-        $attrs = [];
-        foreach ($data as $key => $value) {
-            if ($value === null) {
-                continue;
-            }
-            $attrs[$key] = $value;
-        }
+        $attrs['name'] = $attrs['constraint'] ?? $name;
+        unset($attrs['constraint']);
 
         $type = $attrs['type'] ?? null;
         if ($type === static::CONSTRAINT_FOREIGN) {
             $attrs = $this->_checkForeignKey($attrs);
-            // Map the backwards compatible attributes in. Need to check for existing instance.
-            // TODO continue here, got tired.
-            $attrs = [
-                'name' => $attrs['name'],
-                'columns' => $attrs['columns'],
-                'referencedTable' => $attrs['references'][0],
-                'referencedColumns' => (array)$attrs['references'][1],
-                'update' => $attrs['update'],
-                'delete' => $attrs['delete'],
-            ];
         } elseif ($type === static::CONSTRAINT_PRIMARY) {
             $attrs = [
                 'type' => $type,
@@ -721,19 +702,8 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
                 'length' => $attrs['length'],
             ];
         }
-
-        return match ($type) {
-            static::CONSTRAINT_UNIQUE => new UniqueKey(...$attrs),
-            static::CONSTRAINT_FOREIGN => new ForeignKey(...$attrs),
-            static::CONSTRAINT_PRIMARY => new Constraint(...$attrs),
-            default => new Constraint(...$attrs),
-        };
-        // end copy paste
-
-        if ($attrs['type'] === static::CONSTRAINT_FOREIGN) {
-            $attrs = $this->_checkForeignKey($attrs);
-
-            if (isset($this->_constraints[$name])) {
+        if ($type === static::CONSTRAINT_FOREIGN) {
+            if (isset($this->_constraints[$name]) && $this->_constraints[$name] instanceof ForeignKey) {
                 $constraint = $this->_constraints[$name];
                 assert($constraint instanceof ForeignKey, "{$name} must be a ForeignKey instance.");
 
@@ -755,7 +725,12 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             unset($attrs['references'], $attrs['update'], $attrs['delete']);
         }
 
-        $this->_constraints[$name] = new ForeignKey(...$attrs);
+        $this->_constraints[$name] = match ($type) {
+            static::CONSTRAINT_UNIQUE => new UniqueKey(...$attrs),
+            static::CONSTRAINT_FOREIGN => new ForeignKey(...$attrs),
+            static::CONSTRAINT_PRIMARY => new Constraint(...$attrs),
+            default => new Constraint(...$attrs),
+        };
 
         return $this;
     }
@@ -813,6 +788,11 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             ));
         }
 
+        // Map the backwards compatible attributes in. Need to check for existing instance.
+        $attrs['referencedTable'] = $attrs['references'][0];
+        $attrs['referencedColumns'] = (array)$attrs['references'][1];
+        unset($attrs['type'], $attrs['references'], $attrs['length']);
+
         return $attrs;
     }
 
@@ -834,7 +814,16 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             return null;
         }
 
-        return $constraint->toArray();
+        $data = $constraint->toArray();
+        if ($constraint instanceof ForeignKey) {
+            $data['references'] = [
+                $constraint->getReferencedTable(),
+                $constraint->getReferencedColumns(),
+            ];
+            unset($data['referencedTable'], $data['referencedColumns']);
+        }
+
+        return $data;
     }
 
     /**
@@ -848,8 +837,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function constraint(string $name): Constraint
     {
-        $data = $this->getConstraint($name);
-        if ($data === null) {
+        if (!isset($this->_constraints[$name])) {
             $message = sprintf(
                 'Table `%s` does not contain a constraint named `%s`.',
                 $this->_table,
@@ -857,47 +845,8 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             );
             throw new DatabaseException($message);
         }
-        $data['name'] = $data['constraint'] ?? $name;
-        unset($data['constraint']);
 
-        $attrs = [];
-        foreach ($data as $key => $value) {
-            if ($value === null) {
-                continue;
-            }
-            $attrs[$key] = $value;
-        }
-
-        $type = $attrs['type'] ?? null;
-        if ($type === static::CONSTRAINT_FOREIGN) {
-            $attrs = [
-                'name' => $attrs['name'],
-                'columns' => $attrs['columns'],
-                'referencedTable' => $attrs['references'][0],
-                'referencedColumns' => (array)$attrs['references'][1],
-                'update' => $attrs['update'],
-                'delete' => $attrs['delete'],
-            ];
-        } elseif ($type === static::CONSTRAINT_PRIMARY) {
-            $attrs = [
-                'type' => $type,
-                'name' => $attrs['name'],
-                'columns' => $attrs['columns'],
-            ];
-        } elseif ($type === static::CONSTRAINT_UNIQUE) {
-            $attrs = [
-                'name' => $attrs['name'],
-                'columns' => $attrs['columns'],
-                'length' => $attrs['length'],
-            ];
-        }
-
-        return match ($type) {
-            static::CONSTRAINT_UNIQUE => new UniqueKey(...$attrs),
-            static::CONSTRAINT_FOREIGN => new ForeignKey(...$attrs),
-            static::CONSTRAINT_PRIMARY => new Constraint(...$attrs),
-            default => new Constraint(...$attrs),
-        };
+        return $this->_constraints[$name];
     }
 
     /**

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -636,7 +636,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     {
         foreach ($this->_constraints as $data) {
             if ($data->getType() === static::CONSTRAINT_PRIMARY) {
-                return $data->getColumns();
+                return (array)$data->getColumns();
             }
         }
 
@@ -703,12 +703,10 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             ];
         }
         if ($type === static::CONSTRAINT_FOREIGN) {
-            if (isset($this->_constraints[$name]) && $this->_constraints[$name] instanceof ForeignKey) {
-                $constraint = $this->_constraints[$name];
-                assert($constraint instanceof ForeignKey, "{$name} must be a ForeignKey instance.");
-
+            $constraint = $this->_constraints[$name] ?? null;
+            if ($constraint instanceof ForeignKey) {
                 $constraint->setColumns(array_unique(array_merge(
-                    $constraint->getColumns(),
+                    (array)$constraint->getColumns(),
                     $attrs['columns'],
                 )));
 

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -828,7 +828,10 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             unset($data['referencedTable'], $data['referencedColumns']);
         }
         if ($constraint->getType() === static::CONSTRAINT_PRIMARY && $name === 'primary') {
-            $data['constraint'] = $constraint->getName();
+            $alias = $constraint->getName();
+            if ($alias !== 'primary') {
+                $data['constraint'] = $alias;
+            }
         }
         unset($data['name']);
 

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -64,7 +64,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * Constraints in the table.
      *
-     * @var array<string, array<string, mixed>>
+     * @var array<string, \Cake\Database\Schema\Constraint>
      */
     protected array $_constraints = [];
 
@@ -635,8 +635,8 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     public function getPrimaryKey(): array
     {
         foreach ($this->_constraints as $data) {
-            if ($data['type'] === static::CONSTRAINT_PRIMARY) {
-                return $data['columns'];
+            if ($data->getType() === static::CONSTRAINT_PRIMARY) {
+                return $data->getColumns();
             }
         }
 
@@ -683,20 +683,70 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             }
         }
 
+        /// start copy-paste
+        $data['name'] = $data['constraint'] ?? $name;
+        unset($data['constraint']);
+
+        $attrs = [];
+        foreach ($data as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+            $attrs[$key] = $value;
+        }
+
+        $type = $attrs['type'] ?? null;
+        if ($type === static::CONSTRAINT_FOREIGN) {
+            $attrs = $this->_checkForeignKey($attrs);
+            // Map the backwards compatible attributes in. Need to check for existing instance.
+            // TODO continue here, got tired.
+            $attrs = [
+                'name' => $attrs['name'],
+                'columns' => $attrs['columns'],
+                'referencedTable' => $attrs['references'][0],
+                'referencedColumns' => (array)$attrs['references'][1],
+                'update' => $attrs['update'],
+                'delete' => $attrs['delete'],
+            ];
+        } elseif ($type === static::CONSTRAINT_PRIMARY) {
+            $attrs = [
+                'type' => $type,
+                'name' => $attrs['name'],
+                'columns' => $attrs['columns'],
+            ];
+        } elseif ($type === static::CONSTRAINT_UNIQUE) {
+            $attrs = [
+                'name' => $attrs['name'],
+                'columns' => $attrs['columns'],
+                'length' => $attrs['length'],
+            ];
+        }
+
+        return match ($type) {
+            static::CONSTRAINT_UNIQUE => new UniqueKey(...$attrs),
+            static::CONSTRAINT_FOREIGN => new ForeignKey(...$attrs),
+            static::CONSTRAINT_PRIMARY => new Constraint(...$attrs),
+            default => new Constraint(...$attrs),
+        };
+        // end copy paste
+
         if ($attrs['type'] === static::CONSTRAINT_FOREIGN) {
             $attrs = $this->_checkForeignKey($attrs);
 
             if (isset($this->_constraints[$name])) {
-                $this->_constraints[$name]['columns'] = array_unique(array_merge(
-                    $this->_constraints[$name]['columns'],
-                    $attrs['columns'],
-                ));
+                $constraint = $this->_constraints[$name];
+                assert($constraint instanceof ForeignKey, "{$name} must be a ForeignKey instance.");
 
-                if (isset($this->_constraints[$name]['references'])) {
-                    $this->_constraints[$name]['references'][1] = array_unique(array_merge(
-                        (array)$this->_constraints[$name]['references'][1],
+                $constraint->setColumns(array_unique(array_merge(
+                    $constraint->getColumns(),
+                    $attrs['columns'],
+                )));
+
+                if ($constraint->getReferencedTable()) {
+                    $constraint->setColumns(array_unique(array_merge(
+                        (array)$constraint->getReferencedColumns(),
                         [$attrs['references'][1]],
-                    ));
+                    )));
                 }
 
                 return $this;
@@ -705,7 +755,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             unset($attrs['references'], $attrs['update'], $attrs['delete']);
         }
 
-        $this->_constraints[$name] = $attrs;
+        $this->_constraints[$name] = new ForeignKey(...$attrs);
 
         return $this;
     }
@@ -779,7 +829,12 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function getConstraint(string $name): ?array
     {
-        return $this->_constraints[$name] ?? null;
+        $constraint = $this->_constraints[$name] ?? null;
+        if ($constraint === null) {
+            return null;
+        }
+
+        return $constraint->toArray();
     }
 
     /**

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -288,35 +288,35 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      *
      * @var string
      */
-    public const ACTION_CASCADE = 'cascade';
+    public const ACTION_CASCADE = ForeignKey::CASCADE;
 
     /**
      * Foreign key set null action
      *
      * @var string
      */
-    public const ACTION_SET_NULL = 'setNull';
+    public const ACTION_SET_NULL = ForeignKey::SET_NULL;
 
     /**
      * Foreign key no action
      *
      * @var string
      */
-    public const ACTION_NO_ACTION = 'noAction';
+    public const ACTION_NO_ACTION = ForeignKey::NO_ACTION;
 
     /**
      * Foreign key restrict action
      *
      * @var string
      */
-    public const ACTION_RESTRICT = 'restrict';
+    public const ACTION_RESTRICT = ForeignKey::RESTRICT;
 
     /**
      * Foreign key restrict default
      *
      * @var string
      */
-    public const ACTION_SET_DEFAULT = 'setDefault';
+    public const ACTION_SET_DEFAULT = ForeignKey::SET_DEFAULT;
 
     /**
      * Constructor.
@@ -345,6 +345,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function addColumn(string $name, $attrs)
     {
+        // TODO use index object here.
         if (is_string($attrs)) {
             $attrs = ['type' => $attrs];
         }
@@ -539,6 +540,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function addIndex(string $name, $attrs)
     {
+        // TODO use index object here.
         if (is_string($attrs)) {
             $attrs = ['type' => $attrs];
         }
@@ -589,6 +591,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             return null;
         }
 
+        // TODO use index object and convert to an array
         return $this->_indexes[$name];
     }
 
@@ -602,6 +605,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function index(string $name): Index
     {
+        // TODO use index object
         $data = $this->getIndex($name);
         if ($data === null) {
             $message = sprintf(

--- a/src/Database/Schema/UniqueKey.php
+++ b/src/Database/Schema/UniqueKey.php
@@ -136,4 +136,20 @@ class UniqueKey extends Constraint
     {
         return $this->length;
     }
+
+    /**
+     * Converts a constraint to an array that is compatible
+     * with the constructor.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'type' => $this->type,
+            'columns' => $this->columns,
+            'length' => $this->length,
+        ];
+    }
 }

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -699,7 +699,6 @@ SQL;
             'primary' => [
                 'type' => 'primary',
                 'columns' => ['id'],
-                'length' => [],
             ],
             'length_idx' => [
                 'type' => 'unique',
@@ -712,7 +711,6 @@ SQL;
                 'type' => 'foreign',
                 'columns' => ['author_id'],
                 'references' => ['schema_authors', 'id'],
-                'length' => [],
                 'update' => 'cascade',
                 'delete' => 'restrict',
             ],

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -719,11 +719,10 @@ SQL;
             'primary' => [
                 'type' => 'primary',
                 'columns' => ['id'],
-                'name' => 'schema_authors_pkey',
+                'constraint' => 'schema_authors_pkey',
             ],
             'unique_position' => [
                 'type' => 'unique',
-                'name' => 'unique_position',
                 'columns' => ['position'],
                 'length' => [],
             ],
@@ -792,26 +791,23 @@ SQL;
         $expected = [
             'primary' => [
                 'type' => 'primary',
-                'name' => 'schema_articles_pkey',
                 'columns' => ['id'],
+                'constraint' => 'schema_articles_pkey',
             ],
             'content_idx' => [
                 'type' => 'unique',
-                'name' => 'content_idx',
                 'columns' => ['title', 'body'],
                 'length' => [],
             ],
             'author_idx' => [
                 'type' => 'foreign',
-                'name' => 'author_idx',
                 'columns' => ['author_id'],
-                'references' => ['schema_authors', ['id']],
+                'references' => ['schema_authors', 'id'],
                 'update' => 'cascade',
                 'delete' => 'restrict',
             ],
             'unique_id_idx' => [
                 'type' => 'unique',
-                'name' => 'unique_id_idx',
                 'columns' => [
                     'unique_id',
                 ],
@@ -831,10 +827,6 @@ SQL;
             'length' => [],
         ];
         $this->assertEquals($authorIdx, $result->getIndex('author_idx'));
-
-        // Basic schema API returns the column as a string if there is only one.
-        $expected['author_idx']['references'][1] = 'id';
-        $expected['primary']['name'] = 'primary';
 
         // Compare describeForeignKeys()
         $keys = $dialect->describeForeignKeys('schema_articles');
@@ -877,12 +869,7 @@ SQL;
                     $this->assertEquals([], $value);
                     continue;
                 }
-                // Primary key names are different in different layers :(
-                // We could align the names, but risk breaking compatibility.
-                if ($key === 'name' && $value === 'primary') {
-                    continue;
-                }
-                $this->assertEquals($value, $indexObj->{'get' . ucfirst($key)}(), "Mismatch in {$name} index for {$key}");
+                $this->assertEquals($value, $indexObj->{'get' . ucfirst($key)}());
             }
         }
     }

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -719,11 +719,11 @@ SQL;
             'primary' => [
                 'type' => 'primary',
                 'columns' => ['id'],
-                'length' => [],
-                'constraint' => 'schema_authors_pkey',
+                'name' => 'schema_authors_pkey',
             ],
             'unique_position' => [
                 'type' => 'unique',
+                'name' => 'unique_position',
                 'columns' => ['position'],
                 'length' => [],
             ],
@@ -792,25 +792,26 @@ SQL;
         $expected = [
             'primary' => [
                 'type' => 'primary',
+                'name' => 'schema_articles_pkey',
                 'columns' => ['id'],
-                'length' => [],
-                'constraint' => 'schema_articles_pkey',
             ],
             'content_idx' => [
                 'type' => 'unique',
+                'name' => 'content_idx',
                 'columns' => ['title', 'body'],
                 'length' => [],
             ],
             'author_idx' => [
                 'type' => 'foreign',
+                'name' => 'author_idx',
                 'columns' => ['author_id'],
-                'references' => ['schema_authors', 'id'],
-                'length' => [],
+                'references' => ['schema_authors', ['id']],
                 'update' => 'cascade',
                 'delete' => 'restrict',
             ],
             'unique_id_idx' => [
                 'type' => 'unique',
+                'name' => 'unique_id_idx',
                 'columns' => [
                     'unique_id',
                 ],
@@ -830,6 +831,10 @@ SQL;
             'length' => [],
         ];
         $this->assertEquals($authorIdx, $result->getIndex('author_idx'));
+
+        // Basic schema API returns the column as a string if there is only one.
+        $expected['author_idx']['references'][1] = 'id';
+        $expected['primary']['name'] = 'primary';
 
         // Compare describeForeignKeys()
         $keys = $dialect->describeForeignKeys('schema_articles');
@@ -872,7 +877,12 @@ SQL;
                     $this->assertEquals([], $value);
                     continue;
                 }
-                $this->assertEquals($value, $indexObj->{'get' . ucfirst($key)}());
+                // Primary key names are different in different layers :(
+                // We could align the names, but risk breaking compatibility.
+                if ($key === 'name' && $value === 'primary') {
+                    continue;
+                }
+                $this->assertEquals($value, $indexObj->{'get' . ucfirst($key)}(), "Mismatch in {$name} index for {$key}");
             }
         }
     }

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -574,7 +574,6 @@ SQL;
             'primary' => [
                 'type' => 'primary',
                 'columns' => ['id'],
-                'length' => [],
             ],
             'title_idx' => [
                 'type' => 'unique',
@@ -585,7 +584,6 @@ SQL;
                 'type' => 'foreign',
                 'columns' => ['author_id'],
                 'references' => ['schema_authors', 'id'],
-                'length' => [],
                 'update' => 'cascade',
                 'delete' => 'restrict',
             ],

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -775,10 +775,7 @@ SQL;
         $expected = [
             'primary' => [
                 'type' => 'primary',
-                'columns' => [
-                    'id',
-                ],
-                'length' => [],
+                'columns' => ['id'],
             ],
             'multi_col_author_fk' => [
                 'type' => 'foreign',
@@ -792,7 +789,6 @@ SQL;
                 ],
                 'update' => 'cascade',
                 'delete' => 'noAction',
-                'length' => [],
             ],
             'author_fk' => [
                 'type' => 'foreign',
@@ -805,11 +801,10 @@ SQL;
                 ],
                 'update' => 'cascade',
                 'delete' => 'restrict',
-                'length' => [],
             ],
         ];
         foreach ($expected as $name => $constraint) {
-            $this->assertSame($constraint, $result->getConstraint($name));
+            $this->assertEquals($constraint, $result->getConstraint($name));
         }
         $this->assertCount(3, $result->constraints());
 

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -613,7 +613,6 @@ SQL;
             'primary' => [
                 'type' => 'primary',
                 'columns' => ['id'],
-                'length' => [],
             ],
             'content_idx' => [
                 'type' => 'unique',
@@ -624,7 +623,6 @@ SQL;
                 'type' => 'foreign',
                 'columns' => ['author_id'],
                 'references' => ['schema_authors', 'id'],
-                'length' => [],
                 'update' => 'cascade',
                 'delete' => 'cascade',
             ],

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -560,7 +560,7 @@ class TableSchemaTest extends TestCase
             'name' => 'tag_id_fk',
             'type' => 'foreign',
             'columns' => ['tag_id'],
-            'references' => ['tags', ['id']],
+            'references' => ['tags', 'id'],
             'update' => 'cascade',
             'delete' => 'cascade',
         ];

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -557,12 +557,12 @@ class TableSchemaTest extends TestCase
         $name = 'tag_id_fk';
         $compositeConstraint = $table->getSchema()->getConstraint($name);
         $expected = [
+            'name' => 'tag_id_fk',
             'type' => 'foreign',
             'columns' => ['tag_id'],
-            'references' => ['tags', 'id'],
+            'references' => ['tags', ['id']],
             'update' => 'cascade',
             'delete' => 'cascade',
-            'length' => [],
         ];
         $this->assertEquals($expected, $compositeConstraint);
 

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -557,7 +557,6 @@ class TableSchemaTest extends TestCase
         $name = 'tag_id_fk';
         $compositeConstraint = $table->getSchema()->getConstraint($name);
         $expected = [
-            'name' => 'tag_id_fk',
             'type' => 'foreign',
             'columns' => ['tag_id'],
             'references' => ['tags', 'id'],
@@ -611,7 +610,6 @@ class TableSchemaTest extends TestCase
             ],
             'update' => 'cascade',
             'delete' => 'cascade',
-            'length' => [],
         ];
         $this->assertEquals($expected, $compositeConstraint);
 


### PR DESCRIPTION
I'd like the internals of `TableSchema` to move towards the object based model instead of arrays. This will improve type safety, but also aligns reflection with the rest of the direction we're taking elsewhere in the framework. These objects also gives us a good set of models to use in migrations, as they can become value objects that are using in `$table->addForeignKey($key)` style APIs.

Part of #18362

### TODO

- [x] MySQL support
- [x] Sqlserver support?