### PR TITLE
Add config "nestedCheckboxAndRadio" for the FormHelper.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -156,7 +156,7 @@ class FormHelper extends Helper
             // Radio input element,
             'radio' => '<input type="radio" name="{{name}}" value="{{value}}"{{attrs}}>',
             // Wrapping container for radio input/label,
-            'radioWrapper' => '<div class="radio">{{input}}{{label}}</div>',
+            'radioWrapper' => '{{input}}{{label}}',
             // Textarea input element,
             'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
             // Container for submit buttons.

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -105,9 +105,9 @@ class FormHelper extends Helper
             // Used for checkboxes in checkbox() and multiCheckbox().
             'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>',
             // Input group wrapper for checkboxes created via control().
-            'checkboxFormGroup' => '{{label}}',
+            'checkboxFormGroup' => '{{input}}{{label}}',
             // Wrapper container for checkboxes in a multicheckbox input
-            'checkboxWrapper' => '<div class="checkbox">{{label}}</div>',
+            'checkboxWrapper' => '<div class="checkbox">{{input}}{{label}}</div>',
             // Error message wrapper elements.
             'error' => '<div class="error-message" id="{{id}}">{{content}}</div>',
             // Container for error items.
@@ -156,7 +156,7 @@ class FormHelper extends Helper
             // Radio input element,
             'radio' => '<input type="radio" name="{{name}}" value="{{value}}"{{attrs}}>',
             // Wrapping container for radio input/label,
-            'radioWrapper' => '{{label}}',
+            'radioWrapper' => '<div class="radio">{{input}}{{label}}</div>',
             // Textarea input element,
             'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
             // Container for submit buttons.
@@ -179,6 +179,8 @@ class FormHelper extends Helper
         ],
         // set HTML5 validation message to custom required/empty messages
         'autoSetCustomValidity' => true,
+        // Whether checkboxes and radios should be wrapped in a label element
+        'nestedCheckboxAndRadio' => true,
     ];
 
     /**
@@ -1149,7 +1151,7 @@ class FormHelper extends Helper
 
         $nestedInput = false;
         if ($options['type'] === 'checkbox') {
-            $nestedInput = true;
+            $nestedInput = $this->getConfig('nestedCheckboxAndRadio');
         }
         $nestedInput = $options['nestedInput'] ?? $nestedInput;
         unset($options['nestedInput']);
@@ -1648,6 +1650,7 @@ class FormHelper extends Helper
     {
         $attributes['options'] = $options;
         $attributes['idPrefix'] = $this->_idPrefix;
+        $attributes['nestedInput'] ??= $this->getConfig('nestedCheckboxAndRadio');
 
         $generatedHiddenId = false;
         if (!isset($attributes['id'])) {
@@ -2181,6 +2184,7 @@ class FormHelper extends Helper
 
         if ($attributes['multiple'] === 'checkbox') {
             unset($attributes['multiple'], $attributes['empty']);
+            $attributes['nestedInput'] = $this->getConfig('nestedCheckboxAndRadio');
 
             return $this->multiCheckbox($fieldName, $options, $attributes);
         }

--- a/src/View/Widget/MultiCheckboxWidget.php
+++ b/src/View/Widget/MultiCheckboxWidget.php
@@ -45,6 +45,7 @@ class MultiCheckboxWidget extends BasicWidget
         'idPrefix' => null,
         'templateVars' => [],
         'label' => true,
+        'nestedInput' => true,
     ];
 
     /**
@@ -74,6 +75,7 @@ class MultiCheckboxWidget extends BasicWidget
     {
         parent::__construct($templates);
 
+        $this->defaults['nestedInput'] = $label instanceof NestingLabelWidget;
         $this->_label = $label;
     }
 
@@ -154,6 +156,7 @@ class MultiCheckboxWidget extends BasicWidget
             $checkbox = [
                 'value' => $key,
                 'text' => $val,
+                'nestedInput' => $data['nestedInput'],
             ];
             if (is_array($val) && isset($val['text'], $val['value'])) {
                 $checkbox = $val;
@@ -196,6 +199,9 @@ class MultiCheckboxWidget extends BasicWidget
      */
     protected function _renderInput(array $checkbox, ContextInterface $context): string
     {
+        $nestedInput = $checkbox['nestedInput'];
+        unset($checkbox['nestedInput']);
+
         $input = $this->_templates->format('checkbox', [
             'name' => $checkbox['name'] . '[]',
             'value' => $checkbox['escape'] ? h($checkbox['value']) : $checkbox['value'],
@@ -206,8 +212,12 @@ class MultiCheckboxWidget extends BasicWidget
             ),
         ]);
 
