### PR TITLE
Redis cluster improvements

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,26 +16,6 @@ parameters:
 			path: src/Cache/Engine/RedisEngine.php
 
 		-
-			message: "#^Method RedisCluster\\:\\:scan\\(\\) invoked with 4 parameters, 1\\-3 required\\.$#"
-			count: 1
-			path: src/Cache/Engine/RedisEngine.php
-
-		-
-			message: "#^Parameter \\#3 \\$pattern of method RedisCluster\\:\\:scan\\(\\) expects int, string given\\.$#"
-			count: 1
-			path: src/Cache/Engine/RedisEngine.php
-
-		-
-			message: '#^Cannot cast int\|Redis\|false to int\.$#'
-			identifier: cast.int
-			count: 1
-			path: src/Cache/Engine/RedisEngine.php
-
-		-
-			message: "#^Parameter \\#2 \\$node of method RedisCluster\\:\\:scan\\(\\) expects string, array\\|string\\|null given\\.$#"
-			path: src/Cache/Engine/RedisEngine.php
-
-		-
 			message: '#^Call to function method_exists\(\) with Memcached and ''setSaslAuthData'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -21,6 +21,7 @@ use Cake\Cache\CacheEngine;
 use Cake\Core\Exception\CakeException;
 use Cake\Log\Log;
 use DateInterval;
+use Generator;
 use Redis;
 use RedisCluster;
 use RedisClusterException;
