### PR TITLE
Fix redis bug with initialize

### DIFF
--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -492,7 +492,7 @@ class RedisEngine extends CacheEngine
      */
     public function __destruct()
     {
-        if (empty($this->_config['persistent'])) {
+        if (isset($this->_Redis) && empty($this->_config['persistent'])) {
             $this->_Redis->close();
         }
     }


### PR DESCRIPTION
> Error thrown in .../vendor/cakephp/cakephp/src/Cache/Engine/RedisEngine.php on line 496 while loading bootstrap file .../tests/bootstrap.php: Typed property Cake\Cache\Engine\RedisEngine::$_Redis must not be accessed before initialization

With this fix we are now back to the warning it should have:

> warning: 512 :: The `redis` extension must be enabled to use RedisEngine. on line 157 of /.../vendor/cakephp/cakephp/src/Cache/Cache.php

The warning about Redis extension not being available is expected (since Redis isn't installed), but the fatal error about accessing an uninitialized typed property is fixed.

The fix I applied checks if $_Redis is set before trying to call close() on it in the destructor. This prevents the "Typed property must not be accessed before initialization" error when the Redis connection fails to
  initialize.