### PR TITLE
Add ResultSet iteration support for PHPStan

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,3 +26,7 @@ services:
 		tags:
 			- phpstan.broker.methodsClassReflectionExtension
 			- phpstan.broker.propertiesClassReflectionExtension
+	-
+		class: Cake\PHPStan\ResultSetIteratorTypeExtension
+		tags:
+			- phpstan.dynamicMethodReturnTypeExtension

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -24,7 +24,9 @@ use SplFixedArray;
  * A collection is an immutable list of elements with a handful of functions to
  * iterate, group, transform and extract information from it.
  *
- * @template-extends \IteratorIterator<mixed, mixed, \Traversable<mixed>>
+ * @template T
+ * @template-extends \IteratorIterator<array-key, T, \Traversable<array-key, T>>
+ * @implements \Cake\Collection\CollectionInterface<T>
  */
 class Collection extends IteratorIterator implements CollectionInterface
 {

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -25,7 +25,7 @@ use SplFixedArray;
  * iterate, group, transform and extract information from it.
  *
  * @template T
- * @template-extends \IteratorIterator<array-key, T, \Traversable<array-key, T>>
+ * @template-extends \IteratorIterator<mixed, T, \Traversable<mixed, T>>
  * @implements \Cake\Collection\CollectionInterface<T>
  */
 class Collection extends IteratorIterator implements CollectionInterface

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -28,6 +28,9 @@ use const SORT_NUMERIC;
  *
  * @template T
  * @template-extends \Iterator<array-key, T>
+ * @method T current()
+ * @method T|false first()
+ * @method T|false last()
  */
 interface CollectionInterface extends Iterator, JsonSerializable, Countable
 {

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -26,7 +26,8 @@ use const SORT_NUMERIC;
  * list of elements exposing a number of traversing and extracting method for
  * generating other collections.
  *
- * @template-extends \Iterator<mixed>
+ * @template T
+ * @template-extends \Iterator<array-key, T>
  */
 interface CollectionInterface extends Iterator, JsonSerializable, Countable
 {

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -27,7 +27,7 @@ use const SORT_NUMERIC;
  * generating other collections.
  *
  * @template T
- * @template-extends \Iterator<array-key, T>
+ * @template-extends \Iterator<mixed, T>
  * @method T current()
  * @method T|false first()
  * @method T|false last()

--- a/src/Datasource/ResultSetInterface.php
+++ b/src/Datasource/ResultSetInterface.php
@@ -22,6 +22,7 @@ use Cake\Collection\CollectionInterface;
  * Describes how a collection of datasource results should look like
  *
  * @template T
+ * @extends \Cake\Collection\CollectionInterface<T>
  */
 interface ResultSetInterface extends CollectionInterface
 {

--- a/tests/PHPStan/ResultSetIteratorTypeExtension.php
+++ b/tests/PHPStan/ResultSetIteratorTypeExtension.php
@@ -38,7 +38,7 @@ class ResultSetIteratorTypeExtension implements DynamicMethodReturnTypeExtension
         }
 
         $genericTypes = $calledOnType->getTypes();
-        if (count($genericTypes) > 0) {
+        if ($genericTypes !== []) {
             // Return the generic type parameter (the entity type)
             return $genericTypes[0];
         }

--- a/tests/PHPStan/ResultSetIteratorTypeExtension.php
+++ b/tests/PHPStan/ResultSetIteratorTypeExtension.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\PHPStan;
+
+use Cake\Datasource\ResultSetInterface;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * Helps PHPStan understand that iterating over a ResultSet<Entity> yields Entity objects
+ */
+class ResultSetIteratorTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return ResultSetInterface::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array($methodReflection->getName(), ['current', 'first', 'last']);
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope,
+    ): ?Type {
+        $calledOnType = $scope->getType($methodCall->var);
+
+        if (!$calledOnType instanceof GenericObjectType) {
+            return null;
+        }
+
+        $genericTypes = $calledOnType->getTypes();
+        if (count($genericTypes) > 0) {
+            // Return the generic type parameter (the entity type)
+            return $genericTypes[0];
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
```php
/** @var \Cake\Datasource\ResultSetInterface<\App\Model\Entity\Order> $orders */
$orders = $this->fetchTable('Orders')->find()->all();

// Try typing $order-> here in your IDE
// You should see autocomplete for: id, status, total, user_id, created, modified, user
foreach ($orders as $order) {
    // $order-> (autocomplete should work here) - DOES NOT WORK
    $order->total = '1';
}

// Collection methods preserve types
$filtered = $orders->filter(function ($order) {
    // $order-> (autocomplete should work here too)
    return $order->total = '1';
});

// First/last return the correct type
$first = $orders->first();
if ($first) {
    // $first-> (autocomplete should work here)
    $first->total = '1';
}
```

Unfortunately, it still doesnt autocomplete

PHPStan sees it (first example only):
```
  Line   test_ide_example.php                                                     
 ------ ------------------------------------------------------------------------- 
  65     Property App\Model\Entity\Order::$total (float) does not accept string.  
         🪪  assign.propertyType                                                  
 ------ ------------------------------------------------------------------------- 
```