### PR TITLE
Use hasColumn() instead of getColumn()

### DIFF
--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -131,7 +131,7 @@ class ExistsIn
             /** @var \Cake\ORM\Table $source */
             $schema = $source->getSchema();
             foreach ($fields as $i => $field) {
-                if ($schema->getColumn($field) && $schema->isNullable($field) && $entity->get($field) === null) {
+                if ($schema->hasColumn($field) && $schema->isNullable($field) && $entity->get($field) === null) {
                     unset($bindingKey[$i], $fields[$i]);
                 }
             }
@@ -161,7 +161,7 @@ class ExistsIn
         $nulls = 0;
         $schema = $source->getSchema();
         foreach ($this->_fields as $field) {
-            if ($schema->getColumn($field) && $schema->isNullable($field) && $entity->get($field) === null) {
+            if ($schema->hasColumn($field) && $schema->isNullable($field) && $entity->get($field) === null) {
                 $nulls++;
             }
         }


### PR DESCRIPTION
hasColumn() is slightly more efficient than getColumn() when all we really care about here is that the column exists.
