### PR TITLE
Fix deprecation error on PHP 8.5

### DIFF
--- a/tests/test_app/TestApp/Mailer/Transport/SmtpTestTransport.php
+++ b/tests/test_app/TestApp/Mailer/Transport/SmtpTestTransport.php
@@ -31,9 +31,9 @@ class SmtpTestTransport extends SmtpTransport
      *
      * @return array<string>
      */
-    public function __sleep()
+    public function __serialize(): array
     {
-        return array_diff(array_keys(get_object_vars($this)), ['_socket']);
+        return array_diff_key(get_object_vars($this), ['_socket' => null]);
     }
 
     /**


### PR DESCRIPTION
__sleep() and __wakeup() have been deprecated.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
