### PR TITLE
Fix incorrect query generation with executed subqueries

### DIFF
--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -102,11 +102,13 @@ class QueryCompiler
         );
 
         // Propagate bound parameters from sub-queries if the
-        // placeholders can be found in the SQL statement.
+        // placeholders can be found in the SQL statement. Only
+        // add new placeholders, as sub-queries may have been executed already.
         if ($query->getValueBinder() !== $binder) {
+            $existing = $binder->bindings();
             foreach ($query->getValueBinder()->bindings() as $binding) {
                 $placeholder = ':' . $binding['placeholder'];
-                if (preg_match('/' . $placeholder . '(?:\W|$)/', $sql) > 0) {
+                if (!isset($existing[$placeholder]) && preg_match('/' . $placeholder . '(?:\W|$)/', $sql) > 0) {
                     $binder->bind($placeholder, $binding['value'], $binding['type']);
                 }
             }


### PR DESCRIPTION
Fix incorrectly generated queries that use a subquery, and that subquery has already been executed. If this scenario were to occur in application code, crafted inputs could allow by-pass access controls.

Thanks to Kei Akiyama for reporting this via the security list.

Once we're happy with this, I'll backport it to 4.x as the problem is present there as well.