### PR TITLE
5.3 Use Index inside of TableSchema

### DIFF
--- a/src/Database/Schema/Index.php
+++ b/src/Database/Schema/Index.php
@@ -31,12 +31,12 @@ class Index
     /**
      * @var string
      */
-    public const INDEX = TableSchema::INDEX_INDEX;
+    public const INDEX = 'index';
 
     /**
      * @var string
      */
-    public const FULLTEXT = TableSchema::INDEX_FULLTEXT;
+    public const FULLTEXT = 'fulltext';
 
     /**
      * Constructor
@@ -268,7 +268,7 @@ class Index
     public function setAttributes(array $attributes)
     {
         // Valid Options
-        $validOptions = ['columns', 'concurrently', 'type', 'name', 'length', 'order', 'include', 'where'];
+        $validOptions = ['columns', 'concurrent', 'type', 'name', 'length', 'order', 'include', 'where'];
         foreach ($attributes as $attr => $value) {
             if (!in_array($attr, $validOptions, true)) {
                 throw new RuntimeException(sprintf('"%s" is not a valid index option.', $attr));

--- a/src/Database/Schema/Index.php
+++ b/src/Database/Schema/Index.php
@@ -218,7 +218,7 @@ class Index
      * @param bool $value The concurrent mode for an index.
      * @return $this
      */
-    public function setConcurrently(bool $value)
+    public function setConcurrent(bool $value)
     {
         $this->concurrent = $value;
 
@@ -230,7 +230,7 @@ class Index
      *
      * @return bool
      */
-    public function getConcurrently(): bool
+    public function getConcurrent(): bool
     {
         return $this->concurrent;
     }
@@ -278,5 +278,24 @@ class Index
         }
 
         return $this;
+    }
+
+    /**
+     * Convert an index into an array that is compatible with the Index constructor.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->getName(),
+            'columns' => $this->getColumns(),
+            'type' => $this->getType(),
+            'length' => $this->getLength(),
+            'order' => $this->getOrder(),
+            'include' => $this->getInclude(),
+            'concurrent' => $this->getConcurrent(),
+            'where' => $this->getWhere(),
+        ];
     }
 }

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -563,6 +563,9 @@ class SqliteSchemaDialect extends SchemaDialect
                 'columns' => $columns,
                 'length' => [],
             ];
+            if ($indexType === TableSchema::INDEX_INDEX) {
+                $indexes[$indexName]['concurrent'] = false;
+            }
         }
         // Primary keys aren't always available from the index_info pragma
         // instead we have to read the columns again.

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -275,14 +275,14 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      *
      * @var string
      */
-    public const INDEX_INDEX = 'index';
+    public const INDEX_INDEX = Index ::INDEX;
 
     /**
      * Fulltext index type
      *
      * @var string
      */
-    public const INDEX_FULLTEXT = 'fulltext';
+    public const INDEX_FULLTEXT = Index::FULLTEXT;
 
     /**
      * Foreign key cascade action

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -57,7 +57,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * Indexes in the table.
      *
-     * @var array<string, array>
+     * @var array<string, \Cake\Database\Schema\Index>
      */
     protected array $_indexes = [];
 
@@ -541,10 +541,6 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function addIndex(string $name, $attrs)
     {
-        // TODO use index object here.
-        if (is_string($attrs)) {
-            $attrs = ['type' => $attrs];
-        }
         $attrs = array_intersect_key($attrs, static::$_indexKeys);
         $attrs += static::$_indexKeys;
         unset($attrs['references'], $attrs['update'], $attrs['delete'], $attrs['constraint'], $attrs['deferrable']);
@@ -570,7 +566,9 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
                 throw new DatabaseException($msg);
             }
         }
-        $this->_indexes[$name] = $attrs;
+        $attrs['name'] = $name;
+
+        $this->_indexes[$name] = new Index(...$attrs);
 
         return $this;
     }
@@ -591,9 +589,18 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         if (!isset($this->_indexes[$name])) {
             return null;
         }
+        $index = $this->_indexes[$name];
+        $attrs = $index->toArray();
 
