### PR TITLE
fix plugin collection not clearing configure store

### DIFF
--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -206,6 +206,7 @@ class PluginCollection implements Iterator, Countable
         $this->names = [];
         $this->positions = [];
         $this->loopDepth = -1;
+        Configure::delete('plugins');
 
         return $this;
     }


### PR DESCRIPTION
if executing just the core tests via `vendor/bin/phpunit tests/TestCase/Core` it errors due to a wrong `Configure::read('plugins');` state.

Executing `vendor/bin/phpunit tests/TestCase/Core/PluginConfigTest.php` works fine though, so its not related to those tests, more of a side effect of another core test.

I have not found out which test it is in particular, but the following change fixes this issue.