### PR TITLE
Split out toQuarterRange() from TimeHelper::toQuarter()

### DIFF
--- a/src/I18n/DateTime.php
+++ b/src/I18n/DateTime.php
@@ -598,6 +598,50 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
     }
 
     /**
+     * Returns the quarter
+     *
+     * Deprecated 5.3.0 Argument $range. Use toQuarterRange() to get quarter date ranges instead of passing $range = true
+     *
+     * @param bool $range Range. Deprecated, use toQuarterRange() instead.
+     * @return array|int 1, 2, 3, or 4 quarter of year or array if $range true
+     */
+    public function toQuarter(bool $range = false): int|array
+    {
+        if ($range) {
+            trigger_error(
+                'Passing $range = true to toQuarter() is deprecated. Use toQuarterRange() instead.',
+                E_USER_DEPRECATED,
+            );
+
+            return $this->toQuarterRange();
+        }
+
+        return (int)ceil((int)$this->format('m') / 3);
+    }
+
+    /**
+     * Returns the date range for the quarter this date falls in.
+     *
+     * @return array{0: string, 1: string} Array with start and end dates in 'Y-m-d' format
+     */
+    public function toQuarterRange(): array
+    {
+        $quarter = $this->toQuarter();
+        $year = $this->format('Y');
+
+        switch ($quarter) {
+            case 1:
+                return [$year . '-01-01', $year . '-03-31'];
+            case 2:
+                return [$year . '-04-01', $year . '-06-30'];
+            case 3:
+                return [$year . '-07-01', $year . '-09-30'];
+            default:
+                return [$year . '-10-01', $year . '-12-31'];
+        }
+    }
+
+    /**
      * @inheritDoc
      */
     public function __toString(): string

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -214,16 +214,41 @@ class TimeHelper extends Helper
     /**
      * Returns the quarter
      *
+     * Deprecated 5.3.0 Argument $range. Use toQuarterRange() to get quarter date ranges instead of passing $range = true
+     *
      * @param \Cake\Chronos\ChronosDate|\DateTimeInterface|string|int $dateString UNIX timestamp, strtotime() valid string or DateTime object
-     * @param bool $range if true returns a range in Y-m-d format
+     * @param bool $range if true returns a range in Y-m-d format. Deprecated, use toQuarterRange() instead.
      * @return array<string>|int 1, 2, 3, or 4 quarter of year or array if $range true
-     * @see \Cake\I18n\Time::toQuarter()
+     * @see \Cake\I18n\DateTime::toQuarter()
      */
     public function toQuarter(
         ChronosDate|DateTimeInterface|string|int $dateString,
         bool $range = false,
     ): array|int {
-        return (new DateTime($dateString))->toQuarter($range);
+        if ($range) {
+            trigger_error(
+                'Passing $range = true to TimeHelper::toQuarter() is deprecated. ' .
+                'Use TimeHelper::toQuarterRange() instead.',
+                E_USER_DEPRECATED,
+            );
+
+            return $this->toQuarterRange($dateString);
+        }
+
+        return (new DateTime($dateString))->toQuarter();
+    }
+
+    /**
+     * Returns the date range for the quarter the given date falls in.
+     *
+     * @param \Cake\Chronos\ChronosDate|\DateTimeInterface|string|int $dateString UNIX timestamp, strtotime() valid string or DateTime object
+     * @return array{0: string, 1: string} Array with start and end dates in 'Y-m-d' format
+     * @see \Cake\I18n\DateTime::toQuarterRange()
+     */
+    public function toQuarterRange(
+        ChronosDate|DateTimeInterface|string|int $dateString,
+    ): array {
+        return (new DateTime($dateString))->toQuarterRange();
     }
 
     /**

--- a/tests/TestCase/I18n/DateTimeTest.php
+++ b/tests/TestCase/I18n/DateTimeTest.php
@@ -829,6 +829,54 @@ class DateTimeTest extends TestCase
     }
 
     /**
+     * Test toQuarter method
+     */
+    public function testToQuarter(): void
+    {
+        $date = new DateTime('2007-12-25');
+        $this->assertSame(4, $date->toQuarter());
+
+        $date = new DateTime('2007-01-01');
+        $this->assertSame(1, $date->toQuarter());
+
+        $date = new DateTime('2007-05-15');
+        $this->assertSame(2, $date->toQuarter());
+
+        $date = new DateTime('2007-08-20');
+        $this->assertSame(3, $date->toQuarter());
+    }
+
+    /**
+     * Test toQuarter with deprecated range parameter
+     */
+    public function testToQuarterWithRange(): void
+    {
+        $this->deprecated(function () {
+            $date = new DateTime('2007-12-25');
+            $result = $date->toQuarter(true);
+            $this->assertEquals(['2007-10-01', '2007-12-31'], $result);
+        });
+    }
+
+    /**
+     * Test toQuarterRange method
+     */
+    public function testToQuarterRange(): void
+    {
+        $date = new DateTime('2007-12-25');
+        $this->assertEquals(['2007-10-01', '2007-12-31'], $date->toQuarterRange());
+
+        $date = new DateTime('2007-01-01');
+        $this->assertEquals(['2007-01-01', '2007-03-31'], $date->toQuarterRange());
+
+        $date = new DateTime('2007-05-15');
+        $this->assertEquals(['2007-04-01', '2007-06-30'], $date->toQuarterRange());
+
+        $date = new DateTime('2007-08-20');
+        $this->assertEquals(['2007-07-01', '2007-09-30'], $date->toQuarterRange());
+    }
+
+    /**
      * Custom assert to allow for variation in the version of the intl library, where
      * some translations contain a few extra commas.
      */

