### PR TITLE
Allow config of editor url.

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -65,7 +65,7 @@ class Debugger
         'outputMask' => [],
         'exportFormatter' => null,
         'editor' => 'phpstorm',
-        'editorBase' => null,
+        'editorBasePath' => null,
     ];
 
     /**
@@ -232,9 +232,9 @@ class Debugger
             ));
         }
 
-        $editorBase = $instance->getConfig('editorBase');
-        if ($editorBase !== null && is_string($editorBase)) {
-            $file = str_replace(ROOT, $editorBase, $file);
+        $editorBasePath = $instance->getConfig('editorBasePath');
+        if ($editorBasePath !== null && is_string($editorBasePath)) {
+            $file = str_replace(ROOT, $editorBasePath, $file);
         }
 
         $template = $instance->editors[$editor];

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -65,6 +65,7 @@ class Debugger
         'outputMask' => [],
         'exportFormatter' => null,
         'editor' => 'phpstorm',
+        'editorBase' => null,
     ];
 
     /**
@@ -229,6 +230,11 @@ class Debugger
                 'Cannot format editor URL `%s` is not a known editor.',
                 $editor,
             ));
+        }
+
+        $editorBase = $instance->getConfig('editorBase');
+        if ($editorBase !== null && is_string($editorBase)) {
+            $file = str_replace(ROOT, $editorBase, $file);
         }
 
         $template = $instance->editors[$editor];

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -847,4 +847,24 @@ EXPECTED;
         Debugger::setEditor('open');
         $this->assertSame('test.php/123', Debugger::editorUrl('test.php', 123));
     }
+
+    /**
+     * Test editorBase configuration for path remapping
+     */
+    public function testEditorUrlWithBasePath(): void
+    {
+        // Set up editor base path replacement
+        Configure::write('Debugger.editorBase', '/home/user/projects/myapp');
+        Debugger::getInstance(TestDebugger::class);
+        Debugger::getInstance(Debugger::class);
+
+        Debugger::setEditor('phpstorm');
+
+        // Test that ROOT is replaced with the configured base path
+        $file = ROOT . '/src/Controller/UsersController.php';
+        $result = Debugger::editorUrl($file, 10);
+
+        $expected = 'phpstorm://open?file=/home/user/projects/myapp/src/Controller/UsersController.php&line=10';
+        $this->assertSame($expected, $result);
+    }
 }

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -849,12 +849,12 @@ EXPECTED;
     }
 
     /**
-     * Test editorBase configuration for path remapping
+     * Test editorBasePath configuration for path remapping
      */
     public function testEditorUrlWithBasePath(): void
     {
         // Set up editor base path replacement
-        Configure::write('Debugger.editorBase', '/home/user/projects/myapp');
+        Configure::write('Debugger.editorBasePath', '/home/user/projects/myapp');
         Debugger::getInstance(TestDebugger::class);
         Debugger::getInstance(Debugger::class);
 


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/18894

  Developers can now configure the base path replacement in their application configuration:
```
  'Debugger' => [
      'editorBasePath' => '/home/user/Projects/project',
  ],
```
  This will replace the container's file path (ROOT) with the corresponding path on the host machine, making the "Open in Editor" functionality work correctly in containerized environments.
