### PR TITLE
Allow config DI on UUID generation in light of default changes in v6.

### DIFF
--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Utility;
 
+use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
+use Closure;
 use InvalidArgumentException;
 use Transliterator;
 use function Cake\I18n\__d;
@@ -66,12 +68,28 @@ class Text
      * It should also not be used to create identifiers that have security implications, such as
      * 'unguessable' URL identifiers. Instead, you should use {@link \Cake\Utility\Security::randomBytes()}` for that.
      *
+     * ### Custom UUID generation
+     *
+     * You can configure a custom UUID generator by setting a Closure via Configure:
+     *
+     * ```
+     * Configure::write('Text.uuidGenerator', function () {
+     *     // Return your custom UUID string
+     *     return MyUuidLibrary::generate();
+     * });
+     * ```
+     *
      * @see https://www.ietf.org/rfc/rfc4122.txt
      * @return string RFC 4122 UUID
      * @copyright Matt Farina MIT License https://github.com/lootils/uuid/blob/master/LICENSE
      */
     public static function uuid(): string
     {
+        $generator = Configure::read('Text.uuidGenerator');
+        if ($generator instanceof Closure) {
+            return $generator();
+        }
+
         return sprintf(
             '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
             // 32 bits for "time_low"

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Utility;
 
+use Cake\Core\Configure;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Text;
@@ -79,6 +80,29 @@ class TextTest extends TestCase
             $this->assertNotContains($result, $check);
             $check[] = $result;
         }
+    }
+
+    /**
+     * testUuidGenerationWithClosure method
+     */
+    public function testUuidGenerationWithClosure(): void
+    {
+        $customUuid = 'custom-uuid-12345678-1234-1234-1234-123456789012';
+        Configure::write('Text.uuidGenerator', function () use ($customUuid) {
+            return $customUuid;
+        });
+
+        $result = Text::uuid();
+        $this->assertSame($customUuid, $result);
+
+        // Clean up
+        Configure::delete('Text.uuidGenerator');
+
+        // Test that it falls back to default implementation
+        $result = Text::uuid();
+        $pattern = '/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/';
+        $match = (bool)preg_match($pattern, $result);
+        $this->assertTrue($match);
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/18807