### PR TITLE
Fix up default creation permissions.

### DIFF
--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -880,7 +880,7 @@ class I18nExtractCommand extends Command
     protected function _isPathUsable(string $path): bool
     {
         if (!is_dir($path)) {
-            mkdir($path, 0770, true);
+            mkdir($path, 0755, true);
         }
 
         return is_dir($path) && is_writable($path);

--- a/src/Command/I18nInitCommand.php
+++ b/src/Command/I18nInitCommand.php
@@ -75,7 +75,7 @@ class I18nInitCommand extends Command
         $sourceFolder = rtrim($response, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         $targetFolder = $sourceFolder . $language . DIRECTORY_SEPARATOR;
         if (!is_dir($targetFolder)) {
-            mkdir($targetFolder, 0770, true);
+            mkdir($targetFolder, 0755, true);
         }
 
         $count = 0;


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/18844

 This ensures consistent permissions across the framework, matching what the Filesystem class uses by default (0755). The Filesystem class already creates files with standard permissions, so now both directories and files
  will have consistent, standard permissions instead of the more permissive 0770 for directories.