### PR TITLE
Configure attribute to extend container delegate

### DIFF
--- a/src/Core/Attribute/Configure.php
+++ b/src/Core/Attribute/Configure.php
@@ -19,8 +19,6 @@ namespace Cake\Core\Attribute;
 use Attribute;
 use Cake\Core\Configure as CakeConfigure;
 use League\Container\Attribute\AttributeInterface;
-use League\Container\ContainerAwareInterface;
-use League\Container\ContainerAwareTrait;
 
 /**
  * Configure attribute for dependency injection container delegate.
@@ -43,10 +41,8 @@ use League\Container\ContainerAwareTrait;
  * }
  */
 #[Attribute(Attribute::TARGET_PARAMETER)]
-class Configure implements AttributeInterface, ContainerAwareInterface
+class Configure implements AttributeInterface
 {
-    use ContainerAwareTrait;
-
     /**
      * @param string $name
      */

--- a/src/Core/Attribute/Configure.php
+++ b/src/Core/Attribute/Configure.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
 namespace Cake\Core\Attribute;
 
 use Attribute;

--- a/src/Core/Attribute/Configure.php
+++ b/src/Core/Attribute/Configure.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Core\Attribute;
+
+use Attribute;
+use Cake\Core\Configure as CakeConfigure;
+use League\Container\Attribute\AttributeInterface;
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class Configure implements AttributeInterface, ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @param string $name
+     */
+    public function __construct(private string $name)
+    {
+    }
+
+    /**
+     * @return mixed
+     */
+    public function resolve(): mixed
+    {
+        return CakeConfigure::read($this->name);
+    }
+}

--- a/src/Core/Attribute/Configure.php
+++ b/src/Core/Attribute/Configure.php
@@ -22,6 +22,26 @@ use League\Container\Attribute\AttributeInterface;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
 
+/**
+ * Configure attribute for dependency injection container delegate.
+ *
+ * This provides autowiring config data into constructors when delegate is enabled.
+ *
+ * Example:
+ * ```
+ * <?php
+ * declare(strict_types=1);
+ *
+ * namespace App\Model\WebService;
+ * use Cake\Core\Attribute\Configure;
+ *
+ * class CustomClient
+ * {
+ *     public function __construct(
+ *         #[Configure('CustomService.apiKey')] protected string $apiKey,
+ *     ) { }
+ * }
+ */
 #[Attribute(Attribute::TARGET_PARAMETER)]
 class Configure implements AttributeInterface, ContainerAwareInterface
 {

--- a/tests/TestCase/Core/Attribute/Configure/FakeClient.php
+++ b/tests/TestCase/Core/Attribute/Configure/FakeClient.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 namespace Cake\Test\TestCase\Core\Attribute\Configure;
+
 use Cake\Core\Attribute\Configure;
 
 class FakeClient
@@ -10,8 +11,8 @@ class FakeClient
      * @param string $apiKey
      */
     public function __construct(
-        #[Configure('Star.apiKey')] public string $apiKey,
+        #[Configure('Star.apiKey')]
+        public string $apiKey,
     ) {
-
     }
 }

--- a/tests/TestCase/Core/Attribute/Configure/FakeClient.php
+++ b/tests/TestCase/Core/Attribute/Configure/FakeClient.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Core\Attribute\Configure;
+use Cake\Core\Attribute\Configure;
+
+class FakeClient
+{
+    /**
+     * @param string $apiKey
+     */
+    public function __construct(
+        #[Configure('Star.apiKey')] public string $apiKey,
+    ) {
+
+    }
+}

--- a/tests/TestCase/Core/Attribute/ConfigureTest.php
+++ b/tests/TestCase/Core/Attribute/ConfigureTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Core\Attribute;
+
+use Cake\Core\Configure;
+use Cake\Core\Container;
+use Cake\Test\TestCase\Core\Attribute\Configure\FakeClient;
+use Cake\TestSuite\TestCase;
+use League\Container\ReflectionContainer;
+use TypeError;
+
+class ConfigureTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testValidConfig(): void
+    {
+        $apiKey = '987654321';
+        Configure::write('Star.apiKey', $apiKey);
+        $container = new Container();
+        $container->delegate(new ReflectionContainer());
+        $client = $container->get(FakeClient::class);
+        $this->assertInstanceOf(FakeClient::class, $client);
+        $this->assertSame($apiKey, $client->apiKey);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMissingConfig(): void
+    {
+        $container = new Container();
+        $container->delegate(new ReflectionContainer());
+        $this->expectException(TypeError::class);
+        $container->get(FakeClient::class);
+    }
+}


### PR DESCRIPTION
Related to issue: https://github.com/cakephp/cakephp/issues/18909

With this we can rely on configure keys on container delegate:

```php
<?php
declare(strict_types=1);

namespace Cake\Test\TestCase\Core\Attribute\Configure;

use Cake\Core\Attribute\Configure;

class FakeClient
{
    /**
     * @param string $apiKey
     */
    public function __construct(
        #[Configure('Star.apiKey')]
        public string $apiKey,
    ) {
    }
}
