### PR TITLE
5.3 - Add support for included columns in index generation

### DIFF
--- a/src/Database/Schema/Index.php
+++ b/src/Database/Schema/Index.php
@@ -46,7 +46,7 @@ class Index
      * @param string $type The type of index, e.g. 'index', 'fulltext'.
      * @param array<string, int>|int|null $length The length of the index.
      * @param array<string>|null $order The sort order of the index columns.
-     * @param array<string>|null $includedColumns The included columns for covering indexes.
+     * @param array<string>|null $include The included columns for covering indexes.
      * @param ?string $where The where clause for partial indexes.
      */
     public function __construct(
@@ -55,7 +55,7 @@ class Index
         protected string $type = self::INDEX,
         protected array|int|null $length = null,
         protected ?array $order = null,
-        protected ?array $includedColumns = null,
+        protected ?array $include = null,
         protected ?string $where = null,
     ) {
     }
@@ -193,7 +193,7 @@ class Index
      */
     public function setInclude(array $includedColumns)
     {
-        $this->includedColumns = $includedColumns;
+        $this->include = $includedColumns;
 
         return $this;
     }
@@ -205,7 +205,7 @@ class Index
      */
     public function getInclude(): ?array
     {
-        return $this->includedColumns;
+        return $this->include;
     }
 
     /**

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -379,7 +379,8 @@ class PostgresSchemaDialect extends SchemaDialect
         c2.relname,
         a.attname,
         i.indisprimary,
-        i.indisunique
+        i.indisunique,
+        i.indnkeyatts
         FROM pg_catalog.pg_namespace n
         INNER JOIN pg_catalog.pg_class c ON (n.oid = c.relnamespace)
         INNER JOIN pg_catalog.pg_index i ON (c.oid = i.indrelid)
@@ -446,6 +447,7 @@ class PostgresSchemaDialect extends SchemaDialect
             $type = TableSchema::INDEX_INDEX;
             $name = $row['relname'];
             $constraint = null;
+            $includeColumnIndex = $row['indnkeyatts'];
             if ($row['indisprimary']) {
                 $constraint = $name;
                 $name = TableSchema::CONSTRAINT_PRIMARY;
@@ -465,7 +467,11 @@ class PostgresSchemaDialect extends SchemaDialect
             if ($constraint) {
                 $indexes[$name]['constraint'] = $constraint;
             }
-            $indexes[$name]['columns'][] = $row['attname'];
+            if (count($indexes[$name]['columns']) < $includeColumnIndex) {
+                $indexes[$name]['columns'][] = $row['attname'];
+            } else {
+                $indexes[$name]['include'][] = $row['attname'];
+            }
         }
 
         return array_values($indexes);
@@ -876,18 +882,26 @@ class PostgresSchemaDialect extends SchemaDialect
      */
     public function indexSql(TableSchema $schema, string $name): string
     {
-        $data = $schema->getIndex($name);
-        assert($data !== null);
+        $index = $schema->index($name);
         $columns = array_map(
             $this->_driver->quoteIdentifier(...),
-            $data['columns'],
+            $index->getColumns(),
         );
+        $include = '';
+        if ($index->getInclude()) {
+            $included = array_map(
+                $this->_driver->quoteIdentifier(...),
+                $index->getInclude(),
+            );
+            $include = sprintf(' INCLUDE (%s)', implode(', ', $included));
+        }
 
         return sprintf(
-            'CREATE INDEX %s ON %s (%s)',
+            'CREATE INDEX %s ON %s (%s)%s',
             $this->_driver->quoteIdentifier($name),
             $this->_driver->quoteIdentifier($schema->name()),
             implode(', ', $columns),
+            $include,
         );
     }
 

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -885,7 +885,7 @@ class PostgresSchemaDialect extends SchemaDialect
         $index = $schema->index($name);
         $columns = array_map(
             $this->_driver->quoteIdentifier(...),
-            $index->getColumns(),
+            (array)$index->getColumns(),
         );
         $include = '';
         if ($index->getInclude()) {

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -824,7 +824,7 @@ class SqlserverSchemaDialect extends SchemaDialect
         $index = $schema->index($name);
         $columns = array_map(
             $this->_driver->quoteIdentifier(...),
-            $index->getColumns(),
+            (array)$index->getColumns(),
         );
         $include = '';
         if ($index->getInclude()) {

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -368,7 +368,8 @@ class SqlserverSchemaDialect extends SchemaDialect
                 IC.[index_column_id] AS [index_order],
                 AC.[name] AS [column_name],
                 I.[is_unique], I.[is_primary_key],
-                I.[is_unique_constraint]
+                I.[is_unique_constraint],
+                IC.[is_included_column]
             FROM sys.[tables] AS T
             INNER JOIN sys.[schemas] S ON S.[schema_id] = T.[schema_id]
             INNER JOIN sys.[indexes] I ON T.[object_id] = I.[object_id]
@@ -448,7 +449,11 @@ class SqlserverSchemaDialect extends SchemaDialect
                     'length' => [],
                 ];
             }
-            $indexes[$name]['columns'][] = $row['column_name'];
+            if ($row['is_included_column']) {
+                $indexes[$name]['include'][] = $row['column_name'];
+            } else {
+                $indexes[$name]['columns'][] = $row['column_name'];
+            }
             if ($constraint) {
                 $indexes[$name]['constraint'] = $constraint;
             }