@@ -408,35 +409,18 @@ class RedisEngine extends CacheEngine
      */
     public function clear(): bool
     {
-        if ($this->getConfig('clearUsesFlushDb') && $this->_Redis instanceof Redis) {
-            $this->_Redis->flushDB(false);
+        if ($this->getConfig('clearUsesFlushDb')) {
+            $this->flushDB(false);
 
             return true;
         }
 
-        $this->_Redis->setOption(Redis::OPT_SCAN, (string)Redis::SCAN_RETRY);
-
         $isAllDeleted = true;
         $pattern = $this->_config['prefix'] . '*';
-        $scanCount = (int)$this->_config['scanCount'];
 
-        // Set scan option only if using a Redis instance (not RedisCluster)
-        if ($this->_Redis instanceof Redis) {
-            $this->_Redis->setOption(Redis::OPT_SCAN, Redis::SCAN_RETRY);
-        }
-
-        $nodes = $this->_Redis instanceof RedisCluster
-            ? $this->_Redis->_masters()
-            : [null];
-
-        foreach ($nodes as $node) {
-            $it = null;
-            while (($keys = $this->scanKeys($it, $pattern, $scanCount, $node)) !== false) {
-                foreach ($keys as $key) {
-                    $isDeleted = ((int)$this->_Redis->unlink($key) > 0);
-                    $isAllDeleted = $isAllDeleted && $isDeleted;
-                }
-            }
+        foreach ($this->scanKeys($pattern) as $key) {
+            $isDeleted = ((int)$this->_Redis->unlink($key) > 0);
+            $isAllDeleted = $isAllDeleted && $isDeleted;
         }
 
         return $isAllDeleted;
@@ -449,36 +433,19 @@ class RedisEngine extends CacheEngine
      */
     public function clearBlocking(): bool
     {
-        if ($this->getConfig('clearUsesFlushDb') && $this->_Redis instanceof Redis) {
-            $this->_Redis->flushDB(false);
+        if ($this->getConfig('clearUsesFlushDb')) {
+            $this->flushDB(false);
 
             return true;
         }
 
-        $this->_Redis->setOption(Redis::OPT_SCAN, (string)Redis::SCAN_RETRY);
-
         $isAllDeleted = true;
         $pattern = $this->_config['prefix'] . '*';
-        $scanCount = (int)$this->_config['scanCount'];
 
-        // Set scan option for Redis instance (not supported in RedisCluster)
-        if ($this->_Redis instanceof Redis) {
-            $this->_Redis->setOption(Redis::OPT_SCAN, (string)Redis::SCAN_RETRY);
-        }
-
-        $nodes = $this->_Redis instanceof RedisCluster
-            ? $this->_Redis->_masters()
-            : [null];
-
-        foreach ($nodes as $node) {
-            $it = null;
-            while (($keys = $this->scanKeys($it, $pattern, $scanCount, $node)) !== false) {
-                foreach ($keys as $key) {
-                    // Blocking delete
-                    $isDeleted = ((int)$this->_Redis->del($key) > 0);
-                    $isAllDeleted = $isAllDeleted && $isDeleted;
-                }
-            }
+        foreach ($this->scanKeys($pattern) as $key) {
+            // Blocking delete
+            $isDeleted = ((int)$this->_Redis->del($key) > 0);
+            $isAllDeleted = $isAllDeleted && $isDeleted;
         }
 
         return $isAllDeleted;
@@ -585,21 +552,61 @@ class RedisEngine extends CacheEngine
     }
 
     /**
-     * Unifies Redis and RedisCluster scan() calls.
+     * Unifies Redis and RedisCluster scan() calls and simplifies its use.
      *
-     * @param int|null $it Passed by reference cursor
-     * @param string   $pattern
-     * @param int      $count
-     * @param array|string|null $node Master address for cluster, or null for single node
-     * @return array|false
+     * @param string $pattern Pattern to scan
+     * @return \Generator<string>
      */
-    private function scanKeys(?int &$it, string $pattern, int $count, string|array|null $node = null): array|false
+    private function scanKeys(string $pattern): Generator
+    {
+        $this->_Redis->setOption(Redis::OPT_SCAN, (string)Redis::SCAN_RETRY);
+
+        if ($this->_Redis instanceof RedisCluster) {
+            foreach ($this->_Redis->_masters() as $node) {
+                $iterator = null;
+                while (true) {
+                    // @phpstan-ignore arguments.count, argument.type
+                    $keys = $this->_Redis->scan($iterator, $pattern, (int)$this->_config['scanCount']);
+                    if ($keys === false) {
+                        break;
+                    }
+
+                    foreach ($keys as $key) {
+                        yield $key;
+                    }
+                }
+            }
+        } else {
+            $iterator = null;
+            while (true) {
+                $keys = $this->_Redis->scan($iterator, $pattern, (int)$this->_config['scanCount']);
+                if ($keys === false) {
+                    break;
+                }
+
+                foreach ($keys as $key) {
+                    yield $key;
+                }
+            }
+        }
+    }
+
+    /**
+     * Flushes DB
+     *
+     * @param bool $async Whether to use asynchronous mode
+     * @return void
+     */
+    private function flushDB(bool $async = true): void
     {
         if ($this->_Redis instanceof RedisCluster) {
-            return $this->_Redis->scan($it, $node, $pattern, $count);
+            foreach ($this->_Redis->_masters() as $node) {
+                // @phpstan-ignore arguments.count
+                $this->_Redis->flushDB($node, $async);
+            }
+        } else {
+            $this->_Redis->flushDB($async);
         }
-
-        return $this->_Redis->scan($it, $pattern, $count);
     }
 
     /**

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -580,7 +580,7 @@ class RedisEngine extends CacheEngine
                 $iterator = null;
                 while (true) {
                     // @phpstan-ignore arguments.count, argument.type
-                    $keys = $this->_Redis->scan($iterator, $pattern, (int)$this->_config['scanCount']);
+                    $keys = $this->_Redis->scan($iterator, $node, $pattern, (int)$this->_config['scanCount']);
                     if ($keys === false) {
                         break;
                     }

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -89,7 +89,7 @@ class RedisEngine extends CacheEngine
         'unix_socket' => false,
         'scanCount' => 10,
         'readTimeout' => 0,
-        'nodes' => [],
+        'nodes' => null,
         'failover' => null,
         'clearUsesFlushDb' => false,
     ];

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -424,7 +424,7 @@ class RedisEngine extends CacheEngine
     public function clear(): bool
     {
         if ($this->getConfig('clearUsesFlushDb')) {
-            $this->flushDB(false);
+            $this->flushDB(true);
 
             return true;
         }
@@ -611,7 +611,7 @@ class RedisEngine extends CacheEngine
      * @param bool $async Whether to use asynchronous mode
      * @return void
      */
-    private function flushDB(bool $async = true): void
+    private function flushDB(bool $async): void
     {
         if ($this->_Redis instanceof RedisCluster) {
             foreach ($this->_Redis->_masters() as $node) {

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -140,6 +140,16 @@ class RedisEngine extends CacheEngine
     {
         $connected = false;
 
+        if (empty($this->_config['nodes'])) {
+            // @codeCoverageIgnoreStart
+            if (class_exists(Log::class)) {
+                Log::error('RedisEngine requires one or more nodes in cluster mode');
+            }
+            // @codeCoverageIgnoreEnd
+
+            return false;
+        }
+
         // @codeCoverageIgnoreStart
         $ssl = [];
         if ($this->_config['tls']) {

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -183,10 +183,10 @@ class RedisEngine extends CacheEngine
         }
 
         $failover = match ($this->_config['failover']) {
-            'distribute' => RedisCluster::FAILOVER_DISTRIBUTE,
-            'distribute_slaves' => RedisCluster::FAILOVER_DISTRIBUTE_SLAVES,
-            'error' => RedisCluster::FAILOVER_ERROR,
-            'none' => RedisCluster::FAILOVER_NONE,
+            RedisCluster::FAILOVER_DISTRIBUTE, 'distribute' => RedisCluster::FAILOVER_DISTRIBUTE,
+            RedisCluster::FAILOVER_DISTRIBUTE_SLAVES, 'distribute_slaves' => RedisCluster::FAILOVER_DISTRIBUTE_SLAVES,
+            RedisCluster::FAILOVER_ERROR, 'error' => RedisCluster::FAILOVER_ERROR,
+            RedisCluster::FAILOVER_NONE, 'none' => RedisCluster::FAILOVER_NONE,
             default => null,
         };
 

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -122,7 +122,7 @@ class RedisEngine extends CacheEngine
      */
     protected function _connect(): bool
     {
-        if (!empty($this->_config['nodes'])) {
+        if (!empty($this->_config['nodes']) || !empty($this->_config['clusterName'])) {
             return $this->connectRedisCluster();
         }
 

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -66,6 +66,7 @@ class RedisEngine extends CacheEngine
      *       '<ip>:<port>',
      *       '<ip>:<port>',
      *   ]
+     * - `failover` Failover mode (distribute,distribute_slaves,error,none). Cluster mode only.
      * - `clearUsesFlushDb` Enable clear() and clearBlocking() to use FLUSHDB. This will be
      *   faster than standard clear()/clearBlocking() but will ignore prefixes and will
      *   cause dataloss if other applications are sharing a redis database.
@@ -89,6 +90,7 @@ class RedisEngine extends CacheEngine
         'scanCount' => 10,
         'readTimeout' => 0,
         'nodes' => [],
+        'failover' => null,
         'clearUsesFlushDb' => false,
     ];
 
@@ -178,6 +180,18 @@ class RedisEngine extends CacheEngine
                 Log::error('RedisEngine could not connect to the redis cluster. Got error: ' . $e->getMessage());
             }
             // @codeCoverageIgnoreEnd
+        }
+
+        $failover = match ($this->_config['failover']) {
+            'distribute' => RedisCluster::FAILOVER_DISTRIBUTE,
+            'distribute_slaves' => RedisCluster::FAILOVER_DISTRIBUTE_SLAVES,
+            'error' => RedisCluster::FAILOVER_ERROR,
+            'none' => RedisCluster::FAILOVER_NONE,
+            default => null,
+        };
+
+        if ($failover !== null) {
+            $this->_Redis->setOption(RedisCluster::OPT_SLAVE_FAILOVER, $failover);
         }
 
         return $connected;

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -355,7 +355,7 @@ class RedisEngine extends CacheEngine
     {
         $res = $this->_Redis->exists($this->_key($key));
 
-        return $res > 0 || $res === true;
+        return is_int($res) ? $res > 0 : $res === true;
     }
 
     /**

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -89,7 +89,7 @@ class RedisEngine extends CacheEngine
         'unix_socket' => false,
         'scanCount' => 10,
         'readTimeout' => 0,
-        'nodes' => null,
+        'nodes' => [],
         'failover' => null,
         'clearUsesFlushDb' => false,
     ];

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -349,6 +349,16 @@ class RedisEngine extends CacheEngine
     }
 
     /**
+     * @inheritDoc
+     */
+    public function has(string $key): bool
+    {
+        $res = $this->_Redis->exists($this->_key($key));
+
+        return $res > 0 || $res === true;
+    }
+
+    /**
      * Increments the value of an integer cached key & update the expiry time
      *
      * @param string $key Identifier for the data

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -46,7 +46,7 @@ class RedisClusterEngineTest extends TestCase
                 // phpcs:enable
 
                 if ($socket === false) {
-                    $this->skipTest = ($this->skipTest === null ? '' : "\n") .
+                    $this->skipTest = ($this->skipTest === false ? '' : "\n") .
                         "Connection to Redis node {$node['host']}:{$node['port']} failed: {$errstr} ({$errno})";
                 } else {
                     fclose($socket);

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -16,6 +16,8 @@ use ReflectionClass;
  */
 class RedisClusterEngineTest extends TestCase
 {
+    private ?bool $skipTest = null;
+
     /**
      * setUp method
      *
@@ -30,22 +32,29 @@ class RedisClusterEngineTest extends TestCase
             'Redis extension is not installed or configured properly.',
         );
 
-        $nodes = array_map(function (string $node) {
-            [$host, $port] = explode(':', $node);
+        if ($this->skipTest === null) {
+            $this->skipTest = false;
+            $nodes = array_map(function (strin $node) {
+                [$host, $port] = explode(':', $node);
 
-            return ['host' => $host, 'port' => (int)$port];
-        }, $this->redisClusterNodes());
+                return ['host' => $host, 'port' => (int)$port];
+            }, $this->redisClusterNodes());
 
-        foreach ($nodes as $node) {
-            $socket = fsockopen($node['host'], $node['port'], $errno, $errstr, 1);
+            foreach ($nodes as $node) {
+                $socket = fsockopen($node['host'], $node['port'], $errno, $errstr, 1);
 
-            if (!$socket) {
-                echo "Connection to Redis node {$node['host']}:{$node['port']} failed: {$errstr} ({$errno}) \n";
+                if (!$socket) {
+                    echo "Connection to Redis node {$node['host']}:{$node['port']} failed: {$errstr} ({$errno}) \n";
+                }
+
+                if ($socket === false) {
+                    $this->skipTest = true;
+                } else {
+                    fclose($socket);
+                }
             }
-
-            $this->skipIf(!$socket, "Connection to Redis node {$node['host']}:{$node['port']} failed: {$errstr} ({$errno})");
-            fclose($socket);
         }
+        $this->skipIf($this->skipTest, "Connection to one more Redis cluster nodes failed");
 
         Cache::enable();
         $this->configCache();

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -126,6 +126,7 @@ class RedisClusterEngineTest extends TestCase
             'server' => '127.0.0.1',
             'unix_socket' => false,
             'clearUsesFlushDb' => false,
+            'failover' => null,
         ];
         $this->assertEquals($expecting, $config);
     }

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -16,7 +16,7 @@ use ReflectionClass;
  */
 class RedisClusterEngineTest extends TestCase
 {
-    private ?bool $skipTest = null;
+    private bool|string|null $skipTest = null;
 
     /**
      * setUp method
@@ -41,20 +41,17 @@ class RedisClusterEngineTest extends TestCase
             }, $this->redisClusterNodes());
 
             foreach ($nodes as $node) {
-                $socket = fsockopen($node['host'], $node['port'], $errno, $errstr, 1);
-
-                if (!$socket) {
-                    echo "Connection to Redis node {$node['host']}:{$node['port']} failed: {$errstr} ({$errno}) \n";
-                }
+                $socket = @fsockopen($node['host'], $node['port'], $errno, $errstr, 1);
 
                 if ($socket === false) {
-                    $this->skipTest = true;
+                    $this->skipTest = ($this->skipTest === null ? '' : "\n") .
+                        "Connection to Redis node {$node['host']}:{$node['port']} failed: {$errstr} ({$errno})";
                 } else {
                     fclose($socket);
                 }
             }
         }
-        $this->skipIf($this->skipTest, 'Connection to one more Redis cluster nodes failed');
+        $this->skipIf($this->skipTest === false, $this->skipTest);
 
         Cache::enable();
         $this->configCache();

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -151,6 +151,35 @@ class RedisClusterEngineTest extends TestCase
     }
 
     /**
+     * testConnect method
+     *
+     * @return void
+     */
+    public function testConnectNamedCluster(): void
+    {
+        Cache::setConfig('named_redis_cluster', [
+            'clusterName' => 'mycluster',
+        ]);
+
+        $seeds = '';
+        foreach ($this->redisClusterNodes() as $node) {
+            $seeds .= ($seeds === '' ? '' : '&') . 'mycluster[]=' . $node;
+        }
+
+        ini_set('redis.clusters.seeds', $seeds);
+
+        try {
+            $Redis = new RedisEngine();
+            $this->assertTrue($Redis->init(Cache::pool('named_redis_cluster')->getConfig()));
+            $this->assertTrue(Cache::write('test', 'testValue', 'named_redis_cluster'));
+            $this->assertSame('testValue', Cache::read('test', 'named_redis_cluster'));
+        } finally {
+            Cache::drop('redis.cluster_seeds');
+            ini_restore('redis.cluster_seeds');
+        }
+    }
+
+    /**
      * Test that a Redis cluster connection failure logs an error
      * and returns false from the `init()` method.
      *

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -592,4 +592,16 @@ class RedisClusterEngineTest extends TestCase
         $result = Cache::add('test_add_key', 'test data 2', 'redis');
         $this->assertFalse($result);
     }
+
+    /**
+     * Test has
+     */
+    public function testHas(): void
+    {
+        $redis = Cache::pool('redis');
+        $this->assertFalse($redis->has('nope'));
+
+        $redis->set('yep', 0);
+        $this->assertTrue($redis->has('yep'));
+    }
 }

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -157,10 +157,6 @@ class RedisClusterEngineTest extends TestCase
      */
     public function testConnectNamedCluster(): void
     {
-        Cache::setConfig('named_redis_cluster', [
-            'clusterName' => 'mycluster',
-        ]);
-
         $seeds = '';
         foreach ($this->redisClusterNodes() as $node) {
             $seeds .= ($seeds === '' ? '' : '&') . 'mycluster[]=' . $node;
@@ -168,9 +164,12 @@ class RedisClusterEngineTest extends TestCase
 
         ini_set('redis.clusters.seeds', $seeds);
 
+        Cache::setConfig('named_redis_cluster', [
+            'className' => 'Redis',
+            'clusterName' => 'mycluster',
+        ]);
+
         try {
-            $Redis = new RedisEngine();
-            $this->assertTrue($Redis->init(Cache::pool('named_redis_cluster')->getConfig()));
             $this->assertTrue(Cache::write('test', 'testValue', 'named_redis_cluster'));
             $this->assertSame('testValue', Cache::read('test', 'named_redis_cluster'));
         } finally {

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -54,7 +54,7 @@ class RedisClusterEngineTest extends TestCase
                 }
             }
         }
-        $this->skipIf($this->skipTest, "Connection to one more Redis cluster nodes failed");
+        $this->skipIf($this->skipTest, 'Connection to one more Redis cluster nodes failed');
 
         Cache::enable();
         $this->configCache();

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -16,7 +16,7 @@ use ReflectionClass;
  */
 class RedisClusterEngineTest extends TestCase
 {
-    private bool|string|null $skipTest = null;
+    private false|string|null $skipTest = null;
 
     /**
      * setUp method
@@ -53,7 +53,7 @@ class RedisClusterEngineTest extends TestCase
                 }
             }
         }
-        $this->skipIf($this->skipTest === false, $this->skipTest);
+        $this->skipIf($this->skipTest !== false, $this->skipTest === false ? 'Not skipping' : $this->skipTest);
 
         Cache::enable();
         $this->configCache();

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -41,7 +41,9 @@ class RedisClusterEngineTest extends TestCase
             }, $this->redisClusterNodes());
 
             foreach ($nodes as $node) {
+                // phpcs:disable
                 $socket = @fsockopen($node['host'], $node['port'], $errno, $errstr, 1);
+                // phpcs:enable
 
                 if ($socket === false) {
                     $this->skipTest = ($this->skipTest === null ? '' : "\n") .

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -155,27 +155,28 @@ class RedisClusterEngineTest extends TestCase
      *
      * @return void
      */
-    public function testConnectNamedCluster(): void
+    public function testConnectNamedClusterWithoutNodes(): void
     {
-        $seeds = '';
-        foreach ($this->redisClusterNodes() as $node) {
-            $seeds .= ($seeds === '' ? '' : '&') . 'mycluster[]=' . $node;
-        }
+        // Mock logger
+        $logger = $this->getMockBuilder(ArrayLog::class)
+            ->onlyMethods(['log'])
+            ->getMock();
 
-        ini_set('redis.clusters.seeds', $seeds);
+        $logger->expects($this->once())
+            ->method('log')
+            ->with(
+                $this->equalTo('error'),
+                $this->stringContains('RedisEngine requires one or more nodes in cluster mode'),
+                $this->anything(),
+            );
 
-        Cache::setConfig('named_redis_cluster', [
+        Log::reset();
+        Log::setConfig('default', ['className' => $logger]);
+
+        $this->assertFalse((new RedisEngine())->init([
             'className' => 'Redis',
             'clusterName' => 'mycluster',
-        ]);
-
-        try {
-            $this->assertTrue(Cache::write('test', 'testValue', 'named_redis_cluster'));
-            $this->assertSame('testValue', Cache::read('test', 'named_redis_cluster'));
-        } finally {
-            Cache::drop('redis.cluster_seeds');
-            ini_restore('redis.cluster_seeds');
-        }
+        ]));
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -34,7 +34,7 @@ class RedisClusterEngineTest extends TestCase
 
         if ($this->skipTest === null) {
             $this->skipTest = false;
-            $nodes = array_map(function (strin $node) {
+            $nodes = array_map(function (string $node) {
                 [$host, $port] = explode(':', $node);
 
                 return ['host' => $host, 'port' => (int)$port];

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -62,6 +62,7 @@ class RedisEngineTest extends TestCase
         Cache::drop('redis');
         Cache::drop('redis2');
         Cache::drop('redis_clear_blocking');
+        Cache::drop('redis_dsn');
         Cache::drop('redis_groups');
         Cache::drop('redis_helper');
     }
@@ -107,6 +108,7 @@ class RedisEngineTest extends TestCase
             'clusterName' => null,
             'nodes' => [],
             'clearUsesFlushDb' => false,
+            'failover' => null,
         ];
         $this->assertEquals($expecting, $config);
     }
@@ -140,10 +142,9 @@ class RedisEngineTest extends TestCase
             'clusterName' => null,
             'nodes' => [],
             'clearUsesFlushDb' => false,
+            'failover' => null,
         ];
         $this->assertEquals($expecting, $config);
-
-        Cache::drop('redis_dsn');
     }
 
     /**
@@ -182,10 +183,9 @@ class RedisEngineTest extends TestCase
             'clusterName' => null,
             'nodes' => [],
             'clearUsesFlushDb' => false,
+            'failover' => null,
         ];
         $this->assertEquals($expecting, $config);
-
-        Cache::drop('redis_dsn');
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -33,6 +33,8 @@ class RedisEngineTest extends TestCase
      */
     protected $port = '6379';
 
+    private ?bool $skipTest = null;
+
     /**
      * setUp method
      */
@@ -43,11 +45,16 @@ class RedisEngineTest extends TestCase
 
         $this->port = env('REDIS_PORT', $this->port);
 
-        // phpcs:disable
-        $socket = @fsockopen('127.0.0.1', (int)$this->port, $errno, $errstr, 1);
-        // phpcs:enable
-        $this->skipIf(!$socket, 'Redis is not running.');
-        fclose($socket);
+        if ($this->skipTest === null) {
+            // phpcs:disable
+            $socket = @fsockopen('127.0.0.1', (int)$this->port, $errno, $errstr, 1);
+            // phpcs:enable
+
+            $this->skipTest = $socket === false;
+            fclose($socket);
+        }
+
+        $this->skipIf($this->skipTest, 'Redis is not running.');
 
         Cache::enable();
         $this->_configCache();

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -539,6 +539,18 @@ class RedisEngineTest extends TestCase
     }
 
     /**
+     * Test has
+     */
+    public function testHas(): void
+    {
+        $redis = Cache::pool('redis');
+        $this->assertFalse($redis->has('nope'));
+
+        $redis->set('yep', 0);
+        $this->assertTrue($redis->has('yep'));
+    }
+
+    /**
      * testExpiry method
      */
     public function testExpiry(): void

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -51,7 +51,10 @@ class RedisEngineTest extends TestCase
             // phpcs:enable
 
             $this->skipTest = $socket === false;
-            fclose($socket);
+
+            if ($socket !== false) {
+                fclose($socket);
+            }
         }
 
         $this->skipIf($this->skipTest, 'Redis is not running.');


### PR DESCRIPTION
Ported missing features from the split engine branch into 5.next.

- Improve encapsulation for scan.
- Support flushDB in cluster mode.
- Use cluster mode when using cluster name.
- Added support for fallback mode (without it only master nodes are used for reads).
- Optimize has to avoid fetching and unserializing values.

Future ideas:
- Validate options to ensure we don't allow cluster options in standalone mode.
