### PR TITLE
Fix up Deep associations handling.

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -708,6 +708,10 @@ abstract class Association
             $options['includeFields'] = false;
         }
 
+        // Use the provided alias from options if available, otherwise use the association name
+        $alias = $options['alias'] ?? $this->_name;
+        $options['alias'] = $alias;
+
         if ($options['foreignKey']) {
             $joinCondition = $this->_joinCondition($options);
             if ($joinCondition) {
@@ -744,7 +748,7 @@ abstract class Association
         $dummy->where($options['conditions']);
         $this->_dispatchBeforeFind($dummy);
 
-        $query->join([$this->_name => [
+        $query->join([$alias => [
             'table' => $options['table'],
             'conditions' => $dummy->clause('where'),
             'type' => $options['joinType'],
@@ -768,7 +772,8 @@ abstract class Association
     {
         $target = $this->getTarget();
         if (!empty($options['negateMatch'])) {
-            $primaryKey = $query->aliasFields((array)$target->getPrimaryKey(), $this->_name);
+            $alias = $options['alias'] ?? $this->_name;
+            $primaryKey = $query->aliasFields((array)$target->getPrimaryKey(), $alias);
             $query->andWhere(function ($exp) use ($primaryKey) {
                 /** @var callable $callable */
                 $callable = [$exp, 'isNull'];
@@ -952,7 +957,8 @@ abstract class Association
             $fields = array_merge($fields, $this->getTarget()->getSchema()->columns());
         }
 
-        $query->select($query->aliasFields($fields, $this->_name));
+        $alias = $options['alias'] ?? $this->_name;
+        $query->select($query->aliasFields($fields, $alias));
         $query->addDefaultTypes($this->getTarget());
     }
 
@@ -1070,7 +1076,7 @@ abstract class Association
     protected function _joinCondition(array $options): array
     {
         $conditions = [];
-        $tAlias = $this->_name;
+        $tAlias = $options['alias'] ?? $this->_name;
         $sAlias = $this->getSource()->getAlias();
         $foreignKey = (array)$options['foreignKey'];
         $bindingKey = (array)$this->getBindingKey();

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -422,6 +422,12 @@ class EagerLoader
                     'propertyPath' => $loadable->propertyPath(),
                     'includeFields' => $includeFields,
                 ];
+                // If the alias differs from the association's name (due to conflict resolution),
+                // pass the modified alias to attachTo
+                $assocName = $loadable->instance()->getName();
+                if ($alias !== $assocName) {
+                    $config['alias'] = $alias;
+                }
                 $loadable->instance()->attachTo($query, $config);
                 $processed[$alias] = true;
             }
@@ -588,15 +594,66 @@ class EagerLoader
     protected function _resolveJoins(array $associations, array $matching = []): array
     {
         $result = [];
+        $seen = [];
+
+        // Process matching associations
         foreach ($matching as $table => $loadable) {
             $result[$table] = $loadable;
-            $result += $this->_resolveJoins($loadable->associations(), []);
+            $nested = $this->_resolveJoins($loadable->associations(), []);
+
+            // Check for conflicts when merging nested associations
+            foreach ($nested as $nestedTable => $nestedLoadable) {
+                if (isset($result[$nestedTable])) {
+                    // Check if it's the same path or different
+                    $existingPath = $result[$nestedTable]->aliasPath();
+                    $currentPath = $nestedLoadable->aliasPath();
+                    if ($existingPath !== $currentPath) {
+                        // Conflict detected - both need to use full paths
+                        // Update the existing one if it's using simple name
+                        if (!isset($result[str_replace('.', '_', $existingPath)])) {
+                            $existingLoadable = $result[$nestedTable];
+                            unset($result[$nestedTable]);
+                            $result[str_replace('.', '_', $existingPath)] = $existingLoadable;
+                        }
+                        // Add the new one with full path
+                        $key = str_replace('.', '_', $currentPath);
+                        $result[$key] = $nestedLoadable;
+                        continue;
+                    }
+                }
+                $result[$nestedTable] = $nestedLoadable;
+            }
         }
+
+        // Process regular associations
         foreach ($associations as $table => $loadable) {
             $inMatching = isset($matching[$table]);
             if (!$inMatching && $loadable->canBeJoined()) {
                 $result[$table] = $loadable;
-                $result += $this->_resolveJoins($loadable->associations(), []);
+                $nested = $this->_resolveJoins($loadable->associations(), []);
+
+                // Check for conflicts when merging nested associations
+                foreach ($nested as $nestedTable => $nestedLoadable) {
+                    if (isset($result[$nestedTable])) {
+                        // Check if it's the same path or different
+                        $existingPath = $result[$nestedTable]->aliasPath();
+                        $currentPath = $nestedLoadable->aliasPath();
+                        if ($existingPath !== $currentPath) {
+                            // Conflict detected - both need to use full paths
+                            // Update the existing one if it's using simple name
+                            if (!isset($result[str_replace('.', '_', $existingPath)])) {
+                                $existingLoadable = $result[$nestedTable];
+                                unset($result[$nestedTable]);
+                                $result[str_replace('.', '_', $existingPath)] = $existingLoadable;
+                            }
+                            // Add the new one with full path
+                            $key = str_replace('.', '_', $currentPath);
+                            $result[$key] = $nestedLoadable;
+                            continue;
+                        }
+                    }
+                    $result[$nestedTable] = $nestedLoadable;
+                }
                 continue;
             }
 
@@ -729,12 +786,21 @@ class EagerLoader
             $instance = $meta->instance();
             $associations = $meta->associations();
             $forMatching = $meta->forMatching();
+            // Use the full aliasPath as nestKey for nested joined associations
+            // to ensure unique aliases when same table is joined multiple times
+            $nestKey = $assoc;
+            if ($canBeJoined && str_contains($meta->aliasPath(), '.')) {
+                $nestKey = str_replace('.', '_', $meta->aliasPath());
+            } elseif (!$canBeJoined) {
+                $nestKey = $meta->aliasPath();
+            }
+
             $map[] = [
                 'alias' => $assoc,
                 'instance' => $instance,
                 'canBeJoined' => $canBeJoined,
                 'entityClass' => $instance->getTarget()->getEntityClass(),
-                'nestKey' => $canBeJoined ? $assoc : $meta->aliasPath(),
+                'nestKey' => $nestKey,
                 'matching' => $forMatching ?? $matching,
                 'targetProperty' => $meta->targetProperty(),
             ];

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -3998,4 +3998,77 @@ class SelectQueryTest extends TestCase
             preg_replace('/[`"\[\]]/', '', $function->sql($binder)),
         );
     }
+
+    /**
+     * Test that multiple associations to the same table through different paths
+     * generate unique join aliases to avoid conflicts.
+     *
+     * @return void
+     */
+    public function testNestedAssociationsToSameTableGenerateUniqueAliases(): void
+    {
+        // Create a simple test case that directly replicates the issue
+        // Articles -> Creator (Authors) -> Comments
+        // Articles -> Modifier (Authors) -> Comments
+        $articles = $this->getTableLocator()->get('Articles');
+
+        // Set up Creator and Modifier as BelongsTo associations pointing to Authors
+        $articles->belongsTo('Creator', [
+            'className' => 'Authors',
+            'foreignKey' => 'author_id',
+        ]);
+        $articles->belongsTo('Modifier', [
+            'className' => 'Authors',
+            'foreignKey' => 'author_id',
+        ]);
+
+        // Add hasMany Comments to both instances
+        // We'll use joinWith to force JOIN strategy
+        $articles->getAssociation('Creator')->getTarget()->hasMany('Comments', [
+            'foreignKey' => 'user_id',
+        ]);
+        $articles->getAssociation('Modifier')->getTarget()->hasMany('Comments', [
+            'foreignKey' => 'user_id',
+        ]);
+
+        // Use leftJoinWith to force JOINs instead of subqueries
+        $query = $articles->find()
+            ->leftJoinWith('Creator.Comments')
+            ->leftJoinWith('Modifier.Comments')
+            ->where(['Articles.id' => 1]);
+
+        // Get the SQL to check the joins
+        $sql = $query->sql();
+
+        // Remove quotes/brackets for easier assertion
+        $sql = preg_replace('/[`"\[\]]/', '', $sql);
+
+        // Check that we have unique aliases for the Comments table joins
+        // Creator.Comments should be aliased as Creator_Comments
+        $this->assertStringContainsString('Creator_Comments', $sql, 'Creator.Comments should use unique alias Creator_Comments');
+
+        // Modifier.Comments should be aliased as Modifier_Comments
+        $this->assertStringContainsString('Modifier_Comments', $sql, 'Modifier.Comments should use unique alias Modifier_Comments');
+
+        // Verify both Comments joins are present (not overwriting each other)
+        $creatorCommentsCount = substr_count($sql, 'Creator_Comments');
+        $modifierCommentsCount = substr_count($sql, 'Modifier_Comments');
+
+        $this->assertGreaterThan(0, $creatorCommentsCount, 'Creator_Comments join should be present');
+        $this->assertGreaterThan(0, $modifierCommentsCount, 'Modifier_Comments join should be present');
+
+        // The simple Comments table name should not appear as an alias when joined through nested paths
+        // Look for JOIN pattern with just Comments as alias (not part of Creator_Comments or Modifier_Comments)
+        // Note: We check that if Comments appears as an alias in a JOIN, it's part of the compound aliases
+        preg_match_all('/JOIN\s+comments\s+(\w+)\s+ON/i', $sql, $matches);
+        if (!empty($matches[1])) {
+            foreach ($matches[1] as $alias) {
+                $this->assertMatchesRegularExpression(
+                    '/^(Creator_Comments|Modifier_Comments|Comments)$/i',
+                    $alias,
+                    "Unexpected alias '$alias' for comments table in JOIN",
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
Stab at https://github.com/cakephp/cakephp/issues/18929

BUT:

 the tests are not all green. While our fix works for the specific issue (our test passes) and the EagerLoader tests pass, we're breaking TranslateBehavior tests. The TranslateBehavior tests are failing because:

  1. An extra field Authors_name_translation is appearing in the results
  2. The translated values aren't being applied correctly (expecting 'May-rianoh' but getting 'mariano')

  The issue is that our conflict detection is too aggressive and is creating false positives with the dynamic associations created by TranslateBehavior. We need to refine our approach to only handle the specific case of the
  same table being joined multiple times through different top-level association paths.
