### PR TITLE
 Add wrapScript option to HtmlHelper script methods

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -587,6 +587,9 @@ class HtmlHelper extends Helper
      *
      * - `block` Set to true to append output to view block "script" or provide
      *   custom block name.
+     * - `wrapScript` Set to false to disable automatic script tag wrapping (default: true).
+     *   Note: When using CSP with nonces and wrapScript is false, you must manually add
+     *   the nonce attribute. You can get the nonce value using `$this->Html->getCspScriptNonce()`
      *
      * @param string $script The script to wrap
      * @param array<string, mixed> $options The options to use. Options not listed above will be
@@ -599,12 +602,18 @@ class HtmlHelper extends Helper
         $options += [
             'block' => $this->getConfig('defaultScriptBlock'),
             'nonce' => $this->_View->getRequest()->getAttribute('cspScriptNonce'),
+            'wrapScript' => true,
         ];
 
-        $out = $this->formatTemplate('javascriptblock', [
-            'attrs' => $this->templater()->formatAttributes($options, ['block']),
-            'content' => $script,
-        ]);
+        // If wrapScript is false, output the script content directly without wrapping tags
+        if ($options['wrapScript'] === false) {
+            $out = $script;
+        } else {
+            $out = $this->formatTemplate('javascriptblock', [
+                'attrs' => $this->templater()->formatAttributes($options, ['block', 'wrapScript']),
+                'content' => $script,
+            ]);
+        }
 
         if (empty($options['block'])) {
             return $out;
@@ -626,6 +635,9 @@ class HtmlHelper extends Helper
      *
      * - `block` Set to true to append output to view block "script" or provide
      *   custom block name.
+     * - `wrapScript` Set to false to disable automatic script tag wrapping (default: true).
+     *   Note: When using CSP with nonces and wrapScript is false, you must manually add
+     *   the nonce attribute. You can get the nonce value using `$this->Html->getCspScriptNonce()`
      *
      * @param array<string, mixed> $options Options for the code block.
      * @return void
@@ -635,6 +647,17 @@ class HtmlHelper extends Helper
     {
         $this->_scriptBlockOptions = $options;
         ob_start();
+    }
+
+    /**
+     * Get the CSP script nonce value if available.
+     * Useful when manually writing script tags with wrapScript disabled.
+     *
+     * @return string|null The CSP nonce value or null if not set
+     */
+    public function getCspScriptNonce(): ?string
+    {
+        return $this->_View->getRequest()->getAttribute('cspScriptNonce');
     }
 
     /**

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -1318,6 +1318,96 @@ class HtmlHelperTest extends TestCase
     }
 
     /**
+     * Test scriptBlock with wrapScript option
+     */
+    public function testScriptBlockWithWrapScriptOption(): void
+    {
+        // Test with wrapScript = false
+        $result = $this->Html->scriptBlock('window.foo = 2;', ['wrapScript' => false]);
+        $this->assertEquals('window.foo = 2;', $result);
+
+        // Test with wrapScript = true (default behavior)
+        $result = $this->Html->scriptBlock('window.foo = 2;', ['wrapScript' => true]);
+        $expected = [
+            '<script',
+            'window.foo = 2;',
+            '/script',
+        ];
+        $this->assertHtml($expected, $result);
+
+        // Test without wrapScript option (should default to true)
+        $result = $this->Html->scriptBlock('window.foo = 2;');
+        $expected = [
+            '<script',
+            'window.foo = 2;',
+            '/script',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Test scriptStart and scriptEnd with wrapScript option
+     */
+    public function testScriptStartAndEndWithWrapScriptOption(): void
+    {
+        // Test with wrapScript = false
+        $this->Html->scriptStart(['wrapScript' => false]);
+        echo 'var test = "no wrapper";';
+        $result = $this->Html->scriptEnd();
+        $this->assertEquals('var test = "no wrapper";', $result);
+
+        // Test with wrapScript = true
+        $this->Html->scriptStart(['wrapScript' => true]);
+        echo 'var test = "with wrapper";';
+        $result = $this->Html->scriptEnd();
+        $expected = [
+            '<script',
+            'var test = "with wrapper";',
+            '/script',
+        ];
+        $this->assertHtml($expected, $result);
+
+        // Test with wrapScript = false and block option
+        $this->View->shouldReceive('append')
+            ->with('script', 'var blockTest = "no wrapper in block";')
+            ->once();
+
+        $this->Html->scriptStart(['wrapScript' => false, 'block' => true]);
+        echo 'var blockTest = "no wrapper in block";';
+        $result = $this->Html->scriptEnd();
+        $this->assertNull($result);
+
+        // Test with wrapScript = true and block option
+        $this->View->shouldReceive('append')
+            ->with('script', Mockery::pattern('/<script.*var blockTest = "with wrapper in block";.*<\/script>/s'))
+            ->once();
+
+        $this->Html->scriptStart(['wrapScript' => true, 'block' => true]);
+        echo 'var blockTest = "with wrapper in block";';
+        $result = $this->Html->scriptEnd();
+        $this->assertNull($result);
+    }
+
+    /**
+     * Test getCspScriptNonce method
+     */
+    public function testGetCspScriptNonce(): void
+    {
+        // Test without nonce
+        $result = $this->Html->getCspScriptNonce();
+        $this->assertNull($result);
+
+        // Test with nonce
+        $nonce = 'test-nonce-value';
+        $request = $this->View->getRequest()
+            ->withAttribute('cspScriptNonce', $nonce);
+        $this->View->setRequest($request);
+
+        $result = $this->Html->getCspScriptNonce();
+        $this->assertEquals($nonce, $result);
+    }
+
+    /**
      * testCharsetTag method
      */
     public function testCharsetTag(): void


### PR DESCRIPTION
 Adds a new `wrapScript` option to scriptStart(), scriptEnd(), and
  scriptBlock() methods that allows disabling automatic <script> tag
  generation. This improves IDE JavaScript recognition when developers
  want to write their own script tags in templates.

  Also adds getCspScriptNonce() helper method to retrieve CSP nonce
  values for manual script tag creation, addressing security concerns
  when wrapScript is disabled.

  Fixes #18837
