### PR TITLE
Merge cell events from CakePHP 5.x to 4.x

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -170,8 +170,10 @@ abstract class Cell implements EventDispatcherInterface
 
         $render = function () use ($template) {
             try {
+                $this->dispatchEvent('Cell.beforeAction', [$this, $this->action, $this->args]);
                 $reflect = new ReflectionMethod($this, $this->action);
                 $reflect->invokeArgs($this, $this->args);
+                $this->dispatchEvent('Cell.afterAction', [$this, $this->action, $this->args]);
             } catch (ReflectionException $e) {
                 throw new BadMethodCallException(sprintf(
                     'Class %s does not have a "%s" method.',

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -450,4 +450,32 @@ class CellTest extends TestCase
         Cache::delete('celltest');
         Cache::drop('default');
     }
+
+    /**
+     * Tests events are dispatched correctly
+     */
+    public function testCellRenderDispatchesEvents(): void
+    {
+        $args = ['msg1' => 'dummy', 'msg2' => ' message'];
+        /** @var \TestApp\View\Cell\ArticlesCell $cell */
+        $cell = $this->View->cell('Articles::doEcho', $args);
+
+        $beforeEventIsCalled = $afterEventIsCalled = false;
+        $manager = $this->View->getEventManager();
+        $manager->on('Cell.beforeAction', function ($event, $eventCell, $action, $eventArgs) use ($cell, $args, &$beforeEventIsCalled) {
+            $this->assertSame($eventCell, $cell);
+            $this->assertEquals('doEcho', $action);
+            $this->assertEquals($args, $eventArgs);
+            $beforeEventIsCalled = true;
+        });
+        $manager->on('Cell.afterAction', function ($event, $eventCell, $action, $eventArgs) use ($cell, $args, &$afterEventIsCalled) {
+            $this->assertSame($eventCell, $cell);
+            $this->assertEquals('doEcho', $action);
+            $this->assertEquals($args, $eventArgs);
+            $afterEventIsCalled = true;
+        });
+        $cell->render();
+        $this->assertTrue($beforeEventIsCalled);
+        $this->assertTrue($afterEventIsCalled);
+    }
 }

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -456,7 +456,7 @@ class CellTest extends TestCase
      */
     public function testCellRenderDispatchesEvents(): void
     {
-        $args = ['msg1' => 'dummy', 'msg2' => ' message'];
+        $args = ['dummy', ' message'];
         /** @var \TestApp\View\Cell\ArticlesCell $cell */
         $cell = $this->View->cell('Articles::doEcho', $args);
 


### PR DESCRIPTION
## Description

This PR merges cell events functionality from CakePHP 5.x to 4.x, bringing improved cell event handling and consistency across versions.

## Changes Made

- Merged cell event implementations from CakePHP 5.x
- Updated event handling to match 5.x behavior

