### PR TITLE
Fix Arabic-Indic numeral output in DateTime test

### DIFF
--- a/tests/TestCase/I18n/DateTimeTest.php
+++ b/tests/TestCase/I18n/DateTimeTest.php
@@ -425,7 +425,7 @@ class DateTimeTest extends TestCase
     public function testI18nFormatUsingSystemLocale(): void
     {
         $time = new DateTime(1556864870);
-        I18n::setLocale('ar');
+        I18n::setLocale('ar-u-nu-arab');
         $this->assertSame('٢٠١٩-٠٥-٠٣', $time->i18nFormat('yyyy-MM-dd'));
 
         I18n::setLocale('en');


### PR DESCRIPTION
Updated `testI18nFormatUsingSystemLocale()` to use `'ar-u-nu-arab'` locale.
This ensures Arabic-Indic digits (٠١٢٣٤٥٦٧٨٩) are output correctly for the Arabic locale,
making the test pass consistently across environments.
