### PR TITLE
5.next: Manage nested validation context (parentContext)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,26 +16,6 @@ parameters:
 			path: src/Cache/Engine/RedisEngine.php
 
 		-
-			message: "#^Method RedisCluster\\:\\:scan\\(\\) invoked with 4 parameters, 1\\-3 required\\.$#"
-			count: 1
-			path: src/Cache/Engine/RedisEngine.php
-
-		-
-			message: "#^Parameter \\#3 \\$pattern of method RedisCluster\\:\\:scan\\(\\) expects int, string given\\.$#"
-			count: 1
-			path: src/Cache/Engine/RedisEngine.php
-
-		-
-			message: '#^Cannot cast int\|Redis\|false to int\.$#'
-			identifier: cast.int
-			count: 1
-			path: src/Cache/Engine/RedisEngine.php
-
-		-
-			message: "#^Parameter \\#2 \\$node of method RedisCluster\\:\\:scan\\(\\) expects string, array\\|string\\|null given\\.$#"
-			path: src/Cache/Engine/RedisEngine.php
-
-		-
 			message: '#^Call to function method_exists\(\) with Memcached and ''setSaslAuthData'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -89,7 +89,7 @@ class RoutesCommand extends Command
         }
 
         if ($args->getOption('sort')) {
-            usort($output, function ($a, $b) {
+            usort($output, function (array $a, array $b) {
                 return strcasecmp($a[0], $b[0]);
             });
         }

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -228,7 +228,7 @@ class ConsoleInputArgument
             $values = [$value];
         }
 
-        $unwanted = array_filter($values, fn($value) => !in_array($value, $this->_choices, true));
+        $unwanted = array_filter($values, fn(string $value) => !in_array($value, $this->_choices, true));
         if ($unwanted) {
             throw new ConsoleException(
                 sprintf(

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -300,7 +300,7 @@ class ConsoleInputOption
             $values = array_map('boolval', $values);
         }
 
-        $unwanted = array_filter($values, fn($value) => !in_array($value, $this->_choices, true));
+        $unwanted = array_filter($values, fn(bool|string $value) => !in_array($value, $this->_choices, true));
         if ($unwanted) {
             throw new ConsoleException(
                 sprintf(

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -274,7 +274,7 @@ class Configure
     {
         $engines = array_keys(static::$_engines);
 
-        return array_map(function ($key) {
+        return array_map(function (int|string $key) {
             return (string)$key;
         }, $engines);
     }

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -175,7 +175,7 @@ trait StaticConfigTrait
     {
         $configurations = array_keys(static::$_config);
 
-        return array_map(function ($key) {
+        return array_map(function (int|string $key) {
             return (string)$key;
         }, $configurations);
     }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1646,7 +1646,7 @@ abstract class Query implements ExpressionInterface, Stringable
     {
         if (!array_key_exists($name, $this->_parts)) {
             $clauses = array_keys($this->_parts);
-            array_walk($clauses, fn(&$x) => $x = "`{$x}`");
+            array_walk($clauses, fn(string &$x) => $x = "`{$x}`");
             $clauses = implode(', ', $clauses);
             throw new InvalidArgumentException(sprintf(
                 'The `%s` clause is not defined. Valid clauses are: %s.',

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -359,7 +359,7 @@ class QueryCompiler
             ->getDriver($query->getConnectionRole())
             ->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY);
 
-        $parts = array_map(function ($p) use ($binder, $setOperationsOrderBy) {
+        $parts = array_map(function (array $p) use ($binder, $setOperationsOrderBy) {
             /** @var \Cake\Database\Expression\IdentifierExpression $expr */
             $expr = $p['query'];
             $p['query'] = $expr->sql($binder);

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -751,8 +751,6 @@ class Debugger
             foreach ($filters as $filter => $visibility) {
                 $reflectionProperties = $ref->getProperties($filter);
                 foreach ($reflectionProperties as $reflectionProperty) {
-                    $reflectionProperty->setAccessible(true);
-
                     if (
                         method_exists($reflectionProperty, 'isInitialized') &&
                         !$reflectionProperty->isInitialized($var)

--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -172,7 +172,7 @@ class FormProtector
             return Hash::filter(explode('.', $name));
         }
         $parts = explode('[', $name);
-        $parts = array_map(function ($el) {
+        $parts = array_map(function (string $el) {
             return trim($el, ']');
         }, $parts);
 

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -253,7 +253,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
     protected function checkValues(string $value, array $allowed): void
     {
         if (!in_array($value, $allowed, true)) {
-            array_walk($allowed, fn(&$x) => $x = "`{$x}`");
+            array_walk($allowed, fn(string &$x) => $x = "`{$x}`");
             throw new InvalidArgumentException(sprintf(
                 'Invalid arg `%s`, use one of these: %s.',
                 $value,

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -1891,7 +1891,7 @@ class Message implements JsonSerializable
             $array[$property] = $this->{$property};
         }
 
-        array_walk($array['attachments'], function (&$item, $key): void {
+        array_walk($array['attachments'], function (array &$item, $key): void {
             if (!empty($item['file'])) {
                 $item['data'] = $this->readFile($item['file']);
                 unset($item['file']);

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1447,11 +1447,12 @@ class BelongsToMany extends Association
         $hasMany = $source->getAssociation($junction->getAlias());
         /** @var array<string> $foreignKey */
         $foreignKey = (array)$this->getForeignKey();
-        $foreignKey = array_map(function ($key) {
+        $foreignKey = array_map(function (string $key) {
             return $key . ' IS';
         }, $foreignKey);
+        /** @var array<string> $assocForeignKey */
         $assocForeignKey = (array)$belongsTo->getForeignKey();
-        $assocForeignKey = array_map(function ($key) {
+        $assocForeignKey = array_map(function (string $key) {
             return $key . ' IS';
         }, $assocForeignKey);
         $sourceKey = $sourceEntity->extract((array)$source->getPrimaryKey());

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -171,7 +171,7 @@ class AssociationCollection implements IteratorAggregate
     {
         $class = array_map('strtolower', (array)$class);
 
-        $out = array_filter($this->_items, function ($assoc) use ($class) {
+        $out = array_filter($this->_items, function (Association $assoc) use ($class) {
             [, $name] = namespaceSplit($assoc::class);
 
             return in_array(strtolower($name), $class, true);

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -268,10 +268,11 @@ class Marshaller
      * @param array $data The data to validate.
      * @param string|bool $validator Validator name or `true` for default validator.
      * @param bool $isNew Whether it is a new entity or one to be updated.
+     * @param array<string, mixed> $context Additional validation context.
      * @return array The list of validation errors.
      * @throws \RuntimeException If no validator can be created.
      */
-    protected function _validate(array $data, string|bool $validator, bool $isNew): array
+    protected function _validate(array $data, string|bool $validator, bool $isNew, array $context = []): array
     {
         if (!$validator) {
             return [];
@@ -281,7 +282,7 @@ class Marshaller
             $validator = null;
         }
 
-        return $this->_table->getValidator($validator)->validate($data, $isNew);
+        return $this->_table->getValidator($validator)->validate($data, $isNew, $context);
     }
 
     /**
@@ -582,7 +583,7 @@ class Marshaller
             }
         }
 
-        $errors = $this->_validate($data + $keys, $options['validate'], $isNew);
+        $errors = $this->_validate($data + $keys, $options['validate'], $isNew, ['entity' => $entity]);
         $options['isMerge'] = true;
         $propertyMap = $this->_buildPropertyMap($data, $options);
         $properties = [];

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -209,7 +209,13 @@ class Marshaller
                 $entity->setAccess($key, $value);
             }
         }
-        $errors = $this->_validate($data, $options['validate'], true);
+
+        $fieldsToValidate = $options['strictFields'] ? (array)$options['fields'] : [];
+        $context = [
+            'entity' => $entity,
+            'fields' => $fieldsToValidate,
+        ];
+        $errors = $this->_validate($data, $options['validate'], true, $context);
 
         $options['isMerge'] = false;
         $propertyMap = $this->_buildPropertyMap($data, $options);
@@ -294,7 +300,7 @@ class Marshaller
      */
     protected function _prepareDataAndOptions(array $data, array $options): array
     {
-        $options += ['validate' => true];
+        $options += ['validate' => true, 'fields' => null, 'strictFields' => false];
 
         $tableName = $this->_table->getAlias();
         if (isset($data[$tableName]) && is_array($data[$tableName])) {
@@ -583,7 +589,12 @@ class Marshaller
             }
         }
 
-        $errors = $this->_validate($data + $keys, $options['validate'], $isNew, ['entity' => $entity]);
+        $fieldsToValidate = $options['strictFields'] ? (array)$options['fields'] : [];
+        $context = [
+            'entity' => $entity,
+            'fields' => $fieldsToValidate,
+        ];
+        $errors = $this->_validate($data + $keys, $options['validate'], $isNew, $context);
         $options['isMerge'] = true;
         $propertyMap = $this->_buildPropertyMap($data, $options);
         $properties = [];

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -138,7 +138,7 @@ class ExistsIn
         }
 
         $primary = array_map(
-            fn($key) => $target->aliasField($key) . ' IS',
+            fn(string $key) => $target->aliasField($key) . ' IS',
             $bindingKey,
         );
         $conditions = array_combine(

--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -100,7 +100,7 @@ class ConnectionHelper
 
         $tables = $tables !== null ? array_intersect($tables, $allTables) : $allTables;
         /** @var array<\Cake\Database\Schema\TableSchema> $schemas Specify type for psalm */
-        $schemas = array_map(fn($table) => $collection->describe($table), $tables);
+        $schemas = array_map(fn(string $table) => $collection->describe($table), $tables);
 
         $dialect = $connection->getWriteDriver()->schemaDialect();
         foreach ($schemas as $schema) {
@@ -131,7 +131,7 @@ class ConnectionHelper
         $allTables = $collection->listTablesWithoutViews();
         $tables = $tables !== null ? array_intersect($tables, $allTables) : $allTables;
         /** @var array<\Cake\Database\Schema\TableSchema> $schemas Specify type for psalm */
-        $schemas = array_map(fn($table) => $collection->describe($table), $tables);
+        $schemas = array_map(fn(string $table) => $collection->describe($table), $tables);
 
         self::runWithoutConstraints($connection, function (Connection $connection) use ($schemas): void {
             $dialect = $connection->getWriteDriver()->schemaDialect();

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -203,7 +203,10 @@ class TestFixture implements FixtureInterface
         foreach ($this->records as $index => $record) {
             $recordFields = array_keys($record);
             if ($this->strictFields) {
-                $invalidFields = array_values(array_filter($recordFields, fn($f) => !in_array($f, $columns, true)));
+                $invalidFields = array_values(array_filter(
+                    $recordFields,
+                    fn(int|string $f) => !in_array($f, $columns, true),
+                ));
                 if ($invalidFields !== []) {
                     throw new CakeException(
                         "Record #{$index} in fixture has additional fields that do not exist in the schema. " .

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -731,7 +731,7 @@ trait IntegrationTestTrait
         if ($this->_securityToken === true) {
             $fields = array_diff_key($data, array_flip($this->_unlockedFields));
 
-            $keys = array_map(function ($field) {
+            $keys = array_map(function (int|string $field) {
                 return preg_replace('/(\.\d+)+$/', '', (string)$field);
             }, array_keys(Hash::flatten($fields)));
 

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -43,6 +43,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use ReflectionClass;
 use ReflectionException;
+use ReflectionMethod;
 use function Cake\Core\pluginSplit;
 
 /**
@@ -984,7 +985,7 @@ abstract class TestCase extends BaseTestCase
         $options += ['alias' => $baseClass, 'connection' => $connection];
         $options += $locator->getConfig($alias);
         $reflection = new ReflectionClass($className);
-        $classMethods = array_map(function ($method) {
+        $classMethods = array_map(function (ReflectionMethod $method) {
             return $method->name;
         }, $reflection->getMethods());
 

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -233,7 +233,7 @@ class Text
 
         $dataKeys = array_keys($data);
         $hashKeys = array_map(
-            fn($str) => hash('xxh128', $str),
+            fn(int|string $str) => hash('xxh128', (string)$str),
             $dataKeys,
         );
         /** @var array<string, string> $tempData */

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Utility;
 
+use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
+use Closure;
 use InvalidArgumentException;
 use Transliterator;
 use function Cake\I18n\__d;
@@ -66,12 +68,28 @@ class Text
      * It should also not be used to create identifiers that have security implications, such as
      * 'unguessable' URL identifiers. Instead, you should use {@link \Cake\Utility\Security::randomBytes()}` for that.
      *
+     * ### Custom UUID generation
+     *
+     * You can configure a custom UUID generator by setting a Closure via Configure:
+     *
+     * ```
+     * Configure::write('Text.uuidGenerator', function () {
+     *     // Return your custom UUID string
+     *     return MyUuidLibrary::generate();
+     * });
+     * ```
+     *
      * @see https://www.ietf.org/rfc/rfc4122.txt
      * @return string RFC 4122 UUID
      * @copyright Matt Farina MIT License https://github.com/lootils/uuid/blob/master/LICENSE
      */
     public static function uuid(): string
     {
+        $generator = Configure::read('Text.uuidGenerator');
+        if ($generator instanceof Closure) {
+            return $generator();
+        }
+
         return sprintf(
             '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
             // 32 bits for "time_low"

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -228,6 +228,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $errors = [];
 
         foreach ($this->_fields as $name => $field) {
+            if (!empty($context['fields']) && !in_array($name, $context['fields'], true)) {
+                continue;
+            }
+
             $name = (string)$name;
             $keyPresent = array_key_exists($name, $data);
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2087,7 +2087,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         }
 
         if ($message === null) {
-            $cases = array_map(fn($case) => $case->value, $enumClassName::cases());
+            $cases = array_map(fn(BackedEnum $case) => $case->value, $enumClassName::cases());
             $caseOptions = implode('`, `', $cases);
             if (!$this->_useI18n) {
                 $message = sprintf('The provided value must be one of `%s`', $caseOptions);

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -535,7 +535,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 $provider = $this->getProvider($name);
                 $validator->setProvider($name, $provider);
             }
-            $errors = $validator->validate($value, $context['newRecord']);
+            $errors = $validator->validate($value, $context['newRecord'], ['parentContext' => $context]);
 
             $message = $message ? [static::NESTED => $message] : [];
 
@@ -588,7 +588,11 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 if (!is_array($row)) {
                     return false;
                 }
-                $check = $validator->validate($row, $context['newRecord']);
+                $check = $validator->validate(
+                    $row,
+                    $context['newRecord'],
+                    ['parentContext' => $context, 'nestedManyIndex' => $i],
+                );
                 if ($check) {
                     $errors[$i] = $check;
                 }

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -575,7 +575,7 @@ class EntityContext implements ContextInterface
      */
     protected function _getValidator(array $parts): Validator
     {
-        $keyParts = array_filter(array_slice($parts, 0, -1), function ($part) {
+        $keyParts = array_filter(array_slice($parts, 0, -1), function (string $part) {
             return !is_numeric($part);
         });
         $key = implode('.', $keyParts);
@@ -625,7 +625,7 @@ class EntityContext implements ContextInterface
             return $this->_tables[$this->_rootName];
         }
 
-        $normalized = array_slice(array_filter($parts, function ($part) {
+        $normalized = array_slice(array_filter($parts, function (string $part) {
             return !is_numeric($part);
         }), 0, -1);
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2517,7 +2517,7 @@ class FormHelper extends Helper
             if (is_array($first)) {
                 $disabled = array_filter(
                     $options['options'],
-                    fn($i) => in_array($i['value'], $options['disabled'], true),
+                    fn(array $i) => in_array($i['value'], $options['disabled'], true),
                 );
 
                 return $disabled !== [];
@@ -2681,8 +2681,8 @@ class FormHelper extends Helper
         $diff = array_diff($sources, $this->supportedValueSources);
 
         if ($diff) {
-            array_walk($diff, fn(&$x) => $x = "`{$x}`");
-            array_walk($this->supportedValueSources, fn(&$x) => $x = "`{$x}`");
+            array_walk($diff, fn(string &$x) => $x = "`{$x}`");
+            array_walk($this->supportedValueSources, fn(string &$x) => $x = "`{$x}`");
             throw new InvalidArgumentException(sprintf(
                 'Invalid value source(s): %s. Valid values are: %s.',
                 implode(', ', $diff),

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -624,7 +624,7 @@ class ViewBuilder implements JsonSerializable
         /** @phpstan-ignore-next-line argument.type */
         array_walk_recursive($array['_vars'], $this->_checkViewVars(...));
 
-        return array_filter($array, function ($i) {
+        return array_filter($array, function (array|bool|string|null $i) {
             return !is_array($i) && strlen((string)$i) || !empty($i);
         });
     }

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -30,7 +30,7 @@ class RedisClusterEngineTest extends TestCase
             'Redis extension is not installed or configured properly.',
         );
 
-        $nodes = array_map(function ($node) {
+        $nodes = array_map(function (string $node) {
             [$host, $port] = explode(':', $node);
 
             return ['host' => $host, 'port' => (int)$port];
@@ -168,7 +168,6 @@ class RedisClusterEngineTest extends TestCase
         // Set $_Redis manually using Reflection
         $reflection = new ReflectionClass($mock);
         $property = $reflection->getProperty('_Redis');
-        $property->setAccessible(true);
         $property->setValue($mock, $redisMock);
 
         // Mock logger

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -31,10 +31,7 @@ use LogicException;
  */
 class ConsoleOptionParserTest extends TestCase
 {
-    /**
-     * @var \Cake\Console\ConsoleIo
-     */
-    private $io;
+    private ConsoleIo $io;
 
     protected function setUp(): void
     {

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -1187,10 +1187,8 @@ class ConnectionTest extends TestCase
 
             $newDriver = $this->getMockBuilder(Driver::class)->getMock();
             $prop = new ReflectionProperty($conn, 'readDriver');
-            $prop->setAccessible(true);
             $prop->setValue($conn, $newDriver);
             $prop = new ReflectionProperty($conn, 'writeDriver');
-            $prop->setAccessible(true);
             $prop->setValue($conn, $newDriver);
 
         $newDriver->expects($this->exactly(2))
@@ -1219,10 +1217,8 @@ class ConnectionTest extends TestCase
 
             $newDriver = $this->getMockBuilder(Driver::class)->getMock();
             $prop = new ReflectionProperty($conn, 'readDriver');
-            $prop->setAccessible(true);
             $prop->setValue($conn, $newDriver);
             $prop = new ReflectionProperty($conn, 'writeDriver');
-            $prop->setAccessible(true);
             $oldDriver = $prop->getValue($conn);
             $prop->setValue($conn, $newDriver);
 

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -3066,7 +3066,7 @@ class SelectQueryTest extends TestCase
                 'ye' => '2007',
             ] + $expected;
         } elseif ($driver instanceof Postgres || $driver instanceof Sqlserver) {
-            $expected = array_map(function ($value) {
+            $expected = array_map(function (int|string $value) {
                 return (string)$value;
             }, $expected);
         }

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -38,10 +38,7 @@ use Throwable;
 
 class ExceptionTrapTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    private $memoryLimit;
+    private string $memoryLimit;
 
     private $triggered = false;
 

--- a/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
+++ b/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
@@ -1001,7 +1001,6 @@ class WebExceptionRendererTest extends TestCase
             $exceptionRenderer = new MyCustomExceptionRenderer($exception);
 
             $reflectedMethod = new ReflectionMethod($exceptionRenderer, 'getHttpCode');
-            $reflectedMethod->setAccessible(true);
 
             $this->assertSame(404, $reflectedMethod->invoke($exceptionRenderer, $exception));
         });

--- a/tests/TestCase/Http/Client/Auth/OauthTest.php
+++ b/tests/TestCase/Http/Client/Auth/OauthTest.php
@@ -25,15 +25,9 @@ use Cake\TestSuite\TestCase;
  */
 class OauthTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    private $privateKeyString;
+    private string $privateKeyString;
 
-    /**
-     * @var string
-     */
-    private $privateKeyStringEnc;
+    private string $privateKeyStringEnc;
 
     /**
      * Setup

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -93,7 +93,6 @@ class SessionTest extends TestCase
         $session = new Session($config);
 
         $prop = new ReflectionProperty($session, '_lifetime');
-        $prop->setAccessible(true);
         $this->assertSame(1440, $prop->getValue($session));
     }
 

--- a/tests/TestCase/Log/Engine/BaseLogTest.php
+++ b/tests/TestCase/Log/Engine/BaseLogTest.php
@@ -29,10 +29,7 @@ class BaseLogTest extends TestCase
 {
     private $testData = ['ä', 'ö', 'ü'];
 
-    /**
-     * @var \TestApp\Log\Engine\TestBaseLog
-     */
-    private $logger;
+    private TestBaseLog $logger;
 
     /**
      * Setting up the test case.

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -1340,7 +1340,6 @@ HTML;
         $message = new Message();
         $reflection = new ReflectionClass($message);
         $property = $reflection->getProperty('serializableProperties');
-        $property->setAccessible(true);
         $serializableProperties = $property->getValue($message);
 
         $message

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -2687,6 +2687,38 @@ class MarshallerTest extends TestCase
     }
 
     /**
+     * Test one() with strictFields option
+     */
+    public function testOneWithStrictFields(): void
+    {
+        // Add validation rules
+        $this->articles->getValidator()
+            ->requirePresence('title')
+            ->notEmptyString('title');
+
+        $data = [
+            'title' => '',
+            'body' => 'My content',
+            'author_id' => 'invalid',
+        ];
+        $marshall = new Marshaller($this->articles);
+
+        // Without strictFields, all fields are validated
+        $result = $marshall->one($data, ['fields' => ['body']]);
+        $this->assertInstanceOf(Entity::class, $result);
+        $this->assertEquals(['body' => 'My content'], $result->toArray());
+        // We have validation errors for title even though it wasn't in fields
+        $this->assertNotEmpty($result->getErrors());
+
+        // With strictFields, only the specified fields are validated
+        $result = $marshall->one($data, ['fields' => ['body'], 'strictFields' => true]);
+        $this->assertInstanceOf(Entity::class, $result);
+        $this->assertEquals(['body' => 'My content'], $result->toArray());
+        // No validation errors as we only validate the fields list
+        $this->assertEmpty($result->getErrors());
+    }
+
+    /**
      * Test one() with translations
      */
     public function testOneWithTranslations(): void
@@ -2757,6 +2789,63 @@ class MarshallerTest extends TestCase
         $this->assertSame($entity, $result);
         $this->assertEquals($expected, $result->toArray());
         $this->assertFalse($entity->isAccessible('*'));
+    }
+
+    /**
+     * Tests that it is possible to pass a strict fields option to the merge method
+     */
+    public function testMergeWithFieldsStrict(): void
+    {
+        $this->articles->getValidator()
+            ->requirePresence('title')
+            ->notEmptyString('title');
+
+        $data = [
+            'title' => null,
+            'body' => 'My body',
+            'author_id' => 1,
+        ];
+        $marshall = new Marshaller($this->articles);
+
+        $entity = new Entity([
+            'title' => 'Foo',
+            'body' => 'My content',
+            'author_id' => 2,
+        ]);
+
+        $entity->setAccess('*', false);
+        $entity->setNew(false);
+        $entity->clean();
+        $result = $marshall->merge($entity, $data, ['fields' => ['body']]);
+
+        $expected = [
+            'title' => 'Foo',
+            'body' => 'My body',
+            'author_id' => 2,
+        ];
+
+        $this->assertSame($entity, $result);
+        $this->assertEquals($expected, $result->toArray());
+        $this->assertFalse($entity->isAccessible('*'));
+        // We have validation errors though
+        $this->assertNotEmpty($entity->getErrors());
+
+        $entity = new Entity([
+            'title' => 'Foo',
+            'body' => 'My content',
+            'author_id' => 2,
+        ]);
+
+        $entity->setAccess('*', false);
+        $entity->setNew(false);
+        $entity->clean();
+        $result = $marshall->merge($entity, $data, ['fields' => ['body'], 'strictFields' => true]);
+
+        $this->assertSame($entity, $result);
+        $this->assertEquals($expected, $result->toArray());
+        $this->assertFalse($entity->isAccessible('*'));
+        // We only validate fields list now
+        $this->assertEmpty($entity->getErrors());
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3563,6 +3563,37 @@ class TableTest extends TestCase
     }
 
     /**
+     * Checks that entity is passed into context.
+     *
+     * @return void
+     */
+    public function testValidatorWithEntityInContext(): void
+    {
+        $table = new class (['alias' => 'Users', 'table' => 'users', 'connection' => $this->connection]) extends Table {
+            public function validateMe(string $text, array $context): bool
+            {
+                if (!isset($context['entity'])) {
+                    throw new InvalidArgumentException('Entity not found in context');
+                }
+
+                return true;
+            }
+        };
+
+        $table->getValidator('default')->add(
+            'name',
+            'validateMe',
+            ['rule' => 'validateMe', 'provider' => 'table'],
+        );
+
+        $entity = $table->newEmptyEntity();
+        $result = $table->patchEntity($entity, [
+            'name' => 'test',
+        ]);
+        $this->assertSame('test', $result->get('name'));
+    }
+
+    /**
      * Tests that a InvalidArgumentException is thrown if the custom validator method does not exist.
      */
     public function testValidatorWithMissingMethod(): void

--- a/tests/TestCase/Utility/Crypto/OpenSslTest.php
+++ b/tests/TestCase/Utility/Crypto/OpenSslTest.php
@@ -24,10 +24,7 @@ use Cake\Utility\Crypto\OpenSsl;
  */
 class OpenSslTest extends TestCase
 {
-    /**
-     * @var OpenSsl
-     */
-    private $crypt;
+    private OpenSsl $crypt;
 
     /**
      * Setup function.

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Utility;
 
+use Cake\Core\Configure;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Text;
@@ -79,6 +80,29 @@ class TextTest extends TestCase
             $this->assertNotContains($result, $check);
             $check[] = $result;
         }
+    }
+
+    /**
+     * testUuidGenerationWithClosure method
+     */
+    public function testUuidGenerationWithClosure(): void
+    {
+        $customUuid = 'custom-uuid-12345678-1234-1234-1234-123456789012';
+        Configure::write('Text.uuidGenerator', function () use ($customUuid) {
+            return $customUuid;
+        });
+
+        $result = Text::uuid();
+        $this->assertSame($customUuid, $result);
+
+        // Clean up
+        Configure::delete('Text.uuidGenerator');
+
+        // Test that it falls back to default implementation
+        $result = Text::uuid();
+        $pattern = '/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/';
+        $match = (bool)preg_match($pattern, $result);
+        $this->assertTrue($match);
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -3062,6 +3062,110 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Test that nested validators receive parent context information
+     */
+    public function testNestedValidationWithParentContext(): void
+    {
+        $contextCapture = null;
+
+        $nestedValidator = new Validator();
+        $nestedValidator->add('nested_field', 'custom', [
+            'rule' => function ($value, $context) use (&$contextCapture) {
+                $contextCapture = $context;
+                // Access parent data through context
+                if (isset($context['parentContext'])) {
+                    return $context['parentContext']['data']['parent_field'] === 'valid';
+                }
+
+                return true;
+            },
+            'message' => 'Parent field must be valid',
+        ]);
+
+        $validator = new Validator();
+        $validator->notEmptyString('parent_field');
+        $validator->addNested('nested', $nestedValidator);
+
+        $data = [
+            'parent_field' => 'invalid',
+            'nested' => [
+                'nested_field' => 'test',
+            ],
+        ];
+
+        $errors = $validator->validate($data);
+
+        // Verify parent context was passed
+        $this->assertNotNull($contextCapture);
+        $this->assertArrayHasKey('parentContext', $contextCapture);
+        $this->assertArrayHasKey('data', $contextCapture['parentContext']);
+        $this->assertEquals('invalid', $contextCapture['parentContext']['data']['parent_field']);
+
+        // Should have validation error because parent_field is 'invalid'
+        $this->assertArrayHasKey('nested', $errors);
+        $this->assertArrayHasKey('nested_field', $errors['nested']);
+
+        // Test with valid parent field
+        $data['parent_field'] = 'valid';
+        $errors = $validator->validate($data);
+        $this->assertArrayNotHasKey('nested', $errors);
+    }
+
+    /**
+     * Test that nested many validators receive parent context and index information
+     */
+    public function testNestedManyValidationWithParentContextAndIndex(): void
+    {
+        $contextCaptures = [];
+
+        $nestedValidator = new Validator();
+        $nestedValidator->add('item_name', 'custom', [
+            'rule' => function ($value, $context) use (&$contextCaptures) {
+                $contextCaptures[] = $context;
+                // Validate based on index
+                if (isset($context['nestedManyIndex']) && $context['nestedManyIndex'] === 0) {
+                    // First item must not be empty
+                    return !empty($value);
+                }
+
+                return true;
+            },
+            'message' => 'First item name cannot be empty',
+        ]);
+
+        $validator = new Validator();
+        $validator->notEmptyString('list_name');
+        $validator->addNestedMany('items', $nestedValidator);
+
+        $data = [
+            'list_name' => 'My List',
+            'items' => [
+                ['item_name' => ''], // Should fail - first item
+                ['item_name' => ''], // Should pass - not first item
+                ['item_name' => 'Third'],
+            ],
+        ];
+
+        $errors = $validator->validate($data);
+
+        // Verify context was captured for all items
+        $this->assertCount(3, $contextCaptures);
+
+        // Check each captured context has correct index
+        foreach ($contextCaptures as $i => $context) {
+            $this->assertArrayHasKey('nestedManyIndex', $context);
+            $this->assertEquals($i, $context['nestedManyIndex']);
+            $this->assertArrayHasKey('parentContext', $context);
+            $this->assertEquals('My List', $context['parentContext']['data']['list_name']);
+        }
+
+        // Should have error only for first item
+        $this->assertArrayHasKey('items', $errors);
+        $this->assertArrayHasKey(0, $errors['items']);
+        $this->assertArrayNotHasKey(1, $errors['items']);
+    }
+
+    /**
      * Assert for the data validation message for a given field's rule for a I18n-enabled & a I18n-disabled validator
      *
      * @param string $fieldName The field name.


### PR DESCRIPTION
Replaces https://github.com/cakephp/cakephp/pull/18212

Fixed up with simpler API now that we have context available.

Note: We should squash merge this to have the proper commit message (title).