### PR TITLE
Fix up routing issue with null defaults.

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -705,7 +705,7 @@ class Route
         // values as they should be treated as "not set" for matching purposes
         foreach ($defaults as $key => $val) {
             // Skip null plugin/prefix values - they shouldn't affect matching
-            if (($key === 'plugin' || $key === 'prefix') && $val === null) {
+            if (($key === 'plugin' || $key === 'prefix') && $val === null && !isset($url[$key])) {
                 continue;
             }
             if (isset($url[$key]) && $url[$key] != $val) {

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -701,11 +701,19 @@ class Route
         unset($url['_method'], $url['[method]'], $defaults['_method']);
 
         // Defaults with different values are a fail.
-        // Filter out null values from defaults for comparison as null values
-        // should be treated as "not set" for matching purposes
-        $filteredDefaults = array_filter($defaults, fn($v) => $v !== null);
-        if (array_intersect_key($url, $filteredDefaults) != $filteredDefaults) {
-            return null;
+        // Check each default value against the URL, but skip null plugin/prefix
+        // values as they should be treated as "not set" for matching purposes
+        foreach ($defaults as $key => $val) {
+            // Skip null plugin/prefix values - they shouldn't affect matching
+            if (($key === 'plugin' || $key === 'prefix') && $val === null) {
+                continue;
+            }
+            if (isset($url[$key]) && $url[$key] != $val) {
+                return null;
+            }
+            if (!isset($url[$key]) && $val !== null) {
+                return null;
+            }
         }
 
         // If this route uses pass option, and the passed elements are

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -701,7 +701,10 @@ class Route
         unset($url['_method'], $url['[method]'], $defaults['_method']);
 
         // Defaults with different values are a fail.
-        if (array_intersect_key($url, $defaults) != $defaults) {
+        // Filter out null values from defaults for comparison as null values
+        // should be treated as "not set" for matching purposes
+        $filteredDefaults = array_filter($defaults, fn($v) => $v !== null);
+        if (array_intersect_key($url, $filteredDefaults) != $filteredDefaults) {
             return null;
         }
 

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1410,6 +1410,22 @@ class RouteTest extends TestCase
     }
 
     /**
+     * Test matching with null prefix in defaults
+     */
+    public function testMatchWithNullPrefix(): void
+    {
+        // Test that a route with null prefix can match URLs without prefix
+        $route = new Route('/login', ['controller' => 'Users', 'action' => 'login', 'prefix' => null]);
+        $result = $route->match(['controller' => 'Users', 'action' => 'login']);
+        $this->assertSame('/login', $result);
+
+        // Test that null prefix in defaults should match when URL doesn't have prefix key
+        $route = new Route('/logout', ['controller' => 'Users', 'action' => 'logout', 'prefix' => null]);
+        $result = $route->match(['controller' => 'Users', 'action' => 'logout']);
+        $this->assertSame('/logout', $result);
+    }
+
+    /**
      * Test restructuring args with pass key
      */
     public function testPassArgRestructure(): void

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1419,10 +1419,14 @@ class RouteTest extends TestCase
         $result = $route->match(['controller' => 'Users', 'action' => 'login']);
         $this->assertSame('/login', $result);
 
-        // Test that null prefix in defaults should match when URL doesn't have prefix key
+        // Test that null prefix in defaults should match when URL has a prefix key
         $route = new Route('/logout', ['controller' => 'Users', 'action' => 'logout', 'prefix' => null]);
-        $result = $route->match(['controller' => 'Users', 'action' => 'logout']);
+        $result = $route->match(['controller' => 'Users', 'action' => 'logout', 'prefix' => null]);
         $this->assertSame('/logout', $result);
+
+        $route = new Route('/logout', ['controller' => 'Users', 'action' => 'logout', 'prefix' => null]);
+        $result = $route->match(['controller' => 'Users', 'action' => 'logout', 'prefix' => 'admin']);
+        $this->assertNull($result);
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2087,6 +2087,38 @@ class RouterTest extends TestCase
         }
     }
 
+    /**
+     * Test that null prefix in route defaults works correctly
+     * This is a regression test for https://github.com/cakephp/cakephp/issues/18860
+     */
+    public function testNullPrefixInDefaults(): void
+    {
+        Router::reload();
+        $routes = Router::createRouteBuilder('/');
+
+        // Test the exact issue from the GitHub report
+        $routes->connect('/login', ['controller' => 'Users', 'action' => 'login', 'prefix' => null]);
+        $routes->connect('/logout', ['controller' => 'Users', 'action' => 'logout', 'prefix' => null]);
+
+        // Test that URL generation works with null prefix
+        $url = Router::url(['controller' => 'Users', 'action' => 'login']);
+        $this->assertSame('/login', $url, 'Should generate /login not /users/login');
+
+        $url = Router::url(['controller' => 'Users', 'action' => 'logout']);
+        $this->assertSame('/logout', $url, 'Should generate /logout not /users/logout');
+
+        // Test that parsing works correctly
+        $result = Router::parseRequest(new ServerRequest(['url' => '/login']));
+        $this->assertSame('Users', $result['controller']);
+        $this->assertSame('login', $result['action']);
+        $this->assertNull($result['prefix']);
+
+        $result = Router::parseRequest(new ServerRequest(['url' => '/logout']));
+        $this->assertSame('Users', $result['controller']);
+        $this->assertSame('logout', $result['action']);
+        $this->assertNull($result['prefix']);
+    }
+
     public function testRouteInvalidDefaults(): void
     {
         $this->expectException(CakeException::class);


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/18860

While the fix for static cases is easy, just to remove the nullish keys, this can be a bit more tricky for more dynamically created ones.
So I wonder if we could just remove nullish ones in the routing code?

This seems to fix it in a BC way.