### PR TITLE
RFC: Add RateLimitMiddleware

### DIFF
--- a/src/Http/Exception/TooManyRequestsException.php
+++ b/src/Http/Exception/TooManyRequestsException.php
@@ -37,9 +37,6 @@ class TooManyRequestsException extends HttpException
      */
     public function __construct(string $message = '', ?int $code = null, ?Throwable $previous = null)
     {
-        if (empty($message)) {
-            $message = 'Too Many Requests';
-        }
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message ?: 'Too Many Requests', $code, $previous);
     }
 }

--- a/src/Http/Exception/TooManyRequestsException.php
+++ b/src/Http/Exception/TooManyRequestsException.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\Exception;
+
+use Throwable;
+
+/**
+ * Represents an HTTP 429 Too Many Requests error.
+ */
+class TooManyRequestsException extends HttpException
+{
+    /**
+     * @inheritDoc
+     */
+    protected int $_defaultCode = 429;
+
+    /**
+     * Constructor
+     *
+     * @param string $message The error message
+     * @param int|null $code The error code
+     * @param \Throwable|null $previous The previous exception
+     */
+    public function __construct(string $message = '', ?int $code = null, ?Throwable $previous = null)
+    {
+        if (empty($message)) {
+            $message = 'Too Many Requests';
+        }
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Http/Middleware/RateLimitMiddleware.php
+++ b/src/Http/Middleware/RateLimitMiddleware.php
@@ -121,7 +121,7 @@ class RateLimitMiddleware implements MiddlewareInterface
         $response = $handler->handle($request);
 
         if ($this->config['headers']) {
-            $response = $this->addRateLimitHeaders($response, $result);
+            return $this->addRateLimitHeaders($response, $result);
         }
 
         return $response;
@@ -370,7 +370,7 @@ class RateLimitMiddleware implements MiddlewareInterface
      */
     protected function getRateLimiter(?string $strategy = null): RateLimiterInterface
     {
-        $strategy = $strategy ?? $this->config['strategy'];
+        $strategy ??= $this->config['strategy'];
         $cache = Cache::pool($this->config['cache']);
 
         return match ($strategy) {

--- a/src/Http/Middleware/RateLimitMiddleware.php
+++ b/src/Http/Middleware/RateLimitMiddleware.php
@@ -1,0 +1,289 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\Middleware;
+
+use Cake\Cache\Cache;
+use Cake\Http\Exception\TooManyRequestsException;
+use Cake\Http\RateLimit\FixedWindowRateLimiter;
+use Cake\Http\RateLimit\RateLimiterInterface;
+use Cake\Http\RateLimit\SlidingWindowRateLimiter;
+use Cake\Http\RateLimit\TokenBucketRateLimiter;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Rate limiting middleware
+ *
+ * Provides configurable rate limiting based on various identifiers.
+ * Supports multiple strategies including sliding window, token bucket, and fixed window.
+ */
+class RateLimitMiddleware implements MiddlewareInterface
+{
+    /**
+     * Default configuration
+     *
+     * @var array<string, mixed>
+     */
+    protected array $defaultConfig = [
+        'limit' => 60,
+        'window' => 60,
+        'identifier' => 'ip',
+        'strategy' => 'sliding_window',
+        'cache' => 'default',
+        'headers' => true,
+        'message' => 'Rate limit exceeded. Please try again later.',
+        'skipCheck' => null,
+        'costCallback' => null,
+        'identifierCallback' => null,
+        'limitCallback' => null,
+    ];
+
+    /**
+     * Configuration
+     *
+     * @var array<string, mixed>
+     */
+    protected array $config;
+
+    /**
+     * Constructor
+     *
+     * @param array<string, mixed> $config Configuration options
+     */
+    public function __construct(array $config = [])
+    {
+        $this->config = $config + $this->defaultConfig;
+    }
+
+    /**
+     * Process the request and add rate limiting
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler The handler
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ($this->shouldSkip($request)) {
+            return $handler->handle($request);
+        }
+
+        $identifier = $this->getIdentifier($request);
+        $limit = $this->getLimit($request, $identifier);
+        $window = $this->config['window'];
+        $cost = $this->getCost($request);
+
+        $rateLimiter = $this->getRateLimiter();
+        $result = $rateLimiter->attempt($identifier, $limit, $window, $cost);
+
+        if (!$result['allowed']) {
+            throw new TooManyRequestsException($this->config['message']);
+        }
+
+        $response = $handler->handle($request);
+
+        if ($this->config['headers']) {
+            $response = $this->addRateLimitHeaders($response, $result);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Check if rate limiting should be skipped for this request
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request
+     * @return bool
+     */
+    protected function shouldSkip(ServerRequestInterface $request): bool
+    {
+        if ($this->config['skipCheck'] === null) {
+            return false;
+        }
+
+        return (bool)call_user_func($this->config['skipCheck'], $request);
+    }
+
+    /**
+     * Get the identifier for rate limiting
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request
+     * @return string
+     */
+    protected function getIdentifier(ServerRequestInterface $request): string
+    {
+        if ($this->config['identifierCallback'] !== null) {
+            return (string)call_user_func($this->config['identifierCallback'], $request);
+        }
+
+        return match ($this->config['identifier']) {
+            'ip' => $this->getClientIp($request),
+            'user' => $this->getUserIdentifier($request),
+            'route' => $this->getRouteIdentifier($request),
+            'api_key' => $this->getApiKeyIdentifier($request),
+            default => $this->getClientIp($request),
+        };
+    }
+
+    /**
+     * Get client IP address
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request
+     * @return string
+     */
+    protected function getClientIp(ServerRequestInterface $request): string
+    {
+        $params = $request->getServerParams();
+
+        if (!empty($params['HTTP_CF_CONNECTING_IP'])) {
+            return $params['HTTP_CF_CONNECTING_IP'];
+        }
+
+        if (!empty($params['HTTP_X_FORWARDED_FOR'])) {
+            $ips = explode(',', $params['HTTP_X_FORWARDED_FOR']);
+
+            return trim($ips[0]);
+        }
+
+        if (!empty($params['HTTP_X_REAL_IP'])) {
+            return $params['HTTP_X_REAL_IP'];
+        }
+
+        return $params['REMOTE_ADDR'] ?? 'unknown';
+    }
+
+    /**
+     * Get user identifier
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request
+     * @return string
+     */
+    protected function getUserIdentifier(ServerRequestInterface $request): string
+    {
+        $user = $request->getAttribute('identity');
+        if ($user) {
+            if (method_exists($user, 'getIdentifier')) {
+                return 'user_' . $user->getIdentifier();
+            } elseif (isset($user->id)) {
+                return 'user_' . $user->id;
+            }
+        }
+
+        return $this->getClientIp($request);
+    }
+
+    /**
+     * Get route identifier
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request
+     * @return string
+     */
+    protected function getRouteIdentifier(ServerRequestInterface $request): string
+    {
+        $params = $request->getAttribute('params', []);
+        $route = sprintf(
+            '%s::%s.%s',
+            $params['plugin'] ?? 'app',
+            $params['controller'] ?? 'unknown',
+            $params['action'] ?? 'unknown',
+        );
+
+        return $route . '_' . $this->getClientIp($request);
+    }
+
+    /**
+     * Get API key identifier
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request
+     * @return string
+     */
+    protected function getApiKeyIdentifier(ServerRequestInterface $request): string
+    {
+        $apiKey = $request->getHeaderLine('X-API-Key');
+        if (empty($apiKey)) {
+            $apiKey = $request->getQuery('api_key', '');
+        }
+
+        return !empty($apiKey) ? 'api_' . $apiKey : $this->getClientIp($request);
+    }
+
+    /**
+     * Get rate limit for the request
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request
+     * @param string $identifier The identifier
+     * @return int
+     */
+    protected function getLimit(ServerRequestInterface $request, string $identifier): int
+    {
+        if ($this->config['limitCallback'] !== null) {
+            return (int)call_user_func($this->config['limitCallback'], $request, $identifier);
+        }
+
+        return (int)$this->config['limit'];
+    }
+
+    /**
+     * Get the cost of the request
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request
+     * @return int
+     */
+    protected function getCost(ServerRequestInterface $request): int
+    {
+        if ($this->config['costCallback'] !== null) {
+            return (int)call_user_func($this->config['costCallback'], $request);
+        }
+
+        return 1;
+    }
+
+    /**
+     * Get rate limiter instance based on strategy
+     *
+     * @return \Cake\Http\RateLimit\RateLimiterInterface
+     */
+    protected function getRateLimiter(): RateLimiterInterface
+    {
+        $cache = Cache::pool($this->config['cache']);
+
+        return match ($this->config['strategy']) {
+            'token_bucket' => new TokenBucketRateLimiter($cache),
+            'fixed_window' => new FixedWindowRateLimiter($cache),
+            'sliding_window' => new SlidingWindowRateLimiter($cache),
+            default => new SlidingWindowRateLimiter($cache),
+        };
+    }
+
+    /**
+     * Add rate limit headers to response
+     *
+     * @param \Psr\Http\Message\ResponseInterface $response The response
+     * @param array<string, mixed> $result Rate limit result
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    protected function addRateLimitHeaders(ResponseInterface $response, array $result): ResponseInterface
+    {
+        return $response
+            ->withHeader('X-RateLimit-Limit', (string)$result['limit'])
+            ->withHeader('X-RateLimit-Remaining', (string)$result['remaining'])
+            ->withHeader('X-RateLimit-Reset', (string)$result['reset'])
+            ->withHeader('X-RateLimit-Reset-Date', date('c', $result['reset']));
+    }
+}

--- a/src/Http/RateLimit/FixedWindowRateLimiter.php
+++ b/src/Http/RateLimit/FixedWindowRateLimiter.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\RateLimit;
+
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Fixed window rate limiter implementation
+ */
+class FixedWindowRateLimiter implements RateLimiterInterface
+{
+    /**
+     * Cache instance
+     *
+     * @var \Psr\SimpleCache\CacheInterface
+     */
+    protected CacheInterface $cache;
+
+    /**
+     * Constructor
+     *
+     * @param \Psr\SimpleCache\CacheInterface $cache Cache instance
+     */
+    public function __construct(CacheInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function attempt(string $identifier, int $limit, int $window, int $cost = 1): array
+    {
+        $now = time();
+        $windowStart = (int)($now / $window) * $window;
+        $key = 'rate_limit_' . md5($identifier . '_' . $windowStart);
+
+        $count = (int)$this->cache->get($key, 0);
+        $allowed = $count + $cost <= $limit;
+
+        if ($allowed) {
+            $count += $cost;
+            $ttl = $windowStart + $window - $now;
+            $this->cache->set($key, $count, $ttl);
+        }
+
+        return [
+            'allowed' => $allowed,
+            'limit' => $limit,
+            'remaining' => max(0, $limit - $count),
+            'reset' => $windowStart + $window,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reset(string $identifier): void
+    {
+        $now = time();
+        $window = 3600; // Assume max window of 1 hour for reset
+        $windowStart = (int)($now / $window) * $window;
+        $key = 'rate_limit_' . md5($identifier . '_' . $windowStart);
+        $this->cache->delete($key);
+    }
+}

--- a/src/Http/RateLimit/FixedWindowRateLimiter.php
+++ b/src/Http/RateLimit/FixedWindowRateLimiter.php
@@ -47,7 +47,7 @@ class FixedWindowRateLimiter implements RateLimiterInterface
     {
         $now = time();
         $windowStart = (int)($now / $window) * $window;
-        $key = 'rate_limit_' . md5($identifier . '_' . $windowStart);
+        $key = 'rate_limit_' . hash('xxh3', $identifier . '_' . $windowStart);
 
         $count = (int)$this->cache->get($key, 0);
         $allowed = $count + $cost <= $limit;

--- a/src/Http/RateLimit/RateLimiterInterface.php
+++ b/src/Http/RateLimit/RateLimiterInterface.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\RateLimit;
+
+/**
+ * Rate limiter interface
+ */
+interface RateLimiterInterface
+{
+    /**
+     * Attempt to consume from the rate limit
+     *
+     * @param string $identifier The identifier to rate limit
+     * @param int $limit The maximum number of requests
+     * @param int $window The time window in seconds
+     * @param int $cost The cost of this request
+     * @return array{allowed: bool, limit: int, remaining: int, reset: int}
+     */
+    public function attempt(string $identifier, int $limit, int $window, int $cost = 1): array;
+
+    /**
+     * Reset rate limit for an identifier
+     *
+     * @param string $identifier The identifier to reset
+     * @return void
+     */
+    public function reset(string $identifier): void;
+}

--- a/src/Http/RateLimit/SlidingWindowRateLimiter.php
+++ b/src/Http/RateLimit/SlidingWindowRateLimiter.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\RateLimit;
+
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Sliding window rate limiter implementation
+ */
+class SlidingWindowRateLimiter implements RateLimiterInterface
+{
+    /**
+     * Cache instance
+     *
+     * @var \Psr\SimpleCache\CacheInterface
+     */
+    protected CacheInterface $cache;
+
+    /**
+     * Constructor
+     *
+     * @param \Psr\SimpleCache\CacheInterface $cache Cache instance
+     */
+    public function __construct(CacheInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function attempt(string $identifier, int $limit, int $window, int $cost = 1): array
+    {
+        $now = time();
+        $key = 'rate_limit_' . md5($identifier);
+
+        $data = $this->cache->get($key, [
+            'count' => 0,
+            'reset' => $now + $window,
+            'window_start' => $now,
+        ]);
+
+        $elapsed = $now - $data['window_start'];
+        if ($elapsed >= $window) {
+            $data = [
+                'count' => 0,
+                'reset' => $now + $window,
+                'window_start' => $now,
+            ];
+        } else {
+            $weight = 1 - ($elapsed / $window);
+            $data['count'] = (int)($data['count'] * $weight);
+        }
+
+        $allowed = $data['count'] + $cost <= $limit;
+
+        if ($allowed) {
+            $data['count'] += $cost;
+            $this->cache->set($key, $data, $window);
+        }
+
+        return [
+            'allowed' => $allowed,
+            'limit' => $limit,
+            'remaining' => max(0, $limit - (int)$data['count']),
+            'reset' => $data['reset'],
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reset(string $identifier): void
+    {
+        $key = 'rate_limit_' . md5($identifier);
+        $this->cache->delete($key);
+    }
+}

--- a/src/Http/RateLimit/TokenBucketRateLimiter.php
+++ b/src/Http/RateLimit/TokenBucketRateLimiter.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\RateLimit;
+
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Token bucket rate limiter implementation
+ */
+class TokenBucketRateLimiter implements RateLimiterInterface
+{
+    /**
+     * Cache instance
+     *
+     * @var \Psr\SimpleCache\CacheInterface
+     */
+    protected CacheInterface $cache;
+
+    /**
+     * Constructor
+     *
+     * @param \Psr\SimpleCache\CacheInterface $cache Cache instance
+     */
+    public function __construct(CacheInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function attempt(string $identifier, int $limit, int $window, int $cost = 1): array
+    {
+        $now = microtime(true);
+        $key = 'rate_limit_' . md5($identifier);
+
+        $data = $this->cache->get($key, [
+            'tokens' => $limit,
+            'last_update' => $now,
+        ]);
+
+        // Refill tokens based on time elapsed
+        $elapsed = $now - $data['last_update'];
+        $refillRate = $limit / $window;
+        $tokensToAdd = $elapsed * $refillRate;
+
+        $data['tokens'] = min($limit, $data['tokens'] + $tokensToAdd);
+        $data['last_update'] = $now;
+
+        $allowed = $data['tokens'] >= $cost;
+
+        if ($allowed) {
+            $data['tokens'] -= $cost;
+        }
+
+        $this->cache->set($key, $data, $window);
+
+        // Calculate when bucket will be full
+        $tokensNeeded = $limit - $data['tokens'];
+        $secondsToFull = $tokensNeeded / $refillRate;
+        $reset = (int)($now + $secondsToFull);
+
+        return [
+            'allowed' => $allowed,
+            'limit' => $limit,
+            'remaining' => (int)$data['tokens'],
+            'reset' => $reset,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reset(string $identifier): void
+    {
+        $key = 'rate_limit_' . md5($identifier);
+        $this->cache->delete($key);
+    }
+}

--- a/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
@@ -1,0 +1,347 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http\Middleware;
+
+use Cake\Cache\Cache;
+use Cake\Http\Exception\TooManyRequestsException;
+use Cake\Http\Middleware\RateLimitMiddleware;
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+use stdClass;
+
+/**
+ * RateLimitMiddleware test case
+ */
+class RateLimitMiddlewareTest extends TestCase
+{
+    /**
+     * @var \Psr\Http\Server\RequestHandlerInterface
+     */
+    protected $handler;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::setConfig('rate_limit_test', [
+            'className' => 'Array',
+        ]);
+
+        $this->handler = $this->createMock(RequestHandlerInterface::class);
+        $this->handler->method('handle')
+            ->willReturn(new Response());
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        Cache::drop('rate_limit_test');
+    }
+
+    /**
+     * Test basic rate limiting
+     *
+     * @return void
+     */
+    public function testBasicRateLimit(): void
+    {
+        $middleware = new RateLimitMiddleware([
+            'limit' => 2,
+            'window' => 60,
+            'cache' => 'rate_limit_test',
+        ]);
+
+        $request = new ServerRequest([
+            'environment' => ['REMOTE_ADDR' => '127.0.0.1'],
+        ]);
+
+        // First request should pass
+        $response = $middleware->process($request, $this->handler);
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals('2', $response->getHeaderLine('X-RateLimit-Limit'));
+        $this->assertEquals('1', $response->getHeaderLine('X-RateLimit-Remaining'));
+
+        // Second request should pass
+        $response = $middleware->process($request, $this->handler);
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals('0', $response->getHeaderLine('X-RateLimit-Remaining'));
+
+        // Third request should fail
+        $this->expectException(TooManyRequestsException::class);
+        $this->expectExceptionMessage('Rate limit exceeded. Please try again later.');
+        $middleware->process($request, $this->handler);
+    }
+
+    /**
+     * Test IP-based identification
+     *
+     * @return void
+     */
+    public function testIpIdentification(): void
+    {
+        $middleware = new RateLimitMiddleware([
+            'limit' => 1,
+            'window' => 60,
+            'identifier' => 'ip',
+            'cache' => 'rate_limit_test',
+        ]);
+
+        $request1 = new ServerRequest([
+            'environment' => ['REMOTE_ADDR' => '192.168.1.1'],
+        ]);
+        $request2 = new ServerRequest([
+            'environment' => ['REMOTE_ADDR' => '192.168.1.2'],
+        ]);
+
+        // Different IPs should have separate limits
+        $middleware->process($request1, $this->handler);
+        $middleware->process($request2, $this->handler);
+
+        // Second request from first IP should fail
+        $this->expectException(TooManyRequestsException::class);
+        $middleware->process($request1, $this->handler);
+    }
+
+    /**
+     * Test skip check callback
+     *
+     * @return void
+     */
+    public function testSkipCheck(): void
+    {
+        $middleware = new RateLimitMiddleware([
+            'limit' => 1,
+            'window' => 60,
+            'cache' => 'rate_limit_test',
+            'skipCheck' => function ($request) {
+                return $request->getParam('action') === 'health';
+            },
+        ]);
+
+        $request = new ServerRequest([
+            'environment' => ['REMOTE_ADDR' => '127.0.0.1'],
+            'params' => ['action' => 'health'],
+        ]);
+
+        // Should not be rate limited
+        $middleware->process($request, $this->handler);
+        $middleware->process($request, $this->handler);
+        $middleware->process($request, $this->handler);
+
+        // No exception thrown
+        $this->assertTrue(true);
+    }
+
+    /**
+     * Test custom identifier callback
+     *
+     * @return void
+     */
+    public function testCustomIdentifier(): void
+    {
+        $middleware = new RateLimitMiddleware([
+            'limit' => 1,
+            'window' => 60,
+            'cache' => 'rate_limit_test',
+            'identifierCallback' => function ($request) {
+                return $request->getHeaderLine('X-API-Key');
+            },
+        ]);
+
+        $request1 = (new ServerRequest())->withHeader('X-API-Key', 'key1');
+        $request2 = (new ServerRequest())->withHeader('X-API-Key', 'key2');
+
+        // Different API keys should have separate limits
+        $middleware->process($request1, $this->handler);
+        $middleware->process($request2, $this->handler);
+
+        // Second request with same key should fail
+        $this->expectException(TooManyRequestsException::class);
+        $middleware->process($request1, $this->handler);
+    }
+
+    /**
+     * Test cost callback
+     *
+     * @return void
+     */
+    public function testCostCallback(): void
+    {
+        $middleware = new RateLimitMiddleware([
+            'limit' => 10,
+            'window' => 60,
+            'cache' => 'rate_limit_test',
+            'costCallback' => function ($request) {
+                return $request->getMethod() === 'POST' ? 5 : 1;
+            },
+        ]);
+
+        $getRequest = new ServerRequest([
+            'environment' => ['REMOTE_ADDR' => '127.0.0.1', 'REQUEST_METHOD' => 'GET'],
+        ]);
+        $postRequest = new ServerRequest([
+            'environment' => ['REMOTE_ADDR' => '127.0.0.1', 'REQUEST_METHOD' => 'POST'],
+        ]);
+
+        // GET request costs 1
+        $response = $middleware->process($getRequest, $this->handler);
+        $this->assertEquals('9', $response->getHeaderLine('X-RateLimit-Remaining'));
+
+        // POST request costs 5
+        $response = $middleware->process($postRequest, $this->handler);
+        $this->assertEquals('4', $response->getHeaderLine('X-RateLimit-Remaining'));
+    }
+
+    /**
+     * Test headers are not added when disabled
+     *
+     * @return void
+     */
+    public function testNoHeaders(): void
+    {
+        $middleware = new RateLimitMiddleware([
+            'limit' => 10,
+            'window' => 60,
+            'cache' => 'rate_limit_test',
+            'headers' => false,
+        ]);
+
+        $request = new ServerRequest([
+            'environment' => ['REMOTE_ADDR' => '127.0.0.1'],
+        ]);
+
+        $response = $middleware->process($request, $this->handler);
+        $this->assertFalse($response->hasHeader('X-RateLimit-Limit'));
+        $this->assertFalse($response->hasHeader('X-RateLimit-Remaining'));
+        $this->assertFalse($response->hasHeader('X-RateLimit-Reset'));
+    }
+
+    /**
+     * Test user-based identification
+     *
+     * @return void
+     */
+    public function testUserIdentification(): void
+    {
+        $middleware = new RateLimitMiddleware([
+            'limit' => 1,
+            'window' => 60,
+            'identifier' => 'user',
+            'cache' => 'rate_limit_test',
+        ]);
+
+        $identity = new stdClass();
+        $identity->id = '123';
+
+        $request = (new ServerRequest([
+            'environment' => ['REMOTE_ADDR' => '127.0.0.1'],
+        ]))->withAttribute('identity', $identity);
+
+        $response = $middleware->process($request, $this->handler);
+        $this->assertEquals('0', $response->getHeaderLine('X-RateLimit-Remaining'));
+
+        // Second request should fail
+        $this->expectException(TooManyRequestsException::class);
+        $middleware->process($request, $this->handler);
+    }
+
+    /**
+     * Test route-based identification
+     *
+     * @return void
+     */
+    public function testRouteIdentification(): void
+    {
+        $middleware = new RateLimitMiddleware([
+            'limit' => 1,
+            'window' => 60,
+            'identifier' => 'route',
+            'cache' => 'rate_limit_test',
+        ]);
+
+        $request = (new ServerRequest([
+            'environment' => ['REMOTE_ADDR' => '127.0.0.1'],
+        ]))->withAttribute('params', [
+            'controller' => 'Users',
+            'action' => 'login',
+        ]);
+
+        $response = $middleware->process($request, $this->handler);
+        $this->assertEquals('0', $response->getHeaderLine('X-RateLimit-Remaining'));
+
+        // Different route should work
+        $request2 = (new ServerRequest([
+            'environment' => ['REMOTE_ADDR' => '127.0.0.1'],
+        ]))->withAttribute('params', [
+            'controller' => 'Users',
+            'action' => 'logout',
+        ]);
+
+        $middleware->process($request2, $this->handler);
+
+        // Same route should fail
+        $this->expectException(TooManyRequestsException::class);
+        $middleware->process($request, $this->handler);
+    }
+
+    /**
+     * Test proxy headers for IP detection
+     *
+     * @return void
+     */
+    public function testProxyHeaders(): void
+    {
+        $middleware = new RateLimitMiddleware([
+            'limit' => 1,
+            'window' => 60,
+            'cache' => 'rate_limit_test',
+        ]);
+
+        // Test Cloudflare header
+        $request = new ServerRequest([
+            'environment' => [
+                'REMOTE_ADDR' => '127.0.0.1',
+                'HTTP_CF_CONNECTING_IP' => '192.168.1.100',
+            ],
+        ]);
+        $middleware->process($request, $this->handler);
+
+        // Test X-Forwarded-For
+        $request2 = new ServerRequest([
+            'environment' => [
+                'REMOTE_ADDR' => '127.0.0.1',
+                'HTTP_X_FORWARDED_FOR' => '192.168.1.101, 10.0.0.1',
+            ],
+        ]);
+        $middleware->process($request2, $this->handler);
+
+        // Different IPs should work
+        $this->assertTrue(true);
+    }
+}

--- a/tests/TestCase/Http/RateLimit/SlidingWindowRateLimiterTest.php
+++ b/tests/TestCase/Http/RateLimit/SlidingWindowRateLimiterTest.php
@@ -1,0 +1,258 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http\RateLimit;
+
+use Cake\Cache\Cache;
+use Cake\Http\RateLimit\SlidingWindowRateLimiter;
+use Cake\TestSuite\TestCase;
+
+/**
+ * SlidingWindowRateLimiter test case
+ */
+class SlidingWindowRateLimiterTest extends TestCase
+{
+    /**
+     * @var \Cake\Http\RateLimit\SlidingWindowRateLimiter
+     */
+    protected $limiter;
+
+    /**
+     * @var \Psr\SimpleCache\CacheInterface
+     */
+    protected $cache;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::setConfig('rate_limiter_test', [
+            'className' => 'Array',
+        ]);
+
+        $this->cache = Cache::pool('rate_limiter_test');
+        $this->limiter = new SlidingWindowRateLimiter($this->cache);
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        Cache::drop('rate_limiter_test');
+    }
+
+    /**
+     * Test basic rate limiting
+     *
+     * @return void
+     */
+    public function testBasicAttempt(): void
+    {
+        $result = $this->limiter->attempt('test_user', 5, 60);
+
+        $this->assertTrue($result['allowed']);
+        $this->assertEquals(5, $result['limit']);
+        $this->assertEquals(4, $result['remaining']);
+        $this->assertGreaterThan(time(), $result['reset']);
+    }
+
+    /**
+     * Test rate limit exceeded
+     *
+     * @return void
+     */
+    public function testRateLimitExceeded(): void
+    {
+        $identifier = 'test_user_limit';
+        $limit = 3;
+        $window = 60;
+
+        // Use up the limit
+        for ($i = 0; $i < $limit; $i++) {
+            $result = $this->limiter->attempt($identifier, $limit, $window);
+            $this->assertTrue($result['allowed']);
+            $this->assertEquals($limit - $i - 1, $result['remaining']);
+        }
+
+        // Next attempt should fail
+        $result = $this->limiter->attempt($identifier, $limit, $window);
+        $this->assertFalse($result['allowed']);
+        $this->assertEquals(0, $result['remaining']);
+    }
+
+    /**
+     * Test different identifiers have separate limits
+     *
+     * @return void
+     */
+    public function testSeparateIdentifiers(): void
+    {
+        $result1 = $this->limiter->attempt('user1', 1, 60);
+        $this->assertTrue($result1['allowed']);
+        $this->assertEquals(0, $result1['remaining']);
+
+        $result2 = $this->limiter->attempt('user2', 1, 60);
+        $this->assertTrue($result2['allowed']);
+        $this->assertEquals(0, $result2['remaining']);
+
+        // First user should be blocked
+        $result3 = $this->limiter->attempt('user1', 1, 60);
+        $this->assertFalse($result3['allowed']);
+
+        // Second user should still work
+        $result4 = $this->limiter->attempt('user2', 1, 60);
+        $this->assertFalse($result4['allowed']);
+    }
+
+    /**
+     * Test cost parameter
+     *
+     * @return void
+     */
+    public function testCost(): void
+    {
+        $identifier = 'test_cost';
+        $limit = 10;
+        $window = 60;
+
+        // First request with cost 3
+        $result = $this->limiter->attempt($identifier, $limit, $window, 3);
+        $this->assertTrue($result['allowed']);
+        $this->assertEquals(7, $result['remaining']);
+
+        // Second request with cost 5
+        $result = $this->limiter->attempt($identifier, $limit, $window, 5);
+        $this->assertTrue($result['allowed']);
+        $this->assertEquals(2, $result['remaining']);
+
+        // Third request with cost 3 should fail
+        $result = $this->limiter->attempt($identifier, $limit, $window, 3);
+        $this->assertFalse($result['allowed']);
+        $this->assertEquals(2, $result['remaining']);
+
+        // But cost 2 should work
+        $result = $this->limiter->attempt($identifier, $limit, $window, 2);
+        $this->assertTrue($result['allowed']);
+        $this->assertEquals(0, $result['remaining']);
+    }
+
+    /**
+     * Test reset functionality
+     *
+     * @return void
+     */
+    public function testReset(): void
+    {
+        $identifier = 'test_reset';
+        $limit = 2;
+        $window = 60;
+
+        // Use up limit
+        $this->limiter->attempt($identifier, $limit, $window);
+        $this->limiter->attempt($identifier, $limit, $window);
+
+        $result = $this->limiter->attempt($identifier, $limit, $window);
+        $this->assertFalse($result['allowed']);
+
+        // Reset the limit
+        $this->limiter->reset($identifier);
+
+        // Should be able to make requests again
+        $result = $this->limiter->attempt($identifier, $limit, $window);
+        $this->assertTrue($result['allowed']);
+        $this->assertEquals(1, $result['remaining']);
+    }
+
+    /**
+     * Test sliding window behavior
+     *
+     * @return void
+     */
+    public function testSlidingWindowDecay(): void
+    {
+        $identifier = 'test_sliding';
+        $limit = 10;
+        $window = 2; // 2 second window for testing
+
+        // Make initial request
+        $result = $this->limiter->attempt($identifier, $limit, $window, 5);
+        $this->assertTrue($result['allowed']);
+        $this->assertEquals(5, $result['remaining']);
+
+        // Wait for half the window
+        sleep(1);
+
+        // The count should have decayed by ~50%
+        $result = $this->limiter->attempt($identifier, $limit, $window, 1);
+        $this->assertTrue($result['allowed']);
+        // Due to decay, remaining should be more than 4
+        $this->assertGreaterThan(4, $result['remaining']);
+    }
+
+    /**
+     * Test window expiration
+     *
+     * @return void
+     */
+    public function testWindowExpiration(): void
+    {
+        $identifier = 'test_expiration';
+        $limit = 1;
+        $window = 1; // 1 second window
+
+        // Use up the limit
+        $result = $this->limiter->attempt($identifier, $limit, $window);
+        $this->assertTrue($result['allowed']);
+
+        // Should be blocked
+        $result = $this->limiter->attempt($identifier, $limit, $window);
+        $this->assertFalse($result['allowed']);
+
+        // Wait for window to expire
+        sleep(2);
+
+        // Should be allowed again
+        $result = $this->limiter->attempt($identifier, $limit, $window);
+        $this->assertTrue($result['allowed']);
+    }
+
+    /**
+     * Test reset time calculation
+     *
+     * @return void
+     */
+    public function testResetTime(): void
+    {
+        $identifier = 'test_reset_time';
+        $limit = 5;
+        $window = 60;
+        $startTime = time();
+
+        $result = $this->limiter->attempt($identifier, $limit, $window);
+
+        $this->assertGreaterThanOrEqual($startTime + $window, $result['reset']);
+        $this->assertLessThanOrEqual($startTime + $window + 1, $result['reset']);
+    }
+}


### PR DESCRIPTION
Do we want to have a more native out of the box middleware for this?
The reason to have this can be
- Better built in security
- Good in comparison to PHP framework status quo (not having this can be a con) 

For docs see https://github.com/cakephp/docs/pull/8063

### Frameworks with Built-in Rate Limiting

  Laravel ✅

  Most comprehensive implementation:
```php
  Route::middleware(['throttle:60,1'])->group(function () {
      Route::get('/user', function () {
          //
      });
  });
```

  - Multiple limiters (global, user, route-based)
  - Redis and cache backends
  - Customizable responses

  Symfony ✅

  Added in Symfony 5.2:

```php
  use Symfony\Component\RateLimiter\RateLimiterFactory;

  #[Route('/api/login', methods: ['POST'])]
  #[RateLimit(name: 'login', limit: 5, period: '15 minutes')]
  public function login() { }
```

  - Token bucket and sliding window
  - Multiple storage adapters
  - Framework integration via attributes

  Spiral Framework ✅

  Built-in rate limiter:

```php
  use Spiral\RateLimiter\Middleware\RateLimiterMiddleware;

  $router->addMiddleware(new RateLimiterMiddleware(
      policy: 'api',
      maxAttempts: 100,
      window: 60
  ));
```

  Mezzio (Laminas) ✅

  Via mezzio-rate-limit package:

```php
$app->pipe(RateLimitMiddleware::class);
```

  Frameworks WITHOUT Built-in Rate Limiting

  Yii2 ❌

  Has RateLimiter behavior but requires manual implementation

  CakePHP ❌

  Currently requires plugins like muffin/throttle