### PR TITLE
Fix deprecation error for __wakeup() usage on PHP 8.5

### DIFF
--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -100,15 +100,29 @@ class SmtpTransport extends AbstractTransport
     }
 
     /**
+     * Returns only serializable properties
+     *
+     * @return array<string>
+     */
+    public function __serialize(): array
+    {
+        return array_diff_key(get_object_vars($this), ['_socket' => null]);
+    }
+
+    /**
      * Unserialize handler.
      *
      * Ensure that the socket property isn't reinitialized in a broken state.
      *
      * @return void
      */
-    public function __wakeup(): void
+    public function __unserialize(array $data): void
     {
-        unset($this->_socket);
+        unset($data['_socket']);
+
+        foreach ($data as $key => $val) {
+            $this->{$key} = $val;
+        }
     }
 
     /**

--- a/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
+++ b/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
@@ -961,8 +961,7 @@ class WebExceptionRendererTest extends TestCase
             'driver' => $this->getMockBuilder(Driver::class)->getMock(),
             'params' => ['seven' => 7],
         ]);
-        $pdoException = $this->getMockBuilder(PDOException::class)->getMock();
-        $exception = new QueryException($loggedQuery, $pdoException);
+        $exception = new QueryException($loggedQuery, new PDOException());
 
         $ExceptionRenderer = new WebExceptionRenderer($exception);
         $response = $ExceptionRenderer->render();

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1082,8 +1082,7 @@ class ViewTest extends TestCase
      */
     public function testRenderUsingLayoutArgument(): void
     {
-        $pdoException = $this->getMockBuilder(PDOException::class)->getMock();
-        $error = new QueryException('this is sql string', $pdoException);
+        $error = new QueryException('this is sql string', new PDOException());
         $exceptions = [$error];
         $message = 'it works';
         $trace = $error->getTrace();

--- a/tests/test_app/TestApp/Mailer/Transport/SmtpTestTransport.php
+++ b/tests/test_app/TestApp/Mailer/Transport/SmtpTestTransport.php
@@ -27,16 +27,6 @@ class SmtpTestTransport extends SmtpTransport
     }
 
     /**
-     * Returns only serializable properties
-     *
-     * @return array<string>
-     */
-    public function __serialize(): array
-    {
-        return array_diff_key(get_object_vars($this), ['_socket' => null]);
-    }
-
-    /**
      * Magic function to call protected methods
      *
      * @param string $method


### PR DESCRIPTION
We'll need mockery and phpunit to also address this deprecation, for CI to pass on PHP 8.5.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
