### PR TITLE
Fix regression caused in #17634

### DIFF
--- a/src/Datasource/RulesChecker.php
+++ b/src/Datasource/RulesChecker.php
@@ -362,11 +362,7 @@ class RulesChecker
      */
     public function checkDelete(EntityInterface $entity, array $options = []): bool
     {
-        return $this->_checkRules(
-            $entity,
-            $options,
-            array_merge(array_values($this->_rules), array_values($this->_deleteRules)),
-        );
+        return $this->_checkRules($entity, $options, $this->_deleteRules);
     }
 
     /**

--- a/tests/TestCase/Datasource/RulesCheckerTest.php
+++ b/tests/TestCase/Datasource/RulesCheckerTest.php
@@ -27,6 +27,36 @@ use Cake\TestSuite\TestCase;
 class RulesCheckerTest extends TestCase
 {
     /**
+     * Test adding rule for create and update
+     */
+    public function testAddingRule(): void
+    {
+        $entity = new Entity([
+            'name' => 'larry',
+        ]);
+
+        $rules = new RulesChecker();
+        $rules->add(
+            function () {
+                return false;
+            },
+            'ruleName',
+            ['errorField' => 'name'],
+        );
+
+        // Rules added with `add()` do not apply to delete operations
+        $this->assertTrue($rules->check($entity, RulesChecker::DELETE));
+        $this->assertEmpty($entity->getErrors());
+
+        $this->assertFalse($rules->check($entity, RulesChecker::CREATE));
+        $this->assertEquals(['ruleName' => 'invalid'], $entity->getError('name'));
+
+        $entity->clean();
+        $this->assertFalse($rules->check($entity, RulesChecker::UPDATE));
+        $this->assertEquals(['ruleName' => 'invalid'], $entity->getError('name'));
+    }
+
+    /**
      * Test adding rule for update mode
      */
     public function testAddingRuleDeleteMode(): void


### PR DESCRIPTION
Rules added using the `add()` method should not apply for delete operations. Closes #18800

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
