### PR TITLE
Schema default expression

### DIFF
--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -24,6 +24,7 @@ use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Exception\QueryException;
 use Cake\Database\Expression\ComparisonExpression;
 use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Log\LoggedQuery;
 use Cake\Database\Log\QueryLogger;
 use Cake\Database\Query\DeleteQuery;
@@ -812,6 +813,9 @@ abstract class Driver implements LoggerAwareInterface
             )
         ) {
             return (string)$value;
+        }
+        if ($value instanceof QueryExpression) {
+            return $value->sql(new ValueBinder());
         }
 
         return $this->getPdo()->quote((string)$value, PDO::PARAM_STR);

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -789,6 +789,7 @@ class MysqlSchemaDialect extends SchemaDialect
         if (
             isset($column['default']) &&
             in_array($column['type'], $dateTimeTypes) &&
+            is_string($column['default']) &&
             str_contains(strtolower($column['default']), 'current_timestamp')
         ) {
             $out .= ' DEFAULT CURRENT_TIMESTAMP';

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -765,6 +765,7 @@ class PostgresSchemaDialect extends SchemaDialect
         if (
             isset($column['default']) &&
             in_array($column['type'], $datetimeTypes) &&
+            is_string($column['default']) &&
             strtolower($column['default']) === 'current_timestamp'
         ) {
             $out .= ' DEFAULT CURRENT_TIMESTAMP';

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -754,6 +754,7 @@ class SqlserverSchemaDialect extends SchemaDialect
         if (
             isset($column['default']) &&
             in_array($column['type'], $dateTimeTypes, true) &&
+            is_string($column['default']) &&
             in_array(strtolower($column['default']), $dateTimeDefaults, true)
         ) {
             $out .= ' DEFAULT ' . strtoupper($column['default']);

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -20,6 +20,7 @@ use Cake\Database\Connection;
 use Cake\Database\Driver;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\MysqlSchemaDialect;
 use Cake\Database\Schema\TableSchema;
@@ -860,6 +861,11 @@ SQL;
                 "`role` VARCHAR(10) NOT NULL DEFAULT 'admin'",
             ],
             [
+                'role',
+                ['type' => 'string', 'length' => 10, 'null' => false, 'default' => new QueryExpression("'admin'")],
+                "`role` VARCHAR(10) NOT NULL DEFAULT 'admin'",
+            ],
+            [
                 'id',
                 ['type' => 'char', 'length' => 32, 'fixed' => true, 'null' => false],
                 '`id` CHAR(32) NOT NULL',
@@ -935,6 +941,11 @@ SQL;
                 'config',
                 ['type' => 'json', 'null' => false, 'default' => '{"key":"val"}'],
                 '`config` JSON NOT NULL DEFAULT (\'{"key":"val"}\')',
+            ],
+            [
+                'config',
+                ['type' => 'json', 'default' => new QueryExpression('\'{"key":"v"}\'')],
+                '`config` JSON DEFAULT (\'{"key":"v"}\')',
             ],
             // Blob / binary
             [
@@ -1107,6 +1118,11 @@ SQL;
                 'created',
                 ['type' => 'datetime', 'null' => false, 'default' => 'current_timestamp'],
                 '`created` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP',
+            ],
+            [
+                'created',
+                ['type' => 'datetime', 'null' => false, 'default' => new QueryExpression('now()')],
+                '`created` DATETIME NOT NULL DEFAULT now()',
             ],
             [
                 'open_date',

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Database\Schema;
 use Cake\Database\Connection;
 use Cake\Database\Driver;
 use Cake\Database\Driver\Postgres;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\PostgresSchemaDialect;
 use Cake\Database\Schema\TableSchema;
@@ -907,6 +908,17 @@ SQL;
                 ['type' => 'text', 'null' => false, 'collate' => 'C'],
                 '"body" TEXT COLLATE "C" NOT NULL',
             ],
+            // JSON
+            [
+                'config',
+                ['type' => 'json', 'null' => false],
+                '"config" JSONB NOT NULL',
+            ],
+            [
+                'config',
+                ['type' => 'json', 'null' => false, 'default' => new QueryExpression("'{}'::jsonb")],
+                '"config" JSONB NOT NULL DEFAULT \'{}\'::jsonb',
+            ],
             // Integers
             [
                 'post_id',
@@ -1060,6 +1072,11 @@ SQL;
                 'current_timestamp',
                 ['type' => 'timestamp', 'null' => false, 'default' => 'CURRENT_TIMESTAMP'],
                 '"current_timestamp" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
+            ],
+            [
+                'current_timestamp',
+                ['type' => 'timestamp', 'default' => new QueryExpression('CURRENT_TIMESTAMP')],
+                '"current_timestamp" TIMESTAMP DEFAULT CURRENT_TIMESTAMP',
             ],
             [
                 'current_timestamp_fractional',

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Database\Schema;
 use Cake\Database\Connection;
 use Cake\Database\Driver;
 use Cake\Database\Driver\Sqlite;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\SqliteSchemaDialect;
 use Cake\Database\Schema\TableSchema;
@@ -1051,6 +1052,16 @@ SQL;
                 'open_date',
                 ['type' => 'datetime', 'null' => false, 'default' => '2016-12-07 23:04:00'],
                 '"open_date" DATETIME NOT NULL DEFAULT "2016-12-07 23:04:00"',
+            ],
+            [
+                'created',
+                ['type' => 'datetime', 'default' => new QueryExpression('CURRENT_TIMESTAMP')],
+                '"created" DATETIME DEFAULT CURRENT_TIMESTAMP',
+            ],
+            [
+                'created',
+                ['type' => 'datetime', 'default' => new QueryExpression('now()')],
+                '"created" DATETIME DEFAULT now()',
             ],
             // Date & Time
             [

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Database\Schema;
 use Cake\Database\Connection;
 use Cake\Database\Driver;
 use Cake\Database\Driver\Sqlserver;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\SqlserverSchemaDialect;
 use Cake\Database\Schema\TableSchema;
@@ -891,6 +892,11 @@ SQL;
                 'open_date',
                 ['type' => 'datetime', 'null' => false, 'default' => 'sysdatetimeoffset()'],
                 '[open_date] DATETIME2 NOT NULL DEFAULT SYSDATETIMEOFFSET()',
+            ],
+            [
+                'open_date',
+                ['type' => 'datetime', 'null' => false, 'default' => new QueryExpression('getutcdate()')],
+                '[open_date] DATETIME2 NOT NULL DEFAULT getutcdate()',
             ],
             [
                 'null_date',


### PR DESCRIPTION
Add support for `QueryExpression` as a default value when generating schema. This will help resolve some compatibility issues in migrations in a more robust way. Refs #18845 
