### PR TITLE
Deprecate loading of plugins without plugin classes.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,9 @@
             "TestPluginTwo\\": "tests/test_app/Plugin/TestPluginTwo/src/",
             "Company\\TestPluginThree\\": "tests/test_app/Plugin/Company/TestPluginThree/src/",
             "Company\\TestPluginThree\\Test\\": "tests/test_app/Plugin/Company/TestPluginThree/tests/",
-            "Named\\": "tests/test_app/Plugin/Named/src/"
+            "Named\\": "tests/test_app/Plugin/Named/src/",
+            "TestTheme\\": "tests/test_app/Plugin/TestTheme/src/",
+            "PluginJs\\": "tests/test_app/Plugin/PluginJs/src/"
         }
     },
     "scripts": {

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -276,17 +276,26 @@ class PluginCollection implements Iterator, Countable
         if (!class_exists($className)) {
             $pos = strpos($name, '/');
             if ($pos === false) {
-                $className = $namespace . '\\' . $name . 'Plugin';
+                $namePart = $name;
             } else {
-                $className = $namespace . '\\' . substr($name, $pos + 1) . 'Plugin';
+                $namePart = substr($name, $pos + 1);
             }
 
             // Check for [Vendor/]Foo/FooPlugin
+            $className = $namespace . '\\' . $namePart . 'Plugin';
+
             if (!class_exists($className)) {
                 $className = BasePlugin::class;
                 if (empty($config['path'])) {
                     $config['path'] = $this->findPath($name);
                 }
+
+                deprecationWarning(
+                    '5.3.0',
+                    'Loading plugins without a plugin class is deprecated.'
+                    . " Create a class named `{$namePart}Plugin` which extends `Cake\Core\BasePlugin`"
+                    . ' as shown here https://book.cakephp.org/5/en/plugins.html#plugin-classes',
+                );
             }
         }
 

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -293,8 +293,7 @@ class PluginCollection implements Iterator, Countable
                 deprecationWarning(
                     '5.3.0',
                     'Loading plugins without a plugin class is deprecated.'
-                    . " Create a class named `{$namePart}Plugin` which extends `Cake\Core\BasePlugin`"
-                    . ' as shown here https://book.cakephp.org/5/en/plugins.html#plugin-classes',
+                    . " You can create the missing class using `bin/cake bake plugin {$name} --class-only`.",
                 );
             }
         }

--- a/tests/TestCase/Command/CompletionCommandTest.php
+++ b/tests/TestCase/Command/CompletionCommandTest.php
@@ -55,7 +55,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testStartup(): void
     {
-        $this->exec('completion');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion');
+        });
         $this->assertExitCode(CommandInterface::CODE_ERROR);
 
         $this->assertOutputNotContains('Welcome to CakePHP');
