### PR TITLE
Deprecate Query::newExpr() in favor of Query::expr()

### DIFF
--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -323,7 +323,7 @@ class Sqlserver extends Driver
         }
 
         if ($offset !== null && !$query->clause('order')) {
-            $query->orderBy($query->newExpr()->add('(SELECT NULL)'));
+            $query->orderBy($query->expr()->add('(SELECT NULL)'));
         }
 
         if ($this->version() < 11 && $offset !== null) {
@@ -426,9 +426,9 @@ class Sqlserver extends Driver
         $order = new OrderByExpression($distinct);
         $query
             ->select(function (Query $q) use ($distinct, $order) {
-                $over = $q->newExpr('ROW_NUMBER() OVER')
+                $over = $q->expr('ROW_NUMBER() OVER')
                     ->add('(PARTITION BY')
-                    ->add($q->newExpr()->add($distinct)->setConjunction(','))
+                    ->add($q->expr()->add($distinct)->setConjunction(','))
                     ->add($order)
                     ->add(')')
                     ->setConjunction(' ');

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -270,9 +270,9 @@ class CaseStatementExpression implements ExpressionInterface, TypedResultInterfa
      * ```
      * $query
      *      ->select([
-     *          'val' => $query->newExpr()
+     *          'val' => $query->expr()
      *              ->case()
-     *              ->when($query->newExpr(':userData'))
+     *              ->when($query->expr(':userData'))
      *              ->then(123)
      *      ])
      *      ->bind(':userData', $userData, 'integer')

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -621,15 +621,15 @@ abstract class Query implements ExpressionInterface, Stringable
         $i = count($this->_parts['join']);
         foreach ($tables as $alias => $t) {
             if (!is_array($t)) {
-                $t = ['table' => $t, 'conditions' => $this->newExpr()];
+                $t = ['table' => $t, 'conditions' => $this->expr()];
             }
 
             if ($t['conditions'] instanceof Closure) {
-                $t['conditions'] = $t['conditions']($this->newExpr(), $this);
+                $t['conditions'] = $t['conditions']($this->expr(), $this);
             }
 
             if (!($t['conditions'] instanceof ExpressionInterface)) {
-                $t['conditions'] = $this->newExpr()->add($t['conditions'], $types);
+                $t['conditions'] = $this->expr()->add($t['conditions'], $types);
             }
             $alias = is_string($alias) ? $alias : null;
             $joins[$alias ?: $i++] = $t + ['type' => static::JOIN_TYPE_INNER, 'alias' => $alias];
@@ -855,7 +855,7 @@ abstract class Query implements ExpressionInterface, Stringable
      * ### Using expressions objects:
      *
      * ```
-     * $exp = $query->newExpr()->add(['id !=' => 100, 'author_id' != 1])->tieWith('OR');
+     * $exp = $query->expr()->add(['id !=' => 100, 'author_id' != 1])->tieWith('OR');
      * $query->where(['published' => true], ['published' => 'boolean'])->where($exp);
      * ```
      *
@@ -930,7 +930,7 @@ abstract class Query implements ExpressionInterface, Stringable
         bool $overwrite = false,
     ) {
         if ($overwrite) {
-            $this->_parts['where'] = $this->newExpr();
+            $this->_parts['where'] = $this->expr();
         }
         $this->_conjugate('where', $conditions, 'AND', $types);
 
@@ -950,7 +950,7 @@ abstract class Query implements ExpressionInterface, Stringable
             $fields = [$fields];
         }
 
-        $exp = $this->newExpr();
+        $exp = $this->expr();
 
         foreach ($fields as $field) {
             $exp->isNotNull($field);
@@ -972,7 +972,7 @@ abstract class Query implements ExpressionInterface, Stringable
             $fields = [$fields];
         }
 
-        $exp = $this->newExpr();
+        $exp = $this->expr();
 
         foreach ($fields as $field) {
             $exp->isNull($field);
@@ -1161,7 +1161,7 @@ abstract class Query implements ExpressionInterface, Stringable
      *
      * ```
      * $query
-     *     ->orderBy(['title' => $query->newExpr('DESC NULLS FIRST')])
+     *     ->orderBy(['title' => $query->expr('DESC NULLS FIRST')])
      *     ->orderBy('author_id');
      * ```
      *
@@ -1170,7 +1170,7 @@ abstract class Query implements ExpressionInterface, Stringable
      * `ORDER BY title DESC NULLS FIRST, author_id`
      *
      * ```
-     * $expression = $query->newExpr()->add(['id % 2 = 0']);
+     * $expression = $query->expr()->add(['id % 2 = 0']);
      * $query->orderBy($expression)->orderBy(['title' => 'ASC']);
      * ```
      *
@@ -1230,7 +1230,7 @@ abstract class Query implements ExpressionInterface, Stringable
      *
      * ```
      * $query
-     *     ->orderBy(['title' => $query->newExpr('DESC NULLS FIRST')])
+     *     ->orderBy(['title' => $query->expr('DESC NULLS FIRST')])
      *     ->orderBy('author_id');
      * ```
      *
@@ -1239,7 +1239,7 @@ abstract class Query implements ExpressionInterface, Stringable
      * `ORDER BY title DESC NULLS FIRST, author_id`
      *
      * ```
-     * $expression = $query->newExpr()->add(['id % 2 = 0']);
+     * $expression = $query->expr()->add(['id % 2 = 0']);
      * $query->orderBy($expression)->orderBy(['title' => 'ASC']);
      * ```
      *
@@ -1326,7 +1326,7 @@ abstract class Query implements ExpressionInterface, Stringable
         }
 
         if ($field instanceof Closure) {
-            $field = $field($this->newExpr(), $this);
+            $field = $field($this->expr(), $this);
         }
 
         $this->_parts['order'] ??= new OrderByExpression();
@@ -1382,7 +1382,7 @@ abstract class Query implements ExpressionInterface, Stringable
         }
 
         if ($field instanceof Closure) {
-            $field = $field($this->newExpr(), $this);
+            $field = $field($this->expr(), $this);
         }
 
         $this->_parts['order'] ??= new OrderByExpression();
@@ -1424,7 +1424,7 @@ abstract class Query implements ExpressionInterface, Stringable
      *
      * ```
      * $query->limit(10) // generates LIMIT 10
-     * $query->limit($query->newExpr()->add(['1 + 1'])); // LIMIT (1 + 1)
+     * $query->limit($query->expr()->add(['1 + 1'])); // LIMIT (1 + 1)
      * ```
      *
      * @param \Cake\Database\ExpressionInterface|int|null $limit number of records to be returned
@@ -1450,7 +1450,7 @@ abstract class Query implements ExpressionInterface, Stringable
      *
      * ```
      * $query->offset(10) // generates OFFSET 10
-     * $query->offset($query->newExpr()->add(['1 + 1'])); // OFFSET (1 + 1)
+     * $query->offset($query->expr()->add(['1 + 1'])); // OFFSET (1 + 1)
      * ```
      *
      * @param \Cake\Database\ExpressionInterface|int|null $offset number of records to be skipped
@@ -1474,7 +1474,7 @@ abstract class Query implements ExpressionInterface, Stringable
      * ### Example
      *
      * ```
-     * $query->newExpr()->lte('count', $query->identifier('total'));
+     * $query->expr()->lte('count', $query->identifier('total'));
      * ```
      *
      * @param string $identifier The identifier for an expression
@@ -1557,9 +1557,12 @@ abstract class Query implements ExpressionInterface, Stringable
      *
      * @param \Cake\Database\ExpressionInterface|array|string|null $rawExpression A string, array or anything you want wrapped in an expression object
      * @return \Cake\Database\Expression\QueryExpression
+     * @deprecated 5.3.0 Use `expr()` instead of `newExpr()`.
      */
     public function newExpr(ExpressionInterface|array|string|null $rawExpression = null): QueryExpression
     {
+        deprecationWarning('5.3.0', 'Use `expr()` instead of `newExpr()`.');
+
         return $this->expr($rawExpression);
     }
 
@@ -1776,7 +1779,7 @@ abstract class Query implements ExpressionInterface, Stringable
         array $types,
     ): void {
         /** @var \Cake\Database\Expression\QueryExpression $expression */
-        $expression = $this->_parts[$part] ?: $this->newExpr();
+        $expression = $this->_parts[$part] ?: $this->expr();
         if (!$append) {
             $this->_parts[$part] = $expression;
 
@@ -1784,13 +1787,13 @@ abstract class Query implements ExpressionInterface, Stringable
         }
 
         if ($append instanceof Closure) {
-            $append = $append($this->newExpr(), $this);
+            $append = $append($this->expr(), $this);
         }
 
         if ($expression->getConjunction() === $conjunction) {
             $expression->add($append, $types);
         } else {
-            $expression = $this->newExpr()
+            $expression = $this->expr()
                 ->setConjunction($conjunction)
                 ->add([$expression, $append], $types);
         }

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -328,7 +328,7 @@ class SelectQuery extends Query implements IteratorAggregate
         bool $overwrite = false,
     ) {
         if ($overwrite) {
-            $this->_parts['having'] = $this->newExpr();
+            $this->_parts['having'] = $this->expr();
         }
         $this->_conjugate('having', $conditions, 'AND', $types);
 

--- a/src/Database/Query/UpdateQuery.php
+++ b/src/Database/Query/UpdateQuery.php
@@ -106,11 +106,11 @@ class UpdateQuery extends Query
     public function set(QueryExpression|Closure|array|string $key, mixed $value = null, array|string $types = [])
     {
         if (empty($this->_parts['set'])) {
-            $this->_parts['set'] = $this->newExpr()->setConjunction(',');
+            $this->_parts['set'] = $this->expr()->setConjunction(',');
         }
 
         if ($key instanceof Closure) {
-            $exp = $this->newExpr()->setConjunction(',');
+            $exp = $this->expr()->setConjunction(',');
             /** @var \Cake\Database\Expression\QueryExpression $setExpr */
             $setExpr = $this->_parts['set'];
             $setExpr->add($key($exp));

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -172,7 +172,7 @@ interface QueryInterface
      *
      * ```
      * $query->limit(10) // generates LIMIT 10
-     * $query->limit($query->newExpr()->add(['1 + 1'])); // LIMIT (1 + 1)
+     * $query->limit($query->expr()->add(['1 + 1'])); // LIMIT (1 + 1)
      * ```
      *
      * @param int|null $limit number of records to be returned
@@ -192,7 +192,7 @@ interface QueryInterface
      *
      * ```
      *  $query->offset(10) // generates OFFSET 10
-     *  $query->offset($query->newExpr()->add(['1 + 1'])); // OFFSET (1 + 1)
+     *  $query->offset($query->expr()->add(['1 + 1'])); // OFFSET (1 + 1)
      * ```
      *
      * @param int|null $offset number of records to be skipped
@@ -225,7 +225,7 @@ interface QueryInterface
      *
      * ```
      * $query
-     *     ->orderBy(['title' => $query->newExpr('DESC NULLS FIRST')])
+     *     ->orderBy(['title' => $query->expr('DESC NULLS FIRST')])
      *     ->orderBy('author_id');
      * ```
      *
@@ -234,7 +234,7 @@ interface QueryInterface
      * `ORDER BY title DESC NULLS FIRST, author_id`
      *
      * ```
-     * $expression = $query->newExpr()->add(['id % 2 = 0']);
+     * $expression = $query->expr()->add(['id % 2 = 0']);
      * $query->orderBy($expression)->orderBy(['title' => 'ASC']);
      * ```
      *
@@ -277,7 +277,7 @@ interface QueryInterface
      *
      * ```
      * $query
-     *     ->orderBy(['title' => $query->newExpr('DESC NULLS FIRST')])
+     *     ->orderBy(['title' => $query->expr('DESC NULLS FIRST')])
      *     ->orderBy('author_id');
      * ```
      *
@@ -286,7 +286,7 @@ interface QueryInterface
      * `ORDER BY title DESC NULLS FIRST, author_id`
      *
      * ```
-     * $expression = $query->newExpr()->add(['id % 2 = 0']);
+     * $expression = $query->expr()->add(['id % 2 = 0']);
      * $query->orderBy($expression)->orderBy(['title' => 'ASC']);
      * ```
      *
@@ -404,7 +404,7 @@ interface QueryInterface
      * ### Using expressions objects:
      *
      * ```
-     *  $exp = $query->newExpr()->add(['id !=' => 100, 'author_id' != 1])->tieWith('OR');
+     *  $exp = $query->expr()->add(['id !=' => 100, 'author_id' != 1])->tieWith('OR');
      *  $query->where(['published' => true], ['published' => 'boolean'])->where($exp);
      * ```
      *

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -531,7 +531,7 @@ class BelongsToMany extends Association
                 foreach (array_keys($conds) as $field) {
                     $identifiers[] = new IdentifierExpression($field);
                 }
-                $identifiers = $subquery->newExpr()->add($identifiers)->setConjunction(',');
+                $identifiers = $subquery->expr()->add($identifiers)->setConjunction(',');
                 $nullExp = clone $exp;
 
                 return $exp

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -303,7 +303,7 @@ class SelectLoader
             $conditions = $this->_createTupleCondition($query, $key, $filter, '=');
         } else {
             $filter = current($filter);
-            $conditions = $query->newExpr([$key => $filter]);
+            $conditions = $query->expr([$key => $filter]);
         }
 
         return $query->innerJoin(

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -891,7 +891,7 @@ class TreeBehavior extends Behavior
         /** @var \Cake\Database\Expression\IdentifierExpression $field */
         foreach ([$config['leftField'], $config['rightField']] as $field) {
             $query = $this->_scope($this->_table->updateQuery());
-            $exp = $query->newExpr();
+            $exp = $query->expr();
 
             $movement = clone $exp;
             $movement->add($field)->add((string)$shift)->setConjunction($dir);

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -1238,7 +1238,7 @@ class ConnectionTest extends TestCase
     public function testRunAndStatementIteration(): void
     {
         $query = new SelectQuery($this->connection);
-        $query->select(fields: ['field' => $query->newExpr('1')]);
+        $query->select(fields: ['field' => $query->expr('1')]);
 
         $statement = $this->connection->run($query);
         foreach ($statement as $row) {

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -178,7 +178,7 @@ class PostgresTest extends TestCase
                 'post_count' => $query->func()->count('posts.id'),
             ])
             ->groupBy(['posts.author_id'])
-            ->having([$query->newExpr()->gte('post_count', 2, 'integer')]);
+            ->having([$query->expr()->gte('post_count', 2, 'integer')]);
 
         $expected = 'SELECT posts.author_id, (COUNT(posts.id)) AS "post_count" ' .
             'GROUP BY posts.author_id HAVING COUNT(posts.id) >= :c0';
@@ -206,7 +206,7 @@ class PostgresTest extends TestCase
                 'post_count' => $query->func()->count('posts.id'),
             ])
             ->groupBy(['posts.author_id'])
-            ->having([$query->newExpr()->gte('posts.author_id', 2, 'integer')]);
+            ->having([$query->expr()->gte('posts.author_id', 2, 'integer')]);
 
         $expected = 'SELECT posts.author_id, (COUNT(posts.id)) AS "post_count" ' .
             'GROUP BY posts.author_id HAVING posts.author_id >= :c0';

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -492,7 +492,7 @@ class SqlserverTest extends TestCase
                 'post_count' => $query->func()->count('posts.id'),
             ])
             ->groupBy(['posts.author_id'])
-            ->having([$query->newExpr()->gte('post_count', 2, 'integer')]);
+            ->having([$query->expr()->gte('post_count', 2, 'integer')]);
 
         $expected = 'SELECT posts.author_id, (COUNT(posts.id)) AS post_count ' .
             'GROUP BY posts.author_id HAVING COUNT(posts.id) >= :c0';
@@ -523,7 +523,7 @@ class SqlserverTest extends TestCase
                 'post_count' => $query->func()->count('posts.id'),
             ])
             ->groupBy(['posts.author_id'])
-            ->having([$query->newExpr()->gte('posts.author_id', 2, 'integer')]);
+            ->having([$query->expr()->gte('posts.author_id', 2, 'integer')]);
 
         $expected = 'SELECT posts.author_id, (COUNT(posts.id)) AS post_count ' .
             'GROUP BY posts.author_id HAVING posts.author_id >= :c0';

--- a/tests/TestCase/Database/Query/DeleteQueryTest.php
+++ b/tests/TestCase/Database/Query/DeleteQueryTest.php
@@ -164,7 +164,7 @@ class DeleteQueryTest extends TestCase
                     'AND' => [
                         'b.name NOT IN' => ['foo', 'bar'],
                         'OR' => [
-                            $query->newExpr()->eq(new IdentifierExpression('c.name'), 'zap'),
+                            $query->expr()->eq(new IdentifierExpression('c.name'), 'zap'),
                             'd.name' => 'baz',
                             (new SelectQuery($this->connection))->select(['e.name'])->where(['e.name' => 'oof']),
                         ],

--- a/tests/TestCase/Database/Query/InsertQueryTest.php
+++ b/tests/TestCase/Database/Query/InsertQueryTest.php
@@ -348,7 +348,7 @@ class InsertQueryTest extends TestCase
         $query = new InsertQuery($this->connection);
         $query->insert(['title', 'author_id'])
             ->into('articles')
-            ->values(['title' => $query->newExpr("SELECT 'jose'"), 'author_id' => 99]);
+            ->values(['title' => $query->expr("SELECT 'jose'"), 'author_id' => 99]);
 
         $result = $query->execute();
         $result->closeCursor();
@@ -443,7 +443,7 @@ class InsertQueryTest extends TestCase
         $query
             ->insert(['column'])
             ->into('table')
-            ->values(['column' => $query->newExpr('value')]);
+            ->values(['column' => $query->expr('value')]);
 
         $clause = $query->clause('values');
         $clauseClone = (clone $query)->clause('values');
@@ -485,7 +485,7 @@ class InsertQueryTest extends TestCase
         $this->assertQuotedQuery('INSERT INTO <foo> \(<bar>, <baz>\)', $sql);
 
         $query = new InsertQuery($this->connection);
-        $sql = $query->insert([$query->newExpr('bar')])
+        $sql = $query->insert([$query->expr('bar')])
             ->into('foo')
             ->sql();
         $this->assertQuotedQuery('INSERT INTO <foo> \(\(bar\)\)', $sql);

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -191,8 +191,8 @@ class SelectQueryTest extends TestCase
         $result->closeCursor();
 
         $query = new SelectQuery($this->connection);
-        $exp = $query->newExpr('1 + 1');
-        $comp = $query->newExpr(['article_id +' => 2]);
+        $exp = $query->expr('1 + 1');
+        $comp = $query->expr(['article_id +' => 2]);
         $result = $query->select(['text' => 'comment', 'two' => $exp, 'three' => $comp])
             ->from('comments')->execute();
         $this->assertEquals(['text' => 'First Comment for First Article', 'two' => 2, 'three' => 3], $result->fetch('assoc'));
@@ -235,7 +235,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['title', 'name'])
             ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->expr()->equalFields('author_id', 'a.id')])
             ->orderBy(['title' => 'asc'])
             ->execute();
 
@@ -250,7 +250,7 @@ class SelectQueryTest extends TestCase
         $result->closeCursor();
 
         $result = $query->join([
-            ['table' => 'authors', 'type' => 'INNER', 'conditions' => $query->newExpr()->equalFields('author_id', 'authors.id')],
+            ['table' => 'authors', 'type' => 'INNER', 'conditions' => $query->expr()->equalFields('author_id', 'authors.id')],
         ], [], true)->execute();
         $rows = $result->fetchAll('assoc');
         $this->assertCount(3, $rows);
@@ -268,7 +268,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['title', 'name'])
             ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => [$query->newExpr()->equalFields('author_id ', 'a.id')]])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => [$query->expr()->equalFields('author_id ', 'a.id')]])
             ->orderBy(['title' => 'asc'])
             ->execute();
         $this->assertEquals(['title' => 'First Article', 'name' => 'mariano'], $result->fetch('assoc'));
@@ -276,7 +276,7 @@ class SelectQueryTest extends TestCase
         $result->closeCursor();
 
         $query = new SelectQuery($this->connection);
-        $conditions = $query->newExpr()->equalFields('author_id', 'a.id');
+        $conditions = $query->expr()->equalFields('author_id', 'a.id');
         $result = $query
             ->select(['title', 'name'])
             ->from('articles')
@@ -316,7 +316,7 @@ class SelectQueryTest extends TestCase
         $result->closeCursor();
 
         $query = new SelectQuery($this->connection);
-        $conditions = $query->newExpr('author_id = a.id');
+        $conditions = $query->expr('author_id = a.id');
         $result = $query
             ->select(['title', 'name'])
             ->from('articles')
@@ -823,7 +823,7 @@ class SelectQueryTest extends TestCase
             ->select(['id'])
             ->from('comments')
             ->where(function ($exp, $q) {
-                return $exp->in($q->newExpr('SELECT 1'), []);
+                return $exp->in($q->expr('SELECT 1'), []);
             })
             ->execute();
     }
@@ -1222,7 +1222,7 @@ class SelectQueryTest extends TestCase
             ->where(function ($exp, $q) {
                 return $exp->in(
                     'created',
-                    $q->newExpr("'2007-03-18 10:45:23'"),
+                    $q->expr("'2007-03-18 10:45:23'"),
                     'datetime',
                 );
             })
@@ -1239,7 +1239,7 @@ class SelectQueryTest extends TestCase
             ->where(function ($exp, $q) {
                 return $exp->notIn(
                     'created',
-                    $q->newExpr("'2007-03-18 10:45:23'"),
+                    $q->expr("'2007-03-18 10:45:23'"),
                     'datetime',
                 );
             })
@@ -1414,8 +1414,8 @@ class SelectQueryTest extends TestCase
             ->select(['id'])
             ->from('comments')
             ->where(function (ExpressionInterface $exp, Query $q) {
-                $from = $q->newExpr("'2007-03-18 10:51:00'");
-                $to = $q->newExpr("'2007-03-18 10:54:00'");
+                $from = $q->expr("'2007-03-18 10:51:00'");
+                $to = $q->expr("'2007-03-18 10:54:00'");
 
                 return $exp->between('created', $from, $to);
             })
@@ -1739,7 +1739,7 @@ class SelectQueryTest extends TestCase
         $this->assertEquals(['id' => 3], $result->fetch('assoc'));
         $result->closeCursor();
 
-        $expression = $query->newExpr(['(id + :offset) % 2']);
+        $expression = $query->expr(['(id + :offset) % 2']);
         $result = $query
             ->orderBy([$expression, 'id' => 'desc'], true)
             ->bind(':offset', 1, null)
@@ -2170,7 +2170,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['city', 'state', 'country'])
             ->from(['addresses'])
-            ->modifier($query->newExpr('EXPRESSION'));
+            ->modifier($query->expr('EXPRESSION'));
         $this->assertQuotedQuery(
             'SELECT EXPRESSION <city>, <state>, <country> FROM <addresses>',
             $result->sql(),
@@ -2187,7 +2187,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['total' => 'count(author_id)', 'author_id'])
             ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->expr()->equalFields('author_id', 'a.id')])
             ->groupBy('author_id')
             ->having(['count(author_id) <' => 2], ['count(author_id)' => 'integer'])
             ->execute();
@@ -2217,7 +2217,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['total' => 'count(author_id)', 'author_id'])
             ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->expr()->equalFields('author_id', 'a.id')])
             ->groupBy('author_id')
             ->having(['count(author_id) >' => 2], ['count(author_id)' => 'integer'])
             ->andHaving(['count(author_id) <' => 2], ['count(author_id)' => 'integer'])
@@ -2228,7 +2228,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['total' => 'count(author_id)', 'author_id'])
             ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->expr()->equalFields('author_id', 'a.id')])
             ->groupBy('author_id')
             ->having(['count(author_id)' => 2], ['count(author_id)' => 'integer'])
             ->andHaving(['count(author_id) >' => 1], ['count(author_id)' => 'integer'])
@@ -2240,7 +2240,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['total' => 'count(author_id)', 'author_id'])
             ->from('articles')
-            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->expr()->equalFields('author_id', 'a.id')])
             ->groupBy('author_id')
             ->andHaving(function ($e) {
                 return $e->add('count(author_id) = 2 - 1');
@@ -2413,7 +2413,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select([
                 'id',
-                'ids_added' => $query->newExpr()->add('(user_id + article_id)'),
+                'ids_added' => $query->expr()->add('(user_id + article_id)'),
             ])
             ->from('comments')
             ->orderBy(['ids_added' => 'asc'])
@@ -2439,7 +2439,7 @@ class SelectQueryTest extends TestCase
         $subquery = (new SelectQuery($this->connection))
             ->select('name')
             ->from(['b' => 'authors'])
-            ->where([$query->newExpr()->equalFields('b.id', 'a.id')]);
+            ->where([$query->expr()->equalFields('b.id', 'a.id')]);
         $result = $query
             ->select(['id', 'name' => $subquery])
             ->from(['a' => 'comments'])->execute();
@@ -2606,7 +2606,7 @@ class SelectQueryTest extends TestCase
         $this->assertCount(3, $result->fetchAll());
         $result->closeCursor();
 
-        $query->join(['b' => ['table' => $subquery, 'conditions' => [$query->newExpr()->equalFields('b.id', 'articles.id')]]], [], true);
+        $query->join(['b' => ['table' => $subquery, 'conditions' => [$query->expr()->equalFields('b.id', 'articles.id')]]], [], true);
         $result = $query->execute();
         $this->assertCount(1, $result->fetchAll());
         $result->closeCursor();
@@ -2731,7 +2731,7 @@ class SelectQueryTest extends TestCase
         $intersect = (new SelectQuery($this->connection))
             ->select(['id', 'comment', 'other' => 'id', 'nameish' => 'comment'])
             ->from(['c' => 'comments'])
-            ->where($intersect->newExpr()->like('comment', '%First%'))
+            ->where($intersect->expr()->like('comment', '%First%'))
             ->orderBy(['id' => 'desc']);
         $expectedCount = count($query->select(['foo' => 'id', 'bar' => 'comment'])->execute()->fetchAll());
         $query->select(['foo' => 'id', 'bar' => 'comment'])->intersect($intersect);
@@ -2807,7 +2807,7 @@ class SelectQueryTest extends TestCase
         $intersect = (new SelectQuery($this->connection))
             ->select(['article_id', 'user_id'])
             ->from(['c' => 'comments'])
-            ->where($intersect->newExpr()->like('comment', '%First%'))
+            ->where($intersect->expr()->like('comment', '%First%'))
             ->orderBy(['id' => 'desc']);
         $expectedCount = count($intersect->execute()->fetchAll());
         $query->select(['article_id', 'user_id'], true)->intersectAll($intersect, true);
@@ -3246,7 +3246,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery('SELECT <1 \+ 1> AS <foo>$', $sql);
 
         $query = new SelectQuery($this->connection);
-        $sql = $query->select(['foo' => $query->newExpr('1 + 1')])->sql();
+        $sql = $query->select(['foo' => $query->expr('1 + 1')])->sql();
         $this->assertQuotedQuery('SELECT \(1 \+ 1\) AS <foo>$', $sql);
 
         $query = new SelectQuery($this->connection);
@@ -3269,7 +3269,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery('FROM <something> <foo>$', $sql);
 
         $query = new SelectQuery($this->connection);
-        $sql = $query->select('*')->from(['foo' => $query->newExpr('bar')])->sql();
+        $sql = $query->select('*')->from(['foo' => $query->expr('bar')])->sql();
         $this->assertQuotedQuery('FROM \(bar\) <foo>$', $sql);
     }
 
@@ -3299,7 +3299,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery('JOIN <something> <foo>', $sql);
 
         $query = new SelectQuery($this->connection);
-        $sql = $query->select('*')->join(['foo' => $query->newExpr('bar')])->sql();
+        $sql = $query->select('*')->join(['foo' => $query->expr('bar')])->sql();
         $this->assertQuotedQuery('JOIN \(bar\) <foo>', $sql);
 
         $query = new SelectQuery($this->connection);
@@ -3322,7 +3322,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery('GROUP BY <something>', $sql);
 
         $query = new SelectQuery($this->connection);
-        $sql = $query->select('*')->groupBy([$query->newExpr('bar')])->sql();
+        $sql = $query->select('*')->groupBy([$query->expr('bar')])->sql();
         $this->assertQuotedQuery('GROUP BY \(bar\)', $sql);
 
         $query = new SelectQuery($this->connection);
@@ -3565,8 +3565,8 @@ class SelectQueryTest extends TestCase
     {
         $query = new SelectQuery($this->connection);
         $query
-            ->select($query->newExpr('select'))
-            ->select(['alias' => $query->newExpr('select')]);
+            ->select($query->expr('select'))
+            ->select(['alias' => $query->expr('select')]);
 
         $clause = $query->clause('select');
         $clauseClone = (clone $query)->clause('select');
@@ -3582,7 +3582,7 @@ class SelectQueryTest extends TestCase
     public function testCloneDistinctExpression(): void
     {
         $query = new SelectQuery($this->connection);
-        $query->distinct($query->newExpr('distinct'));
+        $query->distinct($query->expr('distinct'));
 
         $clause = $query->clause('distinct');
         $clauseClone = (clone $query)->clause('distinct');
@@ -3596,7 +3596,7 @@ class SelectQueryTest extends TestCase
     public function testCloneModifierExpression(): void
     {
         $query = new SelectQuery($this->connection);
-        $query->modifier($query->newExpr('modifier'));
+        $query->modifier($query->expr('modifier'));
 
         $clause = $query->clause('modifier');
         $clauseClone = (clone $query)->clause('modifier');
@@ -3660,8 +3660,8 @@ class SelectQueryTest extends TestCase
     {
         $query = new SelectQuery($this->connection);
         $query
-            ->where($query->newExpr('where'))
-            ->where(['field' => $query->newExpr('where')]);
+            ->where($query->expr('where'))
+            ->where(['field' => $query->expr('where')]);
 
         $clause = $query->clause('where');
         $clauseClone = (clone $query)->clause('where');
@@ -3675,7 +3675,7 @@ class SelectQueryTest extends TestCase
     public function testCloneGroupExpression(): void
     {
         $query = new SelectQuery($this->connection);
-        $query->groupBy($query->newExpr('group'));
+        $query->groupBy($query->expr('group'));
 
         $clause = $query->clause('group');
         $clauseClone = (clone $query)->clause('group');
@@ -3691,7 +3691,7 @@ class SelectQueryTest extends TestCase
     public function testCloneHavingExpression(): void
     {
         $query = new SelectQuery($this->connection);
-        $query->having($query->newExpr('having'));
+        $query->having($query->expr('having'));
 
         $clause = $query->clause('having');
         $clauseClone = (clone $query)->clause('having');
@@ -3729,9 +3729,9 @@ class SelectQueryTest extends TestCase
     {
         $query = new SelectQuery($this->connection);
         $query
-            ->orderBy($query->newExpr('order'))
-            ->orderByAsc($query->newExpr('order_asc'))
-            ->orderByDesc($query->newExpr('order_desc'));
+            ->orderBy($query->expr('order'))
+            ->orderByAsc($query->expr('order_asc'))
+            ->orderByDesc($query->expr('order_desc'));
 
         $clause = $query->clause('order');
         $clauseClone = (clone $query)->clause('order');
@@ -3745,7 +3745,7 @@ class SelectQueryTest extends TestCase
     public function testCloneLimitExpression(): void
     {
         $query = new SelectQuery($this->connection);
-        $query->limit($query->newExpr('1'));
+        $query->limit($query->expr('1'));
 
         $clause = $query->clause('limit');
         $clauseClone = (clone $query)->clause('limit');
@@ -3759,7 +3759,7 @@ class SelectQueryTest extends TestCase
     public function testCloneOffsetExpression(): void
     {
         $query = new SelectQuery($this->connection);
-        $query->offset($query->newExpr('1'));
+        $query->offset($query->expr('1'));
 
         $clause = $query->clause('offset');
         $clauseClone = (clone $query)->clause('offset');
@@ -3794,7 +3794,7 @@ class SelectQueryTest extends TestCase
     public function testCloneEpilogExpression(): void
     {
         $query = new SelectQuery($this->connection);
-        $query->epilog($query->newExpr('epilog'));
+        $query->epilog($query->expr('epilog'));
 
         $clause = $query->clause('epilog');
         $clauseClone = (clone $query)->clause('epilog');
@@ -4152,7 +4152,7 @@ class SelectQueryTest extends TestCase
         $subquery = new SelectQuery($connection);
         $subquery
             ->select(
-                $subquery->newExpr()->case()->when(['a.published' => 'N'])->then(1)->else(0),
+                $subquery->expr()->case()->when(['a.published' => 'N'])->then(1)->else(0),
             )
             ->from(['a' => 'articles'])
             ->where([

--- a/tests/TestCase/Database/Query/UpdateQueryTest.php
+++ b/tests/TestCase/Database/Query/UpdateQueryTest.php
@@ -168,7 +168,7 @@ class UpdateQueryTest extends TestCase
     {
         $query = new UpdateQuery($this->connection);
 
-        $expr = $query->newExpr()->equalFields('article_id', 'user_id');
+        $expr = $query->expr()->equalFields('article_id', 'user_id');
 
         $query->update('comments')
             ->set($expr)
@@ -310,7 +310,7 @@ class UpdateQueryTest extends TestCase
                     'AND' => [
                         'b.name NOT IN' => ['foo', 'bar'],
                         'OR' => [
-                            $query->newExpr()->eq(new IdentifierExpression('c.name'), 'zap'),
+                            $query->expr()->eq(new IdentifierExpression('c.name'), 'zap'),
                             'd.name' => 'baz',
                             (new SelectQuery($this->connection))->select(['e.name'])->where(['e.name' => 'oof']),
                         ],
@@ -408,7 +408,7 @@ class UpdateQueryTest extends TestCase
     public function testCloneUpdateExpression(): void
     {
         $query = new UpdateQuery($this->connection);
-        $query->update($query->newExpr('update'));
+        $query->update($query->expr('update'));
 
         $clause = $query->clause('update');
         $clauseClone = (clone $query)->clause('update');
@@ -426,7 +426,7 @@ class UpdateQueryTest extends TestCase
         $query = new UpdateQuery($this->connection);
         $query
             ->update('table')
-            ->set(['column' => $query->newExpr('value')]);
+            ->set(['column' => $query->expr('value')]);
 
         $clause = $query->clause('set');
         $clauseClone = (clone $query)->clause('set');
@@ -470,7 +470,7 @@ class UpdateQueryTest extends TestCase
         $result = $query
             ->update('authors')
             ->set('name', 'mark')
-            ->modifier([$query->newExpr('TOP 10 PERCENT')]);
+            ->modifier([$query->expr('TOP 10 PERCENT')]);
         $this->assertQuotedQuery(
             'UPDATE TOP 10 PERCENT <authors> SET <name> = :c0',
             $result->sql(),

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -172,7 +172,7 @@ class QueryTest extends TestCase
 
     public function testCloneModifierExpression(): void
     {
-        $this->query->modifier($this->query->newExpr('modifier'));
+        $this->query->modifier($this->query->expr('modifier'));
 
         $clause = $this->query->clause('modifier');
         $clauseClone = (clone $this->query)->clause('modifier');
@@ -233,8 +233,8 @@ class QueryTest extends TestCase
     public function testCloneWhereExpression(): void
     {
         $this->query
-            ->where($this->query->newExpr('where'))
-            ->where(['field' => $this->query->newExpr('where')]);
+            ->where($this->query->expr('where'))
+            ->where(['field' => $this->query->expr('where')]);
 
         $clause = $this->query->clause('where');
         $clauseClone = (clone $this->query)->clause('where');
@@ -248,9 +248,9 @@ class QueryTest extends TestCase
     public function testCloneOrderExpression(): void
     {
         $this->query
-            ->orderBy($this->query->newExpr('order'))
-            ->orderByAsc($this->query->newExpr('order_asc'))
-            ->orderByDesc($this->query->newExpr('order_desc'));
+            ->orderBy($this->query->expr('order'))
+            ->orderByAsc($this->query->expr('order_asc'))
+            ->orderByDesc($this->query->expr('order_desc'));
 
         $clause = $this->query->clause('order');
         $clauseClone = (clone $this->query)->clause('order');
@@ -263,7 +263,7 @@ class QueryTest extends TestCase
 
     public function testCloneLimitExpression(): void
     {
-        $this->query->limit($this->query->newExpr('1'));
+        $this->query->limit($this->query->expr('1'));
 
         $clause = $this->query->clause('limit');
         $clauseClone = (clone $this->query)->clause('limit');
@@ -276,7 +276,7 @@ class QueryTest extends TestCase
 
     public function testCloneOffsetExpression(): void
     {
-        $this->query->offset($this->query->newExpr('1'));
+        $this->query->offset($this->query->expr('1'));
 
         $clause = $this->query->clause('offset');
         $clauseClone = (clone $this->query)->clause('offset');
@@ -289,7 +289,7 @@ class QueryTest extends TestCase
 
     public function testCloneEpilogExpression(): void
     {
-        $this->query->epilog($this->query->newExpr('epilog'));
+        $this->query->epilog($this->query->expr('epilog'));
 
         $clause = $this->query->clause('epilog');
         $clauseClone = (clone $this->query)->clause('epilog');
@@ -351,5 +351,17 @@ class QueryTest extends TestCase
 
         $this->query->with([$cte2, fn($query) => $cte1], true);
         $this->assertSame([$cte2, $cte1], $this->query->clause('with'));
+    }
+
+    /**
+     * Test that calling newExpr() emits a deprecation warning.
+     *
+     * @deprecated
+     */
+    public function testNewExprDeprecation(): void
+    {
+        $this->deprecated(function (): void {
+            $this->query->newExpr();
+        });
     }
 }

--- a/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
@@ -70,7 +70,7 @@ class CaseExpressionQueryTest extends TestCase
             ->select(function (Query $query) {
                 return [
                     'name',
-                    'category_name' => $query->newExpr()
+                    'category_name' => $query->expr()
                         ->case($query->identifier('products.category'))
                         ->when(1)
                         ->then('Touring')
@@ -111,7 +111,7 @@ class CaseExpressionQueryTest extends TestCase
                 return [
                     'name',
                     'price',
-                    'price_range' => $query->newExpr()
+                    'price_range' => $query->expr()
                         ->case()
                         ->when(['price <' => 20])
                         ->then('Under $20')
@@ -157,13 +157,13 @@ class CaseExpressionQueryTest extends TestCase
             ->from('comments')
             ->orderByAsc('comments.article_id')
             ->orderByDesc(function (QueryExpression $exp, Query $query) {
-                return $query->newExpr()
+                return $query->expr()
                     ->case($query->identifier('comments.article_id'))
                     ->when(1)
                     ->then($query->identifier('comments.user_id'));
             })
             ->orderByAsc(function (QueryExpression $exp, Query $query) {
-                return $query->newExpr()
+                return $query->expr()
                     ->case($query->identifier('comments.article_id'))
                     ->when(2)
                     ->then($query->identifier('comments.user_id'));
@@ -207,7 +207,7 @@ class CaseExpressionQueryTest extends TestCase
             ->leftJoin('comments', ['comments.article_id = articles.id'])
             ->groupBy(['articles.id', 'articles.title'])
             ->having(function (QueryExpression $exp, Query $query) {
-                $expression = $query->newExpr()
+                $expression = $query->expr()
                     ->case()
                     ->when(['comments.published' => 'Y'])
                     ->then(1);
@@ -248,7 +248,7 @@ class CaseExpressionQueryTest extends TestCase
             ->update('comments')
             ->set([
                 'published' =>
-                    $this->query->newExpr()
+                    $this->query->expr()
                         ->case()
                         ->when(['published' => 'Y'])
                         ->then('N')
@@ -294,11 +294,11 @@ class CaseExpressionQueryTest extends TestCase
         $query = $this->query
             ->select(function (Query $query) {
                 return [
-                    'val' => $query->newExpr()
-                        ->case($query->newExpr(':value'))
-                        ->when($query->newExpr(':when'))
-                        ->then($query->newExpr(':then'))
-                        ->else($query->newExpr(':else')),
+                    'val' => $query->expr()
+                        ->case($query->expr(':value'))
+                        ->when($query->expr(':when'))
+                        ->then($query->expr(':then'))
+                        ->else($query->expr(':else')),
                 ];
             })
             ->from('products')

--- a/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
@@ -131,7 +131,7 @@ class CommonTableExpressionQueryTest extends TestCase
 
                 $recursiveQuery = $query->getConnection()
                     ->selectQuery(function (Query $query) {
-                        return $query->newExpr('col + 1');
+                        return $query->expr('col + 1');
                     }, 'cte')
                     ->where(['col !=' => 3], ['col' => 'integer']);
 
@@ -207,7 +207,7 @@ class CommonTableExpressionQueryTest extends TestCase
                 return $cte
                     ->name('cte')
                     ->field(['title', 'body'])
-                    ->query($query->newExpr("SELECT 'Fourth Article', 'Fourth Article Body'"));
+                    ->query($query->expr("SELECT 'Fourth Article', 'Fourth Article Body'"));
             })
             ->insert(['title', 'body'])
             ->into('articles')
@@ -260,7 +260,7 @@ class CommonTableExpressionQueryTest extends TestCase
                         return $cte
                             ->name('cte')
                             ->field(['title', 'body'])
-                            ->query($query->newExpr("SELECT 'Fourth Article', 'Fourth Article Body'"));
+                            ->query($query->expr("SELECT 'Fourth Article', 'Fourth Article Body'"));
                     })
                     ->select('*')
                     ->from('cte'),

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1524,7 +1524,7 @@ class BelongsToManyTest extends TestCase
         $result = $table
             ->find()
             ->contain(['Tags' => function (SelectQuery $q) {
-                return $q->select(['two' => $q->newExpr('1 + 1')])->enableAutoFields();
+                return $q->select(['two' => $q->expr('1 + 1')])->enableAutoFields();
             }])
             ->first();
 

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1881,7 +1881,7 @@ class MarshallerTest extends TestCase
         $this->articles->Tags->getEventManager()->on('Model.beforeFind', function ($e, $query): void {
             $left = new IdentifierExpression('Tags.id');
             $right = new IdentifierExpression('a.id');
-            $query->leftJoin(['a' => 'tags'], $query->newExpr()->eq($left, $right));
+            $query->leftJoin(['a' => 'tags'], $query->expr()->eq($left, $right));
         });
 
         $marshall = new Marshaller($this->articles);

--- a/tests/TestCase/ORM/Query/CaseExpressionQueryTest.php
+++ b/tests/TestCase/ORM/Query/CaseExpressionQueryTest.php
@@ -34,7 +34,7 @@ class CaseExpressionQueryTest extends TestCase
                 return [
                     'name',
                     'price',
-                    'is_cheap' => $query->newExpr()
+                    'is_cheap' => $query->expr()
                         ->case()
                         ->when(['price <' => 20])
                         ->then(1)
@@ -71,7 +71,7 @@ class CaseExpressionQueryTest extends TestCase
         $query = $this->getTableLocator()->get('Products')
             ->find()
             ->select(function (SelectQuery $query) {
-                $expression = $query->newExpr()
+                $expression = $query->expr()
                     ->case()
                     ->when(['Products.price <' => 20])
                     ->then(true)

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -1069,11 +1069,11 @@ class QueryRegressionTest extends TestCase
         $ratio = $table->find()
             ->select(function ($query) use ($table) {
                 $allCommentsCount = $table->find()->select($query->func()->count('*'));
-                $countToFloat = $query->newExpr([$query->func()->count('*'), '1.0'])->setConjunction('*');
+                $countToFloat = $query->expr([$query->func()->count('*'), '1.0'])->setConjunction('*');
 
                 return [
                     'ratio' => $query
-                        ->newExpr($countToFloat)
+                        ->expr($countToFloat)
                         ->add($allCommentsCount)
                         ->setConjunction('/'),
                 ];
@@ -1457,7 +1457,7 @@ class QueryRegressionTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $query = $table->find();
         $query->orderByDesc(
-            $query->newExpr()->case()->when(['id' => 3])->then(1)->else(0),
+            $query->expr()->case()->when(['id' => 3])->then(1)->else(0),
         );
         $query->orderBy(['title' => 'desc']);
         // Executing the normal query before getting the count
@@ -1467,9 +1467,9 @@ class QueryRegressionTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $query = $table->find();
         $query->orderByDesc(
-            $query->newExpr()->case()->when(['id' => 3])->then(1)->else(0),
+            $query->expr()->case()->when(['id' => 3])->then(1)->else(0),
         );
-        $query->orderByDesc($query->newExpr()->add(['id' => 3]));
+        $query->orderByDesc($query->expr()->add(['id' => 3]));
         // Not executing the query first, just getting the count
         $this->assertSame(3, $query->count());
     }

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -1793,7 +1793,7 @@ class SelectQueryTest extends TestCase
         $table = $this->getTableLocator()->get('articles');
 
         $query = $table->updateQuery();
-        $result = $query->update($query->newExpr('articles, authors'))
+        $result = $query->update($query->expr('articles, authors'))
             ->set(['title' => 'First'])
             ->where(['articles.author_id = authors.id'])
             ->andWhere(['authors.name' => 'mariano'])
@@ -2762,7 +2762,7 @@ class SelectQueryTest extends TestCase
             ->join([
                 'person' => [
                     'table' => 'authors',
-                    'conditions' => [$query->newExpr()->equalFields('person.id', 'articles.author_id')],
+                    'conditions' => [$query->expr()->equalFields('person.id', 'articles.author_id')],
                 ],
             ])
             ->orderBy(['articles.id' => 'ASC'])
@@ -3305,7 +3305,7 @@ class SelectQueryTest extends TestCase
         $result = $table
             ->find()
             ->select(function ($q) {
-                return ['foo' => $q->newExpr('1 + 1')];
+                return ['foo' => $q->expr('1 + 1')];
             })
             ->select($table)
             ->select($table->authors)
@@ -3315,7 +3315,7 @@ class SelectQueryTest extends TestCase
         $expected = $table
             ->find()
             ->select(function ($q) {
-                return ['foo' => $q->newExpr('1 + 1')];
+                return ['foo' => $q->expr('1 + 1')];
             })
             ->enableAutoFields()
             ->contain(['authors'])
@@ -3879,7 +3879,7 @@ class SelectQueryTest extends TestCase
                 'post_count' => $query->func()->count('posts.id'),
             ])
             ->groupBy(['posts.author_id'])
-            ->having([$query->newExpr()->gte('post_count', 2, 'integer')])
+            ->having([$query->expr()->gte('post_count', 2, 'integer')])
             ->enableHydration(false)
             ->toArray();
 


### PR DESCRIPTION
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
