### PR TITLE
Change TestFixture to find alias matching class name

### DIFF
--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -43,7 +43,14 @@ class TestFixture implements FixtureInterface
     public string $connection = 'test';
 
     /**
-     * Full Table Name
+     * ORM table alias
+     *
+     * @var string
+     */
+    public string $alias = '';
+
+    /**
+     * Database table name
      *
      * @var string
      */
@@ -114,25 +121,29 @@ class TestFixture implements FixtureInterface
      */
     public function init(): void
     {
-        if (!$this->table) {
-            $this->table = $this->_tableFromClass();
+        if (!$this->alias) {
+            assert(!($this->alias && $this->table), 'Cannot specify both custom alias and table name');
+            if (!$this->table) {
+                $this->alias = $this->_aliasFromClass();
+            } else {
+                $this->alias = Inflector::camelize($this->table);
+            }
         }
 
         $this->_schemaFromReflection();
     }
 
     /**
-     * Returns the table name using the fixture class
+     * Returns the table alias using the fixture class
      *
      * @return string
      */
-    protected function _tableFromClass(): string
+    protected function _aliasFromClass(): string
     {
         [, $class] = namespaceSplit(static::class);
         preg_match('/^(.*)Fixture$/', $class, $matches);
-        $table = $matches[1] ?? $class;
 
-        return Inflector::tableize($table);
+        return $matches[1] ?? $class;
     }
 
     /**
@@ -146,17 +157,15 @@ class TestFixture implements FixtureInterface
         $db = ConnectionManager::get($this->connection());
         assert($db instanceof Connection);
         try {
-            $name = Inflector::camelize($this->table);
-            $ormTable = $this->fetchTable($name, ['connection' => $db]);
-
-            // Remove the fetched table from the locator to avoid conflicts
-            // with test cases that need to (re)configure the alias.
-            $this->getTableLocator()->remove($name);
+            $ormTable = $this->fetchTable($this->alias, ['connection' => $db]);
+            $this->table = $ormTable->getTable();
 
             $schema = $ormTable->getSchema();
             assert($schema instanceof TableSchema);
             $this->_schema = $schema;
 
+            // Remove the fetched table from the locator to avoid conflicts
+            // with test cases that need to (re)configure the alias.
             $this->getTableLocator()->clear();
         } catch (CakeException $e) {
             $message = sprintf(

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -27,6 +27,7 @@ use Cake\Test\Fixture\ArticlesFixture;
 use Cake\Test\Fixture\PostsFixture;
 use Cake\TestSuite\TestCase;
 use Mockery;
+use TestApp\Test\Fixture\AliasedArticlesFixture;
 use TestApp\Test\Fixture\FeaturedTagsFixture;
 use TestApp\Test\Fixture\LettersFixture;
 
@@ -76,6 +77,13 @@ class TestFixtureTest extends TestCase
 
         $schema = $Fixture->getTableSchema();
         $this->assertInstanceOf(TableSchema::class, $schema);
+    }
+
+    public function testCustomAlias(): void
+    {
+        $fixture = new AliasedArticlesFixture();
+        $this->assertSame('articles', $fixture->table);
+        $this->assertInstanceOf(TableSchema::class, $fixture->getTableSchema());
     }
 
     /**
@@ -155,7 +163,6 @@ class TestFixtureTest extends TestCase
         $fixture = new FeaturedTagsFixture();
 
         $posts = new PostsFixture();
-        $posts->init();
 
         $expected = ['tag_id', 'priority'];
         $this->assertSame($expected, $fixture->getTableSchema()->columns());

--- a/tests/test_app/TestApp/tests/Fixture/AliasedArticlesFixture.php
+++ b/tests/test_app/TestApp/tests/Fixture/AliasedArticlesFixture.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class AliasedArticlesFixture extends TestFixture
+{
+    /**
+     * Alias
+     *
+     * @var string
+     */
+    public string $alias = 'Articles';
+
+    /**
+     * Records property
+     *
+     * @var array
+     */
+    public array $records = [
+    ];
+}


### PR DESCRIPTION
closes https://github.com/cakephp/cakephp/issues/18884

TestFixture should find the table alias matching the class name by default instead of doing a circular conversion from class name to table name to class name.

Since we're storing the alias it can also be overridden as needed.