### PR TITLE
Fixed template path inconsistencies

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1358,10 +1358,8 @@ class View implements EventDispatcherInterface
         } elseif (str_contains($name, DIRECTORY_SEPARATOR)) {
             if (str_starts_with($name, DIRECTORY_SEPARATOR) || $name[1] === ':') {
                 $name = trim($name, DIRECTORY_SEPARATOR);
-            } elseif (!$plugin || $this->templatePath !== $this->name) {
-                $name = $templatePath . $subDir . $name;
             } else {
-                $name = $subDir . $name;
+                $name = $templatePath . $subDir . $name;
             }
         }
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1116,7 +1116,6 @@ class ViewTest extends TestCase
     {
         $this->PostsController->setPlugin('TestPlugin');
         $this->PostsController->setName('Posts');
-        /** @var \TestApp\View\TestView $View */
         $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath('element');
 
@@ -1135,8 +1134,7 @@ class ViewTest extends TestCase
         $this->PostsController->setPlugin('TestPlugin');
         // Create a view where name equals templatePath (both 'Pages')
         // This was the condition that triggered the bug in issue #16895
-        /** @var \TestApp\View\TestView $View */
-        $View = $this->PostsController->createView(TestView::class, null, null, ['name' => 'Pages']);
+        $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath('Pages');
 
         $pluginPath = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS;

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1126,6 +1126,27 @@ class ViewTest extends TestCase
         $this->assertPathEquals($expected, $result);
     }
 
+    /**
+     * Test fix for issue #16895 - nested template paths should work correctly
+     * with plugins even when templatePath equals name property
+     */
+    public function testGetTemplateFileNameNestedPathWithPluginWhenTemplatePathEqualsName(): void
+    {
+        $this->PostsController->setPlugin('TestPlugin');
+        // Create a view where name equals templatePath (both 'Pages')
+        // This was the condition that triggered the bug in issue #16895
+        /** @var \TestApp\View\TestView $View */
+        $View = $this->PostsController->createView(TestView::class, null, null, ['name' => 'Pages']);
+        $View->setTemplatePath('Pages');
+
+        $pluginPath = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS;
+        $result = $View->getTemplateFileName('subfolder/example');
+        // The bug would have resulted in looking for 'templates/subfolder/example.php'
+        // instead of 'templates/Pages/subfolder/example.php'
+        $expected = $pluginPath . 'templates' . DS . 'Pages' . DS . 'subfolder' . DS . 'example.php';
+        $this->assertPathEquals($expected, $result);
+    }
+
     public function testGetTemplateException(): void
     {
         $this->expectException(CakeException::class);

--- a/tests/test_app/Plugin/TestPlugin/templates/Pages/subfolder/example.php
+++ b/tests/test_app/Plugin/TestPlugin/templates/Pages/subfolder/example.php
@@ -1,0 +1,1 @@
+Example template for nested path test


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/16895

  The Problem

  When using plugins with nested template paths (e.g., subfolder/example), if the View's templatePath property equals the name property (commonly happens with PagesController where both are 'Pages'), the View class
  incorrectly skips prepending the templatePath to the template name. This results in looking for templates in the wrong location - directly under templates/ instead of under templates/Pages/.

  The Fix

  The fix removes the problematic condition in /src/View/View.php at line 1361 that was checking if templatePath !== name for plugins. The simplified logic now always prepends the templatePath for nested template paths,
  regardless of plugin status or whether templatePath equals name.



  - Fixes the inconsistent template path resolution for plugin pages
  - All existing tests continue to pass
  - The change simplifies the logic and makes it more consistent
  - No breaking changes - this only fixes incorrect behavior

It shouldnt break stuff anyway, since i wasnt fully certain I targeted 5.next for now.