### PR TITLE
Validate XML string before returning SimpleXMLElement

### DIFF
--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -298,7 +298,27 @@ class Xml
 
         $options['return'] = strtolower($options['return']);
         if ($options['return'] === 'simplexml' || $options['return'] === 'simplexmlelement') {
-            return new SimpleXMLElement((string)$dom->saveXML());
+            $xmlString = (string)$dom->saveXML();
+            $check = new DOMDocument();
+            libxml_use_internal_errors(true);
+
+            if (!$check->loadXML($xmlString, LIBXML_NOWARNING | LIBXML_NOERROR)) {
+                $errors = libxml_get_errors();
+                $messages = [];
+
+                foreach ($errors as $error) {
+                    $messages[] = trim(sprintf(
+                        "File: %s, Line %d, Column %d: %s",
+                        $error->file ?: '[string input]',
+                        $error->line,
+                        $error->column,
+                        $error->message
+                    ));
+                }
+                libxml_clear_errors();
+                throw new XmlException("Invalid XML string:\n" . implode("\n", $messages));
+            }
+            return new SimpleXMLElement($xmlString);
         }
 
         return $dom;

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -308,16 +308,17 @@ class Xml
 
                 foreach ($errors as $error) {
                     $messages[] = trim(sprintf(
-                        "File: %s, Line %d, Column %d: %s",
+                        'File: %s, Line %d, Column %d: %s',
                         $error->file ?: '[string input]',
                         $error->line,
                         $error->column,
-                        $error->message
+                        $error->message,
                     ));
                 }
                 libxml_clear_errors();
                 throw new XmlException("Invalid XML string:\n" . implode("\n", $messages));
             }
+
             return new SimpleXMLElement($xmlString);
         }
 


### PR DESCRIPTION
- Added `DOMDocument::loadXML()` check with `LIBXML_NOWARNING | LIBXML_NOERROR`
- Enabled libxml internal error handling and collected detailed error messages
  (file, line, column, message)
- Throw `XmlException` with detailed context when the XML string is invalid
- Prevents returning malformed `XML` from `fromArray()`