### PR TITLE
Fix usage of the `lock` option for `PaginatorHelper::sort()`

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -423,7 +423,7 @@ class PaginatorHelper extends Helper
         $dir = $defaultDir;
         if ($isSorted) {
             if ($locked) {
-                $template = $dir === 'asc' ? 'sortDescLocked' : 'sortAscLocked';
+                $template = $dir === 'asc' ? 'sortAscLocked' : 'sortDescLocked';
             } else {
                 $dir = $this->sortDir() === 'asc' ? 'desc' : 'asc';
                 $template = $dir === 'asc' ? 'sortDesc' : 'sortAsc';

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -308,6 +308,52 @@ class PaginatorHelperTest extends TestCase
     }
 
     /**
+     * testSortLinksWithLockOption method
+     *
+     * @return void
+     */
+    public function testSortLinksWithLockOption(): void
+    {
+        $request = new ServerRequest([
+            'url' => '/accounts/',
+            'params' => [
+                'plugin' => null,
+                'controller' => 'Accounts',
+                'action' => 'index',
+                'pass' => [],
+            ],
+            'base' => '',
+            'webroot' => '/',
+        ]);
+        Router::setRequest($request);
+
+        $params = [
+            'sort' => 'date',
+            'direction' => 'asc',
+        ];
+        $this->setPaginatedResult($params);
+        $this->Paginator->options(['url' => ['param']]);
+
+        $result = $this->Paginator->sort('distance', options: ['lock' => true]);
+        $expected = [
+            'a' => ['href' => '/Accounts/index/param?sort=distance&amp;direction=asc'],
+            'Distance',
+            '/a',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $this->setPaginatedResult(['sort' => 'distance'], true);
+
+        $result = $this->Paginator->sort('distance', options: ['lock' => true]);
+        $expected = [
+            'a' => ['href' => '/Accounts/index/param?sort=distance&amp;direction=asc', 'class' => 'asc locked'],
+            'Distance',
+            '/a',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * test sort() with escape option
      */
     public function testSortEscape(): void


### PR DESCRIPTION
The test case for this option was lost at some point and the CSS classes generated were not as intended when the feature was originally added in #2132

/cc @dereuromark 
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
