### PR TITLE
PHP 8.5

### DIFF
--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -149,8 +149,7 @@ class MapReduce implements IteratorAggregate
     public function emitIntermediate(mixed $val, mixed $bucket, mixed $key = null): void
     {
         if ($key === null) {
-            $bucket = $bucket ?? '';
-            $this->_intermediate[$bucket][] = $val;
+            $this->_intermediate[$bucket ?? ''][] = $val;
 
             return;
         }

--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -149,6 +149,7 @@ class MapReduce implements IteratorAggregate
     public function emitIntermediate(mixed $val, mixed $bucket, mixed $key = null): void
     {
         if ($key === null) {
+            $bucket = $bucket ?? '';
             $this->_intermediate[$bucket][] = $val;
 
             return;

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -305,7 +305,7 @@ class EagerLoader
                 $repository,
                 $alias,
                 $options,
-                ['root' => null],
+                ['root' => ''],
             );
         }
 


### PR DESCRIPTION
 
PHP 8.5 deprecated `null` offset. 

https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_using_values_null_as_an_array_offset_and_when_calling_array_key_exists