-        // TODO use index object and convert to an array
-        return $this->_indexes[$name];
+        $optional = ['order', 'include', 'concurrent', 'where'];
+        foreach ($optional as $key) {
+            if ($attrs[$key] === null) {
+                unset($attrs[$key]);
+            }
+        }
+        unset($attrs['name']);
+
+        return $attrs;
     }
 
     /**
@@ -606,9 +613,8 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function index(string $name): Index
     {
-        // TODO use index object
-        $data = $this->getIndex($name);
-        if ($data === null) {
+        $index = $this->_indexes[$name] ?? null;
+        if ($index === null) {
             $message = sprintf(
                 'Table `%s` does not contain a index named `%s`.',
                 $this->_table,
@@ -616,16 +622,6 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             );
             throw new DatabaseException($message);
         }
-        $data['name'] = $name;
-
-        $attrs = [];
-        foreach ($data as $key => $value) {
-            if ($value === null) {
-                continue;
-            }
-            $attrs[$key] = $value;
-        }
-        $index = new Index(...$attrs);
 
         return $index;
     }

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -541,6 +541,9 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function addIndex(string $name, $attrs)
     {
+        if (is_string($attrs)) {
+            $attrs = ['type' => $attrs];
+        }
         $attrs = array_intersect_key($attrs, static::$_indexKeys);
         $attrs += static::$_indexKeys;
         unset($attrs['references'], $attrs['update'], $attrs['delete'], $attrs['constraint'], $attrs['deferrable']);

--- a/tests/TestCase/Database/Schema/IndexTest.php
+++ b/tests/TestCase/Database/Schema/IndexTest.php
@@ -84,16 +84,16 @@ class IndexTest extends TestCase
         $this->assertSame(['title', 'name'], $index->getInclude());
     }
 
-    public function testSetConcurrently(): void
+    public function testSetConcurrent(): void
     {
         $index = new Index('title_idx', ['title']);
-        $this->assertFalse($index->getConcurrently());
+        $this->assertFalse($index->getConcurrent());
 
-        $index->setConcurrently(true);
-        $this->assertTrue($index->getConcurrently());
+        $index->setConcurrent(true);
+        $this->assertTrue($index->getConcurrent());
 
-        $index->setConcurrently(false);
-        $this->assertFalse($index->getConcurrently());
+        $index->setConcurrent(false);
+        $this->assertFalse($index->getConcurrent());
     }
 
     public function testSetWhere(): void

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -726,6 +726,7 @@ SQL;
                 'type' => 'index',
                 'columns' => ['author_id'],
                 'length' => [],
+                'concurrent' => false,
             ],
         ];
 

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -850,6 +850,7 @@ SQL;
             'type' => 'index',
             'columns' => ['author_id'],
             'length' => [],
+            'concurrent' => false,
         ];
         $this->assertEquals($authorIdx, $result->getIndex('author_idx'));
 
@@ -936,6 +937,7 @@ SQL;
             'type' => 'index',
             'columns' => ['group_id', 'grade'],
             'length' => [],
+            'concurrent' => false,
         ];
         $this->assertEquals($expected, $result->getIndex('schema_index_nulls'));
         $connection->execute('DROP TABLE schema_index');

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -639,6 +639,7 @@ SQL;
             'type' => 'index',
             'columns' => ['created'],
             'length' => [],
+            'concurrent' => false,
         ];
         $this->assertEquals($expected, $result->getIndex('created_idx'));
 

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -663,6 +663,7 @@ SQL;
             'type' => 'index',
             'columns' => ['author_id'],
             'length' => [],
+            'concurrent' => false,
         ];
         $this->assertEquals($authorIdx, $result->getIndex('author_idx'));
 

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -428,14 +428,17 @@ class TableSchemaTest extends TestCase
         $result = $table->addIndex('faster', [
             'type' => 'index',
             'columns' => ['title'],
-        ]);
+        ])->addIndex('no_columns', 'index');
         $this->assertSame($result, $table);
-        $this->assertEquals(['faster'], $table->indexes());
+        $this->assertEquals(['faster', 'no_columns'], $table->indexes());
 
         $index = $table->index('faster');
         $this->assertEquals('faster', $index->getName());
         $this->assertEquals(['title'], $index->getColumns());
         $this->assertEquals(TableSchema::INDEX_INDEX, $index->getType());
+
+        $noCols = $table->index('no_columns');
+        $this->assertEquals([], $noCols->getColumns());
     }
 
     /**


### PR DESCRIPTION
Use `Index` internally in `TableSchema`. I changed where `Index` related constants are defined so that they are on the `Index` instead of `TableSchema`. I'd like to eventually deprecated the `TableSchema` constants, but that is a task for later.

Part of #18362 

### TODO

- [x] mysql support
- [x] sqlserver support