-        if ($checkbox['label'] === false && !str_contains($this->_templates->get('checkboxWrapper'), '{{input}}')) {
+        if (
+            $checkbox['label'] === false
+            && ($nestedInput || !str_contains($this->_templates->get('checkboxWrapper'), '{{input}}'))
+        ) {
             $label = $input;
+            $input = '';
         } else {
             $labelAttrs = is_array($checkbox['label']) ? $checkbox['label'] : [];
             $labelAttrs += [
@@ -215,8 +225,16 @@ class MultiCheckboxWidget extends BasicWidget
                 'escape' => $checkbox['escape'],
                 'text' => $checkbox['text'],
                 'templateVars' => $checkbox['templateVars'],
-                'input' => $input,
             ];
+
+            if ($nestedInput) {
+                if (!isset($labelAttrs['input']) || $labelAttrs['input'] !== false) {
+                    $labelAttrs['input'] = $input;
+                    $input = '';
+                }
+            } else {
+                $labelAttrs['input'] = '';
+            }
 
             if ($checkbox['checked']) {
                 $selectedClass = $this->_templates->format('selectedClass', []);

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -47,6 +47,7 @@ class RadioWidget extends BasicWidget
         'empty' => false,
         'idPrefix' => null,
         'templateVars' => [],
+        'nestedInput' => true,
     ];
 
     /**
@@ -74,6 +75,7 @@ class RadioWidget extends BasicWidget
     {
         parent::__construct($templates);
 
+        $this->defaults['nestedInput'] = $label instanceof NestingLabelWidget;
         $this->_label = $label;
     }
 
@@ -202,6 +204,9 @@ class RadioWidget extends BasicWidget
             $radio['form'] = $data['form'];
         }
 
+        $nestedInput = $data['nestedInput'];
+        unset($data['nestedInput']);
+
         $input = $this->_templates->format('radio', [
             'name' => $radio['name'],
             'value' => $escape ? h($radio['value']) : $radio['value'],
@@ -212,19 +217,27 @@ class RadioWidget extends BasicWidget
             ),
         ]);
 
-        $label = $this->_renderLabel(
-            $radio,
-            $data['label'],
-            $input,
-            $context,
-            $escape,
-        );
-
         if (
-            $label === false &&
-            !str_contains($this->_templates->get('radioWrapper'), '{{input}}')
+            $data['label'] === false &&
+            ($nestedInput || !str_contains($this->_templates->get('radioWrapper'), '{{input}}'))
         ) {
             $label = $input;
+            $input = '';
+        } else {
+            $labelInput = $input;
+            if ($nestedInput && (!isset($data['label']['input']) || $data['label']['input'] !== false)) {
+                $input = '';
+            } else {
+                $labelInput = '';
+            }
+
+            $label = $this->_renderLabel(
+                $radio,
+                $data['label'],
+                $labelInput,
+                $context,
+                $escape,
+            );
         }
 
         return $this->_templates->format('radioWrapper', [

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -4947,7 +4947,6 @@ class FormHelperTest extends TestCase
             'type' => 'radio',
             'options' => ['A', 'B'],
             'value' => '0',
-            'templates' => ['radioWrapper' => '{{input}}{{label}}'],
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
@@ -4971,7 +4970,6 @@ class FormHelperTest extends TestCase
             'type' => 'radio',
             'options' => ['A', 'B'],
             'label' => false,
-            'templates' => ['radioWrapper' => '{{input}}{{label}}'],
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
@@ -4995,7 +4993,6 @@ class FormHelperTest extends TestCase
                 -1 => 'negative',
             ],
             'label' => false,
-            'templates' => ['radioWrapper' => '{{input}}{{label}}'],
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
@@ -5031,7 +5028,6 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('published', [
             'type' => 'radio',
             'label' => false,
-            'templates' => ['radioWrapper' => '{{input}}{{label}}'],
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
@@ -8443,7 +8439,6 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('confirm', [
             'type' => 'radio',
             'options' => ['Y' => 'Yes', 'N' => 'No'],
-            'templates' => ['radioWrapper' => '{{input}}{{label}}'],
         ]);
         $expected = [
             'div' => ['class' => 'input radio'],
@@ -9028,7 +9023,6 @@ class FormHelperTest extends TestCase
             'type' => 'radio',
             'options' => ['A', 'B'],
             'labelOptions' => ['class' => 'custom-class'],
-            'templates' => ['radioWrapper' => '{{label}}{{input}}'],
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
@@ -9053,7 +9047,6 @@ class FormHelperTest extends TestCase
             'options' => ['A', 'B'],
             'value' => 1,
             'labelOptions' => ['class' => 'custom-class'],
-            'templates' => ['radioWrapper' => '{{label}}{{input}}'],
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
@@ -9078,7 +9071,6 @@ class FormHelperTest extends TestCase
             'options' => ['A', 'B'],
             'value' => 1,
             'labelOptions' => ['class' => ['custom-class', 'custom-class-array']],
-            'templates' => ['radioWrapper' => '{{label}}{{input}}'],
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3288,6 +3288,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('Model.field', ['option A']);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => '', 'id' => 'prefix-model-field'],
+            ['div' => ['class' => 'radio']],
             'label' => ['for' => 'prefix-model-field-0'],
             ['input' => [
                 'type' => 'radio',
@@ -3297,12 +3298,14 @@ class FormHelperTest extends TestCase
             ]],
             'option A',
             '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
 
         $result = $this->Form->radio('Model.field', ['option A', 'option']);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => '', 'id' => 'prefix-model-field'],
+            ['div' => ['class' => 'radio']],
             'label' => ['for' => 'prefix-model-field-0'],
             ['input' => [
                 'type' => 'radio',
@@ -3312,6 +3315,7 @@ class FormHelperTest extends TestCase
             ]],
             'option A',
             '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
 
@@ -4741,14 +4745,18 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('Model.field', ['option A', 'option B']);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => '', 'id' => 'model-field'],
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'model-field-0']],
             ['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => '0', 'id' => 'model-field-0']],
             'option A',
             '/label',
+            '/div',
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'model-field-1']],
             ['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => '1', 'id' => 'model-field-1']],
             'option B',
             '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
 
@@ -4762,28 +4770,36 @@ class FormHelperTest extends TestCase
         );
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Employee[vegetarian]', 'value' => '', 'form' => 'my-form', 'id' => 'id-veg'],
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'id-veg-yes']],
             ['input' => ['type' => 'radio', 'name' => 'Employee[vegetarian]', 'value' => 'yes', 'id' => 'id-veg-yes', 'form' => 'my-form']],
             'Yes',
             '/label',
+            '/div',
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'id-veg-no']],
             ['input' => ['type' => 'radio', 'name' => 'Employee[vegetarian]', 'value' => 'no', 'id' => 'id-veg-no', 'form' => 'my-form']],
             'No',
             '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
 
         $result = $this->Form->radio('Model.field', ['option A', 'option B'], ['name' => 'Model[custom]']);
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'Model[custom]', 'value' => '', 'id' => 'model-field']],
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'model-custom-0']],
             ['input' => ['type' => 'radio', 'name' => 'Model[custom]', 'value' => '0', 'id' => 'model-custom-0']],
             'option A',
             '/label',
+            '/div',
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'model-custom-1']],
             ['input' => ['type' => 'radio', 'name' => 'Model[custom]', 'value' => '1', 'id' => 'model-custom-1']],
             'option B',
             '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
 
@@ -4796,16 +4812,20 @@ class FormHelperTest extends TestCase
         );
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Employee[gender]', 'value' => '', 'id' => 'employee-gender'],
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'employee-gender-male']],
             ['input' => ['type' => 'radio', 'name' => 'Employee[gender]', 'value' => 'male',
                 'id' => 'employee-gender-male', 'style' => 'width:20px']],
             'Male',
             '/label',
+            '/div',
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'employee-gender-female']],
             ['input' => ['type' => 'radio', 'name' => 'Employee[gender]', 'value' => 'female',
                 'id' => 'employee-gender-female', 'style' => 'width:20px']],
             'Female',
             '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
 
@@ -4816,14 +4836,18 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('status', ['Y' => 'Published', 'N' => 'Unpublished']);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'status', 'value' => '', 'id' => 'status'],
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'status-y']],
             ['input' => ['type' => 'radio', 'name' => 'status', 'value' => 'Y', 'id' => 'status-y']],
             'Published',
             '/label',
+            '/div',
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'status-n']],
             ['input' => ['type' => 'radio', 'name' => 'status', 'value' => 'N', 'id' => 'status-n', 'checked' => 'checked']],
             'Unpublished',
             '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -4841,14 +4865,18 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('Model.field', $options, $attrs);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => '', 'id' => 'model-field'],
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'model-field-r']],
             ['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => 'r', 'id' => 'model-field-r']],
             'red',
             '/label',
+            '/div',
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'model-field-b']],
             ['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => 'b', 'id' => 'model-field-b']],
             'blue',
             '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
 
@@ -4876,14 +4904,18 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('title', ['option A', 'option B']);
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'title', 'value' => '', 'id' => 'title']],
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'title-0']],
             ['input' => ['type' => 'radio', 'name' => 'title', 'value' => '0', 'id' => 'title-0']],
             'option A',
             '/label',
+            '/div',
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'title-1']],
             ['input' => ['type' => 'radio', 'name' => 'title', 'value' => '1', 'id' => 'title-1', 'checked' => 'checked']],
             'option B',
             '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -4896,20 +4928,24 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('title', ['option A'], ['hiddenField' => 'N']);
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'title', 'value' => 'N', 'id' => 'title']],
+            ['div' => ['class' => 'radio']],
             'label' => ['for' => 'title-0'],
             ['input' => ['type' => 'radio', 'name' => 'title', 'value' => '0', 'id' => 'title-0']],
             'option A',
             '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
 
         $result = $this->Form->radio('title', ['option A'], ['hiddenField' => '']);
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'title', 'value' => '', 'id' => 'title']],
+            ['div' => ['class' => 'radio']],
             'label' => ['for' => 'title-0'],
             ['input' => ['type' => 'radio', 'name' => 'title', 'value' => '0', 'id' => 'title-0']],
             'option A',
             '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -4931,14 +4967,18 @@ class FormHelperTest extends TestCase
                 'Test',
                 '/label',
                 ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '', 'id' => 'test']],
+                ['div' => ['class' => 'radio']],
                 ['label' => ['for' => 'test-0']],
                     ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
                     'A',
                 '/label',
+                '/div',
+                ['div' => ['class' => 'radio']],
                 ['label' => ['for' => 'test-1']],
                     ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
                     'B',
                 '/label',
+                '/div',
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -4947,6 +4987,7 @@ class FormHelperTest extends TestCase
             'type' => 'radio',
             'options' => ['A', 'B'],
             'value' => '0',
+            'templates' => ['radioWrapper' => '{{input}}{{label}}'],
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
@@ -4970,6 +5011,7 @@ class FormHelperTest extends TestCase
             'type' => 'radio',
             'options' => ['A', 'B'],
             'label' => false,
+            'templates' => ['radioWrapper' => '{{input}}{{label}}'],
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
@@ -4993,6 +5035,7 @@ class FormHelperTest extends TestCase
                 -1 => 'negative',
             ],
             'label' => false,
+            'templates' => ['radioWrapper' => '{{input}}{{label}}'],
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
@@ -5025,7 +5068,11 @@ class FormHelperTest extends TestCase
             EnumType::from(ArticleStatus::class),
         );
         $this->Form->create($articlesTable->newEmptyEntity());
-        $result = $this->Form->control('published', ['type' => 'radio', 'label' => false,]);
+        $result = $this->Form->control('published', [
+            'type' => 'radio',
+            'label' => false,
+            'templates' => ['radioWrapper' => '{{input}}{{label}}'],
+        ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
                 'input' => ['type' => 'hidden', 'name' => 'published', 'value' => '', 'id' => 'published'],
@@ -5052,8 +5099,12 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('Model.field', ['A', 'B'], ['label' => false]);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => '', 'id' => 'model-field'],
+            ['div' => ['class' => 'radio']],
             ['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => '0', 'id' => 'model-field-0']],
+            '/div',
+            ['div' => ['class' => 'radio']],
             ['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => '1', 'id' => 'model-field-1']],
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -5111,10 +5162,12 @@ class FormHelperTest extends TestCase
     {
         $result = $this->Form->radio('Model.1.field', ['option A'], ['hiddenField' => false]);
         $expected = [
+            ['div' => ['class' => 'radio']],
             'label' => ['for' => 'model-1-field-0'],
             'input' => ['type' => 'radio', 'name' => 'Model[1][field]', 'value' => '0', 'id' => 'model-1-field-0'],
             'option A',
             '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -5129,10 +5182,12 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('Model.field', ['v' => 'value'], ['value' => 'nope']);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => '', 'id' => 'model-field'],
+            ['div' => ['class' => 'radio']],
             'label' => ['for' => 'model-field-v'],
             ['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => 'v', 'id' => 'model-field-v']],
             'value',
             '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -8436,6 +8491,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control('confirm', [
             'type' => 'radio',
             'options' => ['Y' => 'Yes', 'N' => 'No'],
+            'templates' => ['radioWrapper' => '{{input}}{{label}}'],
         ]);
         $expected = [
             'div' => ['class' => 'input radio'],
@@ -8586,14 +8642,18 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('field', ['option A', 'option B'], ['id' => true]);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'field', 'value' => '', 'id' => 'field'],
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'field-0']],
             ['input' => ['type' => 'radio', 'name' => 'field', 'value' => '0', 'id' => 'field-0']],
             'option A',
             '/label',
+            '/div',
+            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'field-1']],
             ['input' => ['type' => 'radio', 'name' => 'field', 'value' => '1', 'id' => 'field-1']],
             'option B',
             '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
 
@@ -8973,8 +9033,12 @@ class FormHelperTest extends TestCase
             'Test',
             '/label',
             ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '', 'id' => 'test']],
+            ['div' => ['class' => 'radio']],
             ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
+            '/div',
+            ['div' => ['class' => 'radio']],
             ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
+            '/div',
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -9020,6 +9084,7 @@ class FormHelperTest extends TestCase
             'type' => 'radio',
             'options' => ['A', 'B'],
             'labelOptions' => ['class' => 'custom-class'],
+            'templates' => ['radioWrapper' => '{{label}}{{input}}'],
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
@@ -9044,6 +9109,7 @@ class FormHelperTest extends TestCase
             'options' => ['A', 'B'],
             'value' => 1,
             'labelOptions' => ['class' => 'custom-class'],
+            'templates' => ['radioWrapper' => '{{label}}{{input}}'],
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
@@ -9068,6 +9134,7 @@ class FormHelperTest extends TestCase
             'options' => ['A', 'B'],
             'value' => 1,
             'labelOptions' => ['class' => ['custom-class', 'custom-class-array']],
+            'templates' => ['radioWrapper' => '{{label}}{{input}}'],
         ]);
         $expected = [
             ['div' => ['class' => 'input radio']],
@@ -9096,10 +9163,13 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'test', 'value' => '', 'id' => 'test'],
+            ['div' => ['class' => 'radio']],
             ['label' => ['class' => 'custom-class another-class', 'data-name' => 'bob', 'for' => 'test-0']],
             ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
             'A',
             '/label',
+            '/div',
+            ['div' => ['class' => 'radio']],
             ['label' => ['class' => 'custom-class another-class selected', 'data-name' => 'bob', 'for' => 'test-1']],
             ['input' => [
                 'type' => 'radio',
@@ -9110,6 +9180,7 @@ class FormHelperTest extends TestCase
             ]],
             'B',
             '/label',
+            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -9450,5 +9521,118 @@ class FormHelperTest extends TestCase
             '/div',
         ];
         $this->assertHtml($expected, $result);
+    }
+
+    public function testNestedCheckboxAndRadioDisabled(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->getSchema()->addColumn('active', ['type' => 'boolean', 'default' => null]);
+        $article = $articles->newEmptyEntity();
+
+        $this->Form->create($article);
+
+        $this->Form->setConfig('nestedCheckboxAndRadio', false);
+
+        $result = $this->Form->control('active');
+        $expected = [
+            'div' => ['class' => 'input checkbox'],
+            'input' => ['type' => 'hidden', 'name' => 'active', 'value' => '0'],
+            ['input' => ['type' => 'checkbox', 'name' => 'active', 'value' => '1', 'id' => 'active']],
+            ['label' => ['for' => 'active']],
+            'Active',
+             '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->control('test', [
+            'multiple' => 'checkbox',
+            'options' => [
+                1 => 'A',
+                2 => 'B',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'test']],
+            'Test',
+            '/label',
+            ['input' => [
+                'type' => 'hidden',
+                'name' => 'test',
+                'value' => '',
+                'id' => 'test',
+            ]],
+            ['div' => ['class' => 'checkbox']],
+            ['input' => [
+                'type' => 'checkbox',
+                'name' => 'test[]',
+                'value' => 1,
+                'id' => 'test-1',
+            ]],
+            ['label' => ['for' => 'test-1']],
+            'A',
+            '/label',
+            '/div',
+            ['div' => ['class' => 'checkbox']],
+            ['input' => [
+                'type' => 'checkbox',
+                'name' => 'test[]',
+                'value' => '2',
+                'id' => 'test-2',
+            ]],
+            ['label' => ['for' => 'test-2']],
+            'B',
+            '/label',
+            '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->control('test', [
+            'type' => 'radio',
+            'options' => [
+                1 => 'A',
+                2 => 'B',
+            ],
+        ]);
+        $expected = [
+            ['div' => ['class' => 'input radio']],
+            '<label',
+            'Test',
+            '/label',
+            ['input' => [
+                'type' => 'hidden',
+                'name' => 'test',
+                'value' => '',
+                'id' => 'test',
+            ]],
+            ['div' => ['class' => 'radio']],
+            ['input' => [
+                'type' => 'radio',
+                'name' => 'test',
+                'value' => 1,
+                'id' => 'test-1',
+            ]],
+            ['label' => ['for' => 'test-1']],
+            'A',
+            '/label',
+            '/div',
+            ['div' => ['class' => 'radio']],
+            ['input' => [
+                'type' => 'radio',
+                'name' => 'test',
+                'value' => '2',
+                'id' => 'test-2',
+            ]],
+            ['label' => ['for' => 'test-2']],
+            'B',
+            '/label',
+            '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $this->Form->setConfig('nestedCheckboxAndRadio', true);
     }
 }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3288,7 +3288,6 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('Model.field', ['option A']);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => '', 'id' => 'prefix-model-field'],
-            ['div' => ['class' => 'radio']],
             'label' => ['for' => 'prefix-model-field-0'],
             ['input' => [
                 'type' => 'radio',
@@ -3298,14 +3297,12 @@ class FormHelperTest extends TestCase
             ]],
             'option A',
             '/label',
-            '/div',
         ];
         $this->assertHtml($expected, $result);
 
         $result = $this->Form->radio('Model.field', ['option A', 'option']);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => '', 'id' => 'prefix-model-field'],
-            ['div' => ['class' => 'radio']],
             'label' => ['for' => 'prefix-model-field-0'],
             ['input' => [
                 'type' => 'radio',
@@ -3315,7 +3312,6 @@ class FormHelperTest extends TestCase
             ]],
             'option A',
             '/label',
-            '/div',
         ];
         $this->assertHtml($expected, $result);
 
@@ -4745,18 +4741,14 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('Model.field', ['option A', 'option B']);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => '', 'id' => 'model-field'],
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'model-field-0']],
             ['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => '0', 'id' => 'model-field-0']],
             'option A',
             '/label',
-            '/div',
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'model-field-1']],
             ['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => '1', 'id' => 'model-field-1']],
             'option B',
             '/label',
-            '/div',
         ];
         $this->assertHtml($expected, $result);
 
@@ -4770,36 +4762,28 @@ class FormHelperTest extends TestCase
         );
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Employee[vegetarian]', 'value' => '', 'form' => 'my-form', 'id' => 'id-veg'],
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'id-veg-yes']],
             ['input' => ['type' => 'radio', 'name' => 'Employee[vegetarian]', 'value' => 'yes', 'id' => 'id-veg-yes', 'form' => 'my-form']],
             'Yes',
             '/label',
-            '/div',
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'id-veg-no']],
             ['input' => ['type' => 'radio', 'name' => 'Employee[vegetarian]', 'value' => 'no', 'id' => 'id-veg-no', 'form' => 'my-form']],
             'No',
             '/label',
-            '/div',
         ];
         $this->assertHtml($expected, $result);
 
         $result = $this->Form->radio('Model.field', ['option A', 'option B'], ['name' => 'Model[custom]']);
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'Model[custom]', 'value' => '', 'id' => 'model-field']],
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'model-custom-0']],
             ['input' => ['type' => 'radio', 'name' => 'Model[custom]', 'value' => '0', 'id' => 'model-custom-0']],
             'option A',
             '/label',
-            '/div',
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'model-custom-1']],
             ['input' => ['type' => 'radio', 'name' => 'Model[custom]', 'value' => '1', 'id' => 'model-custom-1']],
             'option B',
             '/label',
-            '/div',
         ];
         $this->assertHtml($expected, $result);
 
@@ -4812,20 +4796,16 @@ class FormHelperTest extends TestCase
         );
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Employee[gender]', 'value' => '', 'id' => 'employee-gender'],
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'employee-gender-male']],
             ['input' => ['type' => 'radio', 'name' => 'Employee[gender]', 'value' => 'male',
                 'id' => 'employee-gender-male', 'style' => 'width:20px']],
             'Male',
             '/label',
-            '/div',
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'employee-gender-female']],
             ['input' => ['type' => 'radio', 'name' => 'Employee[gender]', 'value' => 'female',
                 'id' => 'employee-gender-female', 'style' => 'width:20px']],
             'Female',
             '/label',
-            '/div',
         ];
         $this->assertHtml($expected, $result);
 
@@ -4836,18 +4816,14 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('status', ['Y' => 'Published', 'N' => 'Unpublished']);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'status', 'value' => '', 'id' => 'status'],
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'status-y']],
             ['input' => ['type' => 'radio', 'name' => 'status', 'value' => 'Y', 'id' => 'status-y']],
             'Published',
             '/label',
-            '/div',
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'status-n']],
             ['input' => ['type' => 'radio', 'name' => 'status', 'value' => 'N', 'id' => 'status-n', 'checked' => 'checked']],
             'Unpublished',
             '/label',
-            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -4865,18 +4841,14 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('Model.field', $options, $attrs);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => '', 'id' => 'model-field'],
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'model-field-r']],
             ['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => 'r', 'id' => 'model-field-r']],
             'red',
             '/label',
-            '/div',
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'model-field-b']],
             ['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => 'b', 'id' => 'model-field-b']],
             'blue',
             '/label',
-            '/div',
         ];
         $this->assertHtml($expected, $result);
 
@@ -4904,18 +4876,14 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('title', ['option A', 'option B']);
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'title', 'value' => '', 'id' => 'title']],
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'title-0']],
             ['input' => ['type' => 'radio', 'name' => 'title', 'value' => '0', 'id' => 'title-0']],
             'option A',
             '/label',
-            '/div',
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'title-1']],
             ['input' => ['type' => 'radio', 'name' => 'title', 'value' => '1', 'id' => 'title-1', 'checked' => 'checked']],
             'option B',
             '/label',
-            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -4928,24 +4896,20 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('title', ['option A'], ['hiddenField' => 'N']);
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'title', 'value' => 'N', 'id' => 'title']],
-            ['div' => ['class' => 'radio']],
             'label' => ['for' => 'title-0'],
             ['input' => ['type' => 'radio', 'name' => 'title', 'value' => '0', 'id' => 'title-0']],
             'option A',
             '/label',
-            '/div',
         ];
         $this->assertHtml($expected, $result);
 
         $result = $this->Form->radio('title', ['option A'], ['hiddenField' => '']);
         $expected = [
             ['input' => ['type' => 'hidden', 'name' => 'title', 'value' => '', 'id' => 'title']],
-            ['div' => ['class' => 'radio']],
             'label' => ['for' => 'title-0'],
             ['input' => ['type' => 'radio', 'name' => 'title', 'value' => '0', 'id' => 'title-0']],
             'option A',
             '/label',
-            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -4967,18 +4931,14 @@ class FormHelperTest extends TestCase
                 'Test',
                 '/label',
                 ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '', 'id' => 'test']],
-                ['div' => ['class' => 'radio']],
                 ['label' => ['for' => 'test-0']],
                     ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
                     'A',
                 '/label',
-                '/div',
-                ['div' => ['class' => 'radio']],
                 ['label' => ['for' => 'test-1']],
                     ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
                     'B',
                 '/label',
-                '/div',
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -5099,12 +5059,8 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('Model.field', ['A', 'B'], ['label' => false]);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => '', 'id' => 'model-field'],
-            ['div' => ['class' => 'radio']],
             ['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => '0', 'id' => 'model-field-0']],
-            '/div',
-            ['div' => ['class' => 'radio']],
             ['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => '1', 'id' => 'model-field-1']],
-            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -5162,12 +5118,10 @@ class FormHelperTest extends TestCase
     {
         $result = $this->Form->radio('Model.1.field', ['option A'], ['hiddenField' => false]);
         $expected = [
-            ['div' => ['class' => 'radio']],
             'label' => ['for' => 'model-1-field-0'],
             'input' => ['type' => 'radio', 'name' => 'Model[1][field]', 'value' => '0', 'id' => 'model-1-field-0'],
             'option A',
             '/label',
-            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -5182,12 +5136,10 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('Model.field', ['v' => 'value'], ['value' => 'nope']);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => '', 'id' => 'model-field'],
-            ['div' => ['class' => 'radio']],
             'label' => ['for' => 'model-field-v'],
             ['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => 'v', 'id' => 'model-field-v']],
             'value',
             '/label',
-            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -8642,18 +8594,14 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio('field', ['option A', 'option B'], ['id' => true]);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'field', 'value' => '', 'id' => 'field'],
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'field-0']],
             ['input' => ['type' => 'radio', 'name' => 'field', 'value' => '0', 'id' => 'field-0']],
             'option A',
             '/label',
-            '/div',
-            ['div' => ['class' => 'radio']],
             ['label' => ['for' => 'field-1']],
             ['input' => ['type' => 'radio', 'name' => 'field', 'value' => '1', 'id' => 'field-1']],
             'option B',
             '/label',
-            '/div',
         ];
         $this->assertHtml($expected, $result);
 
@@ -9033,12 +8981,8 @@ class FormHelperTest extends TestCase
             'Test',
             '/label',
             ['input' => ['type' => 'hidden', 'name' => 'test', 'value' => '', 'id' => 'test']],
-            ['div' => ['class' => 'radio']],
             ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
-            '/div',
-            ['div' => ['class' => 'radio']],
             ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '1', 'id' => 'test-1']],
-            '/div',
             '/div',
         ];
         $this->assertHtml($expected, $result);
@@ -9163,13 +9107,10 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'test', 'value' => '', 'id' => 'test'],
-            ['div' => ['class' => 'radio']],
             ['label' => ['class' => 'custom-class another-class', 'data-name' => 'bob', 'for' => 'test-0']],
             ['input' => ['type' => 'radio', 'name' => 'test', 'value' => '0', 'id' => 'test-0']],
             'A',
             '/label',
-            '/div',
-            ['div' => ['class' => 'radio']],
             ['label' => ['class' => 'custom-class another-class selected', 'data-name' => 'bob', 'for' => 'test-1']],
             ['input' => [
                 'type' => 'radio',
@@ -9180,7 +9121,6 @@ class FormHelperTest extends TestCase
             ]],
             'B',
             '/label',
-            '/div',
         ];
         $this->assertHtml($expected, $result);
     }
@@ -9607,7 +9547,6 @@ class FormHelperTest extends TestCase
                 'value' => '',
                 'id' => 'test',
             ]],
-            ['div' => ['class' => 'radio']],
             ['input' => [
                 'type' => 'radio',
                 'name' => 'test',
@@ -9617,8 +9556,6 @@ class FormHelperTest extends TestCase
             ['label' => ['for' => 'test-1']],
             'A',
             '/label',
-            '/div',
-            ['div' => ['class' => 'radio']],
             ['input' => [
                 'type' => 'radio',
                 'name' => 'test',
@@ -9628,7 +9565,6 @@ class FormHelperTest extends TestCase
             ['label' => ['for' => 'test-2']],
             'B',
             '/label',
-            '/div',
             '/div',
         ];
         $this->assertHtml($expected, $result);

--- a/tests/TestCase/View/Widget/RadioWidgetTest.php
+++ b/tests/TestCase/View/Widget/RadioWidgetTest.php
@@ -69,6 +69,7 @@ class RadioWidgetTest extends TestCase
             'name' => 'Crayons[color]',
             'label' => null,
             'options' => ['r' => 'Red', 'b' => 'Black'],
+            'nestedInput' => false,
         ];
         $result = $radio->render($data, $this->context);
         $expected = [
@@ -174,6 +175,7 @@ class RadioWidgetTest extends TestCase
             'name' => 'Crayons[color]',
             'val' => 'r',
             'options' => ['r' => 'Red', 'b' => 'Black'],
+            'nestedInput' => false,
         ];
         $result = $radio->render($data, $this->context);
         $expected = [
@@ -712,6 +714,7 @@ class RadioWidgetTest extends TestCase
                 '1x' => 'one x',
                 '2' => 'two',
             ],
+            'nestedInput' => false,
         ];
         $result = $radio->render($data, $this->context);
         $this->assertStringContainsString(


### PR DESCRIPTION
This config allows easily selecting whether to nest checkboxes and radios inside label tags or not, without additional config or template manipulation.

The only potential issue I see for those upgrading from 5.2 is the addition of `<div class="radio">..</div>` wrapper for radios. But that can be addressed in the migration guide and user and override the `radioWrapper` to 5.2's value.

Refs #18083
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
