### PR TITLE
Remove partial support for Index::$concurrent

### DIFF
--- a/src/Database/Schema/Index.php
+++ b/src/Database/Schema/Index.php
@@ -47,7 +47,6 @@ class Index
      * @param array<string, int>|int|null $length The length of the index.
      * @param array<string>|null $order The sort order of the index columns.
      * @param array<string>|null $includedColumns The included columns for covering indexes.
-     * @param bool $concurrent Whether the index should be created concurrently.
      * @param ?string $where The where clause for partial indexes.
      */
     public function __construct(
@@ -57,7 +56,6 @@ class Index
         protected array|int|null $length = null,
         protected ?array $order = null,
         protected ?array $includedColumns = null,
-        protected bool $concurrent = false,
         protected ?string $where = null,
     ) {
     }
@@ -211,31 +209,6 @@ class Index
     }
 
     /**
-     * Set the concurrent mode for an index
-     *
-     * In postgres, concurrent indexes don't take locks, but cannot be run within transactions.
-     *
-     * @param bool $value The concurrent mode for an index.
-     * @return $this
-     */
-    public function setConcurrent(bool $value)
-    {
-        $this->concurrent = $value;
-
-        return $this;
-    }
-
-    /**
-     * Get the concurrent value for an index.
-     *
-     * @return bool
-     */
-    public function getConcurrent(): bool
-    {
-        return $this->concurrent;
-    }
-
-    /**
      * Set the where clause for partial indexes.
      *
      * @param ?string $where The where clause for partial indexes.
@@ -268,7 +241,7 @@ class Index
     public function setAttributes(array $attributes)
     {
         // Valid Options
-        $validOptions = ['columns', 'concurrent', 'type', 'name', 'length', 'order', 'include', 'where'];
+        $validOptions = ['columns', 'type', 'name', 'length', 'order', 'include', 'where'];
         foreach ($attributes as $attr => $value) {
             if (!in_array($attr, $validOptions, true)) {
                 throw new RuntimeException(sprintf('"%s" is not a valid index option.', $attr));
@@ -294,7 +267,6 @@ class Index
             'length' => $this->getLength(),
             'order' => $this->getOrder(),
             'include' => $this->getInclude(),
-            'concurrent' => $this->getConcurrent(),
             'where' => $this->getWhere(),
         ];
     }

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -563,9 +563,6 @@ class SqliteSchemaDialect extends SchemaDialect
                 'columns' => $columns,
                 'length' => [],
             ];
-            if ($indexType === TableSchema::INDEX_INDEX) {
-                $indexes[$indexName]['concurrent'] = false;
-            }
         }
         // Primary keys aren't always available from the index_info pragma
         // instead we have to read the columns again.

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -599,7 +599,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         $index = $this->_indexes[$name];
         $attrs = $index->toArray();
 
-        $optional = ['order', 'include', 'concurrent', 'where'];
+        $optional = ['order', 'include', 'where'];
         foreach ($optional as $key) {
             if ($attrs[$key] === null) {
                 unset($attrs[$key]);

--- a/tests/TestCase/Database/Schema/IndexTest.php
+++ b/tests/TestCase/Database/Schema/IndexTest.php
@@ -84,18 +84,6 @@ class IndexTest extends TestCase
         $this->assertSame(['title', 'name'], $index->getInclude());
     }
 
-    public function testSetConcurrent(): void
-    {
-        $index = new Index('title_idx', ['title']);
-        $this->assertFalse($index->getConcurrent());
-
-        $index->setConcurrent(true);
-        $this->assertTrue($index->getConcurrent());
-
-        $index->setConcurrent(false);
-        $this->assertFalse($index->getConcurrent());
-    }
-
     public function testSetWhere(): void
     {
         $index = new Index('title_idx', ['title']);

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -726,7 +726,6 @@ SQL;
                 'type' => 'index',
                 'columns' => ['author_id'],
                 'length' => [],
-                'concurrent' => false,
             ],
         ];
 

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -850,7 +850,6 @@ SQL;
             'type' => 'index',
             'columns' => ['author_id'],
             'length' => [],
-            'concurrent' => false,
         ];
         $this->assertEquals($authorIdx, $result->getIndex('author_idx'));
 
@@ -937,7 +936,6 @@ SQL;
             'type' => 'index',
             'columns' => ['group_id', 'grade'],
             'length' => [],
-            'concurrent' => false,
         ];
         $this->assertEquals($expected, $result->getIndex('schema_index_nulls'));
         $connection->execute('DROP TABLE schema_index');

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -639,7 +639,6 @@ SQL;
             'type' => 'index',
             'columns' => ['created'],
             'length' => [],
-            'concurrent' => false,
         ];
         $this->assertEquals($expected, $result->getIndex('created_idx'));
 

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -663,7 +663,6 @@ SQL;
             'type' => 'index',
             'columns' => ['author_id'],
             'length' => [],
-            'concurrent' => false,
         ];
         $this->assertEquals($authorIdx, $result->getIndex('author_idx'));
 


### PR DESCRIPTION
I had this half implemented because it was present in migrations. After finishing the feature off, I decided against it. While having `concurrent` would help migrations it cannot be reflected, and thus would always be null except in the rare circumstances it is needed. Instead we can have `migrations` do a `str_replace()` as required.
