### PR TITLE
Fix entity hydration when selecting only nullable columns in associat…

### DIFF
--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -127,6 +127,8 @@ class HasManyTest extends TestCase
         parent::tearDown();
         ConnectionManager::drop('test_read_write');
         Log::drop('queries');
+        // Clear the table locator to avoid state leaking to next tests
+        $this->getTableLocator()->clear();
     }
 
     /**
@@ -389,14 +391,23 @@ class HasManyTest extends TestCase
         $association = new HasMany('Articles', $config);
         $keys = [1, 2, 3, 4];
 
-        // Create a fresh query that will be returned by the mock
-        $fetchQuery = $this->article->selectQuery();
-        $this->article->method('find')
-            ->with('all')
-            ->willReturn($fetchQuery);
-
-        // The query passed to eagerLoader is a different query
+        // Create a query to be used as sourceQuery
         $sourceQuery = $this->article->selectQuery();
+
+        // Setup the mock to track what happens
+        $queriesReturned = [];
+        $this->article->expects($this->once())
+            ->method('find')
+            ->with('all')
+            ->willReturnCallback(function () use (&$queriesReturned) {
+                $connection = $this->article->getConnection();
+                // Preserve the current auto-quoting state (might be affected by other tests)
+                $query = $this->article->selectQuery();
+                $query->enableAutoFields(false);
+                $queriesReturned[] = $query;
+
+                return $query;
+            });
 
         $loader = $association->eagerLoader([
             'fields' => ['id', 'title'],
@@ -407,10 +418,31 @@ class HasManyTest extends TestCase
         // Verify that the loader was created successfully
         $this->assertIsCallable($loader);
 
-        // The foreign key should be added to the fetch query (the one returned by find())
-        // not the source query that was passed in options
+        // Verify that find was called and a query was returned
+        $this->assertCount(1, $queriesReturned, 'Find should have been called once');
+
+        // Check the query that was actually modified by the loader
+        $fetchQuery = $queriesReturned[0];
         $select = $fetchQuery->clause('select');
-        $this->assertContains('Articles.author_id', $select);
+
+        // The foreign key should be in the select clause
+        // Handle both quoted and non-quoted identifiers
+        $hasAuthorId = false;
+        foreach ($select as $key => $field) {
+            // Check if the field contains author_id (handles both quoted and non-quoted)
+            if (
+                str_contains((string)$field, 'author_id') ||
+                str_contains((string)$key, 'author_id')
+            ) {
+                $hasAuthorId = true;
+                break;
+            }
+        }
+
+        $this->assertTrue(
+            $hasAuthorId,
+            'Foreign key author_id should be added. Select clause: ' . json_encode($select),
+        );
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -379,8 +379,8 @@ class HasManyTest extends TestCase
      */
     public function testEagerLoaderFieldsException(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('You are required to select the "Articles.author_id"');
+        // This test now verifies that missing foreign keys are automatically added
+        // instead of throwing an exception
         $config = [
             'sourceTable' => $this->author,
             'targetTable' => $this->article,
@@ -393,11 +393,18 @@ class HasManyTest extends TestCase
             ->with('all')
             ->willReturn($query);
 
-        $association->eagerLoader([
+        $loader = $association->eagerLoader([
             'fields' => ['id', 'title'],
             'keys' => $keys,
             'query' => $query,
         ]);
+
+        // Verify that the loader was created successfully
+        $this->assertIsCallable($loader);
+
+        // Verify that the query now includes the foreign key field
+        $select = $query->clause('select');
+        $this->assertContains('Articles.author_id', $select);
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -388,22 +388,28 @@ class HasManyTest extends TestCase
         ];
         $association = new HasMany('Articles', $config);
         $keys = [1, 2, 3, 4];
-        $query = $this->article->selectQuery();
+
+        // Create a fresh query that will be returned by the mock
+        $fetchQuery = $this->article->selectQuery();
         $this->article->method('find')
             ->with('all')
-            ->willReturn($query);
+            ->willReturn($fetchQuery);
+
+        // The query passed to eagerLoader is a different query
+        $sourceQuery = $this->article->selectQuery();
 
         $loader = $association->eagerLoader([
             'fields' => ['id', 'title'],
             'keys' => $keys,
-            'query' => $query,
+            'query' => $sourceQuery,
         ]);
 
         // Verify that the loader was created successfully
         $this->assertIsCallable($loader);
 
-        // Verify that the query now includes the foreign key field
-        $select = $query->clause('select');
+        // The foreign key should be added to the fetch query (the one returned by find())
+        // not the source query that was passed in options
+        $select = $fetchQuery->clause('select');
         $this->assertContains('Articles.author_id', $select);
     }
 

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -400,7 +400,6 @@ class HasManyTest extends TestCase
             ->method('find')
             ->with('all')
             ->willReturnCallback(function () use (&$queriesReturned) {
-                $connection = $this->article->getConnection();
                 // Preserve the current auto-quoting state (might be affected by other tests)
                 $query = $this->article->selectQuery();
                 $query->enableAutoFields(false);

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -429,6 +429,9 @@ class EagerLoaderTest extends TestCase
             'clients__company_id' => 'clients.company_id',
             'clients__telephone' => 'clients.telephone',
             'orders__total' => 'orders.total', 'orders__placed' => 'orders.placed',
+            // Primary keys are now auto-added to ensure proper entity hydration
+            'clients__id' => 'clients.id',
+            'orders__id' => 'orders.id',
         ];
         $this->assertEquals($expected, $select);
     }
@@ -457,7 +460,12 @@ class EagerLoaderTest extends TestCase
         $query = new SelectQuery($this->table);
         $query->select('foo.id')->contain($contains)->sql();
         $select = $query->clause('select');
-        $expected = ['foo__id' => 'foo.id', 'clients__name' => 'clients.name'];
+        $expected = [
+            'foo__id' => 'foo.id',
+            'clients__name' => 'clients.name',
+            // Primary key is now auto-added to ensure proper entity hydration
+            'clients__id' => 'clients.id',
+        ];
         $expected = $this->_quoteArray($expected);
         $this->assertEquals($expected, $select);
 

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -429,7 +429,7 @@ class EagerLoaderTest extends TestCase
             'clients__company_id' => 'clients.company_id',
             'clients__telephone' => 'clients.telephone',
             'orders__total' => 'orders.total', 'orders__placed' => 'orders.placed',
-            // Primary keys are now auto-added to ensure proper entity hydration
+            // Primary keys are added to ensure proper entity hydration
             'clients__id' => 'clients.id',
             'orders__id' => 'orders.id',
         ];


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/17116

i wasnt sure if such a change would still be OK for 5.x, so targeted 5.next for now.
Should be safer to communicate with the migration guide / changelog this way.