@@ -816,18 +821,26 @@ class SqlserverSchemaDialect extends SchemaDialect
      */
     public function indexSql(TableSchema $schema, string $name): string
     {
-        $data = $schema->getIndex($name);
-        assert($data !== null);
+        $index = $schema->index($name);
         $columns = array_map(
             $this->_driver->quoteIdentifier(...),
-            $data['columns'],
+            $index->getColumns(),
         );
+        $include = '';
+        if ($index->getInclude()) {
+            $included = array_map(
+                $this->_driver->quoteIdentifier(...),
+                $index->getInclude(),
+            );
+            $include = sprintf(' INCLUDE (%s)', implode(', ', $included));
+        }
 
         return sprintf(
-            'CREATE INDEX %s ON %s (%s)',
+            'CREATE INDEX %s ON %s (%s)%s',
             $this->_driver->quoteIdentifier($name),
             $this->_driver->quoteIdentifier($schema->name()),
             implode(', ', $columns),
+            $include,
         );
     }
 

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -208,6 +208,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         'columns' => [],
         'length' => [],
         'references' => [],
+        'include' => null,
         'update' => 'restrict',
         'delete' => 'restrict',
         'constraint' => null,
@@ -688,7 +689,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         }
 
         $attrs['name'] = $attrs['constraint'] ?? $name;
-        unset($attrs['constraint']);
+        unset($attrs['constraint'], $attrs['include']);
 
         $type = $attrs['type'] ?? null;
         if ($type === static::CONSTRAINT_FOREIGN) {

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -1233,7 +1233,6 @@ SQL;
         $this->assertTextEquals($expected, $schema->indexSql($table, $name));
     }
 
-
     /**
      * Integration test for converting a Schema\Table into MySQL table creates.
      */

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -1194,6 +1194,47 @@ SQL;
     }
 
     /**
+     * Provide data for testing constraintSql
+     *
+     * @return array
+     */
+    public static function indexSqlProvider(): array
+    {
+        return [
+            [
+                'title_idx',
+                ['type' => 'index', 'columns' => ['title']],
+                'CREATE INDEX [title_idx] ON [schema_articles] ([title])',
+            ],
+            [
+                'author_idx',
+                ['type' => 'index', 'columns' => ['author_id'], 'include' => ['title']],
+                'CREATE INDEX [author_idx] ON [schema_articles] ([author_id]) INCLUDE ([title])',
+            ],
+        ];
+    }
+
+    /**
+     * Test the indexSql method.
+     */
+    #[DataProvider('indexSqlProvider')]
+    public function testIndexSql(string $name, array $data, string $expected): void
+    {
+        $driver = $this->_getMockedDriver();
+        $schema = new PostgresSchemaDialect($driver);
+
+        $table = (new TableSchema('schema_articles'))->addColumn('title', [
+            'type' => 'string',
+            'length' => 255,
+        ])->addColumn('author_id', [
+            'type' => 'integer',
+        ])->addIndex($name, $data);
+
+        $this->assertTextEquals($expected, $schema->indexSql($table, $name));
+    }
+
+
+    /**
      * Integration test for converting a Schema\Table into MySQL table creates.
      */
     public function testCreateSql(): void

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -689,6 +689,40 @@ SQL;
     }
 
     /**
+     * Ensure that included columns are included in reflection results
+     */
+    public function testDescribeIndexIncludedFields(): void
+    {
+        $this->_needsConnection();
+        $connection = ConnectionManager::get('test');
+        $sql = <<<SQL
+CREATE TABLE schema_index_include (
+    "id" INTEGER NOT NULL,
+    "site_id" INTEGER NOT NULL,
+    "name" VARCHAR(255),
+    PRIMARY KEY("id")
+);
+SQL;
+        $connection->execute($sql);
+
+        $sql = 'CREATE INDEX [site_id_name] ON [schema_index_include] ([site_id]) INCLUDE ([name])';
+        $connection->execute($sql);
+
+        $dialect = new SqlserverSchemaDialect($connection->getDriver());
+        $indexExists = $dialect->hasIndex('schema_index_include', ['site_id']);
+        $indexExistsName = $dialect->hasIndex('schema_index_include', name: 'site_id_name');
+        $indexes = $dialect->describeIndexes('schema_index_include');
+        $connection->execute('DROP TABLE schema_index_include');
+
+        $this->assertTrue($indexExists);
+        $this->assertTrue($indexExistsName);
+        $this->assertCount(2, $indexes);
+        $this->assertEquals(['id'], $indexes[0]['columns']);
+        $this->assertEquals(['site_id'], $indexes[1]['columns']);
+        $this->assertEquals(['name'], $indexes[1]['include']);
+    }
+
+    /**
      * Column provider for creating column sql
      *
      * @return array

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -1221,7 +1221,7 @@ SQL;
     public function testIndexSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
-        $schema = new PostgresSchemaDialect($driver);
+        $schema = new SqlserverSchemaDialect($driver);
 
         $table = (new TableSchema('schema_articles'))->addColumn('title', [
             'type' => 'string',


### PR DESCRIPTION
This helps reduce breaking changes in migrations and makes the schema reflection of cakephp richer.