### PR TITLE
Add replace function to command collection

### DIFF
--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -116,6 +116,23 @@ class CommandCollection implements IteratorAggregate, Countable
     }
 
     /**
+     * Replace a command from the collection with another command if it exists.
+     *
+     * @param string $oldName Name of command to remove.
+     * @param string $newName The name of the command you want to map.
+     * @param \Cake\Console\CommandInterface|class-string<\Cake\Console\CommandInterface> $command The command to map.
+     * Can be a FQCN or CommandInterface instance.
+     * @return $this
+     */
+    public function replace(string $oldName, string $newName, CommandInterface|string $command)
+    {
+        $this->remove($oldName);
+        $this->add($newName, $command);
+
+        return $this;
+    }
+
+    /**
      * Check whether the named shell exists in the collection.
      *
      * @param string $name The named shell.

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -202,6 +202,42 @@ class CommandCollectionTest extends TestCase
     }
 
     /**
+     * Test has
+     *
+     * @return void
+     */
+    public function testHas()
+    {
+        $collection = new CommandCollection();
+        $collection->add('routes', RoutesCommand::class);
+        $this->assertTrue($collection->has('routes'));
+    }
+
+    /**
+     * Test get
+     *
+     * @return void
+     */
+    public function testGet()
+    {
+        $collection = new CommandCollection();
+        $collection->add('routes', RoutesCommand::class);
+        $this->assertSame(RoutesCommand::class, $collection->get('routes'));
+    }
+
+    /**
+     * Test get invalid
+     *
+     * @return void
+     */
+    public function testGetInvalid()
+    {
+        $collection = new CommandCollection();
+        $this->expectExceptionMessage('The `invalid` is not a known command name.');
+        $collection->get('invalid');
+    }
+
+    /**
      * test getIterator
      */
     public function testGetIterator(): void

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -154,6 +154,54 @@ class CommandCollectionTest extends TestCase
     }
 
     /**
+     * Test replacing a command
+     *
+     * @return void
+     */
+    public function testReplace(): void
+    {
+        $oldName = 'routes';
+        $newName = 'routing';
+        $collection = new CommandCollection();
+        $collection->add($oldName, RoutesCommand::class);
+        $collection->replace($oldName, $newName, RoutesCommand::class);
+        $this->assertFalse($collection->has($oldName));
+        $this->assertTrue($collection->has($newName));
+        $this->assertSame(RoutesCommand::class, $collection->get($newName));
+    }
+
+    /**
+     * Test replacing with an instance of a command
+     *
+     * @return void
+     */
+    public function testReplaceInstance(): void
+    {
+        $oldName = 'routes';
+        $newName = 'routing';
+        $collection = new CommandCollection();
+        $command = new RoutesCommand();
+        $collection->add($oldName, $command);
+        $collection->replace($oldName, $newName, $command);
+        $this->assertFalse($collection->has($oldName));
+        $this->assertTrue($collection->has($newName));
+        $this->assertSame($command, $collection->get($newName));
+    }
+
+    /**
+     * Test replacing a command instance with an invalid name.
+     */
+    public function testReplaceCommandInvalidName(): void
+    {
+        $oldName = 'routes';
+        $newName = ' spaced';
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("The command name `{$newName}` is invalid.");
+        $collection = new CommandCollection();
+        $collection->replace($oldName, $newName, RoutesCommand::class);
+    }
+
+    /**
      * test getIterator
      */
     public function testGetIterator(): void


### PR DESCRIPTION
After using autoDiscover to add all commands and then renaming one command, we noticed that the autoDiscover overwrites the renamed command and the autoDiscovered command needs to be removed before the renamed command can be added. We tought it would be nice to have a replace function to be able to replace a command with another.