@@ -66,7 +69,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testCommands(): void
     {
-        $this->exec('completion commands');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion commands');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $expected = [
@@ -99,7 +105,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testOptionsNoArguments(): void
     {
-        $this->exec('completion options');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion options');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputEmpty();
     }
@@ -109,7 +118,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testOptionsNonExistentCommand(): void
     {
-        $this->exec('completion options foo');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion options foo');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputEmpty();
     }
@@ -119,7 +131,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testOptionsCommand(): void
     {
-        $this->exec('completion options schema_cache');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion options schema_cache');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $expected = [
@@ -138,7 +153,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testOptionsSubCommand(): void
     {
-        $this->exec('completion options cache list');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion options cache list');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $expected = [
@@ -156,7 +174,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testOptionsNestedCommand(): void
     {
-        $this->exec('completion options i18n extract');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion options i18n extract');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $expected = [
@@ -173,7 +194,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testSubCommandsCorePlugin(): void
     {
-        $this->exec('completion subcommands schema_cache');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion subcommands schema_cache');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $expected = 'build clear';
@@ -185,7 +209,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testSubCommandsAppPlugin(): void
     {
-        $this->exec('completion subcommands sample');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion subcommands sample');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('sub');
     }
@@ -195,7 +222,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testSubCommandsCoreMultiwordCommand(): void
     {
-        $this->exec('completion subcommands cache');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion subcommands cache');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $expected = [
@@ -212,7 +242,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testSubCommandsPlugin(): void
     {
-        $this->exec('completion subcommands welcome');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion subcommands welcome');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $expected = 'say_hello';
@@ -224,7 +257,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testSubCommandsPluginDotNotationBackwardCompatibility(): void
     {
-        $this->exec('completion subcommands test_plugin_two.welcome');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion subcommands test_plugin_two.welcome');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $expected = 'say_hello';
@@ -237,7 +273,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testSubCommandsAppDuplicatePluginNoDot(): void
     {
-        $this->exec('completion subcommands sample');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion subcommands sample');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('sub');
     }
@@ -247,7 +286,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testSubCommandsPluginDuplicateApp(): void
     {
-        $this->exec('completion subcommands test_plugin.sample');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion subcommands test_plugin.sample');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $expected = 'sub';
@@ -259,7 +301,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testSubCommandsNoArguments(): void
     {
-        $this->exec('completion subcommands');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion subcommands');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $this->assertOutputEmpty();
@@ -270,7 +315,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testSubCommandsNonExistentCommand(): void
     {
-        $this->exec('completion subcommands foo');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion subcommands foo');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $this->assertOutputEmpty();
@@ -281,7 +329,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testSubCommands(): void
     {
-        $this->exec('completion subcommands schema_cache');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion subcommands schema_cache');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $expected = 'build clear';
@@ -293,7 +344,10 @@ class CompletionCommandTest extends TestCase
      */
     public function testHelp(): void
     {
-        $this->exec('completion --help');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('completion --help');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $this->assertOutputContains('Output a list of available commands');

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -159,9 +159,11 @@ class PluginAssetsCommandsTest extends TestCase
      */
     public function testForPluginWithoutWebroot(): void
     {
-        $this->loadPlugins(['TestPluginTwo']);
-
-        $this->exec('plugin assets symlink');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->loadPlugins(['TestPluginTwo']);
+            $this->exec('plugin assets symlink');
+        });
         $this->assertFileDoesNotExist($this->wwwRoot . 'test_plugin_two');
     }
 

--- a/tests/TestCase/Command/PluginListCommandTest.php
+++ b/tests/TestCase/Command/PluginListCommandTest.php
@@ -45,7 +45,7 @@ class PluginListCommandTest extends TestCase
         if (file_exists($this->pluginsListPath)) {
             unlink($this->pluginsListPath);
         }
-        $this->pluginsConfigPath = CONFIG . DS . 'plugins.php';
+        $this->pluginsConfigPath = CONFIG . 'plugins.php';
         if (file_exists($this->pluginsConfigPath)) {
             $this->originalPluginsConfigContent = file_get_contents($this->pluginsConfigPath);
         }
@@ -139,7 +139,9 @@ return [
 PHP;
         file_put_contents($this->pluginsConfigPath, $config);
 
-        $this->exec('plugin list');
+        $this->deprecated(function () {
+            $this->exec('plugin list');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('TestPlugin');
         $this->assertOutputContains('OtherPlugin');
@@ -205,7 +207,9 @@ PHP;
         file_put_contents($this->pluginsConfigPath, $config);
 
         $path = ROOT . DS . 'tests' . DS . 'composer.lock';
-        $this->exec(sprintf('plugin list --composer-path="%s"', $path));
+        $this->deprecated(function () use ($path) {
+            $this->exec(sprintf('plugin list --composer-path="%s"', $path));
+        });
         $this->assertOutputContains('| Chronos     | X         |            |          |          | 3.0.4   |');
         $this->assertOutputContains('| CodeSniffer | X         |            |          |          | 5.1.1   |');
     }

--- a/tests/TestCase/Command/PluginLoadCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadCommandTest.php
@@ -88,7 +88,10 @@ class PluginLoadCommandTest extends TestCase
 
         // Needed to not have duplicate named routes
         Router::reload();
-        $this->exec('plugin load Company/TestPluginThree --only-debug --only-cli');
+        // Remove the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('plugin load Company/TestPluginThree --only-debug --only-cli');
+        });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $config = include $this->configFile;

--- a/tests/TestCase/Command/PluginUnloadCommandTest.php
+++ b/tests/TestCase/Command/PluginUnloadCommandTest.php
@@ -71,6 +71,7 @@ class PluginUnloadCommandTest extends TestCase
     {
         parent::tearDown();
 
+        Plugin::getCollection()->clear();
         file_put_contents($this->configFile, $this->originalContent);
     }
 
@@ -80,7 +81,10 @@ class PluginUnloadCommandTest extends TestCase
     #[DataProvider('pluginNameProvider')]
     public function testUnload($plugin): void
     {
-        $this->exec('plugin unload ' . $plugin);
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () use ($plugin) {
+            $this->exec('plugin unload ' . $plugin);
+        });
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $contents = file_get_contents($this->configFile);
@@ -108,7 +112,10 @@ class PluginUnloadCommandTest extends TestCase
 
     public function testUnloadUnknownPlugin(): void
     {
-        $this->exec('plugin unload NopeNotThere');
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->exec('plugin unload NopeNotThere');
+        });
         $this->assertExitCode(CommandInterface::CODE_ERROR);
         $this->assertErrorContains('Plugin `NopeNotThere` could not be found');
     }

--- a/tests/TestCase/Core/PluginCollectionTest.php
+++ b/tests/TestCase/Core/PluginCollectionTest.php
@@ -161,6 +161,20 @@ class PluginCollectionTest extends TestCase
         $this->assertSame('TestTheme', $plugin->getName());
     }
 
+    /**
+     * @deprecated
+     */
+    public function testCreateDeprecationMessage(): void
+    {
+        $this->expectDeprecationMessageMatches(
+            '#You can create the missing class using `bin/cake bake plugin TestPluginTwo --class-only`#',
+            function () {
+                $plugins = new PluginCollection();
+                $plugins->create('TestPluginTwo');
+            },
+        );
+    }
+
     public function testCreateException(): void
     {
         $this->expectException(CakeException::class);

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -56,12 +56,16 @@ class PluginTest extends TestCase
 
     /**
      * Tests loading a plugin without a class
+     *
+     * @deprecated
      */
     public function testLoadDynamicClass(): void
     {
-        $this->loadPlugins(['TestPluginTwo']);
-        $instance = Plugin::getCollection()->get('TestPluginTwo');
-        $this->assertSame(BasePlugin::class, $instance::class);
+        $this->deprecated(function () {
+            $this->loadPlugins(['TestPluginTwo']);
+            $instance = Plugin::getCollection()->get('TestPluginTwo');
+            $this->assertSame(BasePlugin::class, $instance::class);
+        });
     }
 
     /**
@@ -69,15 +73,18 @@ class PluginTest extends TestCase
      */
     public function testPath(): void
     {
-        $this->loadPlugins(['TestPlugin', 'TestPluginTwo', 'Company/TestPluginThree']);
+        $this->loadPlugins(['TestPlugin', 'Company/TestPluginThree']);
         $expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS;
         $this->assertPathEquals(Plugin::path('TestPlugin'), $expected);
 
-        $expected = TEST_APP . 'Plugin' . DS . 'TestPluginTwo' . DS;
-        $this->assertPathEquals(Plugin::path('TestPluginTwo'), $expected);
-
         $expected = TEST_APP . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS;
         $this->assertPathEquals(Plugin::path('Company/TestPluginThree'), $expected);
+
+        $this->deprecated(function () {
+            $this->loadPlugins(['TestPluginTwo']);
+            $expected = TEST_APP . 'Plugin' . DS . 'TestPluginTwo' . DS;
+            $this->assertPathEquals(Plugin::path('TestPluginTwo'), $expected);
+        });
     }
 
     /**
@@ -94,15 +101,18 @@ class PluginTest extends TestCase
      */
     public function testClassPath(): void
     {
-        $this->loadPlugins(['TestPlugin', 'TestPluginTwo', 'Company/TestPluginThree']);
+        $this->loadPlugins(['TestPlugin', 'Company/TestPluginThree']);
         $expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'src' . DS;
         $this->assertPathEquals(Plugin::classPath('TestPlugin'), $expected);
 
-        $expected = TEST_APP . 'Plugin' . DS . 'TestPluginTwo' . DS . 'src' . DS;
-        $this->assertPathEquals(Plugin::classPath('TestPluginTwo'), $expected);
-
         $expected = TEST_APP . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'src' . DS;
         $this->assertPathEquals(Plugin::classPath('Company/TestPluginThree'), $expected);
+
+        $this->deprecated(function () {
+            $this->loadPlugins(['TestPluginTwo']);
+            $expected = TEST_APP . 'Plugin' . DS . 'TestPluginTwo' . DS . 'src' . DS;
+            $this->assertPathEquals(Plugin::classPath('TestPluginTwo'), $expected);
+        });
     }
 
     /**
@@ -110,15 +120,18 @@ class PluginTest extends TestCase
      */
     public function testTemplatePath(): void
     {
-        $this->loadPlugins(['TestPlugin', 'TestPluginTwo', 'Company/TestPluginThree']);
+        $this->loadPlugins(['TestPlugin', 'Company/TestPluginThree']);
         $expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'templates' . DS;
         $this->assertPathEquals(Plugin::templatePath('TestPlugin'), $expected);
 
-        $expected = TEST_APP . 'Plugin' . DS . 'TestPluginTwo' . DS . 'templates' . DS;
-        $this->assertPathEquals(Plugin::templatePath('TestPluginTwo'), $expected);
-
         $expected = TEST_APP . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'templates' . DS;
         $this->assertPathEquals(Plugin::templatePath('Company/TestPluginThree'), $expected);
+
+        $this->deprecated(function () {
+            $this->loadPlugins(['TestPluginTwo']);
+            $expected = TEST_APP . 'Plugin' . DS . 'TestPluginTwo' . DS . 'templates' . DS;
+            $this->assertPathEquals(Plugin::templatePath('TestPluginTwo'), $expected);
+        });
     }
 
     /**

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -106,6 +106,8 @@ class BaseApplicationTest extends TestCase
     /**
      * Ensure that plugins with no plugin class can be loaded.
      * This makes adopting the new API easier
+     *
+     * @deprecated
      */
     public function testAddPluginUnknownClass(): void
     {
@@ -210,7 +212,10 @@ class BaseApplicationTest extends TestCase
     {
         $app = $this->app;
         $app->addPlugin('Named');
-        $app->pluginBootstrap();
+        // Remove the deprecated() wrapping once plugin class is added to TestPluginTwo
+        $this->deprecated(function () use ($app): void {
+            $app->pluginBootstrap();
+        });
         $this->assertTrue(
             Configure::check('Named.bootstrap'),
             'Plugin bootstrap should be run',

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -250,10 +250,13 @@ class I18nTest extends TestCase
      */
     public function testPluginOverride(): void
     {
-        $this->loadPlugins([
-            'TestTheme' => [],
-            'TestPluginTwo' => [],
-        ]);
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->loadPlugins([
+                'TestTheme' => [],
+                'TestPluginTwo' => [],
+            ]);
+        });
 
         $translator = I18n::getTranslator('test_theme');
         $this->assertSame(

--- a/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -81,9 +81,10 @@ class MessagesFileLoaderTest extends TestCase
      */
     public function testTranslationFoldersSequence(): void
     {
-        $this->loadPlugins([
-            'TestPluginTwo' => [],
-        ]);
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->loadPlugins(['TestPluginTwo']);
+        });
         $loader = new MessagesFileLoader('test_plugin_two', 'en');
 
         $expected = [
@@ -122,10 +123,10 @@ class MessagesFileLoaderTest extends TestCase
      */
     public function testAppOverridesPlugin(): void
     {
-        $this->loadPlugins([
-            'TestPlugin' => [],
-            'TestPluginTwo' => [],
-        ]);
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->loadPlugins(['TestPlugin', 'TestPluginTwo']);
+        });
 
         $loader = new MessagesFileLoader('test_plugin', 'en');
         $package = $loader();

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -995,7 +995,10 @@ class MailerTest extends TestCase
      */
     public function testSendRenderPlugin(): void
     {
-        $this->loadPlugins(['TestPlugin', 'TestPluginTwo', 'TestTheme']);
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->loadPlugins(['TestPlugin', 'TestPluginTwo', 'TestTheme']);
+        });
 
         $this->mailer->setTransport('debug');
         $this->mailer->setFrom('cake@cakephp.org');

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -349,7 +349,10 @@ class TableLocatorTest extends TestCase
      */
     public function testGetMultiplePlugins(): void
     {
-        $this->loadPlugins(['TestPlugin', 'TestPluginTwo']);
+        // Removed the deprecated() wrapping when plugin class is added to TestPlugin
+        $this->deprecated(function () {
+            $this->loadPlugins(['TestPlugin', 'TestPluginTwo']);
+        });
 
         $app = $this->_locator->get('Comments');
         $plugin1 = $this->_locator->get('TestPlugin.Comments');
@@ -543,7 +546,10 @@ class TableLocatorTest extends TestCase
      */
     public function testRemovePlugin(): void
     {
-        $this->loadPlugins(['TestPlugin', 'TestPluginTwo']);
+        // Removed the deprecated() wrapping when plugin class is added to TestPluginTwo
+        $this->deprecated(function () {
+            $this->loadPlugins(['TestPlugin', 'TestPluginTwo']);
+        });
 
         $app = $this->_locator->get('Comments');
         $this->_locator->get('TestPlugin.Comments');

--- a/tests/test_app/Plugin/PluginJs/src/PluginJsPlugin.php
+++ b/tests/test_app/Plugin/PluginJs/src/PluginJsPlugin.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace PluginJs;
+
+use Cake\Core\BasePlugin;
+
+class PluginJsPlugin extends BasePlugin
+{
+}

--- a/tests/test_app/Plugin/TestTheme/src/TestThemePlugin.php
+++ b/tests/test_app/Plugin/TestTheme/src/TestThemePlugin.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestTheme;
+
+use Cake\Core\BasePlugin;
+
+class TestThemePlugin extends BasePlugin
+{
+}


### PR DESCRIPTION
This will help checking of non existent plugins in the future, when trying to load a plugin.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
