### PR TITLE
Fix up URL comparison.

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -907,7 +907,11 @@ trait IntegrationTestTrait
     }
 
     /**
-     * Asserts that the Location header is correct. Comparison is made against a full URL.
+     * Asserts that the Location header is correct.
+     *
+     * This method normalizes both the expected URL and Location header value to absolute URLs
+     * for comparison. This accommodates differences between authentication plugins and core
+     * framework behavior, where some parts return relative URLs and others return absolute URLs.
      *
      * @param array|string|null $url The URL you expected the client to go to. This
      *   can either be a string URL or an array compatible with Router::url(). Use null to
@@ -925,16 +929,24 @@ trait IntegrationTestTrait
         $this->assertThat(null, new HeaderSet($this->_response, 'Location'), $verboseMessage);
 
         if ($url) {
+            // Create a new response with normalized location for comparison
+            $normalizedLocation = $this->normalizeRedirectUrl($this->_response->getHeaderLine('Location'));
+            $tempResponse = $this->_response->withHeader('Location', $normalizedLocation);
+
             $this->assertThat(
                 Router::url($url, true),
-                new HeaderEquals($this->_response, 'Location'),
+                new HeaderEquals($tempResponse, 'Location'),
                 $verboseMessage,
             );
         }
     }
 
     /**
-     * Asserts that the Location header is correct. Comparison is made against exactly the URL provided.
+     * Asserts that the Location header is correct.
+     *
+     * This method normalizes both the expected URL and Location header value to absolute URLs
+     * for comparison. This accommodates differences between authentication plugins and core
+     * framework behavior, where some parts return relative URLs and others return absolute URLs.
      *
      * @param array|string|null $url The URL you expected the client to go to. This
      *   can either be a string URL or an array compatible with Router::url(). Use null to
@@ -952,7 +964,15 @@ trait IntegrationTestTrait
         $this->assertThat(null, new HeaderSet($this->_response, 'Location'), $verboseMessage);
 
         if ($url) {
-            $this->assertThat(Router::url($url), new HeaderEquals($this->_response, 'Location'), $verboseMessage);
+            // Create a new response with normalized location for comparison
+            $normalizedLocation = $this->normalizeRedirectUrl($this->_response->getHeaderLine('Location'));
+            $tempResponse = $this->_response->withHeader('Location', $normalizedLocation);
+
+            $this->assertThat(
+                Router::url($url, true),
+                new HeaderEquals($tempResponse, 'Location'),
+                $verboseMessage,
+            );
         }
     }
 
@@ -1504,6 +1524,24 @@ trait IntegrationTestTrait
         }
 
         return $message;
+    }
+
+    /**
+     * Normalizes a redirect URL to be absolute.
+     *
+     * If the URL is already absolute, it is returned as-is.
+     * If the URL is relative, it is converted to an absolute URL using Router::url().
+     *
+     * @param string $url The URL to normalize
+     * @return string The normalized absolute URL
+     */
+    protected function normalizeRedirectUrl(string $url): string
+    {
+        if (preg_match('#^https?://#', $url)) {
+            return $url;
+        }
+
+        return Router::url($url, true);
     }
 
     /**

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -929,12 +929,15 @@ trait IntegrationTestTrait
         $this->assertThat(null, new HeaderSet($this->_response, 'Location'), $verboseMessage);
 
         if ($url) {
-            // Create a new response with normalized location for comparison
-            $normalizedLocation = $this->normalizeRedirectUrl($this->_response->getHeaderLine('Location'));
-            $tempResponse = $this->_response->withHeader('Location', $normalizedLocation);
+            // Normalize both URLs to absolute for comparison
+            $expectedUrl = Router::url($url, true);
+            $actualUrl = Router::url($this->_response->getHeaderLine('Location'), true);
+
+            // Create a response with the normalized URL for proper error messages
+            $tempResponse = $this->_response->withHeader('Location', $actualUrl);
 
             $this->assertThat(
-                Router::url($url, true),
+                $expectedUrl,
                 new HeaderEquals($tempResponse, 'Location'),
                 $verboseMessage,
             );
@@ -964,12 +967,15 @@ trait IntegrationTestTrait
         $this->assertThat(null, new HeaderSet($this->_response, 'Location'), $verboseMessage);
 
         if ($url) {
-            // Create a new response with normalized location for comparison
-            $normalizedLocation = $this->normalizeRedirectUrl($this->_response->getHeaderLine('Location'));
-            $tempResponse = $this->_response->withHeader('Location', $normalizedLocation);
+            // Normalize both URLs to absolute for comparison
+            $expectedUrl = Router::url($url, true);
+            $actualUrl = Router::url($this->_response->getHeaderLine('Location'), true);
+
+            // Create a response with the normalized URL for proper error messages
+            $tempResponse = $this->_response->withHeader('Location', $actualUrl);
 
             $this->assertThat(
-                Router::url($url, true),
+                $expectedUrl,
                 new HeaderEquals($tempResponse, 'Location'),
                 $verboseMessage,
             );
@@ -1524,24 +1530,6 @@ trait IntegrationTestTrait
         }
 
         return $message;
-    }
-
-    /**
-     * Normalizes a redirect URL to be absolute.
-     *
-     * If the URL is already absolute, it is returned as-is.
-     * If the URL is relative, it is converted to an absolute URL using Router::url().
-     *
-     * @param string $url The URL to normalize
-     * @return string The normalized absolute URL
-     */
-    protected function normalizeRedirectUrl(string $url): string
-    {
-        if (preg_match('#^https?://#', $url)) {
-            return $url;
-        }
-
-        return Router::url($url, true);
     }
 
     /**

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -1263,6 +1263,76 @@ class IntegrationTestTraitTest extends TestCase
     }
 
     /**
+     * Test assertRedirect with relative URL in Location header
+     */
+    public function testAssertRedirectWithRelativeUrl(): void
+    {
+        $this->_response = new Response();
+        // Simulate authentication plugin returning relative URL
+        $this->_response = $this->_response->withHeader('Location', '/get/users/login');
+
+        // Should work with string URL
+        $this->assertRedirect('/get/users/login');
+
+        // Should work with array URL
+        $this->assertRedirect(['controller' => 'Users', 'action' => 'login']);
+    }
+
+    /**
+     * Test assertRedirectEquals with relative URL in Location header
+     */
+    public function testAssertRedirectEqualsWithRelativeUrl(): void
+    {
+        $this->_response = new Response();
+        // Simulate authentication plugin returning relative URL
+        $this->_response = $this->_response->withHeader('Location', '/get/users/login');
+
+        // Should work with string URL
+        $this->assertRedirectEquals('/get/users/login');
+
+        // Should work with array URL
+        $this->assertRedirectEquals(['controller' => 'Users', 'action' => 'login']);
+    }
+
+    /**
+     * Test assertRedirect with named routes and relative URLs
+     */
+    public function testAssertRedirectWithNamedRouteAndRelativeUrl(): void
+    {
+        Router::createRouteBuilder('/')->connect(
+            '/user/signin',
+            ['controller' => 'Users', 'action' => 'login'],
+            ['_name' => 'login:form'],
+        );
+
+        $this->_response = new Response();
+        // Simulate authentication plugin returning relative URL
+        $this->_response = $this->_response->withHeader('Location', '/user/signin');
+
+        // Should work with named route
+        $this->assertRedirect(['_name' => 'login:form']);
+        $this->assertRedirectEquals(['_name' => 'login:form']);
+    }
+
+    /**
+     * Test assertRedirect handles mixed absolute/relative URLs correctly
+     */
+    public function testAssertRedirectMixedUrlFormats(): void
+    {
+        $this->_response = new Response();
+
+        // Test with absolute URL in header, checking with relative path
+        $this->_response = $this->_response->withHeader('Location', 'http://localhost/get/tasks/view/1');
+        $this->assertRedirect('/get/tasks/view/1');
+        $this->assertRedirectEquals('/get/tasks/view/1');
+
+        // Test with relative URL in header, checking with absolute URL
+        $this->_response = $this->_response->withHeader('Location', '/get/tasks/edit/2');
+        $this->assertRedirect('http://localhost/get/tasks/edit/2');
+        $this->assertRedirectEquals('http://localhost/get/tasks/edit/2');
+    }
+
+    /**
      * Test the header assertion.
      */
     public function testAssertHeader(): void


### PR DESCRIPTION
Fixes https://github.com/cakephp/authentication/issues/684
This should be BC as it would convert if needed and now always compares absolute URLs.