### PR TITLE
Improve SchemaDialect::hasTable()

### DIFF
--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -394,11 +394,18 @@ abstract class SchemaDialect
     /**
      * Get the list of tables and views available in the current connection.
      *
+     * @param string|null $schema The schema to get the tables for. If null the default schema is used.
      * @return array<string> The list of tables and views in the connected database/schema.
      */
-    public function listTables(): array
+    public function listTables(?string $schema = null): array
     {
-        [$sql, $params] = $this->listTablesSql($this->_driver->config());
+        $config = $this->_driver->config();
+        if ($schema !== null) {
+            $config['schema'] = $schema;
+            // Set database for MySQL
+            $config['database'] = $schema;
+        }
+        [$sql, $params] = $this->listTablesSql($config);
         $result = [];
         $statement = $this->_driver->execute($sql, $params);
         while ($row = $statement->fetch()) {
@@ -644,11 +651,12 @@ abstract class SchemaDialect
      * Check if a table exists
      *
      * @param string $tableName The name of the table
+     * @param string|null $schema The schema look for table in. If null the default schema is used.
      * @return bool
      */
-    public function hasTable(string $tableName): bool
+    public function hasTable(string $tableName, ?string $schema = null): bool
     {
-        $tables = $this->listTables();
+        $tables = $this->listTables($schema);
 
         return in_array($tableName, $tables, true);
     }

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -185,7 +185,20 @@ class SchemaDialectTest extends TestCase
         $this->assertFalse($this->dialect->hasTable('nope'));
         $this->assertFalse($this->dialect->hasTable('USERS'));
         $this->assertFalse($this->dialect->hasTable('user'));
-        $this->assertTrue($this->dialect->hasTable('users'));
+        $this->assertTrue($this->dialect->hasTable('users'), 'Should exist in implicit default.');
+    }
+
+    public function testHasTableWithSchema(): void
+    {
+        $connection = ConnectionManager::get('test');
+        $driver = $connection->getDriver();
+        $this->skipIf($driver instanceof Sqlite, 'sqlite does not support schemas');
+        $this->skipIf($driver instanceof MySql, 'mysql fails because db is missing.');
+
+        $schema = $connection->config()['schema'] ?? null;
+        $this->assertTrue($this->dialect->hasTable('users'), 'Should exist in implicit schema');
+        $this->assertTrue($this->dialect->hasTable('users', $schema), 'Should exist in default schema');
+        $this->assertFalse($this->dialect->hasTable('users', 'other'), 'Should not exist on other schema');
     }
 
     public function testHasIndex(): void


### PR DESCRIPTION
To provide better backwards compatibility with migrations, hasTable() needs to support a $schema parameter.
