### PR TITLE
upgrade rector to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -134,7 +134,7 @@
         "stan-setup": "phive install",
         "lowest": "validate-prefer-lowest",
         "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json",
-        "rector-setup": "cp composer.json composer.backup && composer require --dev rector/rector:\"^1.2\" && mv composer.backup composer.json",
+        "rector-setup": "cp composer.json composer.backup && composer require --dev rector/rector:\"^2.1\" && mv composer.backup composer.json",
         "rector-check": "vendor/bin/rector process --dry-run",
         "rector-fix": "vendor/bin/rector process",
         "test": "phpunit",

--- a/rector.php
+++ b/rector.php
@@ -84,8 +84,6 @@ return RectorConfig::configure()
         \Rector\Php73\Rector\String_\SensitiveHereNowDocRector::class,
         \Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector::class,
         \Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector::class,
-        \Rector\Php80\Rector\FunctionLike\MixedTypeRector::class,
-        \Rector\Php81\Rector\ClassMethod\NewInInitializerRector::class,
         \Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector::class,
         \Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class,
         \Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector::class,


### PR DESCRIPTION
https://github.com/rectorphp/rector/blob/2.0.0/rules/Php80/Rector/FunctionLike/MixedTypeRector.php#L28 was removed after 2.0 as it seems.

The other rector rule was never skipped, so I removed it as well to remove the warning.