### PR TITLE
Improve association property name clash check.

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -220,7 +220,6 @@ abstract class Association
             'foreignKey',
             'joinType',
             'tableLocator',
-            'propertyName',
             'sourceTable',
             'targetTable',
         ];
@@ -228,6 +227,10 @@ abstract class Association
             if (isset($options[$property])) {
                 $this->{'_' . $property} = $options[$property];
             }
+        }
+
+        if (isset($options['propertyName'])) {
+            $this->setProperty($options['propertyName']);
         }
 
         $this->_className ??= $alias;
@@ -554,6 +557,19 @@ abstract class Association
     {
         $this->_propertyName = $name;
 
+        try {
+            if (in_array($this->_propertyName, $this->_sourceTable->getSchema()->columns(), true)) {
+                $msg = 'Association property name `%s` clashes with field of same name of table `%s`.' .
+                    ' You should specify an alterate name using the `propertyName` option or `setProperty()` method.';
+                trigger_error(
+                    sprintf($msg, $this->_propertyName, $this->_sourceTable->getTable()),
+                    E_USER_WARNING,
+                );
+            }
+        } catch (DatabaseException $e) {
+            // Schema is not yet loaded, can't check for clashes
+        }
+
         return $this;
     }
 
@@ -566,15 +582,7 @@ abstract class Association
     public function getProperty(): string
     {
         if (!isset($this->_propertyName)) {
-            $this->_propertyName = $this->_propertyName();
-            if (in_array($this->_propertyName, $this->_sourceTable->getSchema()->columns(), true)) {
-                $msg = 'Association property name `%s` clashes with field of same name of table `%s`.' .
-                    ' You should explicitly specify the `propertyName` option.';
-                trigger_error(
-                    sprintf($msg, $this->_propertyName, $this->_sourceTable->getTable()),
-                    E_USER_WARNING,
-                );
-            }
+            $this->setProperty($this->_propertyName());
         }
 
         return $this->_propertyName;

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1399,7 +1399,7 @@ class BelongsToManyTest extends TestCase
      */
     public function testPropertyOption(): void
     {
-        $config = ['propertyName' => 'thing_placeholder'];
+        $config = ['propertyName' => 'thing_placeholder', 'sourceTable' => $this->article];
         $association = new BelongsToMany('Thing', $config);
         $this->assertSame('thing_placeholder', $association->getProperty());
     }

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -341,7 +341,7 @@ class BelongsToTest extends TestCase
      */
     public function testPropertyOption(): void
     {
-        $config = ['propertyName' => 'thing_placeholder'];
+        $config = ['propertyName' => 'thing_placeholder', 'sourceTable' => $this->client];
         $association = new BelongsTo('Thing', $config);
         $this->assertSame('thing_placeholder', $association->getProperty());
     }

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -663,7 +663,7 @@ class HasManyTest extends TestCase
      */
     public function testPropertyOption(): void
     {
-        $config = ['propertyName' => 'thing_placeholder'];
+        $config = ['propertyName' => 'thing_placeholder', 'sourceTable' => $this->author];
         $association = new HasMany('Thing', $config);
         $this->assertSame('thing_placeholder', $association->getProperty());
     }

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -253,7 +253,7 @@ class HasOneTest extends TestCase
      */
     public function testPropertyOption(): void
     {
-        $config = ['propertyName' => 'thing_placeholder'];
+        $config = ['propertyName' => 'thing_placeholder', 'sourceTable' => $this->user];
         $association = new HasOne('Thing', $config);
         $this->assertSame('thing_placeholder', $association->getProperty());
     }


### PR DESCRIPTION
Check for name clash even when property name is explicitly set, not just auto generated.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
