### PR TITLE
Update SelectQuery return typehints to match updated ResultSetInterface

### DIFF
--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -227,7 +227,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * iterated without having to call execute() manually, thus making it look like
      * a result set instead of the query itself.
      *
-     * @return \Cake\Datasource\ResultSetInterface<\Cake\Datasource\EntityInterface|array>
+     * @return \Cake\Datasource\ResultSetInterface<array-key, \Cake\Datasource\EntityInterface|array>
      */
     public function getIterator(): ResultSetInterface
     {
@@ -365,7 +365,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * ResultSetDecorator is a traversable object that implements the methods found
      * on Cake\Collection\Collection.
      *
-     * @return \Cake\Datasource\ResultSetInterface<mixed>
+     * @return \Cake\Datasource\ResultSetInterface<array-key, mixed>
      */
     public function all(): ResultSetInterface
     {
@@ -725,7 +725,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * Decorates the results iterator with MapReduce routines and formatters
      *
      * @param iterable $result Original results
-     * @return \Cake\Datasource\ResultSetInterface<\Cake\Datasource\EntityInterface|mixed>
+     * @return \Cake\Datasource\ResultSetInterface<array-key, \Cake\Datasource\EntityInterface|mixed>
      */
     protected function _decorateResults(iterable $result): ResultSetInterface
     {
@@ -1728,7 +1728,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * Part of JsonSerializable interface.
      *
-     * @return \Cake\Datasource\ResultSetInterface<(\Cake\Datasource\EntityInterface|mixed)> The data to convert to JSON.
+     * @return \Cake\Datasource\ResultSetInterface<array-key, (\Cake\Datasource\EntityInterface|mixed)> The data to convert to JSON.
      */
     public function jsonSerialize(): ResultSetInterface
     {


### PR DESCRIPTION
In relation to changes to [ResultSetInterface](https://github.com/cakephp/cakephp/blob/5.x/src/Datasource/ResultSetInterface.php)

Change to SelectQuery @return interfaces to include both required template variables

related conversation: https://github.com/cakephp/cakephp/pull/18867
change: 
https://github.com/cakephp/cakephp/commit/923620b77f5e9f74f5a06dcbf989f6401eacb91a
https://github.com/cakephp/cakephp/pull/18806/files#diff-ef7a1551c15fd8984eb0cf77bd248348055e104689d622609e671f1974e7c53e

