### PR TITLE
More clear assignment.

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -213,22 +213,35 @@ abstract class Association
     {
         $this->sourceTable = $sourceTable;
 
-        $defaults = [
-            'cascadeCallbacks',
-            'className',
-            'conditions',
-            'dependent',
-            'finder',
-            'bindingKey',
-            'foreignKey',
-            'joinType',
-            'tableLocator',
-            'targetTable',
-        ];
-        foreach ($defaults as $property) {
-            if (isset($options[$property])) {
-                $this->{$property} = $options[$property];
-            }
+        if (isset($options['cascadeCallbacks'])) {
+            $this->cascadeCallbacks = $options['cascadeCallbacks'];
+        }
+        if (isset($options['className'])) {
+            $this->className = $options['className'];
+        }
+        if (isset($options['conditions'])) {
+            $this->conditions = $options['conditions'];
+        }
+        if (isset($options['dependent'])) {
+            $this->dependent = $options['dependent'];
+        }
+        if (isset($options['finder'])) {
+            $this->finder = $options['finder'];
+        }
+        if (isset($options['bindingKey'])) {
+            $this->bindingKey = $options['bindingKey'];
+        }
+        if (isset($options['foreignKey'])) {
+            $this->foreignKey = $options['foreignKey'];
+        }
+        if (isset($options['joinType'])) {
+            $this->joinType = $options['joinType'];
+        }
+        if (isset($options['tableLocator'])) {
+            $this->tableLocator = $options['tableLocator'];
+        }
+        if (isset($options['targetTable'])) {
+            $this->targetTable = $options['targetTable'];
         }
 
         if (isset($options['propertyName'])) {

--- a/src/ORM/EagerLoadable.php
+++ b/src/ORM/EagerLoadable.php
@@ -133,14 +133,29 @@ class EagerLoadable
     public function __construct(string $name, array $config = [])
     {
         $this->name = $name;
-        $allowed = [
-            'associations', 'instance', 'config', 'canBeJoined',
-            'aliasPath', 'propertyPath', 'forMatching', 'targetProperty',
-        ];
-        foreach ($allowed as $property) {
-            if (isset($config[$property])) {
-                $this->{$property} = $config[$property];
-            }
+        if (isset($config['associations'])) {
+            $this->associations = $config['associations'];
+        }
+        if (isset($config['instance'])) {
+            $this->instance = $config['instance'];
+        }
+        if (isset($config['config'])) {
+            $this->config = $config['config'];
+        }
+        if (isset($config['canBeJoined'])) {
+            $this->canBeJoined = $config['canBeJoined'];
+        }
+        if (isset($config['aliasPath'])) {
+            $this->aliasPath = $config['aliasPath'];
+        }
+        if (isset($config['propertyPath'])) {
+            $this->propertyPath = $config['propertyPath'];
+        }
+        if (isset($config['forMatching'])) {
+            $this->forMatching = $config['forMatching'];
+        }
+        if (isset($config['targetProperty'])) {
+            $this->targetProperty = $config['targetProperty'];
         }
     }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -290,18 +290,23 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function __construct(array $config = [])
     {
-        $methodConfigs = [
-            'registryAlias',
-            'table',
-            'alias',
-            'connection',
-            'schema',
-            'entityClass',
-        ];
-        foreach ($methodConfigs as $cfg) {
-            if (isset($config[$cfg])) {
-                $this->{'set' . $cfg}($config[$cfg]);
-            }
+        if (isset($config['registryAlias'])) {
+            $this->setRegistryAlias($config['registryAlias']);
+        }
+        if (isset($config['table'])) {
+            $this->setTable($config['table']);
+        }
+        if (isset($config['alias'])) {
+            $this->setAlias($config['alias']);
+        }
+        if (isset($config['connection'])) {
+            $this->setConnection($config['connection']);
+        }
+        if (isset($config['schema'])) {
+            $this->setSchema($config['schema']);
+        }
+        if (isset($config['entityClass'])) {
+            $this->setEntityClass($config['entityClass']);
         }
         if (isset($config['validator'])) {
             if (is_array($config['validator'])) {


### PR DESCRIPTION
  1. ORM/Association.php - Replaced $this->{'_' . $property} = $value with explicit property assignments
  2. ORM/EagerLoadable.php - Replaced dynamic property assignment with explicit assignments
  3. ORM/Table.php - Replaced $this->{'set' . $cfg}($config[$cfg]) with explicit setter method calls

Is this something we want to see?