--- a/tests/TestCase/I18n/DateTimeTest.php
+++ b/tests/TestCase/I18n/DateTimeTest.php
@@ -851,7 +851,7 @@ class DateTimeTest extends TestCase
      */
     public function testToQuarterWithRange(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $date = new DateTime('2007-12-25');
             $result = $date->toQuarter(true);
             $this->assertEquals(['2007-10-01', '2007-12-31'], $result);

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -146,7 +146,20 @@ class TimeHelperTest extends TestCase
     public function testToQuarter(): void
     {
         $this->assertSame(4, $this->Time->toQuarter('2007-12-25'));
-        $this->assertEquals(['2007-10-01', '2007-12-31'], $this->Time->toQuarter('2007-12-25', true));
+        $this->deprecated(function () {
+            $this->assertEquals(['2007-10-01', '2007-12-31'], $this->Time->toQuarter('2007-12-25', true));
+        });
+    }
+
+    /**
+     * testToQuarterRange method
+     */
+    public function testToQuarterRange(): void
+    {
+        $this->assertEquals(['2007-10-01', '2007-12-31'], $this->Time->toQuarterRange('2007-12-25'));
+        $this->assertEquals(['2007-01-01', '2007-03-31'], $this->Time->toQuarterRange('2007-01-01'));
+        $this->assertEquals(['2007-04-01', '2007-06-30'], $this->Time->toQuarterRange('2007-05-15'));
+        $this->assertEquals(['2007-07-01', '2007-09-30'], $this->Time->toQuarterRange('2007-08-20'));
     }
 
     /**

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -146,7 +146,7 @@ class TimeHelperTest extends TestCase
     public function testToQuarter(): void
     {
         $this->assertSame(4, $this->Time->toQuarter('2007-12-25'));
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $this->assertEquals(['2007-10-01', '2007-12-31'], $this->Time->toQuarter('2007-12-25', true));
         });
     }


### PR DESCRIPTION
Process some of https://github.com/cakephp/cakephp/wiki/6.0-Ideas cleanup

Refs https://github.com/cakephp/chronos/pull/479
But since there wont be a major any time soon copy this over seems to be the best choice of action for now, we can clean this up with cake6 and chronos major for that version.