### PR TITLE
5.x Fix methods to be extendable.

### DIFF
--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -270,8 +270,8 @@ class FormProtector
      * Return hash parts for the token generation
      *
      * @param array<string, array> $formData Form data.
-     * @return array<string, array>
-     * @phpstan-return array{fields: array, unlockedFields: array<string>}
+     * @return array<string, array> Contains 'fields' and 'unlockedFields' keys. Additional keys allowed.
+     * @phpstan-return array{fields: array, unlockedFields: array<string>, ...}
      */
     protected function extractHashParts(array $formData): array
     {
@@ -380,8 +380,8 @@ class FormProtector
      *
      * @param string $url Form URL.
      * @param string $sessionId Session ID.
-     * @return array<string, string> The token data.
-     * @phpstan-return array{fields: string, unlocked: string, debug: string}
+     * @return array<string, string> The token data. Contains 'fields', 'unlocked', and 'debug' keys. Additional keys allowed.
+     * @phpstan-return array{fields: string, unlocked: string, debug: string, ...}
      */
     public function buildTokenData(string $url = '', string $sessionId = ''): array
     {

--- a/src/Mailer/AbstractTransport.php
+++ b/src/Mailer/AbstractTransport.php
@@ -37,8 +37,8 @@ abstract class AbstractTransport
      * Send mail
      *
      * @param \Cake\Mailer\Message $message Email message.
-     * @return array
-     * @phpstan-return array{headers: string, message: string}
+     * @return array<string, mixed> Contains 'headers' and 'message' keys. Additional keys allowed.
+     * @phpstan-return array{headers: string, message: string, ...}
      */
     abstract public function send(Message $message): array;
 

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -314,10 +314,10 @@ class Mailer implements EventListenerInterface
      *   If no action is specified then all other method arguments will be ignored.
      * @param array $args Arguments to pass to the triggered mailer action.
      * @param array $headers Headers to set.
-     * @return array
+     * @return array<string, mixed> Contains 'headers' and 'message' keys. Additional keys allowed.
+     * @phpstan-return array{headers: string, message: string, ...}
      * @throws \Cake\Mailer\Exception\MissingActionException
      * @throws \BadMethodCallException
-     * @phpstan-return array{headers: string, message: string}
      */
     public function send(?string $action = null, array $args = [], array $headers = []): array
     {
@@ -372,8 +372,8 @@ class Mailer implements EventListenerInterface
      * Render content and send email using configured transport.
      *
      * @param string $content Content.
-     * @return array
-     * @phpstan-return array{headers: string, message: string}
+     * @return array<string, mixed> Contains 'headers' and 'message' keys. Additional keys allowed.
+     * @phpstan-return array{headers: string, message: string, ...}
      */
     public function deliver(string $content = ''): array
     {
@@ -551,9 +551,9 @@ class Mailer implements EventListenerInterface
     /**
      * Log the email message delivery.
      *
-     * @param array $contents The content with 'headers' and 'message' keys.
+     * @param array<string, mixed> $contents The content with 'headers' and 'message' keys.
+     * @phpstan-param array{headers: string, message: string, ...} $contents
      * @return void
-     * @phpstan-param array{headers: string, message: string} $contents
      */
     protected function logDelivery(array $contents): void
     {

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -188,7 +188,8 @@ class SmtpTransport extends AbstractTransport
      * Send mail
      *
      * @param \Cake\Mailer\Message $message Message instance
-     * @return array{headers: string, message: string, ...}
+     * @return array<string, mixed> Contains 'headers' and 'message' keys. Additional keys allowed.
+     * @phpstan-return array{headers: string, message: string, ...}
      * @throws \Cake\Network\Exception\SocketException
      */
     public function send(Message $message): array

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -188,7 +188,7 @@ class SmtpTransport extends AbstractTransport
      * Send mail
      *
      * @param \Cake\Mailer\Message $message Message instance
-     * @return array{headers: string, message: string}
+     * @return array{headers: string, message: string, ...}
      * @throws \Cake\Network\Exception\SocketException
      */
     public function send(Message $message): array

--- a/src/TestSuite/TestEmailTransport.php
+++ b/src/TestSuite/TestEmailTransport.php
@@ -38,7 +38,8 @@ class TestEmailTransport extends DebugTransport
      * Stores email for later assertions
      *
      * @param \Cake\Mailer\Message $message Message
-     * @return array{headers: string, message: string}
+     * @return array<string, mixed> Contains 'headers' and 'message' keys. Additional keys allowed.
+     * @phpstan-return array{headers: string, message: string, ...}
      */
     public function send(Message $message): array
     {


### PR DESCRIPTION
We cannot declare the returns that strict.
Otherwise, extending classes are impossible to satisfy this when using different `array<string, mixed>` return keys, e.g.
"code" and others specific to API pushing mailers.

```
PHPDoc tag @var with type array<string, mixed> is not subtype of type array{headers: string, message: string}.  
         🪪  varTag.type   
```

so we should not declare concrete keys as only valid ones.