### PR TITLE
Declare closures static where applicable

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -82,7 +82,7 @@ trait CollectionTrait
      */
     public function filter(?callable $callback = null): CollectionInterface
     {
-        $callback ??= fn($v) => (bool)$v;
+        $callback ??= static fn($v) => (bool)$v;
 
         return new FilterIterator($this->unwrap(), $callback);
     }
@@ -92,7 +92,7 @@ trait CollectionTrait
      */
     public function reject(?callable $callback = null): CollectionInterface
     {
-        $callback ??= fn($v) => (bool)$v;
+        $callback ??= static fn($v) => (bool)$v;
 
         return new FilterIterator($this->unwrap(), fn($value, $key, $items) => !$callback($value, $key, $items));
     }
@@ -102,7 +102,7 @@ trait CollectionTrait
      */
     public function unique(?callable $callback = null): CollectionInterface
     {
-        $callback ??= fn($v) => $v;
+        $callback ??= static fn($v) => $v;
 
         return new UniqueIterator($this->unwrap(), $callback);
     }
@@ -513,7 +513,7 @@ trait CollectionTrait
             return $this->newCollection($iterator);
         }
 
-        $generator = function ($iterator, $length): Generator {
+        $generator = static function ($iterator, $length): Generator {
             $result = [];
             $bucket = 0;
             $offset = 0;
@@ -882,7 +882,7 @@ trait CollectionTrait
      */
     public function unfold(?callable $callback = null): CollectionInterface
     {
-        $callback ??= fn($v) => $v;
+        $callback ??= static fn($v) => $v;
 
         return $this->newCollection(
             new RecursiveIteratorIterator(
@@ -1041,7 +1041,7 @@ trait CollectionTrait
         $changeIndex = $lastIndex;
 
         while (!($changeIndex === 0 && $currentIndexes[0] === $collectionArraysCounts[0])) {
-            $currentCombination = array_map(function ($value, $keys, $index) {
+            $currentCombination = array_map(static function ($value, $keys, $index) {
                 return $value[$keys[$index]];
             }, $collectionArrays, $collectionArraysKeys, $currentIndexes);
 

--- a/src/Collection/ExtractTrait.php
+++ b/src/Collection/ExtractTrait.php
@@ -135,12 +135,12 @@ trait ExtractTrait
         $matchers = [];
         foreach ($conditions as $property => $value) {
             $extractor = $this->_propertyExtractor($property);
-            $matchers[] = function ($v) use ($extractor, $value): bool {
+            $matchers[] = static function ($v) use ($extractor, $value): bool {
                 return $extractor($v) == $value;
             };
         }
 
-        return function ($value) use ($matchers) {
+        return static function ($value) use ($matchers) {
             foreach ($matchers as $match) {
                 if (!$match($value)) {
                     return false;

--- a/src/Collection/Iterator/TreeIterator.php
+++ b/src/Collection/Iterator/TreeIterator.php
@@ -102,7 +102,7 @@ class TreeIterator extends RecursiveIteratorIterator implements CollectionInterf
     ): TreePrinter {
         if (!$keyPath) {
             $counter = 0;
-            $keyPath = function () use (&$counter): int {
+            $keyPath = static function () use (&$counter): int {
                 return $counter++;
             };
         }

--- a/src/Command/Helper/BannerHelper.php
+++ b/src/Command/Helper/BannerHelper.php
@@ -78,7 +78,7 @@ class BannerHelper extends Helper
             throw new InvalidArgumentException('At least one argument is required');
         }
 
-        $lengths = array_map(fn($i) => mb_strlen($i), $args);
+        $lengths = array_map(static fn($i) => mb_strlen($i), $args);
         $maxLength = max($lengths);
         $bannerLength = $maxLength + $this->padding * 2;
         $start = "<{$this->style}>";

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -541,7 +541,7 @@ class I18nExtractCommand extends Command
         $paths = $this->_paths;
         $paths[] = realpath(APP) . DIRECTORY_SEPARATOR;
 
-        usort($paths, function (string $a, string $b) {
+        usort($paths, static function (string $a, string $b) {
             return strlen($a) - strlen($b);
         });
 

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -86,7 +86,7 @@ class RoutesCommand extends Command
         }
 
         if ($args->getOption('sort')) {
-            usort($output, function (array $a, array $b) {
+            usort($output, static function (array $a, array $b) {
                 return strcasecmp($a[0], $b[0]);
             });
         }

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -185,7 +185,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
      */
     protected function getShortestName(array $names): string
     {
-        usort($names, function ($a, $b) {
+        usort($names, static function ($a, $b) {
             return strlen($a) - strlen($b);
         });
 

--- a/src/Console/ConsoleInput.php
+++ b/src/Console/ConsoleInput.php
@@ -109,7 +109,7 @@ class ConsoleInput
 
         /** @var string|null $error */
         $error = null;
-        set_error_handler(function (int $code, string $message) use (&$error) {
+        set_error_handler(static function (int $code, string $message) use (&$error) {
             $error = "stream_select failed with code={$code} message={$message}.";
 
             return true;

--- a/src/Console/TestSuite/Constraint/ContentsContainRow.php
+++ b/src/Console/TestSuite/Constraint/ContentsContainRow.php
@@ -32,7 +32,7 @@ class ContentsContainRow extends ContentsRegExp
      */
     public function matches(mixed $other): bool
     {
-        $row = array_map(function ($cell) {
+        $row = array_map(static function ($cell) {
             return preg_quote($cell, '/');
         }, (array)$other);
         $cells = implode('\s+\|\s+', $row);

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -274,7 +274,7 @@ class Configure
     {
         $engines = array_keys(static::$_engines);
 
-        return array_map(function (int|string $key) {
+        return array_map(static function (int|string $key) {
             return (string)$key;
         }, $engines);
     }

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -175,7 +175,7 @@ trait StaticConfigTrait
     {
         $configurations = array_keys(static::$_config);
 
-        return array_map(function (int|string $key) {
+        return array_map(static function (int|string $key) {
             return (string)$key;
         }, $configurations);
     }

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -486,7 +486,7 @@ class Sqlserver extends Driver
                 break;
             case 'DATEDIFF':
                 $hasDay = false;
-                $visitor = function ($value) use (&$hasDay) {
+                $visitor = static function ($value) use (&$hasDay) {
                     if ($value === 'day') {
                         $hasDay = true;
                     }
@@ -515,7 +515,7 @@ class Sqlserver extends Driver
                 break;
             case 'DATE_ADD':
                 $params = [];
-                $visitor = function ($p, $key) use (&$params) {
+                $visitor = static function ($p, $key) use (&$params) {
                     if ($key === 0) {
                         $params[2] = $p;
                     } else {

--- a/src/Database/Expression/CommonTableExpression.php
+++ b/src/Database/Expression/CommonTableExpression.php
@@ -187,7 +187,7 @@ class CommonTableExpression implements ExpressionInterface
     {
         $fields = '';
         if ($this->fields) {
-            $expressions = array_map(fn(IdentifierExpression $e) => $e->sql($binder), $this->fields);
+            $expressions = array_map(static fn(IdentifierExpression $e) => $e->sql($binder), $this->fields);
             $fields = sprintf('(%s)', implode(', ', $expressions));
         }
 

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -499,7 +499,7 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     public function equalFields(string $leftField, string $rightField)
     {
-        $wrapIdentifier = function ($field): ExpressionInterface {
+        $wrapIdentifier = static function ($field): ExpressionInterface {
             if ($field instanceof ExpressionInterface) {
                 return $field;
             }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1649,7 +1649,7 @@ abstract class Query implements ExpressionInterface, Stringable
     {
         if (!array_key_exists($name, $this->_parts)) {
             $clauses = array_keys($this->_parts);
-            array_walk($clauses, fn(string &$x) => $x = "`{$x}`");
+            array_walk($clauses, static fn(string &$x) => $x = "`{$x}`");
             $clauses = implode(', ', $clauses);
             throw new InvalidArgumentException(sprintf(
                 'The `%s` clause is not defined. Valid clauses are: %s.',
@@ -1872,7 +1872,7 @@ abstract class Query implements ExpressionInterface, Stringable
         try {
             set_error_handler(
                 /** @return no-return */
-                function ($errno, $errstr): void {
+                static function ($errno, $errstr): void {
                     throw new CakeException($errstr, $errno);
                 },
                 E_ALL,

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -361,7 +361,7 @@ class QueryCompiler
             ->getDriver($query->getConnectionRole())
             ->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY);
 
-        $parts = array_map(function (array $p) use ($binder, $setOperationsOrderBy) {
+        $parts = array_map(static function (array $p) use ($binder, $setOperationsOrderBy) {
             /** @var \Cake\Database\Expression\IdentifierExpression $expr */
             $expr = $p['query'];
             $p['query'] = $expr->sql($binder);

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -1281,7 +1281,7 @@ trait EntityTrait
             return $object->getErrors();
         }
 
-        $array = array_map(function ($val) {
+        $array = array_map(static function ($val) {
             if ($val instanceof EntityInterface) {
                 return $val->getErrors();
             }
@@ -1376,7 +1376,7 @@ trait EntityTrait
     public function setAccess(array|string $field, bool $set)
     {
         if ($field === '*') {
-            $this->_accessible = array_map(fn($p) => $set, $this->_accessible);
+            $this->_accessible = array_map(static fn($p) => $set, $this->_accessible);
             $this->_accessible['*'] = $set;
 
             return $this;

--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -172,7 +172,7 @@ class FormProtector
             return Hash::filter(explode('.', $name));
         }
         $parts = explode('[', $name);
-        $parts = array_map(function (string $el) {
+        $parts = array_map(static function (string $el) {
             return trim($el, ']');
         }, $parts);
 

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -253,7 +253,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
     protected function checkValues(string $value, array $allowed): void
     {
         if (!in_array($value, $allowed, true)) {
-            array_walk($allowed, fn(string &$x) => $x = "`{$x}`");
+            array_walk($allowed, static fn(string &$x) => $x = "`{$x}`");
             throw new InvalidArgumentException(sprintf(
                 'Invalid arg `%s`, use one of these: %s.',
                 $value,

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -351,7 +351,7 @@ class TranslatorRegistry
             return $loader;
         }
 
-        return function () use ($loader, $fallbackDomain) {
+        return static function () use ($loader, $fallbackDomain) {
             /** @var \Cake\I18n\Package $package */
             $package = $loader();
             if (!$package->getFallback()) {

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -1895,7 +1895,7 @@ class Message implements JsonSerializable
             }
         });
 
-        return array_filter($array, function ($i) {
+        return array_filter($array, static function ($i) {
             return $i !== null && !is_array($i) && !is_bool($i) && strlen($i) || !empty($i);
         });
     }
@@ -1923,7 +1923,7 @@ class Message implements JsonSerializable
     public function __serialize(): array
     {
         $array = $this->jsonSerialize();
-        array_walk_recursive($array, function (&$item, $key): void {
+        array_walk_recursive($array, static function (&$item, $key): void {
             if ($item instanceof SimpleXMLElement) {
                 $item = json_decode((string)json_encode((array)$item), true);
             }

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1443,12 +1443,12 @@ class BelongsToMany extends Association
         $hasMany = $source->getAssociation($junction->getAlias());
         /** @var array<string> $foreignKey */
         $foreignKey = (array)$this->getForeignKey();
-        $foreignKey = array_map(function (string $key) {
+        $foreignKey = array_map(static function (string $key) {
             return $key . ' IS';
         }, $foreignKey);
         /** @var array<string> $assocForeignKey */
         $assocForeignKey = (array)$belongsTo->getForeignKey();
-        $assocForeignKey = array_map(function (string $key) {
+        $assocForeignKey = array_map(static function (string $key) {
             return $key . ' IS';
         }, $assocForeignKey);
         $sourceKey = $sourceEntity->extract((array)$source->getPrimaryKey());

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -582,7 +582,7 @@ class HasMany extends Association
         return !in_array(
             false,
             array_map(
-                function ($prop) use ($table) {
+                static function ($prop) use ($table) {
                     return $table->getSchema()->isNullable($prop);
                 },
                 $properties,

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -537,7 +537,7 @@ class SelectLoader
 
         $sourceKey = $sourceKeys[0];
 
-        return function ($row) use ($resultMap, $sourceKey, $nestKey) {
+        return static function ($row) use ($resultMap, $sourceKey, $nestKey) {
             if (isset($row[$sourceKey], $resultMap[$row[$sourceKey]])) {
                 $row[$nestKey] = $resultMap[$row[$sourceKey]];
             }
@@ -558,7 +558,7 @@ class SelectLoader
      */
     protected function _multiKeysInjector(array $resultMap, array $sourceKeys, string $nestKey): Closure
     {
-        return function ($row) use ($resultMap, $sourceKeys, $nestKey) {
+        return static function ($row) use ($resultMap, $sourceKeys, $nestKey) {
             $values = [];
             foreach ($sourceKeys as $key) {
                 $values[] = $row[$key];

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -171,7 +171,7 @@ class AssociationCollection implements IteratorAggregate
     {
         $class = array_map('strtolower', (array)$class);
 
-        $out = array_filter($this->_items, function (Association $assoc) use ($class) {
+        $out = array_filter($this->_items, static function (Association $assoc) use ($class) {
             [, $name] = namespaceSplit($assoc::class);
 
             return in_array(strtolower($name), $class, true);

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -384,7 +384,7 @@ class CounterCacheBehavior extends Behavior
      */
     protected function _shouldUpdateCount(array $conditions): bool
     {
-        return !empty(array_filter($conditions, function ($value) {
+        return !empty(array_filter($conditions, static function ($value) {
             return $value !== null;
         }));
     }

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -223,7 +223,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
             return true;
         }
 
-        $select = array_filter($query->clause('select'), function ($field) {
+        $select = array_filter($query->clause('select'), static function ($field) {
             return is_string($field);
         });
 

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -381,7 +381,7 @@ class EagerLoader
             if (isset($options['queryBuilder'], $pointer[$table]['queryBuilder'])) {
                 $first = $pointer[$table]['queryBuilder'];
                 $second = $options['queryBuilder'];
-                $options['queryBuilder'] = fn($query) => $second($first($query));
+                $options['queryBuilder'] = static fn($query) => $second($first($query));
             }
 
             if (!is_array($options)) {

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -75,7 +75,7 @@ class LazyEagerLoader
         $primaryKey = $source->getPrimaryKey();
         $method = is_string($primaryKey) ? 'get' : 'extract';
 
-        $keys = Hash::map($entities, '{*}', fn(EntityInterface $entity) => $entity->{$method}($primaryKey));
+        $keys = Hash::map($entities, '{*}', static fn(EntityInterface $entity) => $entity->{$method}($primaryKey));
 
         $query = $source
             ->find()

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -76,7 +76,7 @@ class Marshaller
             $prop = (string)$prop;
             $columnType = $schema->getColumnType($prop);
             if ($columnType) {
-                $map[$prop] = fn($value) => TypeFactory::build($columnType)->marshal($value);
+                $map[$prop] = static fn($value) => TypeFactory::build($columnType)->marshal($value);
             }
         }
 

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -138,7 +138,7 @@ class ExistsIn
         }
 
         $primary = array_map(
-            fn(string $key) => $target->aliasField($key) . ' IS',
+            static fn(string $key) => $target->aliasField($key) . ' IS',
             $bindingKey,
         );
         $conditions = array_combine(

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1463,7 +1463,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
             $fields = $options[$field];
             $glue = in_array($field, ['keyField', 'parentField'], true) ? ';' : $options['valueSeparator'];
-            $options[$field] = function ($row) use ($fields, $glue): string {
+            $options[$field] = static function ($row) use ($fields, $glue): string {
                 $matches = [];
                 foreach ($fields as $field) {
                     $matches[] = $row[$field];
@@ -1525,7 +1525,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
         if (count($key) !== count($primaryKey)) {
             $primaryKey = $primaryKey ?: [null];
-            $primaryKey = array_map(function ($key) {
+            $primaryKey = array_map(static function ($key) {
                 return var_export($key, true);
             }, $primaryKey);
 
@@ -2144,7 +2144,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $primary = array_combine($primary, $id);
         $primary = array_intersect_key($data, $primary) + $primary;
 
-        $filteredKeys = array_filter($primary, function ($v) {
+        $filteredKeys = array_filter($primary, static function ($v) {
             return $v !== null;
         });
         $data += $filteredKeys;
@@ -2363,7 +2363,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             throw new PersistenceFailedException($failed, ['saveMany']);
         }
 
-        $cleanupOnSuccess = function (EntityInterface $entity) use (&$cleanupOnSuccess): void {
+        $cleanupOnSuccess = static function (EntityInterface $entity) use (&$cleanupOnSuccess): void {
             $entity->clean();
             $entity->setNew(false);
 

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -134,7 +134,7 @@ class Route
      */
     public function __construct(string $template, array $defaults = [], array $options = [])
     {
-        $checker = function () use ($defaults): bool {
+        $checker = static function () use ($defaults): bool {
             foreach (['plugin', 'prefix', 'controller', 'action'] as $key) {
                 if (isset($defaults[$key]) && !is_string($defaults[$key])) {
                     throw new CakeException(
@@ -815,7 +815,7 @@ class Route
      */
     protected function _writeUrl(array $params, array $pass = [], array $query = []): string
     {
-        $pass = array_map(function ($value) {
+        $pass = array_map(static function ($value) {
             return rawurlencode((string)$value);
         }, $pass);
         $pass = implode('/', $pass);

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -141,7 +141,7 @@ class RouteCollection
             // decode urlencoded segments, but don't decode %2f aka /
             $parts = explode('/', $urlPath);
             $parts = array_map(
-                fn(string $part) => str_replace('/', '%2f', urldecode($part)),
+                static fn(string $part) => str_replace('/', '%2f', urldecode($part)),
                 $parts,
             );
             $urlPath = implode('/', $parts);

--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -100,7 +100,7 @@ class ConnectionHelper
 
         $tables = $tables !== null ? array_intersect($tables, $allTables) : $allTables;
         /** @var array<\Cake\Database\Schema\TableSchema> $schemas Specify type for psalm */
-        $schemas = array_map(fn(string $table) => $collection->describe($table), $tables);
+        $schemas = array_map(static fn(string $table) => $collection->describe($table), $tables);
 
         $dialect = $connection->getWriteDriver()->schemaDialect();
         foreach ($schemas as $schema) {
@@ -131,9 +131,9 @@ class ConnectionHelper
         $allTables = $collection->listTablesWithoutViews();
         $tables = $tables !== null ? array_intersect($tables, $allTables) : $allTables;
         /** @var array<\Cake\Database\Schema\TableSchema> $schemas Specify type for psalm */
-        $schemas = array_map(fn(string $table) => $collection->describe($table), $tables);
+        $schemas = array_map(static fn(string $table) => $collection->describe($table), $tables);
 
-        self::runWithoutConstraints($connection, function (Connection $connection) use ($schemas): void {
+        self::runWithoutConstraints($connection, static function (Connection $connection) use ($schemas): void {
             $dialect = $connection->getWriteDriver()->schemaDialect();
             foreach ($schemas as $schema) {
                 foreach ($dialect->truncateTableSql($schema) as $statement) {

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -205,7 +205,7 @@ class TestFixture implements FixtureInterface
             if ($this->strictFields) {
                 $invalidFields = array_values(array_filter(
                     $recordFields,
-                    fn(int|string $f) => !in_array($f, $columns, true),
+                    static fn(int|string $f) => !in_array($f, $columns, true),
                 ));
                 if ($invalidFields !== []) {
                     throw new CakeException(

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -732,7 +732,7 @@ trait IntegrationTestTrait
         if ($this->_securityToken === true) {
             $fields = array_diff_key($data, array_flip($this->_unlockedFields));
 
-            $keys = array_map(function (int|string $field) {
+            $keys = array_map(static function (int|string $field) {
                 return preg_replace('/(\.\d+)+$/', '', (string)$field);
             }, array_keys(Hash::flatten($fields)));
 

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -180,7 +180,7 @@ abstract class TestCase extends BaseTestCase
         $deprecation = false;
 
         $previousHandler = set_error_handler(
-            function (
+            static function (
                 $code,
                 $message,
                 $file,
@@ -1055,7 +1055,7 @@ abstract class TestCase extends BaseTestCase
         $options += ['alias' => $baseClass, 'connection' => $connection];
         $options += $locator->getConfig($alias);
         $reflection = new ReflectionClass($className);
-        $classMethods = array_map(function (ReflectionMethod $method) {
+        $classMethods = array_map(static function (ReflectionMethod $method) {
             return $method->name;
         }, $reflection->getMethods());
 

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -233,7 +233,7 @@ class Text
 
         $dataKeys = array_keys($data);
         $hashKeys = array_map(
-            fn(int|string $str) => hash('xxh128', (string)$str),
+            static fn(int|string $str) => hash('xxh128', (string)$str),
             $dataKeys,
         );
         /** @var array<string, string> $tempData */
@@ -731,7 +731,7 @@ class Text
         $pattern = '/&[0-9a-z]{2,8};|&#[0-9]{1,7};|&#x[0-9a-f]{1,6};/i';
         $replace = (string)preg_replace_callback(
             $pattern,
-            function ($match) use ($strlen) {
+            static function ($match) use ($strlen) {
                 $utf8 = html_entity_decode($match[0], ENT_HTML5 | ENT_QUOTES, 'UTF-8');
 
                 return str_repeat(' ', $strlen($utf8, 'UTF-8'));

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -149,7 +149,7 @@ class Xml
         return static::load(
             $input,
             $options,
-            function ($input, $options, $flags) {
+            static function ($input, $options, $flags) {
                 if ($options['return'] === 'simplexml' || $options['return'] === 'simplexmlelement') {
                     $flags |= LIBXML_NOCDATA;
                     $xml = new SimpleXMLElement($input, $flags);
@@ -182,7 +182,7 @@ class Xml
         return static::load(
             $input,
             $options,
-            function ($input, $options, $flags) {
+            static function ($input, $options, $flags) {
                 $xml = new DOMDocument();
                 $xml->loadHTML($input, $flags);
 

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1186,7 +1186,7 @@ class Validation
         $defaults = ['in' => null, 'max' => null, 'min' => null];
         $options += $defaults;
 
-        $check = array_filter((array)$check, function ($value) {
+        $check = array_filter((array)$check, static function ($value) {
             return $value || is_numeric($value);
         });
         if (!$check) {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1055,7 +1055,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             return $when === static::WHEN_CREATE ? static::WHEN_UPDATE : static::WHEN_CREATE;
         }
         if ($when instanceof Closure) {
-            return fn($context) => !$when($context);
+            return static fn($context) => !$when($context);
         }
 
         return $when;
@@ -2091,7 +2091,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         }
 
         if ($message === null) {
-            $cases = array_map(fn(BackedEnum $case) => $case->value, $enumClassName::cases());
+            $cases = array_map(static fn(BackedEnum $case) => $case->value, $enumClassName::cases());
             $caseOptions = implode('`, `', $cases);
             if (!$this->_useI18n) {
                 $message = sprintf('The provided value must be one of `%s`', $caseOptions);

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -575,7 +575,7 @@ class EntityContext implements ContextInterface
      */
     protected function _getValidator(array $parts): Validator
     {
-        $keyParts = array_filter(array_slice($parts, 0, -1), function (string $part) {
+        $keyParts = array_filter(array_slice($parts, 0, -1), static function (string $part) {
             return !is_numeric($part);
         });
         $key = implode('.', $keyParts);
@@ -625,7 +625,7 @@ class EntityContext implements ContextInterface
             return $this->_tables[$this->_rootName];
         }
 
-        $normalized = array_slice(array_filter($parts, function (string $part) {
+        $normalized = array_slice(array_filter($parts, static function (string $part) {
             return !is_numeric($part);
         }), 0, -1);
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2519,7 +2519,7 @@ class FormHelper extends Helper
             if (is_array($first)) {
                 $disabled = array_filter(
                     $options['options'],
-                    fn(array $i) => in_array($i['value'], $options['disabled'], true),
+                    static fn(array $i) => in_array($i['value'], $options['disabled'], true),
                 );
 
                 return $disabled !== [];
@@ -2683,8 +2683,8 @@ class FormHelper extends Helper
         $diff = array_diff($sources, $this->supportedValueSources);
 
         if ($diff) {
-            array_walk($diff, fn(string &$x) => $x = "`{$x}`");
-            array_walk($this->supportedValueSources, fn(string &$x) => $x = "`{$x}`");
+            array_walk($diff, static fn(string &$x) => $x = "`{$x}`");
+            array_walk($this->supportedValueSources, static fn(string &$x) => $x = "`{$x}`");
             throw new InvalidArgumentException(sprintf(
                 'Invalid value source(s): %s. Valid values are: %s.',
                 implode(', ', $diff),

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -624,7 +624,7 @@ class ViewBuilder implements JsonSerializable
         /** @phpstan-ignore-next-line argument.type */
         array_walk_recursive($array['_vars'], $this->_checkViewVars(...));
 
-        return array_filter($array, function (array|bool|string|null $i) {
+        return array_filter($array, static function (array|bool|string|null $i) {
             return !is_array($i) && strlen((string)$i) || !empty($i);
         });
     }

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -831,7 +831,7 @@ class CacheTest extends TestCase
     {
         $this->_configCache();
         $counter = 0;
-        $cacher = function () use ($counter) {
+        $cacher = static function () use ($counter) {
             return 'This is some data ' . $counter;
         };
 

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -34,7 +34,7 @@ class RedisClusterEngineTest extends TestCase
 
         if ($this->skipTest === null) {
             $this->skipTest = false;
-            $nodes = array_map(function (string $node) {
+            $nodes = array_map(static function (string $node) {
                 [$host, $port] = explode(':', $node);
 
                 return ['host' => $host, 'port' => (int)$port];

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -140,7 +140,7 @@ class RoutesCommandTest extends TestCase
      */
     public function testRouteListSorted(): void
     {
-        Configure::write('TestApp.routes', function ($routes): void {
+        Configure::write('TestApp.routes', static function ($routes): void {
             $routes->connect(
                 new Route('/a/route/sorted', [], ['_name' => '_aRoute']),
             );
@@ -301,7 +301,7 @@ class RoutesCommandTest extends TestCase
 
     public function testGenerateNameWithColon(): void
     {
-        Configure::write('TestApp.routes', function ($routes): void {
+        Configure::write('TestApp.routes', static function ($routes): void {
             $routes->connect(
                 '/example/update',
                 ['controller' => 'Example', 'action' => 'update'],
@@ -328,7 +328,7 @@ class RoutesCommandTest extends TestCase
      */
     public function testRouteDuplicateWarning(): void
     {
-        Configure::write('TestApp.routes', function ($builder): void {
+        Configure::write('TestApp.routes', static function ($builder): void {
             $builder->connect(
                 new Route('/unique-path', [], ['_name' => '_aRoute']),
             );

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -55,7 +55,7 @@ class AppTest extends TestCase
     {
         static::setAppNamespace();
         $i = 0;
-        TestApp::$existsInBaseCallback = function ($name, $namespace) use ($existsInBase, $class, $expected, &$i) {
+        TestApp::$existsInBaseCallback = static function ($name, $namespace) use ($existsInBase, $class, $expected, &$i) {
             if ($i++ === 0) {
                 return $existsInBase;
             }

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -3066,7 +3066,7 @@ class SelectQueryTest extends TestCase
                 'ye' => '2007',
             ] + $expected;
         } elseif ($driver instanceof Postgres || $driver instanceof Sqlserver) {
-            $expected = array_map(function (int|string $value) {
+            $expected = array_map(static function (int|string $value) {
                 return (string)$value;
             }, $expected);
         }

--- a/tests/TestCase/Datasource/Paging/NumericPaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/NumericPaginatorTest.php
@@ -39,7 +39,7 @@ class NumericPaginatorTest extends TestCase
      */
     public function testPaginateCustomFind(): void
     {
-        $titleExtractor = function ($result) {
+        $titleExtractor = static function ($result) {
             $ids = [];
             foreach ($result as $record) {
                 $ids[] = $record->title;

--- a/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
@@ -57,7 +57,7 @@ class SimplePaginatorTest extends NumericPaginatorTest
      */
     public function testPaginateCustomFind(): void
     {
-        $titleExtractor = function ($result) {
+        $titleExtractor = static function ($result) {
             $ids = [];
             foreach ($result as $record) {
                 $ids[] = $record->title;

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -841,7 +841,7 @@ EXPECTED;
      */
     public function testEditorUrlClosure(): void
     {
-        Debugger::addEditor('open', function (string $file, int $line) {
+        Debugger::addEditor('open', static function (string $file, int $line) {
             return "{$file}/{$line}";
         });
         Debugger::setEditor('open');

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -366,7 +366,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
     {
         $request = ServerRequestFactory::fromGlobals();
 
-        $factory = function () {
+        $factory = static function () {
             return new class implements ExceptionRendererInterface
             {
                 public function render(): ResponseInterface|string

--- a/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
@@ -150,7 +150,7 @@ class BodyParserMiddlewareTest extends TestCase
         $f1 = function (string $body) {
             return json_decode($body, true);
         };
-        $f2 = function (string $body) {
+        $f2 = static function (string $body) {
             return ['overridden'];
         };
         $parser->addParser(['application/json'], $f1);

--- a/tests/TestCase/Http/RunnerTest.php
+++ b/tests/TestCase/Http/RunnerTest.php
@@ -61,13 +61,13 @@ class RunnerTest extends TestCase
 
         $this->queue = new MiddlewareQueue();
 
-        $this->ok = function ($request, $handler) {
+        $this->ok = static function ($request, $handler) {
             return $handler->handle($request->withAttribute('ok', true));
         };
-        $this->pass = function ($request, $handler) {
+        $this->pass = static function ($request, $handler) {
             return $handler->handle($request->withAttribute('pass', true));
         };
-        $this->fail = function ($request, $handler): void {
+        $this->fail = static function ($request, $handler): void {
             throw new RuntimeException('A bad thing');
         };
     }

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -748,12 +748,12 @@ class ServerRequestTest extends TestCase
     {
         $request = new ServerRequest();
 
-        ServerRequest::addDetector('closure', function ($request) {
+        ServerRequest::addDetector('closure', static function ($request) {
             return true;
         });
         $this->assertTrue($request->is('closure'));
 
-        ServerRequest::addDetector('get', function ($request) {
+        ServerRequest::addDetector('get', static function ($request) {
             return $request->getEnv('REQUEST_METHOD') === 'GET';
         });
         $request = $request->withEnv('REQUEST_METHOD', 'GET');
@@ -800,7 +800,7 @@ class ServerRequestTest extends TestCase
         $request->clearDetectorCache();
         $this->assertFalse($request->isIndex());
 
-        ServerRequest::addDetector('withParams', function ($request, array $params) {
+        ServerRequest::addDetector('withParams', static function ($request, array $params) {
             foreach ($params as $name => $value) {
                 if ($request->getParam($name) != $value) {
                     return false;
@@ -818,7 +818,7 @@ class ServerRequestTest extends TestCase
         $request->clearDetectorCache();
         $this->assertFalse($request->isWithParams(['controller' => 'Pages', 'action' => 'index']));
 
-        ServerRequest::addDetector('callme', function ($request) {
+        ServerRequest::addDetector('callme', static function ($request) {
             return $request->getAttribute('return');
         });
         $request = $request->withAttribute('return', true);

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -38,7 +38,7 @@ class DateTest extends TestCase
         parent::setUp();
 
         Cache::clear('_cake_translations_');
-        I18n::setTranslator('cake', function () {
+        I18n::setTranslator('cake', static function () {
             $package = new Package();
             $package->setMessages([
                 '{0} ago' => '{0} ago (translated)',

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -169,7 +169,7 @@ class I18nTest extends TestCase
      */
     public function testCreateCustomTranslationPackage(): void
     {
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'Cow' => 'Le moo',
@@ -201,7 +201,7 @@ class I18nTest extends TestCase
             }
         };
 
-        I18n::config('custom', function ($domain, $locale) use ($loader) {
+        I18n::config('custom', static function ($domain, $locale) use ($loader) {
             return new $loader(
                 $domain,
                 $locale,
@@ -295,7 +295,7 @@ class I18nTest extends TestCase
      */
     public function testGetTranslatorByDefaultLocale(): void
     {
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'Cow' => 'Le moo',
@@ -395,7 +395,7 @@ class I18nTest extends TestCase
      */
     public function testBasicDomainFunction(): void
     {
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'Cow' => 'Le moo',
@@ -434,7 +434,7 @@ class I18nTest extends TestCase
      */
     public function testBasicDomainPluralFunction(): void
     {
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'Cow' => 'Le Moo',
@@ -461,7 +461,7 @@ class I18nTest extends TestCase
      */
     public function testBasicContextFunction(): void
     {
-        I18n::setTranslator('default', function (): Package {
+        I18n::setTranslator('default', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'letter' => [
@@ -517,7 +517,7 @@ class I18nTest extends TestCase
      */
     public function testBasicContextFunctionNoString(): void
     {
-        I18n::setTranslator('default', function (): Package {
+        I18n::setTranslator('default', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'letter' => [
@@ -539,7 +539,7 @@ class I18nTest extends TestCase
      */
     public function testBasicContextFunctionInvalidContext(): void
     {
-        I18n::setTranslator('default', function (): Package {
+        I18n::setTranslator('default', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'letter' => [
@@ -561,7 +561,7 @@ class I18nTest extends TestCase
      */
     public function testPluralContextFunction(): void
     {
-        I18n::setTranslator('default', function (): Package {
+        I18n::setTranslator('default', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'letter' => [
@@ -613,7 +613,7 @@ class I18nTest extends TestCase
      */
     public function testDomainContextFunction(): void
     {
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'letter' => [
@@ -666,7 +666,7 @@ class I18nTest extends TestCase
      */
     public function testDomainPluralContextFunction(): void
     {
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'letter' => [
@@ -788,7 +788,7 @@ class I18nTest extends TestCase
      */
     public function testFallbackLoaderFactory(): void
     {
-        I18n::config(TranslatorRegistry::FALLBACK_LOADER, function (string $name, string $locale) {
+        I18n::config(TranslatorRegistry::FALLBACK_LOADER, static function (string $name, string $locale) {
             $package = new Package('default');
 
             if ($name === 'custom') {
@@ -816,7 +816,7 @@ class I18nTest extends TestCase
      */
     public function testFallbackTranslator(): void
     {
-        I18n::setTranslator('default', function (): Package {
+        I18n::setTranslator('default', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'Dog' => 'Le bark',
@@ -825,7 +825,7 @@ class I18nTest extends TestCase
             return $package;
         }, 'fr_FR');
 
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'Cow' => 'Le moo',
@@ -846,14 +846,14 @@ class I18nTest extends TestCase
     {
         I18n::useFallback(false);
 
-        I18n::setTranslator('default', function (): Package {
+        I18n::setTranslator('default', static function (): Package {
             $package = new Package('default');
             $package->setMessages(['Dog' => 'Le bark']);
 
             return $package;
         }, 'fr_FR');
 
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages(['Cow' => 'Le moo']);
 
@@ -871,7 +871,7 @@ class I18nTest extends TestCase
      */
     public function testFallbackTranslatorWithFactory(): void
     {
-        I18n::setTranslator('default', function (): Package {
+        I18n::setTranslator('default', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'Dog' => 'Le bark',

--- a/tests/TestCase/I18n/Parser/PoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/PoFileParserTest.php
@@ -167,7 +167,7 @@ class PoFileParserTest extends TestCase
         $file = $this->path . 'en' . DS . 'context.po';
         $messages = $parser->parse($file);
 
-        I18n::setTranslator('default', function () use ($messages) {
+        I18n::setTranslator('default', static function () use ($messages) {
             $package = new Package('default');
             $package->setMessages($messages);
 
@@ -201,7 +201,7 @@ class PoFileParserTest extends TestCase
         $file = $this->path . 'en' . DS . 'context.po';
         $messages = $parser->parse($file);
 
-        I18n::setTranslator('default', function () use ($messages) {
+        I18n::setTranslator('default', static function () use ($messages) {
             $package = new Package('default');
             $package->setMessages($messages);
 

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -132,7 +132,7 @@ class TimeTest extends TestCase
         Time::setJsonEncodeFormat('HH:mm:ss');
         $this->assertTimeFormat('"10:10:10"', json_encode($time));
 
-        Time::setJsonEncodeFormat(fn(Time $time) => 'custom format');
+        Time::setJsonEncodeFormat(static fn(Time $time) => 'custom format');
         $this->assertTimeFormat('"custom format"', json_encode($time));
     }
 

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1128,7 +1128,7 @@ class BelongsToManyTest extends TestCase
         $tag1 = $tags->find()->where(['Tags.name' => 'tag1'])->firstOrFail();
         $tag2 = $tags->find()->where(['Tags.name' => 'tag2'])->firstOrFail();
 
-        $findArticle = function ($article) use ($articles) {
+        $findArticle = static function ($article) use ($articles) {
             return $articles->find()
                 ->where(['CompositeKeyArticles.author_id' => $article->author_id])
                 ->contain('Tags')

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -463,7 +463,7 @@ class HasManyTest extends TestCase
             ->with('all')
             ->willReturn($query);
 
-        $queryBuilder = function ($query) {
+        $queryBuilder = static function ($query) {
             return $query->select(['author_id'])->join('comments')->where(['comments.id' => 1]);
         };
         $association->eagerLoader(compact('keys', 'query', 'queryBuilder'));

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -93,7 +93,7 @@ class TranslateBehaviorEavTest extends TestCase
                 return [];
             }
 
-            return array_map(function (EntityInterface $entity) {
+            return array_map(static function (EntityInterface $entity) {
                 return $entity->toArray();
             }, $translations);
         });
@@ -784,7 +784,7 @@ class TranslateBehaviorEavTest extends TestCase
                 '_locale' => 'eng',
             ],
         ];
-        $results = array_map(function (EntityInterface $r) {
+        $results = array_map(static function (EntityInterface $r) {
             return $r->toArray();
         }, $results->toArray());
         $this->assertEquals($expected, $results);

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -2444,7 +2444,7 @@ class SelectQueryTest extends TestCase
         $table->belongsTo('Articles');
         $table->getAssociation('Articles')->getTarget()->belongsTo('Authors');
 
-        $builder = function ($q) {
+        $builder = static function ($q) {
             return $q
                 ->formatResults(function ($results) {
                     return $results->map(function ($result) {

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -1691,7 +1691,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rulesChecker = $Comments->rulesChecker();
 
         Closure::bind(
-            function () use ($rulesChecker): void {
+            static function () use ($rulesChecker): void {
                 $rulesChecker->{'_useI18n'} = false;
             },
             null,
@@ -1736,7 +1736,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rulesChecker = $Comments->rulesChecker();
 
         Closure::bind(
-            function () use ($rulesChecker): void {
+            static function () use ($rulesChecker): void {
                 $rulesChecker->{'_useI18n'} = false;
             },
             null,

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3428,13 +3428,13 @@ class TableTest extends TestCase
         $table->Articles->setDependent(true);
 
         $called = false;
-        $listener = function ($e, $entity, $options) use (&$called): void {
+        $listener = static function ($e, $entity, $options) use (&$called): void {
             $called = true;
         };
         $table->getEventManager()->on('Model.afterDeleteCommit', $listener);
 
         $called2 = false;
-        $listener = function ($e, $entity, $options) use (&$called2): void {
+        $listener = static function ($e, $entity, $options) use (&$called2): void {
             $called2 = true;
         };
         $table->Articles->getEventManager()->on('Model.afterDeleteCommit', $listener);
@@ -6194,7 +6194,7 @@ class TableTest extends TestCase
         );
         $eventManager->on(
             'Model.afterSave',
-            $afterSaveCallback = function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$afterSaveCount): void {
+            $afterSaveCallback = static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$afterSaveCount): void {
                 $afterSaveCount++;
             },
         );

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1095,13 +1095,13 @@ class RouterTest extends TestCase
         Router::setRequest($request);
 
         $calledCount = 0;
-        Router::addUrlFilter(function ($url, $request) use (&$calledCount) {
+        Router::addUrlFilter(static function ($url, $request) use (&$calledCount) {
             $calledCount++;
             $url['lang'] = $request->getParam('lang');
 
             return $url;
         });
-        Router::addUrlFilter(function ($url, $request) use (&$calledCount) {
+        Router::addUrlFilter(static function ($url, $request) use (&$calledCount) {
             $calledCount++;
             $url[] = '1234';
 
@@ -1134,7 +1134,7 @@ class RouterTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        Router::addUrlFilter(function ($url, $request): void {
+        Router::addUrlFilter(static function ($url, $request): void {
             throw new RuntimeException('nope');
         });
         Router::url(['controller' => 'Posts', 'action' => 'index', 'lang' => 'en']);
@@ -1162,7 +1162,7 @@ class RouterTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        Router::addUrlFilter(function (): void {
+        Router::addUrlFilter(static function (): void {
             throw new Exception();
         });
         Router::url(['controller' => 'Posts', 'action' => 'index', 'lang' => 'en']);
@@ -3547,7 +3547,7 @@ class RouterTest extends TestCase
      */
     protected function _connectDefaultRoutes(): void
     {
-        Router::scope('/', function (RouteBuilder $routes): void {
+        Router::scope('/', static function (RouteBuilder $routes): void {
             $routes->fallbacks('InflectedRoute');
         });
     }

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -321,7 +321,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testExceptionsInMiddlewareJsonView(): void
     {
         Router::reload();
-        Configure::write('TestApp.routes', function (RouteBuilder $routes): void {
+        Configure::write('TestApp.routes', static function (RouteBuilder $routes): void {
             $routes->connect('/json_response/api_get_data', [
                 'controller' => 'JsonResponse',
                 'action' => 'apiGetData',
@@ -1057,7 +1057,7 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testPostSessionCsrfSuccessWithSetCookieName(): void
     {
-        Configure::write('TestApp.routes', function (RouteBuilder $routes): void {
+        Configure::write('TestApp.routes', static function (RouteBuilder $routes): void {
             $routes->scope('/custom-cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes): void {
                 $routes->registerMiddleware('cookieCsrf', new CsrfProtectionMiddleware(
                     [
@@ -1083,7 +1083,7 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testPostSessionCsrfFailureWithSetCookieName(): void
     {
-        Configure::write('TestApp.routes', function (RouteBuilder $routes): void {
+        Configure::write('TestApp.routes', static function (RouteBuilder $routes): void {
             $routes->scope('/custom-cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes): void {
                 $routes->registerMiddleware('cookieCsrf', new CsrfProtectionMiddleware(
                     [

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -243,7 +243,7 @@ class TestCaseTest extends TestCase
          * setting stackframe = 0 and having same method
          * to have same deprecation message and same line for all cases
          */
-        $fun = function (): void {
+        $fun = static function (): void {
             deprecationWarning('5.0.0', 'Test same deprecation message', 0);
         };
         $this->deprecated(function () use ($fun): void {

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -88,7 +88,7 @@ class TextTest extends TestCase
     public function testUuidGenerationWithClosure(): void
     {
         $customUuid = 'custom-uuid-12345678-1234-1234-1234-123456789012';
-        Configure::write('Text.uuidGenerator', function () use ($customUuid) {
+        Configure::write('Text.uuidGenerator', static function () use ($customUuid) {
             return $customUuid;
         });
 
@@ -1849,7 +1849,7 @@ HTML;
     public function testStrlen(): void
     {
         $method = new ReflectionMethod(Text::class, '_strlen');
-        $strlen = function () use ($method) {
+        $strlen = static function () use ($method) {
             return $method->invokeArgs(null, func_get_args());
         };
 
@@ -1872,7 +1872,7 @@ HTML;
     public function testSubstr(): void
     {
         $method = new ReflectionMethod(Text::class, '_substr');
-        $substr = function () use ($method) {
+        $substr = static function () use ($method) {
             return $method->invokeArgs(null, func_get_args());
         };
 

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -3003,7 +3003,7 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::numElements($array, Validation::COMPARE_GREATER, 3));
         $this->assertFalse(Validation::numElements($array, Validation::COMPARE_LESS, 1));
 
-        $callable = function () {
+        $callable = static function () {
             return '';
         };
 

--- a/tests/test_app/Plugin/TestPlugin/config/routes.php
+++ b/tests/test_app/Plugin/TestPlugin/config/routes.php
@@ -5,7 +5,7 @@ use Cake\Routing\RouteBuilder;
 
 Configure::write('PluginTest.test_plugin.routes', 'loaded plugin routes');
 
-return function (RouteBuilder $routes): void {
+return static function (RouteBuilder $routes): void {
     $routes->get(
         '/test_plugin',
         ['controller' => 'TestPlugin', 'plugin' => 'TestPlugin', 'action' => 'index'],

--- a/tests/test_app/TestApp/Collection/CountableIterator.php
+++ b/tests/test_app/TestApp/Collection/CountableIterator.php
@@ -13,7 +13,7 @@ class CountableIterator extends IteratorIterator implements Countable
      */
     public function __construct($items)
     {
-        $f = function () use ($items) {
+        $f = static function () use ($items) {
             foreach ($items as $e) {
                 yield $e;
             }

--- a/tests/test_app/TestApp/Database/Type/OrderedUuidType.php
+++ b/tests/test_app/TestApp/Database/Type/OrderedUuidType.php
@@ -30,7 +30,7 @@ class OrderedUuidType extends BaseType implements ExpressionTypeInterface
         if ($value instanceof UuidValue) {
             $value = $value->value;
         }
-        $substr = function ($start, $length = null) use ($value) {
+        $substr = static function ($start, $length = null) use ($value) {
             return new FunctionExpression(
                 'SUBSTR',
                 $length === null ? [$value, $start] : [$value, $start, $length],

--- a/tests/test_app/TestApp/Http/TestRequestHandler.php
+++ b/tests/test_app/TestApp/Http/TestRequestHandler.php
@@ -25,7 +25,7 @@ class TestRequestHandler implements RequestHandlerInterface
 
     public function __construct(?callable $callable = null)
     {
-        $this->callable = $callable ?: function ($request) {
+        $this->callable = $callable ?: static function ($request) {
             return new Response();
         };
     }

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -15,7 +15,7 @@
 
 use Cake\Routing\RouteBuilder;
 
-return function (RouteBuilder $routes): void {
+return static function (RouteBuilder $routes): void {
     $routes->setExtensions('json');
     $routes->scope('/', function (RouteBuilder $routes): void {
         $routes->connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);

--- a/tests/test_app/invalid_routes/routes.php
+++ b/tests/test_app/invalid_routes/routes.php
@@ -8,7 +8,7 @@ use Cake\Routing\RouteBuilder;
  * Application requests should have InvalidArgument error rendered.
  */
 
-return function (RouteBuilder $routes): void {
+return static function (RouteBuilder $routes): void {
     $routes->setRouteClass('DoesNotExist');
     $routes->get('/', ['controller' => 'Pages']);
 };


### PR DESCRIPTION
The following article led me to this proposal:

https://dev.to/jszutkowski/static-vs-non-static-closures-in-php-a-surprising-benchmark-4ief

All these closures did not access the instance (`$this`), thus I made them static.

From the PHP documentation on anonymous functions:

> When declared in the context of a class, the current class is automatically bound to it, making $this available inside of the function's scope. If this automatic binding of the current class is not wanted, then static anonymous functions may be used instead.

https://www.php.net/manual/en/functions.anonymous.php


