### PR TITLE
fix now() not working for new migrations default value

### DIFF
--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -790,8 +790,9 @@ class MysqlSchemaDialect extends SchemaDialect
             isset($column['default']) &&
             in_array($column['type'], $dateTimeTypes) &&
             (
-                str_contains(strtolower($column['default']), 'current_timestamp') ||
-                str_contains(strtolower($column['default']), 'now')
+                strtolower($column['default']) === 'current_timestamp' ||
+                strtolower($column['default']) === 'current_timestamp()' ||
+                strtolower($column['default']) === 'now()'
             )
         ) {
             $out .= ' DEFAULT CURRENT_TIMESTAMP';

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -789,7 +789,10 @@ class MysqlSchemaDialect extends SchemaDialect
         if (
             isset($column['default']) &&
             in_array($column['type'], $dateTimeTypes) &&
-            str_contains(strtolower($column['default']), 'current_timestamp')
+            (
+                str_contains(strtolower($column['default']), 'current_timestamp') ||
+                str_contains(strtolower($column['default']), 'now')
+            )
         ) {
             $out .= ' DEFAULT CURRENT_TIMESTAMP';
             if (isset($column['precision'])) {

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -767,7 +767,7 @@ class PostgresSchemaDialect extends SchemaDialect
             in_array($column['type'], $datetimeTypes) &&
             (
                 strtolower($column['default']) === 'current_timestamp' ||
-                str_contains(strtolower($column['default']), 'now')
+                strtolower($column['default']) == 'now()'
             )
         ) {
             $out .= ' DEFAULT CURRENT_TIMESTAMP';

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -767,7 +767,7 @@ class PostgresSchemaDialect extends SchemaDialect
             in_array($column['type'], $datetimeTypes) &&
             (
                 strtolower($column['default']) === 'current_timestamp' ||
-                strtolower($column['default']) == 'now()'
+                strtolower($column['default']) === 'now()'
             )
         ) {
             $out .= ' DEFAULT CURRENT_TIMESTAMP';

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -765,7 +765,10 @@ class PostgresSchemaDialect extends SchemaDialect
         if (
             isset($column['default']) &&
             in_array($column['type'], $datetimeTypes) &&
-            strtolower($column['default']) === 'current_timestamp'
+            (
+                strtolower($column['default']) === 'current_timestamp' ||
+                str_contains(strtolower($column['default']), 'now')
+            )
         ) {
             $out .= ' DEFAULT CURRENT_TIMESTAMP';
         } elseif (isset($column['default'])) {

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -840,7 +840,7 @@ class SqliteSchemaDialect extends SchemaDialect
             isset($column['default']) && is_string($column['default']) &&
             (
                 str_contains(strtolower($column['default']), 'current_timestamp') ||
-                str_contains(strtolower($column['default']), 'now')
+                strtolower($column['default']) === 'now()'
             )
         ) {
             $out .= ' DEFAULT current_timestamp';

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -839,7 +839,7 @@ class SqliteSchemaDialect extends SchemaDialect
         if (
             isset($column['default']) && is_string($column['default']) &&
             (
-                str_contains(strtolower($column['default']), 'current_timestamp') ||
+                strtolower($column['default']) === 'current_timestamp' ||
                 strtolower($column['default']) === 'now()'
             )
         ) {

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -836,6 +836,16 @@ class SqliteSchemaDialect extends SchemaDialect
         if (isset($column['null']) && $column['null'] === true && in_array($column['type'], $timestampTypes, true)) {
             $out .= ' DEFAULT NULL';
         }
+        if (
+            isset($column['default']) && is_string($column['default']) &&
+            (
+                str_contains(strtolower($column['default']), 'current_timestamp') ||
+                str_contains(strtolower($column['default']), 'now')
+            )
+        ) {
+            $out .= ' DEFAULT current_timestamp';
+            unset($column['default']);
+        }
         if (isset($column['default'])) {
             $out .= ' DEFAULT ' . $this->_driver->schemaValue($column['default']);
         }

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -1098,6 +1098,11 @@ SQL;
                 '`created` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP',
             ],
             [
+                'created_now',
+                ['type' => 'datetime', 'null' => false, 'default' => 'now()'],
+                '`created_now` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP',
+            ],
+            [
                 'open_date',
                 ['type' => 'datetime', 'null' => false, 'default' => '2016-12-07 23:04:00'],
                 "`open_date` DATETIME NOT NULL DEFAULT '2016-12-07 23:04:00'",
@@ -1106,6 +1111,11 @@ SQL;
                 'created_with_precision',
                 ['type' => 'datetimefractional', 'precision' => 3, 'null' => false, 'default' => 'current_timestamp'],
                 '`created_with_precision` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)',
+            ],
+            [
+                'created_now_with_precision',
+                ['type' => 'datetime', 'precision' => 3, 'null' => false, 'default' => 'now()'],
+                '`created_now_with_precision` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP(3)',
             ],
             // Date & Time
             [

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -1066,6 +1066,11 @@ SQL;
                 ['type' => 'timestampfractional', 'null' => false, 'default' => 'CURRENT_TIMESTAMP'],
                 '"current_timestamp_fractional" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
             ],
+            [
+                'my_now_col',
+                ['type' => 'timestamp', 'null' => false, 'default' => 'now()'],
+                '"my_now_col" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
+            ],
             // Geospatial
             [
                 'g',

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -1048,6 +1048,16 @@ SQL;
                 '"created" DATETIME',
             ],
             [
+                'created',
+                ['type' => 'datetime', 'null' => false, 'default' => 'current_timestamp'],
+                '"created" DATETIME NOT NULL DEFAULT current_timestamp',
+            ],
+            [
+                'created_now',
+                ['type' => 'datetime', 'null' => false, 'default' => 'now()'],
+                '"created_now" DATETIME NOT NULL DEFAULT current_timestamp',
+            ],
+            [
                 'open_date',
                 ['type' => 'datetime', 'null' => false, 'default' => '2016-12-07 23:04:00'],
                 '"open_date" DATETIME NOT NULL DEFAULT "2016-12-07 23:04:00"',


### PR DESCRIPTION
@nook24 reported in slack, that 
```
->addColumn('entry_time', 'datetime', [
    'timezone' => true,
    'default' => Literal::from('now()'),
    'limit'   => null,
    'null'    => false,
])
```

doesn't work in the new migrations plugin. It returned `DEFAULT 'now()'` which is not valid.

Reason behind that is the fact, that we didn't handle those cases separately till now. We only checked for `current_timestamp`

As far as I have checked in most DBMSs `now()` and `current_timestamp` are equal