### PR TITLE
Consolidate Doc links

### DIFF
--- a/src/Command/CacheClearCommand.php
+++ b/src/Command/CacheClearCommand.php
@@ -47,7 +47,7 @@ class CacheClearCommand extends Command
     /**
      * Hook method for defining this command's option parser.
      *
-     * @see https://book.cakephp.org/5/en/console-commands/option-parsers.html
+     * @link https://book.cakephp.org/5/en/console-commands/option-parsers.html
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to be defined
      * @return \Cake\Console\ConsoleOptionParser The built parser.
      */

--- a/src/Command/CacheClearGroupCommand.php
+++ b/src/Command/CacheClearGroupCommand.php
@@ -48,7 +48,7 @@ class CacheClearGroupCommand extends Command
     /**
      * Hook method for defining this command's option parser.
      *
-     * @see https://book.cakephp.org/5/en/console-commands/option-parsers.html
+     * @link https://book.cakephp.org/5/en/console-commands/option-parsers.html
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to be defined
      * @return \Cake\Console\ConsoleOptionParser The built parser.
      */

--- a/src/Command/CacheClearallCommand.php
+++ b/src/Command/CacheClearallCommand.php
@@ -47,7 +47,7 @@ class CacheClearallCommand extends Command
     /**
      * Hook method for defining this command's option parser.
      *
-     * @see https://book.cakephp.org/5/en/console-commands/option-parsers.html
+     * @link https://book.cakephp.org/5/en/console-commands/option-parsers.html
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to be defined
      * @return \Cake\Console\ConsoleOptionParser The built parser.
      */

--- a/src/Command/CacheListCommand.php
+++ b/src/Command/CacheListCommand.php
@@ -45,7 +45,7 @@ class CacheListCommand extends Command
     /**
      * Hook method for defining this command's option parser.
      *
-     * @see https://book.cakephp.org/5/en/console-commands/option-parsers.html
+     * @link https://book.cakephp.org/5/en/console-commands/option-parsers.html
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to be defined
      * @return \Cake\Console\ConsoleOptionParser The built parser.
      */

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -214,7 +214,7 @@ class ConsoleIo
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout
      *   or null if provided $level is greater than current level.
-     * @see https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::out
+     * @link https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::out
      */
     public function info(array|string $message, int $newlines = 1, int $level = self::NORMAL): ?int
     {
@@ -232,7 +232,7 @@ class ConsoleIo
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout
      *   or null if provided $level is greater than current level.
-     * @see https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::out
+     * @link https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::out
      */
     public function comment(array|string $message, int $newlines = 1, int $level = self::NORMAL): ?int
     {
@@ -248,7 +248,7 @@ class ConsoleIo
      * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to stderr.
-     * @see https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::err
+     * @link https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::err
      */
     public function warning(array|string $message, int $newlines = 1): int
     {
@@ -264,7 +264,7 @@ class ConsoleIo
      * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to stderr.
-     * @see https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::err
+     * @link https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::err
      */
     public function error(array|string $message, int $newlines = 1): int
     {
@@ -282,7 +282,7 @@ class ConsoleIo
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout
      *   or null if provided $level is greater than current level.
-     * @see https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::out
+     * @link https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::out
      */
     public function success(array|string $message, int $newlines = 1, int $level = self::NORMAL): ?int
     {

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -167,7 +167,7 @@ class DecimalTypeTest extends TestCase
         $result = $this->type->marshal('2.51');
         $this->assertSame('2.51', $result);
 
-        // allow custom decimal format (@see https://github.com/cakephp/cakephp/issues/12800)
+        // allow custom decimal format (https://github.com/cakephp/cakephp/issues/12800)
         $result = $this->type->marshal('1 230,73');
         $this->assertSame('1 230,73', $result);
 

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -139,7 +139,7 @@ class FloatTypeTest extends TestCase
         $result = $this->type->marshal('2.51');
         $this->assertSame(2.51, $result);
 
-        // allow custom decimal format (@see https://github.com/cakephp/cakephp/issues/12800)
+        // allow custom decimal format (https://github.com/cakephp/cakephp/issues/12800)
         $result = $this->type->marshal('1 230,73');
         $this->assertSame('1 230,73', $result);
 


### PR DESCRIPTION
If we decide to prefer link over see for doc linking, then this would be the diff
Refs https://github.com/cakephp/app/pull/1050

All other tags are already `@link`