### PR TITLE
Fix hasIndex() with primary keys

### DIFF
--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -684,13 +684,19 @@ abstract class SchemaDialect
                 $found = $index;
                 break;
             }
-            if ($columns === [] && $name !== null && $index['name'] === $name) {
-                $found = $index;
-                break;
+            if ($columns === [] && $name !== null) {
+                if ($index['name'] === $name) {
+                    $found = $index;
+                    break;
+                }
+                if (isset($index['constraint']) && $index['constraint'] === $name) {
+                    $found = $index;
+                    break;
+                }
             }
         }
         // Both columns and name provided, both must match;
-        if ($found !== null && $name !== null && $found['name'] !== $name) {
+        if ($columns && $found && $name !== null && $found['name'] !== $name) {
             return false;
         }
 

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -1774,6 +1774,20 @@ SQL;
     }
 
     /**
+     * Test that hasIndex considers constraint keys.
+     * This test is for postgres out of convenience, as not all databases
+     * provide names for primary keys.
+     */
+    public function testHasIndexPrimaryKeyName(): void
+    {
+        $this->_needsConnection();
+
+        $connection = ConnectionManager::get('test');
+        $dialect = new PostgresSchemaDialect($connection->getDriver());
+        $this->assertTrue($dialect->hasIndex('schema_authors', [], 'schema_authors_pkey'));
+    }
+
+    /**
      * Get a schema instance with a mocked driver/pdo instances
      */
     protected function _getMockedDriver(array $config = []): Driver

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -213,7 +213,7 @@ class SchemaDialectTest extends TestCase
 
         $this->assertTrue($this->dialect->hasIndex('orders', ['product_category', 'product_id']));
         $this->assertTrue($this->dialect->hasIndex('orders', ['product_category', 'product_id'], 'product_category'));
-        $this->assertTrue($this->dialect->hasIndex('orders', [], 'orders_pkey'));
+        $this->assertTrue($this->dialect->hasIndex('orders', [], 'product_category'));
     }
 
     public function testHasForeignKey(): void

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -213,6 +213,7 @@ class SchemaDialectTest extends TestCase
 
         $this->assertTrue($this->dialect->hasIndex('orders', ['product_category', 'product_id']));
         $this->assertTrue($this->dialect->hasIndex('orders', ['product_category', 'product_id'], 'product_category'));
+        $this->assertTrue($this->dialect->hasIndex('orders', [], 'orders_pkey'));
     }
 
     public function testHasForeignKey(): void


### PR DESCRIPTION
Found this while updating migrations to use the new schema dialect features.
