### PR TITLE
Accessor fixups.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -22,6 +22,7 @@ use Cake\ORM\Entity;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
+use ReflectionMethod;
 use function Cake\Core\deprecationWarning;
 
 /**
@@ -378,10 +379,11 @@ trait EntityTrait
      * Returns the value of a field by name
      *
      * @param string $field the name of the field to retrieve
+     * @param bool $forPersistence Whether the value is being retrieved for persistence (save operations)
      * @return mixed
      * @throws \InvalidArgumentException if an empty field name is passed
      */
-    public function &get(string $field): mixed
+    public function &get(string $field, bool $forPersistence = false): mixed
     {
         if ($field === '') {
             throw new InvalidArgumentException('Cannot get an empty field');
@@ -396,8 +398,18 @@ trait EntityTrait
 
         $method = static::_accessor($field, 'get');
         if ($method) {
+            // Check if the accessor method accepts the forPersistence parameter
+            $reflection = new ReflectionMethod($this, $method);
+            $params = $reflection->getParameters();
+
             // Must be variable before returning: Only variable references should be returned by reference.
-            $result = $this->{$method}($value);
+            if (count($params) >= 2) {
+                // New style accessor with forPersistence parameter
+                $result = $this->{$method}($value, $forPersistence);
+            } else {
+                // Legacy accessor without forPersistence parameter
+                $result = $this->{$method}($value);
+            }
 
             return $result;
         }
@@ -687,7 +699,7 @@ trait EntityTrait
     {
         $result = [];
         foreach ($this->getVisible() as $field) {
-            $value = $this->get($field);
+            $value = $this->get($field, false);
             if (is_array($value)) {
                 $result[$field] = [];
                 foreach ($value as $k => $entity) {
@@ -812,14 +824,15 @@ trait EntityTrait
      *
      * @param array<string> $fields list of fields to be returned
      * @param bool $onlyDirty Return the requested field only if it is dirty
+     * @param bool $forPersistence Whether the values are being extracted for persistence (save operations)
      * @return array<string, mixed>
      */
-    public function extract(array $fields, bool $onlyDirty = false): array
+    public function extract(array $fields, bool $onlyDirty = false, bool $forPersistence = false): array
     {
         $result = [];
         foreach ($fields as $field) {
             if (!$onlyDirty || $this->isDirty($field)) {
-                $result[$field] = $this->has($field) ? $this->get($field) : null;
+                $result[$field] = $this->has($field) ? $this->get($field, $forPersistence) : null;
             }
         }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2059,7 +2059,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             return false;
         }
 
-        $data = $entity->extract($this->getSchema()->columns(), true);
+        $data = $entity->extract($this->getSchema()->columns(), true, true);
         $isNew = $entity->isNew();
 
         if ($isNew) {

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1776,4 +1776,208 @@ class EntityTest extends TestCase
 
         $this->assertFalse($entity->hasErrors());
     }
+
+    /**
+     * Test accessor with forPersistence parameter for encryption use case
+     */
+    public function testAccessorWithForPersistenceParameter(): void
+    {
+        $entity = new class extends Entity {
+            protected function _getEncryptedField(?string $value, bool $forPersistence = false): ?string
+            {
+                if ($value === null) {
+                    return null;
+                }
+
+                // For persistence, return the raw encrypted value
+                if ($forPersistence) {
+                    return $value;
+                }
+
+                // For display, decrypt the value
+                return base64_decode($value);
+            }
+
+            protected function _setEncryptedField(?string $value): ?string
+            {
+                if ($value === null) {
+                    return null;
+                }
+
+                // Encrypt the value when setting
+                return base64_encode($value);
+            }
+        };
+
+        // Set a plain text value
+        $plainText = 'sensitive data';
+        $entity->set('encrypted_field', $plainText);
+
+        // Getting for display should decrypt
+        $this->assertEquals($plainText, $entity->get('encrypted_field', false));
+
+        // Getting for persistence should return encrypted
+        $this->assertEquals(base64_encode($plainText), $entity->get('encrypted_field', true));
+    }
+
+    /**
+     * Test backward compatibility with legacy accessors without forPersistence
+     */
+    public function testLegacyAccessorBackwardCompatibility(): void
+    {
+        $entity = new class extends Entity {
+            protected function _getLegacyField(?string $value): ?string
+            {
+                if ($value === null) {
+                    return null;
+                }
+
+                return strtoupper($value);
+            }
+        };
+
+        $entity->set('legacy_field', 'test');
+
+        // Both calls should work and return the same transformed value
+        $this->assertEquals('TEST', $entity->get('legacy_field', false));
+        $this->assertEquals('TEST', $entity->get('legacy_field', true));
+    }
+
+    /**
+     * Test extract method with forPersistence parameter
+     */
+    public function testExtractWithForPersistence(): void
+    {
+        $entity = new class extends Entity {
+            protected function _getPassword(?string $value, bool $forPersistence = false): ?string
+            {
+                if ($value === null) {
+                    return null;
+                }
+
+                // For persistence, return the hash
+                if ($forPersistence) {
+                    return $value;
+                }
+
+                // For display, return masked
+                return '********';
+            }
+
+            protected function _setPassword(?string $value): ?string
+            {
+                if ($value === null) {
+                    return null;
+                }
+
+                // Simple hash for testing
+                return '$hash$' . base64_encode($value);
+            }
+        };
+
+        $entity->set('password', 'secret');
+        $entity->set('username', 'john');
+
+        // Extract for display
+        $displayData = $entity->extract(['username', 'password'], false, false);
+        $this->assertEquals('john', $displayData['username']);
+        $this->assertEquals('********', $displayData['password']);
+
+        // Extract for persistence
+        $saveData = $entity->extract(['username', 'password'], false, true);
+        $this->assertEquals('john', $saveData['username']);
+        $this->assertEquals('$hash$' . base64_encode('secret'), $saveData['password']);
+    }
+
+    /**
+     * Test toArray uses display values (forPersistence=false)
+     */
+    public function testToArrayUsesDisplayValues(): void
+    {
+        $entity = new class extends Entity {
+            protected function _getSensitiveData(?string $value, bool $forPersistence = false): ?string
+            {
+                if ($value === null) {
+                    return null;
+                }
+
+                if ($forPersistence) {
+                    return $value;
+                }
+
+                // Mask for display
+                return 'REDACTED';
+            }
+
+            protected function _setSensitiveData(?string $value): ?string
+            {
+                return 'encrypted:' . $value;
+            }
+        };
+
+        $entity->set('sensitive_data', 'secret');
+        $entity->set('public_data', 'visible');
+
+        $array = $entity->toArray();
+
+        // toArray should use display value (masked)
+        $this->assertEquals('REDACTED', $array['sensitive_data']);
+        $this->assertEquals('visible', $array['public_data']);
+    }
+
+    /**
+     * Test real-world scenario: fixing the double-transformation issue
+     */
+    public function testFixesDoubleTransformationIssue(): void
+    {
+        // Simulate encrypted field that was problematic in issue #17921
+        $entity = new class extends Entity {
+            protected function _getEncrypted(?string $value, bool $forPersistence = false): ?string
+            {
+                if ($value === null) {
+                    return null;
+                }
+
+                // This is the fix: return raw value for persistence
+                if ($forPersistence) {
+                    return $value;
+                }
+
+                // Decrypt for display (simplified)
+                if (strpos($value, 'enc:') === 0) {
+                    return substr($value, 4);
+                }
+
+                return $value;
+            }
+
+            protected function _setEncrypted(?string $value): ?string
+            {
+                if ($value === null) {
+                    return null;
+                }
+
+                // Encrypt on set
+                return 'enc:' . $value;
+            }
+        };
+
+        // Set a value
+        $entity->set('encrypted', 'mydata');
+
+        // Display should show decrypted
+        $this->assertEquals('mydata', $entity->get('encrypted'));
+
+        // Persistence should save encrypted
+        $this->assertEquals('enc:mydata', $entity->get('encrypted', true));
+
+        // Simulate loading from database
+        $loadedEntity = new (get_class($entity))(['encrypted' => 'enc:mydata'], ['useSetters' => false]);
+
+        // Should decrypt correctly for display
+        $this->assertEquals('mydata', $loadedEntity->get('encrypted'));
+
+        // Should save the same encrypted value back
+        $this->assertEquals('enc:mydata', $loadedEntity->get('encrypted', true));
+    }
 }


### PR DESCRIPTION
Do we want to fix up https://github.com/cakephp/cakephp/issues/17921 during 5.* ?
If so, would this be a correct approach to it? I dont think so, but I am not sure how to tackle this.

So for, this PR seems to
- Fixes data corruption issues with encryption/decryption
- Allows proper separation of display vs persistence logic
- Maintains full backward compatibility