### PR TITLE
Use `associated` as a table name passed as string such as `Plugin.Table` will not work

### DIFF
--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -92,14 +92,14 @@ class RulesChecker extends BaseRulesChecker
      *
      * @param array<string>|string $field The field or list of fields to check for existence by
      * primary key lookup in the other table.
-     * @param \Cake\ORM\Table|\Cake\ORM\Association|string $table The table name where the fields existence will be checked.
+     * @param \Cake\ORM\Table|\Cake\ORM\Association|string $associated The alias name of the table where the fields existence will be checked.
      * @param array<string, mixed>|string|null $message The error message to show in case the rule does not pass. Can
      *   also be an array of options. When an array, the 'message' key can be used to provide a message.
      * @return \Cake\Datasource\RuleInvoker
      */
     public function existsIn(
         array|string $field,
-        Table|Association|string $table,
+        Table|Association|string $associated,
         array|string|null $message = null,
     ): RuleInvoker {
         $options = [];
@@ -119,7 +119,7 @@ class RulesChecker extends BaseRulesChecker
 
         $errorField = is_string($field) ? $field : current($field);
 
-        return $this->_addError(new ExistsIn($field, $table, $options), '_existsIn', compact('errorField', 'message'));
+        return $this->_addError(new ExistsIn($field, $associated, $options), '_existsIn', compact('errorField', 'message'));
     }
 
     /**

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -92,7 +92,8 @@ class RulesChecker extends BaseRulesChecker
      *
      * @param array<string>|string $field The field or list of fields to check for existence by
      * primary key lookup in the other table.
-     * @param \Cake\ORM\Table|\Cake\ORM\Association|string $associated The alias name of the table where the fields existence will be checked.
+     * @param \Cake\ORM\Table|\Cake\ORM\Association|string $associated The alias name of the table
+     *   where the fields existence will be checked.
      * @param array<string, mixed>|string|null $message The error message to show in case the rule does not pass. Can
      *   also be an array of options. When an array, the 'message' key can be used to provide a message.
      * @return \Cake\Datasource\RuleInvoker


### PR DESCRIPTION
The `existsIn` rule expects the second parameter to be `Table|Association|string $table` So I expected it to be with plugin prefix like `Pluginname.Tablename`
This throws an error:

```
ExistsIn rule for `object_id` is invalid. `Pluginname.Tablename` is not associated with `AssociatedTablename`.
```

CakePHP uses the associated table name instead of the Table name, so in my opinion `$associated` is a better name for the parameter than `$table` to make this more clear.
