### PR TITLE
Add rector to make closures static where applicable.

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\Config\RectorConfig;
-use Rector\Set\ValueObject\SetList;
 
 $cacheDir = getenv('RECTOR_CACHE_DIR') ?: sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'rector';
 
@@ -23,13 +22,17 @@ return RectorConfig::configure()
     ->withPhpSets()
     ->withAttributesSets()
 
-    ->withSets([
-        SetList::CODE_QUALITY,
-        SetList::CODING_STYLE,
-        SetList::DEAD_CODE,
-        SetList::EARLY_RETURN,
-        SetList::INSTANCEOF,
-        SetList::TYPE_DECLARATION,
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        codingStyle: true,
+        typeDeclarations: true,
+        instanceOf: true,
+        earlyReturn: true,
+    )
+
+    ->withRules([
+        \Rector\CodingStyle\Rector\Closure\StaticClosureRector::class,
     ])
 
     ->withSkip([

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -456,7 +456,7 @@ class FileEngine extends CacheEngine
         );
         $filtered = new CallbackFilterIterator(
             $contents,
-            function (SplFileInfo $current) use ($group, $prefix) {
+            static function (SplFileInfo $current) use ($group, $prefix) {
                 if (!$current->isFile()) {
                     return false;
                 }

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -185,7 +185,7 @@ trait CollectionTrait
         $extractor = new ExtractIterator($this->unwrap(), $path);
         if (is_string($path) && str_contains($path, '{*}')) {
             return $extractor
-                ->filter(function ($data) {
+                ->filter(static function ($data) {
                     return is_iterable($data);
                 })
                 ->unfold();
@@ -220,7 +220,7 @@ trait CollectionTrait
             $result = $result->extract($path);
         }
         $result = $result
-            ->reduce(function (array $acc, $current) {
+            ->reduce(static function (array $acc, $current) {
                 [$count, $sum] = $acc;
 
                 return [$count + 1, $sum + $current];
@@ -513,7 +513,7 @@ trait CollectionTrait
             return $this->newCollection($iterator);
         }
 
-        $generator = function ($iterator, $length): Generator {
+        $generator = static function ($iterator, $length): Generator {
             $result = [];
             $bucket = 0;
             $offset = 0;
@@ -648,7 +648,7 @@ trait CollectionTrait
             'groupPath' => $groupPath ? $this->_propertyExtractor($groupPath) : null,
         ];
 
-        $mapper = function ($value, $key, MapReduce $mapReduce) use ($options) {
+        $mapper = static function ($value, $key, MapReduce $mapReduce) use ($options) {
             $rowKey = $options['keyPath'];
             $rowVal = $options['valuePath'];
 
@@ -694,7 +694,7 @@ trait CollectionTrait
             );
         };
 
-        $reducer = function ($values, $key, MapReduce $mapReduce): void {
+        $reducer = static function ($values, $key, MapReduce $mapReduce): void {
             $result = [];
             foreach ($values as $value) {
                 $result += $value;
@@ -718,7 +718,16 @@ trait CollectionTrait
         $parentPath = $this->_propertyExtractor($parentPath);
         $isObject = true;
 
-        $mapper = function ($row, $key, MapReduce $mapReduce) use (&$parents, $idPath, $parentPath, $nestingKey): void {
+        $mapper = static function (
+            $row,
+            $key,
+            MapReduce $mapReduce,
+        ) use (
+            &$parents,
+            $idPath,
+            $parentPath,
+            $nestingKey,
+        ): void {
             $row[$nestingKey] = [];
             $id = $idPath($row, $key);
             $parentId = $parentPath($row, $key);
@@ -726,7 +735,7 @@ trait CollectionTrait
             $mapReduce->emitIntermediate($id, $parentId);
         };
 
-        $reducer = function ($values, $key, MapReduce $mapReduce) use (&$parents, &$isObject, $nestingKey) {
+        $reducer = static function ($values, $key, MapReduce $mapReduce) use (&$parents, &$isObject, $nestingKey) {
             static $foundOutType = false;
             if (!$foundOutType) {
                 $isObject = is_object(current($parents));
@@ -749,7 +758,7 @@ trait CollectionTrait
         };
 
         return $this->newCollection(new MapReduce($this->unwrap(), $mapper, $reducer))
-            ->map(function ($value) use ($isObject) {
+            ->map(static function ($value) use ($isObject) {
                 /** @var \ArrayIterator|\ArrayObject $value */
                 return $isObject ? $value : $value->getArrayCopy();
             });
@@ -931,7 +940,7 @@ trait CollectionTrait
      */
     public function chunk(int $chunkSize): CollectionInterface
     {
-        return $this->map(function ($v, $k, Iterator $iterator) use ($chunkSize) {
+        return $this->map(static function ($v, $k, Iterator $iterator) use ($chunkSize) {
             $values = [$v];
             for ($i = 1; $i < $chunkSize; $i++) {
                 $iterator->next();
@@ -950,7 +959,7 @@ trait CollectionTrait
      */
     public function chunkWithKeys(int $chunkSize, bool $keepKeys = true): CollectionInterface
     {
-        return $this->map(function ($v, $k, Iterator $iterator) use ($chunkSize, $keepKeys) {
+        return $this->map(static function ($v, $k, Iterator $iterator) use ($chunkSize, $keepKeys) {
             $key = 0;
             if ($keepKeys) {
                 $key = $k;
@@ -1041,7 +1050,7 @@ trait CollectionTrait
         $changeIndex = $lastIndex;
 
         while (!($changeIndex === 0 && $currentIndexes[0] === $collectionArraysCounts[0])) {
-            $currentCombination = array_map(function ($value, $keys, $index) {
+            $currentCombination = array_map(static function ($value, $keys, $index) {
                 return $value[$keys[$index]];
             }, $collectionArrays, $collectionArraysKeys, $currentIndexes);
 

--- a/src/Collection/ExtractTrait.php
+++ b/src/Collection/ExtractTrait.php
@@ -135,12 +135,12 @@ trait ExtractTrait
         $matchers = [];
         foreach ($conditions as $property => $value) {
             $extractor = $this->_propertyExtractor($property);
-            $matchers[] = function ($v) use ($extractor, $value): bool {
+            $matchers[] = static function ($v) use ($extractor, $value): bool {
                 return $extractor($v) == $value;
             };
         }
 
-        return function ($value) use ($matchers) {
+        return static function ($value) use ($matchers) {
             foreach ($matchers as $match) {
                 if (!$match($value)) {
                     return false;

--- a/src/Collection/Iterator/TreeIterator.php
+++ b/src/Collection/Iterator/TreeIterator.php
@@ -102,7 +102,7 @@ class TreeIterator extends RecursiveIteratorIterator implements CollectionInterf
     ): TreePrinter {
         if (!$keyPath) {
             $counter = 0;
-            $keyPath = function () use (&$counter): int {
+            $keyPath = static function () use (&$counter): int {
                 return $counter++;
             };
         }

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -541,7 +541,7 @@ class I18nExtractCommand extends Command
         $paths = $this->_paths;
         $paths[] = realpath(APP) . DIRECTORY_SEPARATOR;
 
-        usort($paths, function (string $a, string $b) {
+        usort($paths, static function (string $a, string $b) {
             return strlen($a) - strlen($b);
         });
 

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -86,7 +86,7 @@ class RoutesCommand extends Command
         }
 
         if ($args->getOption('sort')) {
-            usort($output, function (array $a, array $b) {
+            usort($output, static function (array $a, array $b) {
                 return strcasecmp($a[0], $b[0]);
             });
         }

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -185,7 +185,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
      */
     protected function getShortestName(array $names): string
     {
-        usort($names, function ($a, $b) {
+        usort($names, static function ($a, $b) {
             return strlen($a) - strlen($b);
         });
 

--- a/src/Console/ConsoleInput.php
+++ b/src/Console/ConsoleInput.php
@@ -109,7 +109,7 @@ class ConsoleInput
 
         /** @var string|null $error */
         $error = null;
-        set_error_handler(function (int $code, string $message) use (&$error) {
+        set_error_handler(static function (int $code, string $message) use (&$error) {
             $error = "stream_select failed with code={$code} message={$message}.";
 
             return true;

--- a/src/Console/TestSuite/Constraint/ContentsContainRow.php
+++ b/src/Console/TestSuite/Constraint/ContentsContainRow.php
@@ -32,7 +32,7 @@ class ContentsContainRow extends ContentsRegExp
      */
     public function matches(mixed $other): bool
     {
-        $row = array_map(function ($cell) {
+        $row = array_map(static function ($cell) {
             return preg_quote($cell, '/');
         }, (array)$other);
         $cells = implode('\s+\|\s+', $row);

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -274,7 +274,7 @@ class Configure
     {
         $engines = array_keys(static::$_engines);
 
-        return array_map(function (int|string $key) {
+        return array_map(static function (int|string $key) {
             return (string)$key;
         }, $engines);
     }

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -175,7 +175,7 @@ trait StaticConfigTrait
     {
         $configurations = array_keys(static::$_config);
 
-        return array_map(function (int|string $key) {
+        return array_map(static function (int|string $key) {
             return (string)$key;
         }, $configurations);
     }

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -684,7 +684,7 @@ abstract class Driver implements LoggerAwareInterface
         $conditions = $query->clause('where');
         assert($conditions === null || $conditions instanceof ExpressionInterface);
         if ($conditions) {
-            $conditions->traverse(function ($expression) {
+            $conditions->traverse(static function ($expression) {
                 if ($expression instanceof ComparisonExpression) {
                     $field = $expression->getField();
                     if (

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -280,7 +280,7 @@ class Postgres extends Driver
                 $expression
                     ->setName('')
                     ->setConjunction('-')
-                    ->iterateParts(function ($p) {
+                    ->iterateParts(static function ($p) {
                         if (is_string($p)) {
                             $p = ['value' => [$p => 'literal'], 'type' => null];
                         } else {
@@ -308,7 +308,7 @@ class Postgres extends Driver
                 $expression
                     ->setName('')
                     ->setConjunction(' + INTERVAL')
-                    ->iterateParts(function ($p, $key) {
+                    ->iterateParts(static function ($p, $key) {
                         if ($key === 1) {
                             return sprintf("'%s'", $p);
                         }

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -248,7 +248,7 @@ class Sqlite extends Driver
                 $expression
                     ->setName('ROUND')
                     ->setConjunction('-')
-                    ->iterateParts(function ($p) {
+                    ->iterateParts(static function ($p) {
                         return new FunctionExpression('JULIANDAY', [$p['value']], [$p['type']]);
                     });
                 break;
@@ -285,7 +285,7 @@ class Sqlite extends Driver
                 $expression
                     ->setName('DATE')
                     ->setConjunction(',')
-                    ->iterateParts(function ($p, $key) {
+                    ->iterateParts(static function ($p, $key) {
                         if ($key === 1) {
                             return ['value' => $p, 'type' => null];
                         }

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -358,7 +358,7 @@ class Sqlserver extends Driver
             $select = $original->clause('select');
             $order = new OrderByExpression();
             $originalOrder
-                ->iterateParts(function ($direction, $orderBy) use ($select, $order) {
+                ->iterateParts(static function ($direction, $orderBy) use ($select, $order) {
                     $key = $orderBy;
                     if (
                         isset($select[$orderBy]) &&
@@ -397,7 +397,7 @@ class Sqlserver extends Driver
 
         // Decorate the original query as that is what the
         // end developer will be calling execute() on originally.
-        $original->decorateResults(function ($row) {
+        $original->decorateResults(static function ($row) {
             if (isset($row['_cake_page_rownum_'])) {
                 unset($row['_cake_page_rownum_']);
             }
@@ -425,7 +425,7 @@ class Sqlserver extends Driver
 
         $order = new OrderByExpression($distinct);
         $query
-            ->select(function (Query $q) use ($distinct, $order) {
+            ->select(static function (Query $q) use ($distinct, $order) {
                 $over = $q->expr('ROW_NUMBER() OVER')
                     ->add('(PARTITION BY')
                     ->add($q->expr()->add($distinct)->setConjunction(','))
@@ -448,7 +448,7 @@ class Sqlserver extends Driver
 
         // Decorate the original query as that is what the
         // end developer will be calling execute() on originally.
-        $original->decorateResults(function ($row) {
+        $original->decorateResults(static function ($row) {
             if (isset($row['_cake_distinct_pivot_'])) {
                 unset($row['_cake_distinct_pivot_']);
             }
@@ -486,7 +486,7 @@ class Sqlserver extends Driver
                 break;
             case 'DATEDIFF':
                 $hasDay = false;
-                $visitor = function ($value) use (&$hasDay) {
+                $visitor = static function ($value) use (&$hasDay) {
                     if ($value === 'day') {
                         $hasDay = true;
                     }
@@ -515,7 +515,7 @@ class Sqlserver extends Driver
                 break;
             case 'DATE_ADD':
                 $params = [];
-                $visitor = function ($p, $key) use (&$params) {
+                $visitor = static function ($p, $key) use (&$params) {
                     if ($key === 0) {
                         $params[2] = $p;
                     } else {
@@ -526,7 +526,7 @@ class Sqlserver extends Driver
 
                     return $p;
                 };
-                $manipulator = function ($p, $key) use (&$params) {
+                $manipulator = static function ($p, $key) use (&$params) {
                     return $params[$key];
                 };
 
@@ -548,7 +548,7 @@ class Sqlserver extends Driver
                 if (count($expression) < 4) {
                     $params = [];
                     $expression
-                        ->iterateParts(function ($p) use (&$params) {
+                        ->iterateParts(static function ($p) use (&$params) {
                             return $params[] = $p;
                         })
                         ->add([new FunctionExpression('LEN', [$params[0]]), ['string']]);

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -499,7 +499,7 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     public function equalFields(string $leftField, string $rightField)
     {
-        $wrapIdentifier = function ($field): ExpressionInterface {
+        $wrapIdentifier = static function ($field): ExpressionInterface {
             if ($field instanceof ExpressionInterface) {
                 return $field;
             }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1872,7 +1872,7 @@ abstract class Query implements ExpressionInterface, Stringable
         try {
             set_error_handler(
                 /** @return no-return */
-                function ($errno, $errstr): void {
+                static function ($errno, $errstr): void {
                     throw new CakeException($errstr, $errno);
                 },
                 E_ALL,

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -361,7 +361,7 @@ class QueryCompiler
             ->getDriver($query->getConnectionRole())
             ->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY);
 
-        $parts = array_map(function (array $p) use ($binder, $setOperationsOrderBy) {
+        $parts = array_map(static function (array $p) use ($binder, $setOperationsOrderBy) {
             /** @var \Cake\Database\Expression\IdentifierExpression $expr */
             $expr = $p['query'];
             $p['query'] = $expr->sql($binder);

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -1088,7 +1088,7 @@ trait EntityTrait
         $this->_hasBeenVisited = true;
         try {
             $errors = $this->_errors + (new Collection($diff))
-                ->filter(function ($value) {
+                ->filter(static function ($value) {
                     return is_array($value) || $value instanceof EntityInterface;
                 })
                 ->map(function ($value) {
@@ -1281,7 +1281,7 @@ trait EntityTrait
             return $object->getErrors();
         }
 
-        $array = array_map(function ($val) {
+        $array = array_map(static function ($val) {
             if ($val instanceof EntityInterface) {
                 return $val->getErrors();
             }

--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -172,7 +172,7 @@ class FormProtector
             return Hash::filter(explode('.', $name));
         }
         $parts = explode('[', $name);
-        $parts = array_map(function (string $el) {
+        $parts = array_map(static function (string $el) {
             return trim($el, ']');
         }, $parts);
 

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -351,7 +351,7 @@ class TranslatorRegistry
             return $loader;
         }
 
-        return function () use ($loader, $fallbackDomain) {
+        return static function () use ($loader, $fallbackDomain) {
             /** @var \Cake\I18n\Package $package */
             $package = $loader();
             if (!$package->getFallback()) {

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -1895,7 +1895,7 @@ class Message implements JsonSerializable
             }
         });
 
-        return array_filter($array, function ($i) {
+        return array_filter($array, static function ($i) {
             return $i !== null && !is_array($i) && !is_bool($i) && strlen($i) || !empty($i);
         });
     }
@@ -1923,7 +1923,7 @@ class Message implements JsonSerializable
     public function __serialize(): array
     {
         $array = $this->jsonSerialize();
-        array_walk_recursive($array, function (&$item, $key): void {
+        array_walk_recursive($array, static function (&$item, $key): void {
             if ($item instanceof SimpleXMLElement) {
                 $item = json_decode((string)json_encode((array)$item), true);
             }

--- a/src/Mailer/Transport/MailTransport.php
+++ b/src/Mailer/Transport/MailTransport.php
@@ -53,7 +53,7 @@ class MailTransport extends AbstractTransport
                 'bcc',
             ],
             $eol,
-            function ($val) {
+            static function ($val) {
                 return str_replace("\r\n", '', $val);
             },
         );

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -777,7 +777,7 @@ abstract class Association
         $target = $this->getTarget();
         if (!empty($options['negateMatch'])) {
             $primaryKey = $query->aliasFields((array)$target->getPrimaryKey(), $this->_name);
-            $query->andWhere(function ($exp) use ($primaryKey) {
+            $query->andWhere(static function ($exp) use ($primaryKey) {
                 /** @var callable $callable */
                 $callable = [$exp, 'isNull'];
                 array_map($callable, $primaryKey);
@@ -1016,7 +1016,14 @@ abstract class Association
         $property = $options['propertyPath'];
         $propertyPath = explode('.', $property);
         $query->formatResults(
-            function (CollectionInterface $results, SelectQuery $query) use ($formatters, $property, $propertyPath) {
+            static function (
+                CollectionInterface $results,
+                SelectQuery $query,
+            ) use (
+                $formatters,
+                $property,
+                $propertyPath,
+            ) {
                 $extracted = [];
                 foreach ($results as $result) {
                     foreach ($propertyPath as $propertyPathItem) {
@@ -1039,7 +1046,7 @@ abstract class Association
 
                 $results = $results->insert($property, $extracted);
                 if ($query->isHydrationEnabled()) {
-                    return $results->map(function (EntityInterface $result) {
+                    return $results->map(static function (EntityInterface $result) {
                         $result->clean();
 
                         return $result;

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -526,7 +526,7 @@ class BelongsToMany extends Association
         $subquery = $this->_appendJunctionJoin($subquery);
 
         $query
-            ->andWhere(function (QueryExpression $exp) use ($subquery, $conds) {
+            ->andWhere(static function (QueryExpression $exp) use ($subquery, $conds) {
                 $identifiers = [];
                 foreach (array_keys($conds) as $field) {
                     $identifiers[] = new IdentifierExpression($field);
@@ -1443,12 +1443,12 @@ class BelongsToMany extends Association
         $hasMany = $source->getAssociation($junction->getAlias());
         /** @var array<string> $foreignKey */
         $foreignKey = (array)$this->getForeignKey();
-        $foreignKey = array_map(function (string $key) {
+        $foreignKey = array_map(static function (string $key) {
             return $key . ' IS';
         }, $foreignKey);
         /** @var array<string> $assocForeignKey */
         $assocForeignKey = (array)$belongsTo->getForeignKey();
-        $assocForeignKey = array_map(function (string $key) {
+        $assocForeignKey = array_map(static function (string $key) {
             return $key . ' IS';
         }, $assocForeignKey);
         $sourceKey = $sourceEntity->extract((array)$source->getPrimaryKey());

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -295,7 +295,7 @@ class HasMany extends Association
             $pkFields = (array)$this->getTarget()->getPrimaryKey();
             $targetEntities = (new Collection($targetEntities))
                 ->reject(
-                    function (EntityInterface $entity) use ($currentEntities, $pkFields) {
+                    static function (EntityInterface $entity) use ($currentEntities, $pkFields) {
                         if ($entity->isNew()) {
                             return false;
                         }
@@ -389,7 +389,7 @@ class HasMany extends Association
 
         $conditions = [
             'OR' => (new Collection($targetEntities))
-                ->map(function (EntityInterface $entity) use ($targetPrimaryKey) {
+                ->map(static function (EntityInterface $entity) use ($targetPrimaryKey) {
                     /** @var array<string> $targetPrimaryKey */
                     return $entity->extract($targetPrimaryKey);
                 })
@@ -404,7 +404,7 @@ class HasMany extends Association
                 $property,
                 (new Collection($sourceEntity->get($property)))
                 ->reject(
-                    function ($assoc) use ($targetEntities) {
+                    static function ($assoc) use ($targetEntities) {
                         return in_array($assoc, $targetEntities);
                     },
                 )
@@ -498,12 +498,12 @@ class HasMany extends Association
         $primaryKey = (array)$target->getPrimaryKey();
         $exclusions = new Collection($remainingEntities);
         $exclusions = $exclusions->map(
-            function (EntityInterface $ent) use ($primaryKey) {
+            static function (EntityInterface $ent) use ($primaryKey) {
                 return $ent->extract($primaryKey);
             },
         )
         ->filter(
-            function ($v) {
+            static function ($v) {
                 return !in_array(null, $v, true);
             },
         )
@@ -542,7 +542,7 @@ class HasMany extends Association
         if ($mustBeDependent) {
             if ($this->_cascadeCallbacks) {
                 $conditions = new QueryExpression($conditions);
-                $conditions->traverse(function ($entry) use ($target): void {
+                $conditions->traverse(static function ($entry) use ($target): void {
                     if ($entry instanceof FieldInterface) {
                         $field = $entry->getField();
                         if (is_string($field)) {
@@ -582,7 +582,7 @@ class HasMany extends Association
         return !in_array(
             false,
             array_map(
-                function ($prop) use ($table) {
+                static function ($prop) use ($table) {
                     return $table->getSchema()->isNullable($prop);
                 },
                 $properties,

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -457,7 +457,7 @@ class SelectLoader
         $order = $query->clause('order');
         if ($order) {
             $columns = $query->clause('select');
-            $order->iterateParts(function ($direction, $field) use (&$fields, $columns): void {
+            $order->iterateParts(static function ($direction, $field) use (&$fields, $columns): void {
                 if (isset($columns[$field])) {
                     $fields[$field] = $columns[$field];
                 }
@@ -537,7 +537,7 @@ class SelectLoader
 
         $sourceKey = $sourceKeys[0];
 
-        return function ($row) use ($resultMap, $sourceKey, $nestKey) {
+        return static function ($row) use ($resultMap, $sourceKey, $nestKey) {
             if (isset($row[$sourceKey], $resultMap[$row[$sourceKey]])) {
                 $row[$nestKey] = $resultMap[$row[$sourceKey]];
             }
@@ -558,7 +558,7 @@ class SelectLoader
      */
     protected function _multiKeysInjector(array $resultMap, array $sourceKeys, string $nestKey): Closure
     {
-        return function ($row) use ($resultMap, $sourceKeys, $nestKey) {
+        return static function ($row) use ($resultMap, $sourceKeys, $nestKey) {
             $values = [];
             foreach ($sourceKeys as $key) {
                 $values[] = $row[$key];

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -171,7 +171,7 @@ class AssociationCollection implements IteratorAggregate
     {
         $class = array_map('strtolower', (array)$class);
 
-        $out = array_filter($this->_items, function (Association $assoc) use ($class) {
+        $out = array_filter($this->_items, static function (Association $assoc) use ($class) {
             [, $name] = namespaceSplit($assoc::class);
 
             return in_array(strtolower($name), $class, true);

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -384,7 +384,7 @@ class CounterCacheBehavior extends Behavior
      */
     protected function _shouldUpdateCount(array $conditions): bool
     {
-        return !empty(array_filter($conditions, function ($value) {
+        return !empty(array_filter($conditions, static function ($value) {
             return $value !== null;
         }));
     }

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -223,7 +223,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
             return true;
         }
 
-        $select = array_filter($query->clause('select'), function ($field) {
+        $select = array_filter($query->clause('select'), static function ($field) {
             return is_string($field);
         });
 
@@ -274,7 +274,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
         $joinRequired = false;
 
         $clause->iterateParts(
-            function ($c, &$field) use ($fields, $alias, $mainTableAlias, $mainTableFields, &$joinRequired) {
+            static function ($c, &$field) use ($fields, $alias, $mainTableAlias, $mainTableFields, &$joinRequired) {
                 if (!is_string($field) || str_contains($field, '.')) {
                     return $c;
                 }
@@ -320,7 +320,15 @@ class ShadowTableStrategy implements TranslateStrategyInterface
         $joinRequired = false;
 
         $clause->traverse(
-            function ($expression) use ($fields, $alias, $mainTableAlias, $mainTableFields, &$joinRequired): void {
+            static function (
+                $expression,
+            ) use (
+                $fields,
+                $alias,
+                $mainTableAlias,
+                $mainTableFields,
+                &$joinRequired,
+            ): void {
                 if (!($expression instanceof FieldInterface)) {
                     return;
                 }
@@ -490,7 +498,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
     {
         $allowEmpty = $this->_config['allowEmptyTranslations'];
 
-        return $results->map(function ($row) use ($allowEmpty, $locale) {
+        return $results->map(static function ($row) use ($allowEmpty, $locale) {
             if ($row === null) {
                 return $row;
             }
@@ -556,7 +564,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
      */
     public function groupTranslations(CollectionInterface $results): CollectionInterface
     {
-        return $results->map(function ($row) {
+        return $results->map(static function ($row) {
             if (!$row instanceof EntityInterface) {
                 return $row;
             }

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -347,7 +347,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
         $targetAlias = $this->getStrategy()->getTranslationTable()->getAlias();
 
         return $query
-            ->contain([$targetAlias => function (QueryInterface $query) use ($locales, $targetAlias) {
+            ->contain([$targetAlias => static function (QueryInterface $query) use ($locales, $targetAlias) {
                 if ($locales) {
                     $query->where(["{$targetAlias}.locale IN" => $locales]);
                 }

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -366,7 +366,7 @@ class TreeBehavior extends Behavior
     {
         $config = $this->getConfig();
         $this->_table->updateAll(
-            function (QueryExpression $exp) use ($config) {
+            static function (QueryExpression $exp) use ($config) {
                 $leftInverse = clone $exp;
                 $leftInverse->setConjunction('*')->add('-1');
                 $rightInverse = clone $leftInverse;

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -80,7 +80,7 @@ class LazyEagerLoader
         $query = $source
             ->find()
             ->select((array)$primaryKey)
-            ->where(function (QueryExpression $exp, SelectQuery $q) use ($primaryKey, $keys, $source) {
+            ->where(static function (QueryExpression $exp, SelectQuery $q) use ($primaryKey, $keys, $source) {
                 if (is_array($primaryKey) && count($primaryKey) === 1) {
                     $primaryKey = current($primaryKey);
                 }

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -684,7 +684,7 @@ class Marshaller
         $primary = (array)$this->_table->getPrimaryKey();
 
         $indexed = (new Collection($data))
-            ->groupBy(function ($el) use ($primary) {
+            ->groupBy(static function ($el) use ($primary) {
                 $keys = [];
                 foreach ($primary as $key) {
                     $keys[] = $el[$key] ?? '';
@@ -692,7 +692,7 @@ class Marshaller
 
                 return implode(';', $keys);
             })
-            ->map(function ($element, $key) {
+            ->map(static function ($element, $key) {
                 return $key === '' ? $element : $element[0];
             })
             ->toArray();
@@ -716,7 +716,7 @@ class Marshaller
         }
 
         $conditions = (new Collection($indexed))
-            ->map(function ($data, $key) {
+            ->map(static function ($data, $key) {
                 return explode(';', (string)$key);
             })
             ->filter(fn($keys) => count(Hash::filter($keys)) === count($primary))

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1463,7 +1463,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
             $fields = $options[$field];
             $glue = in_array($field, ['keyField', 'parentField'], true) ? ';' : $options['valueSeparator'];
-            $options[$field] = function ($row) use ($fields, $glue): string {
+            $options[$field] = static function ($row) use ($fields, $glue): string {
                 $matches = [];
                 foreach ($fields as $field) {
                     $matches[] = $row[$field];
@@ -1525,7 +1525,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
         if (count($key) !== count($primaryKey)) {
             $primaryKey = $primaryKey ?: [null];
-            $primaryKey = array_map(function ($key) {
+            $primaryKey = array_map(static function ($key) {
                 return var_export($key, true);
             }, $primaryKey);
 
@@ -2144,7 +2144,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $primary = array_combine($primary, $id);
         $primary = array_intersect_key($data, $primary) + $primary;
 
-        $filteredKeys = array_filter($primary, function ($v) {
+        $filteredKeys = array_filter($primary, static function ($v) {
             return $v !== null;
         });
         $data += $filteredKeys;
@@ -2363,7 +2363,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             throw new PersistenceFailedException($failed, ['saveMany']);
         }
 
-        $cleanupOnSuccess = function (EntityInterface $entity) use (&$cleanupOnSuccess): void {
+        $cleanupOnSuccess = static function (EntityInterface $entity) use (&$cleanupOnSuccess): void {
             $entity->clean();
             $entity->setNew(false);
 

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -134,7 +134,7 @@ class Route
      */
     public function __construct(string $template, array $defaults = [], array $options = [])
     {
-        $checker = function () use ($defaults): bool {
+        $checker = static function () use ($defaults): bool {
             foreach (['plugin', 'prefix', 'controller', 'action'] as $key) {
                 if (isset($defaults[$key]) && !is_string($defaults[$key])) {
                     throw new CakeException(
@@ -815,7 +815,7 @@ class Route
      */
     protected function _writeUrl(array $params, array $pass = [], array $query = []): string
     {
-        $pass = array_map(function ($value) {
+        $pass = array_map(static function ($value) {
             return rawurlencode((string)$value);
         }, $pass);
         $pass = implode('/', $pass);

--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -133,7 +133,7 @@ class ConnectionHelper
         /** @var array<\Cake\Database\Schema\TableSchema> $schemas Specify type for psalm */
         $schemas = array_map(fn(string $table) => $collection->describe($table), $tables);
 
-        self::runWithoutConstraints($connection, function (Connection $connection) use ($schemas): void {
+        self::runWithoutConstraints($connection, static function (Connection $connection) use ($schemas): void {
             $dialect = $connection->getWriteDriver()->schemaDialect();
             foreach ($schemas as $schema) {
                 foreach ($dialect->truncateTableSql($schema) as $statement) {
@@ -155,7 +155,7 @@ class ConnectionHelper
         if ($connection->getWriteDriver()->supports(DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION)) {
             $connection->disableConstraints(fn(Connection $connection) => $callback($connection));
         } else {
-            $connection->transactional(function (Connection $connection) use ($callback): void {
+            $connection->transactional(static function (Connection $connection) use ($callback): void {
                 $connection->disableConstraints(fn(Connection $connection) => $callback($connection));
             });
         }

--- a/src/TestSuite/Constraint/EventFiredWith.php
+++ b/src/TestSuite/Constraint/EventFiredWith.php
@@ -76,7 +76,7 @@ class EventFiredWith extends Constraint
         }
 
         $eventGroup = (new Collection($firedEvents))
-            ->groupBy(function (EventInterface $event): string {
+            ->groupBy(static function (EventInterface $event): string {
                 return $event->getName();
             })
             ->toArray();

--- a/src/TestSuite/Fixture/SchemaLoader.php
+++ b/src/TestSuite/Fixture/SchemaLoader.php
@@ -152,7 +152,7 @@ class SchemaLoader
          * @var \Cake\Database\Connection $connection
          */
         $connection = ConnectionManager::get($connectionName);
-        $connection->disableConstraints(function (Connection $connection) use ($tables): void {
+        $connection->disableConstraints(static function (Connection $connection) use ($tables): void {
             foreach ($tables as $tableName => $table) {
                 $name = $table['table'] ?? $tableName;
                 if (!is_string($name)) {

--- a/src/TestSuite/Fixture/TransactionFixtureStrategy.php
+++ b/src/TestSuite/Fixture/TransactionFixtureStrategy.php
@@ -52,7 +52,7 @@ class TransactionFixtureStrategy implements FixtureStrategyInterface
     {
         $this->fixtures = $this->helper->loadFixtures($fixtureNames);
 
-        $this->helper->runPerConnection(function ($connection): void {
+        $this->helper->runPerConnection(static function ($connection): void {
             if ($connection instanceof Connection) {
                 assert(
                     $connection->inTransaction() === false,
@@ -80,7 +80,7 @@ class TransactionFixtureStrategy implements FixtureStrategyInterface
      */
     public function teardownTest(): void
     {
-        $this->helper->runPerConnection(function (Connection $connection): void {
+        $this->helper->runPerConnection(static function (Connection $connection): void {
             if ($connection->inTransaction()) {
                 $connection->rollback(true);
             }

--- a/src/TestSuite/Fixture/TransactionStrategy.php
+++ b/src/TestSuite/Fixture/TransactionStrategy.php
@@ -56,7 +56,7 @@ class TransactionStrategy implements FixtureStrategyInterface
 
         $this->fixtures = $this->helper->loadFixtures($fixtureNames);
 
-        $this->helper->runPerConnection(function ($connection): void {
+        $this->helper->runPerConnection(static function ($connection): void {
             if ($connection instanceof Connection) {
                 assert(
                     $connection->inTransaction() === false,
@@ -85,7 +85,7 @@ class TransactionStrategy implements FixtureStrategyInterface
      */
     public function teardownTest(): void
     {
-        $this->helper->runPerConnection(function (Connection $connection): void {
+        $this->helper->runPerConnection(static function (Connection $connection): void {
             if ($connection->inTransaction()) {
                 $connection->rollback(true);
             }

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -732,7 +732,7 @@ trait IntegrationTestTrait
         if ($this->_securityToken === true) {
             $fields = array_diff_key($data, array_flip($this->_unlockedFields));
 
-            $keys = array_map(function (int|string $field) {
+            $keys = array_map(static function (int|string $field) {
                 return preg_replace('/(\.\d+)+$/', '', (string)$field);
             }, array_keys(Hash::flatten($fields)));
 

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -180,7 +180,7 @@ abstract class TestCase extends BaseTestCase
         $deprecation = false;
 
         $previousHandler = set_error_handler(
-            function (
+            static function (
                 $code,
                 $message,
                 $file,
@@ -1055,7 +1055,7 @@ abstract class TestCase extends BaseTestCase
         $options += ['alias' => $baseClass, 'connection' => $connection];
         $options += $locator->getConfig($alias);
         $reflection = new ReflectionClass($className);
-        $classMethods = array_map(function (ReflectionMethod $method) {
+        $classMethods = array_map(static function (ReflectionMethod $method) {
             return $method->name;
         }, $reflection->getMethods());
 

--- a/src/Utility/Filesystem.php
+++ b/src/Utility/Filesystem.php
@@ -86,7 +86,7 @@ class Filesystem
 
         $dirFilter = new RecursiveCallbackFilterIterator(
             $directory,
-            function (SplFileInfo $current) {
+            static function (SplFileInfo $current) {
                 if (str_starts_with($current->getFilename(), '.') && $current->isDir()) {
                     return false;
                 }

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -731,7 +731,7 @@ class Text
         $pattern = '/&[0-9a-z]{2,8};|&#[0-9]{1,7};|&#x[0-9a-f]{1,6};/i';
         $replace = (string)preg_replace_callback(
             $pattern,
-            function ($match) use ($strlen) {
+            static function ($match) use ($strlen) {
                 $utf8 = html_entity_decode($match[0], ENT_HTML5 | ENT_QUOTES, 'UTF-8');
 
                 return str_repeat(' ', $strlen($utf8, 'UTF-8'));

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -149,7 +149,7 @@ class Xml
         return static::load(
             $input,
             $options,
-            function ($input, $options, $flags) {
+            static function ($input, $options, $flags) {
                 if ($options['return'] === 'simplexml' || $options['return'] === 'simplexmlelement') {
                     $flags |= LIBXML_NOCDATA;
                     $xml = new SimpleXMLElement($input, $flags);
@@ -182,7 +182,7 @@ class Xml
         return static::load(
             $input,
             $options,
-            function ($input, $options, $flags) {
+            static function ($input, $options, $flags) {
                 $xml = new DOMDocument();
                 $xml->loadHTML($input, $flags);
 

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1186,7 +1186,7 @@ class Validation
         $defaults = ['in' => null, 'max' => null, 'min' => null];
         $options += $defaults;
 
-        $check = array_filter((array)$check, function ($value) {
+        $check = array_filter((array)$check, static function ($value) {
             return $value || is_numeric($value);
         });
         if (!$check) {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2909,7 +2909,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'hasAtLeast', $extra + [
-            'rule' => function ($value) use ($count) {
+            'rule' => static function ($value) use ($count) {
                 if (is_array($value) && isset($value['_ids'])) {
                     $value = $value['_ids'];
                 }
@@ -2944,7 +2944,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'hasAtMost', $extra + [
-            'rule' => function ($value) use ($count) {
+            'rule' => static function ($value) use ($count) {
                 if (is_array($value) && isset($value['_ids'])) {
                     $value = $value['_ids'];
                 }

--- a/src/View/Form/ContextFactory.php
+++ b/src/View/Form/ContextFactory.php
@@ -59,7 +59,7 @@ class ContextFactory
         $providers = [
             [
                 'type' => 'orm',
-                'callable' => function ($request, $data) {
+                'callable' => static function ($request, $data) {
                     if ($data['entity'] instanceof EntityInterface) {
                         return new EntityContext($data);
                     }
@@ -78,7 +78,7 @@ class ContextFactory
             ],
             [
                 'type' => 'form',
-                'callable' => function ($request, $data) {
+                'callable' => static function ($request, $data) {
                     if ($data['entity'] instanceof Form) {
                         return new FormContext($data);
                     }
@@ -86,7 +86,7 @@ class ContextFactory
             ],
             [
                 'type' => 'array',
-                'callable' => function ($request, $data) {
+                'callable' => static function ($request, $data) {
                     if (is_array($data['entity']) && isset($data['entity']['schema'])) {
                         return new ArrayContext($data['entity']);
                     }
@@ -94,7 +94,7 @@ class ContextFactory
             ],
             [
                 'type' => 'null',
-                'callable' => function ($request, $data) {
+                'callable' => static function ($request, $data) {
                     if ($data['entity'] === null) {
                         return new NullContext($data);
                     }

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -575,7 +575,7 @@ class EntityContext implements ContextInterface
      */
     protected function _getValidator(array $parts): Validator
     {
-        $keyParts = array_filter(array_slice($parts, 0, -1), function (string $part) {
+        $keyParts = array_filter(array_slice($parts, 0, -1), static function (string $part) {
             return !is_numeric($part);
         });
         $key = implode('.', $keyParts);
@@ -625,7 +625,7 @@ class EntityContext implements ContextInterface
             return $this->_tables[$this->_rootName];
         }
 
-        $normalized = array_slice(array_filter($parts, function (string $part) {
+        $normalized = array_slice(array_filter($parts, static function (string $part) {
             return !is_numeric($part);
         }), 0, -1);
 

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -624,7 +624,7 @@ class ViewBuilder implements JsonSerializable
         /** @phpstan-ignore-next-line argument.type */
         array_walk_recursive($array['_vars'], $this->_checkViewVars(...));
 
-        return array_filter($array, function (array|bool|string|null $i) {
+        return array_filter($array, static function (array|bool|string|null $i) {
             return !is_array($i) && strlen((string)$i) || !empty($i);
         });
     }

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -89,7 +89,7 @@ class CacheTest extends TestCase
             'prefix' => 'test_',
         ]);
 
-        $this->expectWarningMessageMatches('/^.* is not writable/', function () use (&$engine): void {
+        $this->expectWarningMessageMatches('/^.* is not writable/', static function () use (&$engine): void {
             $engine = Cache::pool('tests');
         });
         $path = $engine->getConfig('path');
@@ -115,7 +115,7 @@ class CacheTest extends TestCase
             'fallback' => false,
         ]);
 
-        $this->expectErrorMessageMatches('/^Cache engine `.*TestAppCacheEngine.*` is not properly configured/', function (): void {
+        $this->expectErrorMessageMatches('/^Cache engine `.*TestAppCacheEngine.*` is not properly configured/', static function (): void {
             Cache::pool('tests');
         });
     }
@@ -136,7 +136,7 @@ class CacheTest extends TestCase
 
         $e = null;
         try {
-            $this->expectWarningMessageMatches('/^.* is not writable/', function (): void {
+            $this->expectWarningMessageMatches('/^.* is not writable/', static function (): void {
                 Cache::pool('tests');
             });
         } catch (InvalidArgumentException $e) {
@@ -171,7 +171,7 @@ class CacheTest extends TestCase
             'groups' => ['group3', 'group1'],
         ]);
 
-        $this->expectWarningMessageMatches('/^.* is not writable/', function () use (&$result): void {
+        $this->expectWarningMessageMatches('/^.* is not writable/', static function () use (&$result): void {
             $result = Cache::groupConfigs('group1');
         });
         $this->assertSame(['group1' => ['tests', 'tests_fallback']], $result);
@@ -279,7 +279,7 @@ class CacheTest extends TestCase
         ]);
 
         $regex = '/^Cache engine `.*TestAppCacheEngine.*/';
-        $this->expectWarningMessageMatches($regex, function () use (&$engine): void {
+        $this->expectWarningMessageMatches($regex, static function () use (&$engine): void {
             $engine = Cache::pool('tests');
         });
 
@@ -831,7 +831,7 @@ class CacheTest extends TestCase
     {
         $this->_configCache();
         $counter = 0;
-        $cacher = function () use ($counter) {
+        $cacher = static function () use ($counter) {
             return 'This is some data ' . $counter;
         };
 

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -34,7 +34,7 @@ class RedisClusterEngineTest extends TestCase
 
         if ($this->skipTest === null) {
             $this->skipTest = false;
-            $nodes = array_map(function (string $node) {
+            $nodes = array_map(static function (string $node) {
                 [$host, $port] = explode(':', $node);
 
                 return ['host' => $host, 'port' => (int)$port];

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -219,7 +219,7 @@ class CollectionTest extends TestCase
         $collection = new Collection($items);
 
         $results = [];
-        $collection->each(function ($value, $key) use (&$results): void {
+        $collection->each(static function ($value, $key) use (&$results): void {
             $results[] = [$key => $value];
         });
         $this->assertSame([['a' => 1], ['b' => 2], ['c' => 3]], $results);
@@ -255,13 +255,13 @@ class CollectionTest extends TestCase
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
 
-        $filtered = $collection->filter(function ($value, $key, $iterator) {
+        $filtered = $collection->filter(static function ($value, $key, $iterator) {
             return $value > 2;
         });
         $this->assertInstanceOf(Collection::class, $filtered);
 
         $results = [];
-        $filtered->each(function ($value, $key) use (&$results): void {
+        $filtered->each(static function ($value, $key) use (&$results): void {
             $results[] = [$key => $value];
         });
         $this->assertSame([['c' => 3]], $results);
@@ -273,7 +273,7 @@ class CollectionTest extends TestCase
     public function testReject(): void
     {
         $collection = new Collection([]);
-        $result = $collection->reject(function ($v) {
+        $result = $collection->reject(static function ($v) {
             return false;
         });
         $this->assertSame([], iterator_to_array($result));
@@ -326,7 +326,7 @@ class CollectionTest extends TestCase
         $collection = new Collection($items);
 
         $results = [];
-        $this->assertTrue($collection->every(function ($value, $key) use (&$results) {
+        $this->assertTrue($collection->every(static function ($value, $key) use (&$results) {
             $results[] = [$key => $value];
 
             return true;
@@ -343,7 +343,7 @@ class CollectionTest extends TestCase
         $collection = new Collection($items);
 
         $results = [];
-        $this->assertFalse($collection->every(function ($value, $key) use (&$results) {
+        $this->assertFalse($collection->every(static function ($value, $key) use (&$results) {
             $results[] = [$key => $value];
 
             return $key !== 'b';
@@ -357,7 +357,7 @@ class CollectionTest extends TestCase
     public function testSomeReturnTrue(): void
     {
         $collection = new Collection([]);
-        $result = $collection->some(function ($v) {
+        $result = $collection->some(static function ($v) {
             return true;
         });
         $this->assertFalse($result);
@@ -366,7 +366,7 @@ class CollectionTest extends TestCase
         $collection = new Collection($items);
 
         $results = [];
-        $this->assertTrue($collection->some(function ($value, $key) use (&$results) {
+        $this->assertTrue($collection->some(static function ($value, $key) use (&$results) {
             $results[] = [$key => $value];
 
             return $key === 'b';
@@ -383,7 +383,7 @@ class CollectionTest extends TestCase
         $collection = new Collection($items);
 
         $results = [];
-        $this->assertFalse($collection->some(function ($value, $key) use (&$results) {
+        $this->assertFalse($collection->some(static function ($value, $key) use (&$results) {
             $results[] = [$key => $value];
 
             return false;
@@ -445,7 +445,7 @@ class CollectionTest extends TestCase
     public function testReduceWithInitialValue(iterable $items): void
     {
         $collection = new Collection($items);
-        $this->assertSame(20, $collection->reduce(function ($reduction, $value, $key) {
+        $this->assertSame(20, $collection->reduce(static function ($reduction, $value, $key) {
             return $value + $reduction;
         }, 10));
     }
@@ -457,7 +457,7 @@ class CollectionTest extends TestCase
     public function testReduceWithoutInitialValue(iterable $items): void
     {
         $collection = new Collection($items);
-        $this->assertSame(10, $collection->reduce(function ($reduction, $value, $key) {
+        $this->assertSame(10, $collection->reduce(static function ($reduction, $value, $key) {
             return $value + $reduction;
         }));
     }
@@ -542,7 +542,7 @@ class CollectionTest extends TestCase
     public function testMaxCallback(iterable $items): void
     {
         $collection = new Collection($items);
-        $callback = function ($e) {
+        $callback = static function ($e) {
             return $e['a']['b']['c'] * -1;
         };
         $this->assertEquals(['a' => ['b' => ['c' => 4]]], $collection->max($callback));
@@ -555,7 +555,7 @@ class CollectionTest extends TestCase
     public function testMaxCallable(iterable $items): void
     {
         $collection = new Collection($items);
-        $this->assertEquals(['a' => ['b' => ['c' => 4]]], $collection->max(function ($e) {
+        $this->assertEquals(['a' => ['b' => ['c' => 4]]], $collection->max(static function ($e) {
             return $e['a']['b']['c'] * -1;
         }));
     }
@@ -662,7 +662,7 @@ class CollectionTest extends TestCase
                 ['id' => 2, 'name' => 'bar', 'parent_id' => 11],
             ],
         ];
-        $grouped = $collection->groupBy(function ($element) {
+        $grouped = $collection->groupBy(static function ($element) {
             return $element['parent_id'];
         });
         $this->assertEquals($expected, iterator_to_array($grouped));
@@ -825,7 +825,7 @@ class CollectionTest extends TestCase
     public function testIndexByCallback(iterable $items): void
     {
         $collection = new Collection($items);
-        $grouped = $collection->indexBy(function ($element) {
+        $grouped = $collection->indexBy(static function ($element) {
             return $element['id'];
         });
         $expected = [
@@ -846,7 +846,7 @@ class CollectionTest extends TestCase
             ['id' => 2, 'name' => 'bar', 'thing' => NonBacked::Advanced],
         ];
         $collection = new Collection($items);
-        $grouped = $collection->indexBy(function ($element) {
+        $grouped = $collection->indexBy(static function ($element) {
             return $element['thing'];
         });
         $expected = [
@@ -866,7 +866,7 @@ class CollectionTest extends TestCase
             ['id' => 2, 'name' => 'bar', 'thing' => Priority::High],
         ];
         $collection = new Collection($items);
-        $grouped = $collection->indexBy(function ($element) {
+        $grouped = $collection->indexBy(static function ($element) {
             return $element['thing'];
         });
         $expected = [
@@ -928,7 +928,7 @@ class CollectionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot index by path that does not exist or contains a null value');
 
-        $collection->indexBy(function ($e) {
+        $collection->indexBy(static function ($e) {
             return null;
         });
     }
@@ -961,7 +961,7 @@ class CollectionTest extends TestCase
             11 => 1,
         ];
         $collection = new Collection($items);
-        $grouped = $collection->countBy(function ($element) {
+        $grouped = $collection->countBy(static function ($element) {
             return $element['parent_id'];
         });
         $this->assertEquals($expected, iterator_to_array($grouped));
@@ -1276,7 +1276,7 @@ class CollectionTest extends TestCase
 
         $results = [];
         $compiled = $collection
-            ->map(function ($value, $key) use (&$results) {
+            ->map(static function ($value, $key) use (&$results) {
                 $results[] = [$key => $value];
 
                 return $value + 3;
@@ -1346,13 +1346,13 @@ class CollectionTest extends TestCase
             '2-3' => ['baz-2-3' => '2-3-baz'],
         ];
         $collection = (new Collection($items))->combine(
-            function ($value, $key) {
+            static function ($value, $key) {
                 return $value['name'] . '-' . $key;
             },
-            function ($value, $key) {
+            static function ($value, $key) {
                 return $key . '-' . $value['name'];
             },
-            function ($value, $key) {
+            static function ($value, $key) {
                 return $key . '-' . $value['id'];
             },
         );
@@ -1835,7 +1835,7 @@ class CollectionTest extends TestCase
             ['id' => 1, 'stuff' => [['id' => 2, 'stuff' => [['id' => 3]]]]],
             ['id' => 4, 'stuff' => [['id' => 5]]],
         ];
-        $collection = (new Collection($items))->listNested('desc', function ($item) {
+        $collection = (new Collection($items))->listNested('desc', static function ($item) {
             return $item['stuff'] ?? [];
         });
         $this->assertEquals(range(1, 5), $collection->extract('id')->toArray(false));
@@ -1885,7 +1885,7 @@ class CollectionTest extends TestCase
     #[DataProvider('sumOfProvider')]
     public function testSumOfCallable(iterable $items, $expected): void
     {
-        $sum = (new Collection($items))->sumOf(function ($v) {
+        $sum = (new Collection($items))->sumOf(static function ($v) {
             return $v['invoice']['total'];
         });
         $this->assertEquals($expected, $sum);
@@ -1897,7 +1897,7 @@ class CollectionTest extends TestCase
     #[DataProvider('simpleProvider')]
     public function testStopWhenCallable(iterable $items): void
     {
-        $collection = (new Collection($items))->stopWhen(function ($v) {
+        $collection = (new Collection($items))->stopWhen(static function ($v) {
             return $v > 3;
         });
         $this->assertEquals(['a' => 1, 'b' => 2, 'c' => 3], $collection->toArray());
@@ -1959,7 +1959,7 @@ class CollectionTest extends TestCase
     public function testUnfoldWithCallable(): void
     {
         $items = [1, 2, 3];
-        $collection = (new Collection($items))->unfold(function ($item) {
+        $collection = (new Collection($items))->unfold(static function ($item) {
             return range($item, $item * 2);
         });
         $expected = [1, 2, 2, 3, 4, 3, 4, 5, 6];
@@ -1972,7 +1972,7 @@ class CollectionTest extends TestCase
     public function testThrough(): void
     {
         $items = [1, 2, 3];
-        $collection = (new Collection($items))->through(function ($collection) {
+        $collection = (new Collection($items))->through(static function ($collection) {
             return $collection->append($collection->toList());
         });
 
@@ -1985,7 +1985,7 @@ class CollectionTest extends TestCase
     public function testThroughReturnArray(): void
     {
         $items = [1, 2, 3];
-        $collection = (new Collection($items))->through(function ($collection) {
+        $collection = (new Collection($items))->through(static function ($collection) {
             $list = $collection->toList();
 
             return array_merge($list, $list);
@@ -2001,7 +2001,7 @@ class CollectionTest extends TestCase
     public function testComplexSortBy(): void
     {
         $results = collection([3, 7])
-            ->unfold(function ($value) {
+            ->unfold(static function ($value) {
                 return [
                     ['sorting' => $value * 2],
                     ['sorting' => $value * 2],
@@ -2048,7 +2048,7 @@ class CollectionTest extends TestCase
         $result = $collection->__debugInfo();
         $this->assertStringContainsString('NoRewindIterator', $result['innerIterator']::class);
 
-        $filter = function ($value): void {
+        $filter = static function ($value): void {
             throw new Exception('filter exception');
         };
         $iterator = new CallbackFilterIterator(new ArrayIterator($items), $filter);
@@ -2066,7 +2066,7 @@ class CollectionTest extends TestCase
         $collection = new Collection([1, 2, 3]);
         $this->assertFalse($collection->isEmpty());
 
-        $collection = $collection->map(function () {
+        $collection = $collection->map(static function () {
             return null;
         });
         $this->assertFalse($collection->isEmpty());
@@ -2115,12 +2115,12 @@ class CollectionTest extends TestCase
     public function testZipWith(): void
     {
         $collection = new Collection([1, 2]);
-        $zipped = $collection->zipWith([3, 4], function ($a, $b) {
+        $zipped = $collection->zipWith([3, 4], static function ($a, $b) {
             return $a * $b;
         });
         $this->assertEquals([3, 8], $zipped->toList());
 
-        $zipped = $collection->zipWith([3, 4], [5, 6, 7], function (...$args) {
+        $zipped = $collection->zipWith([3, 4], [5, 6, 7], static function (...$args) {
             return array_sum($args);
         });
         $this->assertEquals([9, 12], $zipped->toList());
@@ -2183,7 +2183,7 @@ class CollectionTest extends TestCase
         $collection = new Collection([1, 2, 3]);
         $this->assertSame(3, $collection->last());
 
-        $collection = $collection->map(function ($e) {
+        $collection = $collection->map(static function ($e) {
             return $e * 2;
         });
         $this->assertSame(6, $collection->last());
@@ -2405,11 +2405,11 @@ class CollectionTest extends TestCase
     public function testSerializeWithNestedIterators(): void
     {
         $collection = new Collection([1, 2, 3]);
-        $collection = $collection->map(function ($e) {
+        $collection = $collection->map(static function ($e) {
             return $e * 3;
         });
 
-        $collection = $collection->groupBy(function ($e) {
+        $collection = $collection->groupBy(static function ($e) {
             return $e % 2;
         });
 
@@ -2557,9 +2557,9 @@ class CollectionTest extends TestCase
 
         $collection = new Collection([[1, 2, 3], ['A', 'B', 'C'], ['a', 'b', 'c']]);
 
-        $result = $collection->cartesianProduct(function ($value) {
+        $result = $collection->cartesianProduct(static function ($value) {
             return [strval($value[0]) . $value[1] . $value[2]];
-        }, function ($value) {
+        }, static function ($value) {
             return $value[0] >= 2;
         });
 
@@ -2588,9 +2588,9 @@ class CollectionTest extends TestCase
 
         $collection = new Collection([['1', '2', '3', '4'], ['A', 'B', 'C'], ['name', 'surname', 'telephone']]);
 
-        $result = $collection->cartesianProduct(function ($value) {
+        $result = $collection->cartesianProduct(static function ($value) {
             return [$value[0] => [$value[1] => $value[2]]];
-        }, function ($value) {
+        }, static function ($value) {
             return $value[2] !== 'surname';
         });
 

--- a/tests/TestCase/Collection/Iterator/ExtractIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/ExtractIteratorTest.php
@@ -87,7 +87,7 @@ class ExtractIteratorTest extends TestCase
             ['a' => 1, 'b' => 2],
             ['a' => 3, 'b' => 4],
         ];
-        $extractor = new ExtractIterator($items, function ($item) {
+        $extractor = new ExtractIterator($items, static function ($item) {
             return $item['b'];
         });
         $this->assertEquals([2, 4], iterator_to_array($extractor));

--- a/tests/TestCase/Collection/Iterator/MapReduceTest.php
+++ b/tests/TestCase/Collection/Iterator/MapReduceTest.php
@@ -36,13 +36,13 @@ class MapReduceTest extends TestCase
             'document_2' => 'History is not only amazing but boring',
             'document_3' => 'One thing that is not boring is dogs',
         ];
-        $mapper = function ($row, $document, $mr): void {
+        $mapper = static function ($row, $document, $mr): void {
             $words = array_map('strtolower', explode(' ', $row));
             foreach ($words as $word) {
                 $mr->emitIntermediate($document, $word);
             }
         };
-        $reducer = function ($documents, $word, $mr): void {
+        $reducer = static function ($documents, $word, $mr): void {
             $mr->emit(array_unique($documents), $word);
         };
         $results = new MapReduce(new ArrayIterator($data), $mapper, $reducer);
@@ -74,13 +74,13 @@ class MapReduceTest extends TestCase
             'document_2' => 'one three',
             'document_3' => 'two four',
         ];
-        $mapper = function ($row, $document, $mr): void {
+        $mapper = static function ($row, $document, $mr): void {
             $words = array_map('strtolower', explode(' ', $row));
             foreach ($words as $word) {
                 $mr->emitIntermediate($document, $word, $document);
             }
         };
-        $reducer = function ($documents, $word, $mr): void {
+        $reducer = static function ($documents, $word, $mr): void {
             $mr->emit(array_unique($documents), $word);
         };
         $results = new MapReduce(new ArrayIterator($data), $mapper, $reducer);
@@ -99,7 +99,7 @@ class MapReduceTest extends TestCase
     public function testEmitFinalInMapper(): void
     {
         $data = ['a' => ['one', 'two'], 'b' => ['three', 'four']];
-        $mapper = function ($row, $key, $mr): void {
+        $mapper = static function ($row, $key, $mr): void {
             foreach ($row as $number) {
                 $mr->emit($number);
             }
@@ -116,7 +116,7 @@ class MapReduceTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $data = ['a' => ['one', 'two'], 'b' => ['three', 'four']];
-        $mapper = function ($row, $key, $mr): void {
+        $mapper = static function ($row, $key, $mr): void {
             foreach ($row as $number) {
                 $mr->emitIntermediate('a', $number);
             }

--- a/tests/TestCase/Collection/Iterator/SortIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/SortIteratorTest.php
@@ -40,7 +40,7 @@ class SortIteratorTest extends TestCase
     public function testSortNumbersIdentity(): void
     {
         $items = new ArrayObject([3, 5, 1, 2, 4]);
-        $identity = function ($a) {
+        $identity = static function ($a) {
             return $a;
         };
         $sorted = new SortIterator($items, $identity);
@@ -58,7 +58,7 @@ class SortIteratorTest extends TestCase
     public function testSortNumbersCustom(): void
     {
         $items = new ArrayObject([3, 5, 1, 2, 4]);
-        $callback = function ($a) {
+        $callback = static function ($a) {
             return $a * -1;
         };
         $sorted = new SortIterator($items, $callback);
@@ -81,7 +81,7 @@ class SortIteratorTest extends TestCase
             ['foo' => 2, 'bar' => 'a'],
             ['foo' => 13, 'bar' => 'a'],
         ]);
-        $callback = function ($a) {
+        $callback = static function ($a) {
             return $a['foo'];
         };
         $sorted = new SortIterator($items, $callback, SORT_DESC, SORT_NUMERIC);
@@ -114,7 +114,7 @@ class SortIteratorTest extends TestCase
             ['foo' => 'foo_2', 'bar' => 'a'],
             ['foo' => 'foo_13', 'bar' => 'a'],
         ]);
-        $callback = function ($a) {
+        $callback = static function ($a) {
             return $a['foo'];
         };
         $sorted = new SortIterator($items, $callback, SORT_DESC, SORT_NATURAL);
@@ -200,7 +200,7 @@ class SortIteratorTest extends TestCase
             new DateTimeImmutable('2013-08-12'),
         ]);
 
-        $callback = function ($a) {
+        $callback = static function ($a) {
             return $a->add(new DateInterval('P1Y'));
         };
         $sorted = new SortIterator($items, $callback);

--- a/tests/TestCase/Collection/Iterator/TreeIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/TreeIteratorTest.php
@@ -96,7 +96,7 @@ class TreeIteratorTest extends TestCase
         ];
         $items = new NestIterator($items, 'stuff');
         $result = (new TreeIterator($items))
-            ->printer(function ($element, $key, $iterator) {
+            ->printer(static function ($element, $key, $iterator) {
                 return ($iterator->getDepth() + 1 ) . '.' . $key . ' ' . $element['name'];
             }, null, '')
             ->toArray();

--- a/tests/TestCase/Command/Helper/ProgressHelperTest.php
+++ b/tests/TestCase/Command/Helper/ProgressHelperTest.php
@@ -91,7 +91,7 @@ class ProgressHelperTest extends TestCase
      */
     public function testOutputSuccess(): void
     {
-        $this->helper->output([function (ProgressHelper $progress): void {
+        $this->helper->output([static function (ProgressHelper $progress): void {
             $progress->increment(20);
         }]);
         $expected = [
@@ -119,7 +119,7 @@ class ProgressHelperTest extends TestCase
         $this->helper->output([
             'total' => 10,
             'width' => 20,
-            'callback' => function (ProgressHelper $progress): void {
+            'callback' => static function (ProgressHelper $progress): void {
                 $progress->increment(2);
             },
         ]);

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -140,7 +140,7 @@ class RoutesCommandTest extends TestCase
      */
     public function testRouteListSorted(): void
     {
-        Configure::write('TestApp.routes', function ($routes): void {
+        Configure::write('TestApp.routes', static function ($routes): void {
             $routes->connect(
                 new Route('/a/route/sorted', [], ['_name' => '_aRoute']),
             );
@@ -301,7 +301,7 @@ class RoutesCommandTest extends TestCase
 
     public function testGenerateNameWithColon(): void
     {
-        Configure::write('TestApp.routes', function ($routes): void {
+        Configure::write('TestApp.routes', static function ($routes): void {
             $routes->connect(
                 '/example/update',
                 ['controller' => 'Example', 'action' => 'update'],
@@ -328,7 +328,7 @@ class RoutesCommandTest extends TestCase
      */
     public function testRouteDuplicateWarning(): void
     {
-        Configure::write('TestApp.routes', function ($builder): void {
+        Configure::write('TestApp.routes', static function ($builder): void {
             $builder->connect(
                 new Route('/unique-path', [], ['_name' => '_aRoute']),
             );

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -460,7 +460,7 @@ class CommandRunnerTest extends TestCase
         $app->expects($this->once())
             ->method('pluginConsole')
             ->with($this->isinstanceOf(CommandCollection::class))
-            ->willReturnCallback(function ($commands) {
+            ->willReturnCallback(static function ($commands) {
                 return $commands;
             });
         $app->expects($this->once())->method('routes');

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -226,7 +226,7 @@ class ConsoleOptionParserTest extends TestCase
             'short' => 't',
         ]);
 
-        $this->deprecated(function () use ($parser): void {
+        $this->deprecated(static function () use ($parser): void {
             $parser->addOption('other', [
                 'short' => 't',
             ]);

--- a/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -176,7 +176,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     public function testExecWithMockServiceDependencies(): void
     {
-        $this->mockService(stdClass::class, function () {
+        $this->mockService(stdClass::class, static function () {
             return json_decode('{"console-mock":true}');
         });
         $this->exec('dependency');

--- a/tests/TestCase/Controller/Component/FormProtectionComponentTest.php
+++ b/tests/TestCase/Controller/Component/FormProtectionComponentTest.php
@@ -265,7 +265,7 @@ class FormProtectionComponentTest extends TestCase
 
     public function testCallbackReturnResponse(): void
     {
-        $this->FormProtection->setConfig('validationFailureCallback', function (FormProtectionException $exception) {
+        $this->FormProtection->setConfig('validationFailureCallback', static function (FormProtectionException $exception) {
             return new Response(['body' => 'from callback']);
         });
 
@@ -298,7 +298,7 @@ class FormProtectionComponentTest extends TestCase
         $this->expectException(NotFoundException::class);
         $this->expectExceptionMessage('error description');
 
-        $this->FormProtection->setConfig('validationFailureCallback', function (FormProtectionException $exception): void {
+        $this->FormProtection->setConfig('validationFailureCallback', static function (FormProtectionException $exception): void {
             throw new NotFoundException('error description');
         });
 

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -119,9 +119,9 @@ class ComponentTest extends TestCase
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('The `Banana` alias has already been loaded. The `property` key');
         $Collection = new ComponentRegistry(new Controller(new ServerRequest()));
-        $Collection->load('Banana', ['property' => ['closure' => function (): void {
+        $Collection->load('Banana', ['property' => ['closure' => static function (): void {
         }]]);
-        $Collection->load('Banana', ['property' => ['closure' => function (): void {
+        $Collection->load('Banana', ['property' => ['closure' => static function (): void {
         }]]);
 
         $this->assertInstanceOf(BananaComponent::class, $Collection->Banana, 'class is wrong');

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -912,7 +912,7 @@ class ControllerFactoryTest extends TestCase
      */
     public function testInvokeComponentFromContainer(): void
     {
-        $this->container->add(FlashComponent::class, function (ComponentRegistry $registry, array $config) {
+        $this->container->add(FlashComponent::class, static function (ComponentRegistry $registry, array $config) {
             return new FlashComponent($registry, $config);
         })
         ->addArgument(ComponentRegistry::class)

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -110,7 +110,7 @@ class ControllerTest extends TestCase
      */
     public function testUndefinedPropertyError(): void
     {
-        $this->expectNoticeMessageMatches('/Undefined property `Controller::\$Foo` in `.*` on line \d+/', function (): void {
+        $this->expectNoticeMessageMatches('/Undefined property `Controller::\$Foo` in `.*` on line \d+/', static function (): void {
             $controller = new Controller(new ServerRequest());
             $controller->Foo->baz();
         });
@@ -423,7 +423,7 @@ class ControllerTest extends TestCase
     {
         $Controller = new Controller(new ServerRequest());
 
-        $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $event): void {
+        $Controller->getEventManager()->on('Controller.beforeRender', static function (EventInterface $event): void {
             $controller = $event->getSubject();
             $controller->viewBuilder()->setClassName('Json');
         });
@@ -446,7 +446,7 @@ class ControllerTest extends TestCase
     {
         $Controller = new Controller(new ServerRequest());
 
-        $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $event): void {
+        $Controller->getEventManager()->on('Controller.beforeRender', static function (EventInterface $event): void {
             $event->stopPropagation();
         });
 
@@ -507,7 +507,7 @@ class ControllerTest extends TestCase
     {
         $Controller = new Controller(new ServerRequest());
 
-        $Controller->getEventManager()->on('Controller.beforeRedirect', function (EventInterface $event, $url, Response $response): void {
+        $Controller->getEventManager()->on('Controller.beforeRedirect', static function (EventInterface $event, $url, Response $response): void {
             $controller = $event->getSubject();
             $controller->setResponse($response->withLocation('https://book.cakephp.org'));
         });
@@ -524,7 +524,7 @@ class ControllerTest extends TestCase
     {
         $Controller = new Controller(new ServerRequest());
 
-        $Controller->getEventManager()->on('Controller.beforeRedirect', function (EventInterface $event, $url, Response $response): void {
+        $Controller->getEventManager()->on('Controller.beforeRedirect', static function (EventInterface $event, $url, Response $response): void {
             $controller = $event->getSubject();
             $controller->setResponse($response->withStatus(302));
         });
@@ -540,7 +540,7 @@ class ControllerTest extends TestCase
         $Controller = new Controller(new ServerRequest());
 
         $newResponse = new Response();
-        $Controller->getEventManager()->on('Controller.beforeRedirect', function (EventInterface $event, $url, Response $response) use ($newResponse): void {
+        $Controller->getEventManager()->on('Controller.beforeRedirect', static function (EventInterface $event, $url, Response $response) use ($newResponse): void {
             $event->setResult($newResponse);
         });
 
@@ -619,13 +619,13 @@ class ControllerTest extends TestCase
 
         $eventManager
             ->shouldHaveReceived('dispatch')
-            ->withArgs(function ($event) {
+            ->withArgs(static function ($event) {
                 return $event->getName() === 'Controller.initialize';
             });
 
         $eventManager
             ->shouldHaveReceived('dispatch')
-            ->withArgs(function ($event) {
+            ->withArgs(static function ($event) {
                 return $event->getName() === 'Controller.startup';
             });
     }
@@ -641,7 +641,7 @@ class ControllerTest extends TestCase
 
         $eventManager->shouldHaveReceived('dispatch')
             ->once()
-            ->withArgs(function ($event) {
+            ->withArgs(static function ($event) {
                 return $event->getName() === 'Controller.shutdown';
             });
     }
@@ -911,7 +911,7 @@ class ControllerTest extends TestCase
             'params' => ['prefix' => 'Admin'],
         ]);
         $Controller = new AdminPostsController($request);
-        $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $e): void {
+        $Controller->getEventManager()->on('Controller.beforeRender', static function (EventInterface $e): void {
             $e->setResult($e->getSubject()->getResponse());
         });
         $Controller->render();
@@ -919,7 +919,7 @@ class ControllerTest extends TestCase
 
         $request = $request->withParam('prefix', 'admin/super');
         $Controller = new AdminPostsController($request);
-        $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $e): void {
+        $Controller->getEventManager()->on('Controller.beforeRender', static function (EventInterface $e): void {
             $e->setResult($e->getSubject()->getResponse());
         });
         $Controller->render();
@@ -932,7 +932,7 @@ class ControllerTest extends TestCase
             ],
         ]);
         $Controller = new PagesController($request);
-        $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $e): void {
+        $Controller->getEventManager()->on('Controller.beforeRender', static function (EventInterface $e): void {
             $e->setResult($e->getSubject()->getResponse());
         });
         $Controller->render();
@@ -993,7 +993,7 @@ class ControllerTest extends TestCase
     public function testLoadComponentWithContainer(): void
     {
         $container = new Container();
-        $container->add(FlashComponent::class, function (ComponentRegistry $registry, array $config) {
+        $container->add(FlashComponent::class, static function (ComponentRegistry $registry, array $config) {
             return new FlashComponent($registry, $config);
         })
         ->addArgument(ComponentRegistry::class)
@@ -1030,7 +1030,7 @@ class ControllerTest extends TestCase
     {
         $controller = new AdminPostsController(new ServerRequest());
 
-        $controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $event): void {
+        $controller->getEventManager()->on('Controller.beforeRender', static function (EventInterface $event): void {
             /** @var \Cake\Controller\Controller $controller */
             $controller = $event->getSubject();
 

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -55,7 +55,7 @@ class AppTest extends TestCase
     {
         static::setAppNamespace();
         $i = 0;
-        TestApp::$existsInBaseCallback = function ($name, $namespace) use ($existsInBase, $class, $expected, &$i) {
+        TestApp::$existsInBaseCallback = static function ($name, $namespace) use ($existsInBase, $class, $expected, &$i) {
             if ($i++ === 0) {
                 return $existsInBase;
             }

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -217,7 +217,7 @@ class BasePluginTest extends TestCase
         {
             public function events(EventManagerInterface $eventManager): EventManagerInterface
             {
-                $eventManager->on('testTrue', function ($event) {
+                $eventManager->on('testTrue', static function ($event) {
                     return true;
                 });
 
@@ -244,7 +244,7 @@ class BasePluginTest extends TestCase
         {
             public function events(EventManagerInterface $eventManager): EventManagerInterface
             {
-                $eventManager->on('testTrue', function ($event) {
+                $eventManager->on('testTrue', static function ($event) {
                     return true;
                 });
 

--- a/tests/TestCase/Core/FunctionsGlobalTest.php
+++ b/tests/TestCase/Core/FunctionsGlobalTest.php
@@ -269,7 +269,7 @@ class FunctionsGlobalTest extends TestCase
      */
     public function testDeprecationWarningEnabled(): void
     {
-        $error = $this->captureError(E_ALL, function (): void {
+        $error = $this->captureError(E_ALL, static function (): void {
             deprecationWarning('4.5.0', 'This is deprecated ' . uniqid(), 2);
         });
         $this->assertMatchesRegularExpression(
@@ -283,7 +283,7 @@ class FunctionsGlobalTest extends TestCase
      */
     public function testDeprecationWarningEnabledDefaultFrame(): void
     {
-        $error = $this->captureError(E_ALL, function (): void {
+        $error = $this->captureError(E_ALL, static function (): void {
             deprecationWarning('5.0.0', 'This is going away too ' . uniqid());
         });
         $this->assertMatchesRegularExpression(
@@ -300,7 +300,7 @@ class FunctionsGlobalTest extends TestCase
         $this->expectNotToPerformAssertions();
 
         Configure::write('Error.ignoredDeprecationPaths', ['src/TestSuite/*']);
-        $this->withErrorReporting(E_ALL, function (): void {
+        $this->withErrorReporting(E_ALL, static function (): void {
             deprecationWarning('5.0.1', 'This will be gone soon');
         });
     }
@@ -312,7 +312,7 @@ class FunctionsGlobalTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
 
-        $this->withErrorReporting(E_ALL ^ E_USER_DEPRECATED, function (): void {
+        $this->withErrorReporting(E_ALL ^ E_USER_DEPRECATED, static function (): void {
             deprecationWarning('5.0.0', 'This is leaving');
         });
     }

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -329,7 +329,7 @@ class FunctionsTest extends TestCase
     public function testDeprecationWarningEnabled(): void
     {
         $this->expectDeprecationMessageMatches('/Since 5.0.0: This is going away\n(.*?)[\/\\\]FunctionsTest.php, line\: \d+/', function (): void {
-            $this->withErrorReporting(E_ALL, function (): void {
+            $this->withErrorReporting(E_ALL, static function (): void {
                 deprecationWarning('5.0.0', 'This is going away', 2);
             });
         });
@@ -341,7 +341,7 @@ class FunctionsTest extends TestCase
     public function testDeprecationWarningEnabledDefaultFrame(): void
     {
         $this->expectDeprecationMessageMatches('/Since 5.0.0: This is going away too\n(.*?)[\/\\\]TestCase.php, line\: \d+/', function (): void {
-            $this->withErrorReporting(E_ALL, function (): void {
+            $this->withErrorReporting(E_ALL, static function (): void {
                 deprecationWarning('5.0.0', 'This is going away too');
             });
         });
@@ -355,7 +355,7 @@ class FunctionsTest extends TestCase
         $this->expectNotToPerformAssertions();
 
         Configure::write('Error.ignoredDeprecationPaths', ['src/TestSuite/*']);
-        $this->withErrorReporting(E_ALL, function (): void {
+        $this->withErrorReporting(E_ALL, static function (): void {
             deprecationWarning('5.0.0', 'This will be gone soon');
         });
     }
@@ -367,7 +367,7 @@ class FunctionsTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
 
-        $this->withErrorReporting(E_ALL ^ E_USER_DEPRECATED, function (): void {
+        $this->withErrorReporting(E_ALL ^ E_USER_DEPRECATED, static function (): void {
             deprecationWarning('5.0.0', 'This is leaving');
         });
     }

--- a/tests/TestCase/Core/PluginCollectionTest.php
+++ b/tests/TestCase/Core/PluginCollectionTest.php
@@ -168,7 +168,7 @@ class PluginCollectionTest extends TestCase
     {
         $this->expectDeprecationMessageMatches(
             '#You can create the missing class using `bin/cake bake plugin TestPluginTwo --class-only`#',
-            function (): void {
+            static function (): void {
                 $plugins = new PluginCollection();
                 $plugins->create('TestPluginTwo');
             },

--- a/tests/TestCase/Core/Retry/CommandRetryTest.php
+++ b/tests/TestCase/Core/Retry/CommandRetryTest.php
@@ -31,7 +31,7 @@ class CommandRetryTest extends TestCase
     public function testRetry(): void
     {
         $count = 0;
-        $action = function () use (&$count) {
+        $action = static function () use (&$count) {
             if ($count < 2) {
                 ++$count;
                 throw new Exception('this is failing');
@@ -51,7 +51,7 @@ class CommandRetryTest extends TestCase
     public function testExceedAttempts(): void
     {
         $count = 0;
-        $action = function () use (&$count) {
+        $action = static function () use (&$count) {
             if ($count < 2) {
                 ++$count;
                 throw new Exception('this is failing');
@@ -72,7 +72,7 @@ class CommandRetryTest extends TestCase
      */
     public function testRespectStrategy(): void
     {
-        $action = function (): void {
+        $action = static function (): void {
             throw new Exception('this is failing');
         };
 

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -1050,7 +1050,7 @@ class ConnectionTest extends TestCase
     public function testNestedTransactionRollbackExceptionNotThrown(): void
     {
         $this->connection->transactional(function () {
-            $this->connection->transactional(function () {
+            $this->connection->transactional(static function () {
                 return true;
             });
 
@@ -1059,7 +1059,7 @@ class ConnectionTest extends TestCase
         $this->assertFalse($this->connection->inTransaction());
 
         $this->connection->transactional(function () {
-            $this->connection->transactional(function () {
+            $this->connection->transactional(static function () {
                 return true;
             });
 
@@ -1068,7 +1068,7 @@ class ConnectionTest extends TestCase
         $this->assertFalse($this->connection->inTransaction());
 
         $this->connection->transactional(function () {
-            $this->connection->transactional(function () {
+            $this->connection->transactional(static function () {
                 return false;
             });
 
@@ -1088,7 +1088,7 @@ class ConnectionTest extends TestCase
         $e = null;
         try {
             $this->connection->transactional(function () {
-                $this->connection->transactional(function () {
+                $this->connection->transactional(static function () {
                     return false;
                 });
                 $this->rollbackSourceLine = __LINE__ - 1;
@@ -1122,14 +1122,14 @@ class ConnectionTest extends TestCase
             $this->connection->transactional(function () {
                 $this->pushNestedTransactionState();
 
-                $this->connection->transactional(function () {
+                $this->connection->transactional(static function () {
                     return true;
                 });
 
                 $this->connection->transactional(function () {
                     $this->pushNestedTransactionState();
 
-                    $this->connection->transactional(function () {
+                    $this->connection->transactional(static function () {
                         return false;
                     });
                     $this->rollbackSourceLine = __LINE__ - 1;
@@ -1142,7 +1142,7 @@ class ConnectionTest extends TestCase
                     return true;
                 });
 
-                $this->connection->transactional(function () {
+                $this->connection->transactional(static function () {
                     return false;
                 });
 

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -173,7 +173,7 @@ class SqliteTest extends TestCase
             ->shouldAllowMockingMethod('quoteIdentifier')
             ->makePartial();
         $mock->shouldReceive('quote')
-            ->andReturnUsing(function ($value) {
+            ->andReturnUsing(static function ($value) {
                 return '"' . $value . '"';
             });
 

--- a/tests/TestCase/Database/Expression/AggregateExpressionTest.php
+++ b/tests/TestCase/Database/Expression/AggregateExpressionTest.php
@@ -57,7 +57,7 @@ class AggregateExpressionTest extends FunctionExpressionTest
             $f->sql(new ValueBinder()),
         );
 
-        $f->filter(function (QueryExpression $q) {
+        $f->filter(static function (QueryExpression $q) {
             return $q->add(['this2' => new IdentifierExpression('that2')]);
         });
         $this->assertEqualsSql(
@@ -172,7 +172,7 @@ class AggregateExpressionTest extends FunctionExpressionTest
             ->over();
 
         $expressions = [];
-        $w->traverse(function ($expression) use (&$expressions): void {
+        $w->traverse(static function ($expression) use (&$expressions): void {
             $expressions[] = $expression;
         });
 

--- a/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
@@ -319,7 +319,7 @@ class CaseStatementExpressionTest extends TestCase
     {
         $expression = (new CaseStatementExpressionStub())
             ->setTypeMap(new TypeMap(['Table.column' => 'boolean']))
-            ->when(function (WhenThenExpression $whenThen) {
+            ->when(static function (WhenThenExpression $whenThen) {
                 return $whenThen;
             });
 
@@ -468,12 +468,12 @@ class CaseStatementExpressionTest extends TestCase
 
         $expression = (new CaseStatementExpression())
             ->setTypeMap($typeMap)
-            ->when(function (WhenThenExpression $whenThen) {
+            ->when(static function (WhenThenExpression $whenThen) {
                 return $whenThen
                     ->when(['Table.column_a' => true])
                     ->then(1);
             })
-            ->when(function (WhenThenExpression $whenThen) {
+            ->when(static function (WhenThenExpression $whenThen) {
                 return $whenThen
                     ->when(['Table.column_b' => 'foo'])
                     ->then(2);
@@ -527,12 +527,12 @@ class CaseStatementExpressionTest extends TestCase
 
         $expression = (new CaseStatementExpression())
             ->setTypeMap($typeMap)
-            ->when(function (WhenThenExpression $whenThen) {
+            ->when(static function (WhenThenExpression $whenThen) {
                 return $whenThen
                     ->when(['Table.column_a' => 123], ['Table.column_a' => 'integer'])
                     ->then(1);
             })
-            ->when(function (WhenThenExpression $whenThen) {
+            ->when(static function (WhenThenExpression $whenThen) {
                 return $whenThen
                     ->when(['Table.column_b' => 'foo'])
                     ->then(2);
@@ -1034,7 +1034,7 @@ class CaseStatementExpressionTest extends TestCase
     public function testWhenGetThenClause(): void
     {
         $expression = (new CaseStatementExpression())
-            ->when(function (WhenThenExpression $whenThen) {
+            ->when(static function (WhenThenExpression $whenThen) {
                 return $whenThen;
             });
 
@@ -1120,7 +1120,7 @@ class CaseStatementExpressionTest extends TestCase
     public function testWhenCallables(): void
     {
         $expression = (new CaseStatementExpression())
-            ->when(function (WhenThenExpression $whenThen) {
+            ->when(static function (WhenThenExpression $whenThen) {
                 return $whenThen
                     ->when([
                         'Table.column_a' => true,
@@ -1128,7 +1128,7 @@ class CaseStatementExpressionTest extends TestCase
                     ])
                     ->then(1);
             })
-            ->when(function (WhenThenExpression $whenThen) {
+            ->when(static function (WhenThenExpression $whenThen) {
                 return $whenThen
                     ->when([
                         'Table.column_c' => true,
@@ -1153,7 +1153,7 @@ class CaseStatementExpressionTest extends TestCase
     public function testWhenCallablesWithCustomWhenThenExpressions(): void
     {
         $expression = (new CaseStatementExpression())
-            ->when(function () {
+            ->when(static function () {
                 return (new CustomWhenThenExpression())
                     ->when([
                         'Table.column_a' => true,
@@ -1161,7 +1161,7 @@ class CaseStatementExpressionTest extends TestCase
                     ])
                     ->then(1);
             })
-            ->when(function () {
+            ->when(static function () {
                 return (new CustomWhenThenExpression())
                     ->when([
                         'Table.column_c' => true,
@@ -1191,9 +1191,9 @@ class CaseStatementExpressionTest extends TestCase
             '`\Cake\Database\Expression\WhenThenExpression`, `null` given.',
         );
 
-        $this->deprecated(function (): void {
+        $this->deprecated(static function (): void {
             (new CaseStatementExpression())
-                ->when(function () {
+                ->when(static function () {
                     return null;
                 });
         });
@@ -1278,7 +1278,7 @@ class CaseStatementExpressionTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Case expression must have at least one when statement.');
 
-        $this->deprecated(function (): void {
+        $this->deprecated(static function (): void {
             (new CaseStatementExpression())->sql(new ValueBinder());
         });
     }
@@ -1288,7 +1288,7 @@ class CaseStatementExpressionTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Case expression has incomplete when clause. Missing `then()` after `when()`.');
 
-        $this->deprecated(function (): void {
+        $this->deprecated(static function (): void {
             (new CaseStatementExpression())
                 ->when(['Table.column' => true])
                 ->sql(new ValueBinder());
@@ -1300,9 +1300,9 @@ class CaseStatementExpressionTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Case expression has incomplete when clause. Missing `when()`.');
 
-        $this->deprecated(function (): void {
+        $this->deprecated(static function (): void {
             (new CaseStatementExpression())
-                ->when(function (WhenThenExpression $whenThen) {
+                ->when(static function (WhenThenExpression $whenThen) {
                     return $whenThen->then(1);
                 })
                 ->sql(new ValueBinder());
@@ -1314,9 +1314,9 @@ class CaseStatementExpressionTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Case expression has incomplete when clause. Missing `then()` after `when()`.');
 
-        $this->deprecated(function (): void {
+        $this->deprecated(static function (): void {
             (new CaseStatementExpression())
-                ->when(function (WhenThenExpression $whenThen) {
+                ->when(static function (WhenThenExpression $whenThen) {
                     return $whenThen->when(1);
                 })
                 ->sql(new ValueBinder());
@@ -1847,7 +1847,7 @@ class CaseStatementExpressionTest extends TestCase
         return [
             [[], 'array'],
             [
-                function (): void {
+                static function (): void {
                 },
                 'Closure',
             ],
@@ -1891,7 +1891,7 @@ class CaseStatementExpressionTest extends TestCase
         return [
             [[], 'array'],
             [
-                function (): void {
+                static function (): void {
                 },
                 'Closure',
             ],
@@ -1927,7 +1927,7 @@ class CaseStatementExpressionTest extends TestCase
             [1.0],
             [new stdClass()],
             [
-                function (): void {
+                static function (): void {
                 },
             ],
             [$res], // resource (closed)
@@ -1955,7 +1955,7 @@ class CaseStatementExpressionTest extends TestCase
         return [
             [[], 'array'],
             [
-                function (): void {
+                static function (): void {
                 },
                 'Closure',
             ],
@@ -1993,7 +1993,7 @@ class CaseStatementExpressionTest extends TestCase
             [new stdClass()],
             [
                 // Closure
-                function (): void {
+                static function (): void {
                 },
             ],
             [
@@ -2037,7 +2037,7 @@ class CaseStatementExpressionTest extends TestCase
             ->else($else);
 
         $expressions = [];
-        $expression->traverse(function ($expression) use (&$expressions): void {
+        $expression->traverse(static function ($expression) use (&$expressions): void {
             $expressions[] = $expression;
         });
 
@@ -2060,12 +2060,12 @@ class CaseStatementExpressionTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Case expression has incomplete when clause. Missing `then()` after `when()`.');
 
-        $this->deprecated(function (): void {
+        $this->deprecated(static function (): void {
             $expression = (new CaseStatementExpression())
                 ->when(['Table.column' => true]);
 
             $expression->traverse(
-                function (): void {
+                static function (): void {
                 },
             );
         });
@@ -2101,7 +2101,7 @@ class CaseStatementExpressionTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Case expression has incomplete when clause. Missing `then()` after `when()`.');
 
-        $this->deprecated(function (): void {
+        $this->deprecated(static function (): void {
             $expression = (new CaseStatementExpression())
                 ->when(['Table.column' => true]);
 

--- a/tests/TestCase/Database/Expression/CommonTableExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CommonTableExpressionTest.php
@@ -114,7 +114,7 @@ class CommonTableExpressionTest extends TestCase
         $cte = (new CommonTableExpression('test', $query))->field('field');
 
         $expressions = [];
-        $cte->traverse(function ($expression) use (&$expressions): void {
+        $cte->traverse(static function ($expression) use (&$expressions): void {
             $expressions[] = $expression;
         });
 

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -164,7 +164,7 @@ class QueryExpressionTest extends TestCase
         $this->assertEquals($dupe, $expr);
         $this->assertNotSame($dupe, $expr);
         $originalParts = [];
-        $expr->iterateParts(function ($part) use (&$originalParts): void {
+        $expr->iterateParts(static function ($part) use (&$originalParts): void {
             $originalParts[] = $part;
         });
         $dupe->iterateParts(function ($part, $i) use ($originalParts): void {

--- a/tests/TestCase/Database/Expression/TupleComparisonTest.php
+++ b/tests/TestCase/Database/Expression/TupleComparisonTest.php
@@ -97,7 +97,7 @@ class TupleComparisonTest extends TestCase
         $f = new TupleComparison(['field1', $field2], [$value1, 2], ['integer', 'integer'], '=');
         $expressions = [];
 
-        $collector = function ($e) use (&$expressions): void {
+        $collector = static function ($e) use (&$expressions): void {
             $expressions[] = $e;
         };
 

--- a/tests/TestCase/Database/Expression/WindowExpressionTest.php
+++ b/tests/TestCase/Database/Expression/WindowExpressionTest.php
@@ -64,7 +64,7 @@ class WindowExpressionTest extends TestCase
             $w->sql(new ValueBinder()),
         );
 
-        $w = (new WindowExpression())->partition(function (QueryExpression $expr) {
+        $w = (new WindowExpression())->partition(static function (QueryExpression $expr) {
             return $expr->add(new AggregateExpression('MyAggregate', ['param']));
         });
         $this->assertEqualsSql(
@@ -97,10 +97,10 @@ class WindowExpressionTest extends TestCase
         );
 
         $w = (new WindowExpression())
-            ->orderBy(function () {
+            ->orderBy(static function () {
                 return 'test';
             })
-            ->orderBy(function (QueryExpression $expr) {
+            ->orderBy(static function (QueryExpression $expr) {
                 return [$expr->add('test2'), new OrderClauseExpression(new IdentifierExpression('test3'), 'DESC')];
             });
         $this->assertEqualsSql(
@@ -414,7 +414,7 @@ class WindowExpressionTest extends TestCase
             ->range(new QueryExpression("'1 day'"));
 
         $expressions = [];
-        $w->traverse(function ($expression) use (&$expressions): void {
+        $w->traverse(static function ($expression) use (&$expressions): void {
             $expressions[] = $expression;
         });
 
@@ -426,7 +426,7 @@ class WindowExpressionTest extends TestCase
         $w->range(new QueryExpression("'1 day'"), new QueryExpression("'10 days'"));
 
         $expressions = [];
-        $w->traverse(function ($expression) use (&$expressions): void {
+        $w->traverse(static function ($expression) use (&$expressions): void {
             $expressions[] = $expression;
         });
 

--- a/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
@@ -136,7 +136,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
     {
         $this->_insert();
         $result = $this->connection->selectQuery(fields: 'id', table: 'ordered_uuid_items')
-            ->where(function (QueryExpression $exp) {
+            ->where(static function (QueryExpression $exp) {
                 return $exp->between(
                     'id',
                     '482b7756-8da0-419a-b21f-27da40cf8569',
@@ -157,7 +157,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
     {
         $this->_insert();
         $result = $this->connection->selectQuery(fields: 'id', table: 'ordered_uuid_items')
-            ->where(function (QueryExpression $exp, Query $q) {
+            ->where(static function (QueryExpression $exp, Query $q) {
                 return $exp->eq(
                     'id',
                     $q->func()->concat(['48298a29-81c0-4c26-a7fb', '-413140cf8569'], []),

--- a/tests/TestCase/Database/ExpressionTypeCastingTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingTest.php
@@ -53,7 +53,7 @@ class ExpressionTypeCastingTest extends TestCase
         $this->assertSame('the thing', $binder->bindings()[':param0']['value']);
 
         $found = false;
-        $comparison->traverse(function ($exp) use (&$found): void {
+        $comparison->traverse(static function ($exp) use (&$found): void {
             $found = $exp instanceof FunctionExpression;
         });
         $this->assertTrue($found, 'The expression is not included in the tree');
@@ -73,7 +73,7 @@ class ExpressionTypeCastingTest extends TestCase
         $this->assertSame('3', $binder->bindings()[':param2']['value']);
 
         $found = false;
-        $comparison->traverse(function ($exp) use (&$found): void {
+        $comparison->traverse(static function ($exp) use (&$found): void {
             $found = $exp instanceof FunctionExpression;
         });
         $this->assertTrue($found, 'The expression is not included in the tree');
@@ -92,7 +92,7 @@ class ExpressionTypeCastingTest extends TestCase
         $this->assertSame('to', $binder->bindings()[':param2']['value']);
 
         $expressions = [];
-        $between->traverse(function ($exp) use (&$expressions): void {
+        $between->traverse(static function ($exp) use (&$expressions): void {
             $expressions[] = $exp instanceof FunctionExpression ? 1 : 0;
         });
 
@@ -112,7 +112,7 @@ class ExpressionTypeCastingTest extends TestCase
         $this->assertSame('2016-01', $binder->bindings()[':param0']['value']);
 
         $expressions = [];
-        $function->traverse(function ($exp) use (&$expressions): void {
+        $function->traverse(static function ($exp) use (&$expressions): void {
             $expressions[] = $exp instanceof FunctionExpression ? 1 : 0;
         });
 
@@ -139,7 +139,7 @@ class ExpressionTypeCastingTest extends TestCase
         $this->assertSame('bar', $binder->bindings()[':param2']['value']);
 
         $expressions = [];
-        $values->traverse(function ($exp) use (&$expressions): void {
+        $values->traverse(static function ($exp) use (&$expressions): void {
             $expressions[] = $exp instanceof FunctionExpression ? 1 : 0;
         });
 

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -822,7 +822,7 @@ class SelectQueryTest extends TestCase
         $query
             ->select(['id'])
             ->from('comments')
-            ->where(function ($exp, $q) {
+            ->where(static function ($exp, $q) {
                 return $exp->in($q->expr('SELECT 1'), []);
             })
             ->execute();
@@ -884,7 +884,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->eq('id', 1);
             })
             ->execute();
@@ -897,7 +897,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp
                     ->eq('id', 1)
                     ->eq('created', new DateTime('2007-03-18 10:45:23'), 'datetime');
@@ -912,7 +912,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp
                     ->eq('id', 1)
                     ->eq('created', new DateTime('2021-12-30 15:00'), 'datetime');
@@ -933,7 +933,7 @@ class SelectQueryTest extends TestCase
             ->where([
                 'OR' => [
                     'id' => 1,
-                    function (ExpressionInterface $exp) {
+                    static function (ExpressionInterface $exp) {
                         return $exp->eq('id', 2);
                     },
                 ],
@@ -958,7 +958,7 @@ class SelectQueryTest extends TestCase
             ->select(['id'])
             ->from('comments')
             ->where(['id' => '1'])
-            ->andWhere(function (ExpressionInterface $exp) {
+            ->andWhere(static function (ExpressionInterface $exp) {
                 return $exp->eq('created', new DateTime('2007-03-18 10:45:23'), 'datetime');
             })
             ->execute();
@@ -972,7 +972,7 @@ class SelectQueryTest extends TestCase
             ->select(['id'])
             ->from('comments')
             ->where(['id' => '1'])
-            ->andWhere(function (ExpressionInterface $exp) {
+            ->andWhere(static function (ExpressionInterface $exp) {
                 return $exp->eq('created', new DateTime('2022-12-21 12:00'), 'datetime');
             })
             ->execute();
@@ -990,7 +990,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 $field = clone $exp;
                 $field->add('SELECT min(id) FROM comments');
 
@@ -1011,7 +1011,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['title'])
             ->from('articles')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->gt('id', 1);
             })
             ->execute();
@@ -1023,7 +1023,7 @@ class SelectQueryTest extends TestCase
         $query = new SelectQuery($this->connection);
         $result = $query->select(['title'])
             ->from('articles')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->lt('id', 2);
             })
             ->execute();
@@ -1035,7 +1035,7 @@ class SelectQueryTest extends TestCase
         $query = new SelectQuery($this->connection);
         $result = $query->select(['title'])
             ->from('articles')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->lte('id', 2);
             })
             ->execute();
@@ -1046,7 +1046,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['title'])
             ->from('articles')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->gte('id', 1);
             })
             ->execute();
@@ -1057,7 +1057,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['title'])
             ->from('articles')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->lte('id', 1);
             })
             ->execute();
@@ -1068,7 +1068,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['title'])
             ->from('articles')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->notEq('id', 2);
             })
             ->execute();
@@ -1081,7 +1081,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['title'])
             ->from('articles')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->like('title', 'First Article');
             })
             ->execute();
@@ -1094,7 +1094,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['title'])
             ->from('articles')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->like('title', '%Article%');
             })
             ->execute();
@@ -1105,7 +1105,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['title'])
             ->from('articles')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->notLike('title', '%Article%');
             })
             ->execute();
@@ -1116,7 +1116,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->isNull('published');
             })
             ->execute();
@@ -1127,7 +1127,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->isNotNull('published');
             })
             ->execute();
@@ -1138,7 +1138,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->in('published', ['Y', 'N']);
             })
             ->execute();
@@ -1149,7 +1149,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->in(
                     'created',
                     [new DateTime('2007-03-18 10:45:23'), new DateTime('2007-03-18 10:47:23')],
@@ -1167,7 +1167,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->notIn(
                     'created',
                     [new DateTime('2007-03-18 10:45:23'), new DateTime('2007-03-18 10:47:23')],
@@ -1190,7 +1190,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->in('created', '2007-03-18 10:45:23', 'datetime');
             })
             ->execute();
@@ -1203,7 +1203,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->notIn('created', '2007-03-18 10:45:23', 'datetime');
             })
             ->execute();
@@ -1219,7 +1219,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function ($exp, $q) {
+            ->where(static function ($exp, $q) {
                 return $exp->in(
                     'created',
                     $q->expr("'2007-03-18 10:45:23'"),
@@ -1236,7 +1236,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function ($exp, $q) {
+            ->where(static function ($exp, $q) {
                 return $exp->notIn(
                     'created',
                     $q->expr("'2007-03-18 10:45:23'"),
@@ -1303,7 +1303,7 @@ class SelectQueryTest extends TestCase
             ->where([
                 'id' => 'Cake\Error\Debugger::dump',
                 'title' => ['Cake\Error\Debugger', 'dump'],
-                'author_id' => function (ExpressionInterface $exp) {
+                'author_id' => static function (ExpressionInterface $exp) {
                     return 1;
                 },
             ]);
@@ -1339,7 +1339,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->between('id', 5, 6, 'integer');
             })
             ->execute();
@@ -1362,7 +1362,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 $from = new DateTime('2007-03-18 10:51:00');
                 $to = new DateTime('2007-03-18 10:54:00');
 
@@ -1388,7 +1388,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function ($exp, $q) {
+            ->where(static function ($exp, $q) {
                 $field = $q->func()->coalesce([new IdentifierExpression('id'), 1 => 'literal']);
 
                 return $exp->between($field, 5, 6, 'integer');
@@ -1413,7 +1413,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp, Query $q) {
+            ->where(static function (ExpressionInterface $exp, Query $q) {
                 $from = $q->expr("'2007-03-18 10:51:00'");
                 $to = $q->expr("'2007-03-18 10:54:00'");
 
@@ -1438,7 +1438,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 $and = $exp->and(['id' => 2, 'id >' => 1]);
 
                 return $exp->add($and);
@@ -1453,7 +1453,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 $and = $exp->and(['id' => 2, 'id <' => 2]);
 
                 return $exp->add($and);
@@ -1466,8 +1466,8 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
-                $and = $exp->and(function ($and) {
+            ->where(static function (ExpressionInterface $exp) {
+                $and = $exp->and(static function ($and) {
                     return $and->eq('id', 1)->gt('id', 0);
                 });
 
@@ -1483,7 +1483,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 $or = $exp->or(['id' => 1]);
                 $and = $exp->and(['id >' => 2, 'id <' => 4]);
 
@@ -1500,8 +1500,8 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
-                $or = $exp->or(function ($or) {
+            ->where(static function (ExpressionInterface $exp) {
+                $or = $exp->or(static function ($or) {
                     return $or->eq('id', 1)->eq('id', 2);
                 });
 
@@ -1525,7 +1525,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->not(
                     $exp->and(['id' => 2, 'created' => new DateTime('2007-03-18 10:47:23')], ['created' => 'datetime']),
                 );
@@ -1541,7 +1541,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->not(
                     $exp->and(['id' => 2, 'created' => new DateTime('2012-12-21 12:00')], ['created' => 'datetime']),
                 );
@@ -1851,7 +1851,7 @@ class SelectQueryTest extends TestCase
         $query
             ->select('*')
             ->from('articles')
-            ->orderBy(function (ExpressionInterface $exp) {
+            ->orderBy(static function (ExpressionInterface $exp) {
                 return [$exp->add(['id % 2 = 0']), 'title' => 'ASC'];
             });
 
@@ -1865,7 +1865,7 @@ class SelectQueryTest extends TestCase
         $query
             ->select('*')
             ->from('articles')
-            ->orderBy(function (ExpressionInterface $exp) {
+            ->orderBy(static function (ExpressionInterface $exp) {
                 return $exp->add('a + b');
             });
 
@@ -1879,7 +1879,7 @@ class SelectQueryTest extends TestCase
         $query
             ->select('*')
             ->from('articles')
-            ->orderBy(function ($exp, $q) {
+            ->orderBy(static function ($exp, $q) {
                 return $q->func()->sum('a');
             });
 
@@ -1930,7 +1930,7 @@ class SelectQueryTest extends TestCase
         $query = new SelectQuery($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->orderByAsc(function (QueryExpression $exp, Query $query) {
+            ->orderByAsc(static function (QueryExpression $exp, Query $query) {
                 return $exp
                     ->case()
                     ->when(['author_id' => 1])
@@ -1992,7 +1992,7 @@ class SelectQueryTest extends TestCase
         $query = new SelectQuery($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->orderByDesc(function (QueryExpression $exp, Query $query) {
+            ->orderByDesc(static function (QueryExpression $exp, Query $query) {
                 return $exp
                     ->case()
                     ->when(['author_id' => 1])
@@ -2199,7 +2199,7 @@ class SelectQueryTest extends TestCase
         $expected = [['total' => 2, 'author_id' => 1]];
         $this->assertEquals($expected, $result->fetchAll('assoc'));
 
-        $result = $query->having(function ($e) {
+        $result = $query->having(static function ($e) {
             return $e->add('count(author_id) = 1 + 1');
         }, [], true)
             ->execute();
@@ -2242,7 +2242,7 @@ class SelectQueryTest extends TestCase
             ->from('articles')
             ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->expr()->equalFields('author_id', 'a.id')])
             ->groupBy('author_id')
-            ->andHaving(function ($e) {
+            ->andHaving(static function ($e) {
                 return $e->add('count(author_id) = 2 - 1');
             })
             ->execute();
@@ -2550,13 +2550,13 @@ class SelectQueryTest extends TestCase
         $subQuery = (new SelectQuery($this->connection))
             ->select(['id'])
             ->from('articles')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->equalFields('authors.id', 'articles.author_id');
             });
         $result = $query
             ->select(['id'])
             ->from('authors')
-            ->where(function ($exp) use ($subQuery) {
+            ->where(static function ($exp) use ($subQuery) {
                 return $exp->exists($subQuery);
             })
             ->execute();
@@ -2569,13 +2569,13 @@ class SelectQueryTest extends TestCase
         $subQuery = (new SelectQuery($this->connection))
             ->select(['id'])
             ->from('articles')
-            ->where(function (ExpressionInterface $exp) {
+            ->where(static function (ExpressionInterface $exp) {
                 return $exp->equalFields('authors.id', 'articles.author_id');
             });
         $result = $query
             ->select(['id'])
             ->from('authors')
-            ->where(function ($exp) use ($subQuery) {
+            ->where(static function ($exp) use ($subQuery) {
                 return $exp->notExists($subQuery);
             })
             ->execute();
@@ -2829,7 +2829,7 @@ class SelectQueryTest extends TestCase
             ->select(['id', 'title'])
             ->from('articles')
             ->orderBy(['id' => 'ASC'])
-            ->decorateResults(function ($row) {
+            ->decorateResults(static function ($row) {
                 $row['modified_id'] = $row['id'] + 1;
 
                 return $row;
@@ -2841,7 +2841,7 @@ class SelectQueryTest extends TestCase
         }
 
         $result = $query
-            ->decorateResults(function ($row) {
+            ->decorateResults(static function ($row) {
                 $row['modified_id']--;
 
                 return $row;
@@ -2853,7 +2853,7 @@ class SelectQueryTest extends TestCase
         }
 
         $result = $query
-            ->decorateResults(function ($row) {
+            ->decorateResults(static function ($row) {
                 $row['foo'] = 'bar';
 
                 return $row;
@@ -2879,7 +2879,7 @@ class SelectQueryTest extends TestCase
         $query
             ->select(['id', 'title'])
             ->from('articles')
-            ->decorateResults(function ($row) {
+            ->decorateResults(static function ($row) {
                 $row['generated'] = 'test';
 
                 return $row;
@@ -2922,7 +2922,7 @@ class SelectQueryTest extends TestCase
         $query
             ->select(['id', 'title'])
             ->from('articles')
-            ->decorateResults(function ($row) {
+            ->decorateResults(static function ($row) {
                 $row['generated'] = 'test';
 
                 return $row;
@@ -2962,7 +2962,7 @@ class SelectQueryTest extends TestCase
     {
         $query = new SelectQuery($this->connection);
         $result = $query->select(
-            function ($q) {
+            static function ($q) {
                 return ['total' => $q->func()->count('*')];
             },
         )
@@ -3066,7 +3066,7 @@ class SelectQueryTest extends TestCase
                 'ye' => '2007',
             ] + $expected;
         } elseif ($driver instanceof Postgres || $driver instanceof Sqlserver) {
-            $expected = array_map(function (int|string $value) {
+            $expected = array_map(static function (int|string $value) {
                 return (string)$value;
             }, $expected);
         }
@@ -3420,7 +3420,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['name'])
             ->from(['authors'])
-            ->where(function ($exp) use ($subquery) {
+            ->where(static function ($exp) use ($subquery) {
                 return $exp->isNotNull($subquery);
             })
             ->execute();
@@ -3429,7 +3429,7 @@ class SelectQueryTest extends TestCase
         $result = (new SelectQuery($this->connection))
             ->select(['name'])
             ->from(['authors'])
-            ->where(function ($exp) use ($subquery) {
+            ->where(static function ($exp) use ($subquery) {
                 return $exp->isNull($subquery);
             })
             ->execute();
@@ -3444,13 +3444,13 @@ class SelectQueryTest extends TestCase
     {
         $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new SelectQuery($this->connection);
-        $query->select('*')->from('things')->where(function (ExpressionInterface $exp) {
+        $query->select('*')->from('things')->where(static function (ExpressionInterface $exp) {
             return $exp->isNull('field');
         });
         $this->assertQuotedQuery('WHERE \(<field>\) IS NULL', $query->sql());
 
         $query = new SelectQuery($this->connection);
-        $query->select('*')->from('things')->where(function (ExpressionInterface $exp) {
+        $query->select('*')->from('things')->where(static function (ExpressionInterface $exp) {
             return $exp->isNotNull('field');
         });
         $this->assertQuotedQuery('WHERE \(<field>\) IS NOT NULL', $query->sql());
@@ -3544,7 +3544,7 @@ class SelectQueryTest extends TestCase
                     new SelectQuery($this->connection),
                 ),
             )
-            ->with(function (CommonTableExpression $cte, Query $query) {
+            ->with(static function (CommonTableExpression $cte, Query $query) {
                 return $cte
                     ->name('cte2')
                     ->query($query);
@@ -3707,7 +3707,7 @@ class SelectQueryTest extends TestCase
         $query = new SelectQuery($this->connection);
         $query
             ->window('window1', new WindowExpression())
-            ->window('window2', function (WindowExpression $window) {
+            ->window('window2', static function (WindowExpression $window) {
                 return $window;
             });
 
@@ -3909,7 +3909,7 @@ class SelectQueryTest extends TestCase
         $query->select('id')
             ->from('comments')
             ->setDefaultTypes(['created' => 'datetime'])
-            ->where(function ($expr) {
+            ->where(static function ($expr) {
                 $from = new DateTime('2007-03-18 10:45:00');
                 $to = new DateTime('2007-03-18 10:48:00');
 

--- a/tests/TestCase/Database/Query/UpdateQueryTest.php
+++ b/tests/TestCase/Database/Query/UpdateQueryTest.php
@@ -255,7 +255,7 @@ class UpdateQueryTest extends TestCase
         $query = new UpdateQuery($this->connection);
         $date = new DateTime();
         $query->update('comments')
-            ->set(function ($exp) use ($date) {
+            ->set(static function ($exp) use ($date) {
                 return $exp
                     ->eq('comment', 'mark')
                     ->eq('created', $date, 'date');

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -153,7 +153,7 @@ class QueryTest extends TestCase
                     $this->newQuery(),
                 ),
             )
-            ->with(function (CommonTableExpression $cte, Query $query) {
+            ->with(static function (CommonTableExpression $cte, Query $query) {
                 return $cte
                     ->name('cte2')
                     ->query($query);

--- a/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
@@ -67,7 +67,7 @@ class CaseExpressionQueryTest extends TestCase
     public function testSimpleCase(): void
     {
         $query = $this->query
-            ->select(function (Query $query) {
+            ->select(static function (Query $query) {
                 return [
                     'name',
                     'category_name' => $query->expr()
@@ -107,7 +107,7 @@ class CaseExpressionQueryTest extends TestCase
         ]);
 
         $query = $this->query
-            ->select(function (Query $query) {
+            ->select(static function (Query $query) {
                 return [
                     'name',
                     'price',
@@ -156,13 +156,13 @@ class CaseExpressionQueryTest extends TestCase
             ->select(['article_id', 'user_id'])
             ->from('comments')
             ->orderByAsc('comments.article_id')
-            ->orderByDesc(function (QueryExpression $exp, Query $query) {
+            ->orderByDesc(static function (QueryExpression $exp, Query $query) {
                 return $query->expr()
                     ->case($query->identifier('comments.article_id'))
                     ->when(1)
                     ->then($query->identifier('comments.user_id'));
             })
-            ->orderByAsc(function (QueryExpression $exp, Query $query) {
+            ->orderByAsc(static function (QueryExpression $exp, Query $query) {
                 return $query->expr()
                     ->case($query->identifier('comments.article_id'))
                     ->when(2)
@@ -206,7 +206,7 @@ class CaseExpressionQueryTest extends TestCase
             ->from('articles')
             ->leftJoin('comments', ['comments.article_id = articles.id'])
             ->groupBy(['articles.id', 'articles.title'])
-            ->having(function (QueryExpression $exp, Query $query) {
+            ->having(static function (QueryExpression $exp, Query $query) {
                 $expression = $query->expr()
                     ->case()
                     ->when(['comments.published' => 'Y'])
@@ -292,7 +292,7 @@ class CaseExpressionQueryTest extends TestCase
         ]);
 
         $query = $this->query
-            ->select(function (Query $query) {
+            ->select(static function (Query $query) {
                 return [
                     'val' => $query->expr()
                         ->case($query->expr(':value'))

--- a/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
@@ -126,11 +126,11 @@ class CommonTableExpressionQueryTest extends TestCase
     public function testWithRecursiveCte(): void
     {
         $query = $this->connection->selectQuery()
-            ->with(function (CommonTableExpression $cte, SelectQuery $query) {
+            ->with(static function (CommonTableExpression $cte, SelectQuery $query) {
                 $anchorQuery = $query->select(1);
 
                 $recursiveQuery = $query->getConnection()
-                    ->selectQuery(function (Query $query) {
+                    ->selectQuery(static function (Query $query) {
                         return $query->expr('col + 1');
                     }, 'cte')
                     ->where(['col !=' => 3], ['col' => 'integer']);
@@ -203,7 +203,7 @@ class CommonTableExpressionQueryTest extends TestCase
 
         $query = $this->connection
             ->insertQuery()
-            ->with(function (CommonTableExpression $cte, SelectQuery $query) {
+            ->with(static function (CommonTableExpression $cte, SelectQuery $query) {
                 return $cte
                     ->name('cte')
                     ->field(['title', 'body'])
@@ -256,7 +256,7 @@ class CommonTableExpressionQueryTest extends TestCase
             ->insert(['title', 'body'])
             ->values(
                 $this->connection->selectQuery()
-                    ->with(function (CommonTableExpression $cte, SelectQuery $query) {
+                    ->with(static function (CommonTableExpression $cte, SelectQuery $query) {
                         return $cte
                             ->name('cte')
                             ->field(['title', 'body'])
@@ -310,7 +310,7 @@ class CommonTableExpressionQueryTest extends TestCase
         $result->closeCursor();
 
         $query = $this->connection->updateQuery()
-            ->with(function (CommonTableExpression $cte, SelectQuery $query) {
+            ->with(static function (CommonTableExpression $cte, SelectQuery $query) {
                 $cteQuery = $query
                     ->select('articles.id')
                     ->from('articles')
@@ -322,7 +322,7 @@ class CommonTableExpressionQueryTest extends TestCase
             })
             ->update('articles')
             ->set('published', 'N')
-            ->where(function (QueryExpression $exp, Query $query) {
+            ->where(static function (QueryExpression $exp, Query $query) {
                 return $exp->in(
                     'articles.id',
                     $query
@@ -366,7 +366,7 @@ class CommonTableExpressionQueryTest extends TestCase
         $result->closeCursor();
 
         $query = $this->connection->deleteQuery()
-            ->with(function (CommonTableExpression $cte, SelectQuery $query) {
+            ->with(static function (CommonTableExpression $cte, SelectQuery $query) {
                 $query->select('articles.id')
                     ->from('articles')
                     ->where(['articles.id !=' => 1]);
@@ -376,7 +376,7 @@ class CommonTableExpressionQueryTest extends TestCase
                     ->query($query);
             })
             ->from(['a' => 'articles'])
-            ->where(function (QueryExpression $exp, Query $query) {
+            ->where(static function (QueryExpression $exp, Query $query) {
                 return $exp->in(
                     'a.id',
                     $query

--- a/tests/TestCase/Database/QueryTests/WindowQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/WindowQueryTest.php
@@ -90,7 +90,7 @@ class WindowQueryTest extends TestCase
         $this->assertRegExpSql('SELECT \* WINDOW <name> AS \(\), <name2> AS \(<name>\)', $sql, !$this->autoQuote);
 
         $sql = $query
-            ->window('name', function ($window, $query) {
+            ->window('name', static function ($window, $query) {
                 return $window->name('name3');
             }, true)
             ->sql();
@@ -101,7 +101,7 @@ class WindowQueryTest extends TestCase
     {
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('You must return a `WindowExpression`');
-        (new SelectQuery($this->connection))->window('name', function () {
+        (new SelectQuery($this->connection))->window('name', static function () {
             return new QueryExpression();
         });
     }

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -1880,7 +1880,7 @@ SQL;
             ->getMock();
         $this->pdo->expects($this->any())
             ->method('quote')
-            ->willReturnCallback(function ($value) {
+            ->willReturnCallback(static function ($value) {
                 return "'{$value}'";
             });
 

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -1871,7 +1871,7 @@ SQL;
             ->getMock();
         $mock->expects($this->any())
             ->method('quote')
-            ->willReturnCallback(function ($value) {
+            ->willReturnCallback(static function ($value) {
                 return "'{$value}'";
             });
 
@@ -1886,7 +1886,7 @@ SQL;
 
         $driver->expects($this->any())
             ->method('version')
-            ->willReturnCallback(function () {
+            ->willReturnCallback(static function () {
                 return '10.0.0';
             });
 

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -1631,7 +1631,7 @@ SQL;
             ->getMock();
         $this->pdo->expects($this->any())
             ->method('quote')
-            ->willReturnCallback(function ($value) {
+            ->willReturnCallback(static function ($value) {
                 return '"' . $value . '"';
             });
 

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -1407,7 +1407,7 @@ SQL;
             ->getMock();
         $mock->expects($this->any())
             ->method('quote')
-            ->willReturnCallback(function ($value) {
+            ->willReturnCallback(static function ($value) {
                 return "'{$value}'";
             });
 

--- a/tests/TestCase/Datasource/Paging/NumericPaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/NumericPaginatorTest.php
@@ -39,7 +39,7 @@ class NumericPaginatorTest extends TestCase
      */
     public function testPaginateCustomFind(): void
     {
-        $titleExtractor = function ($result) {
+        $titleExtractor = static function ($result) {
             $ids = [];
             foreach ($result as $record) {
                 $ids[] = $record->title;

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -167,9 +167,9 @@ trait PaginatorTestTrait
         $tags = $this->getTableLocator()->get('Tags');
         $tags->associations()->remove('Authors');
         $tags->belongsToMany('Authors');
-        $articles->getEventManager()->on('Model.beforeFind', function ($event, $query): void {
-            $query->matching('Tags', function ($q) {
-                return $q->matching('Authors', function ($q) {
+        $articles->getEventManager()->on('Model.beforeFind', static function ($event, $query): void {
+            $query->matching('Tags', static function ($q) {
+                return $q->matching('Authors', static function ($q) {
                     return $q->where(['Authors.name' => 'larry']);
                 });
             });

--- a/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
@@ -57,7 +57,7 @@ class SimplePaginatorTest extends NumericPaginatorTest
      */
     public function testPaginateCustomFind(): void
     {
-        $titleExtractor = function ($result) {
+        $titleExtractor = static function ($result) {
             $ids = [];
             foreach ($result as $record) {
                 $ids[] = $record->title;

--- a/tests/TestCase/Datasource/QueryCacherTest.php
+++ b/tests/TestCase/Datasource/QueryCacherTest.php
@@ -80,7 +80,7 @@ class QueryCacherTest extends TestCase
         $this->engine->set('my_key', 'A winner');
         $query = new stdClass();
 
-        $cacher = new QueryCacher(function ($q) {
+        $cacher = new QueryCacher(static function ($q) {
             return false;
         }, 'queryCache');
 

--- a/tests/TestCase/Datasource/RuleInvokerTest.php
+++ b/tests/TestCase/Datasource/RuleInvokerTest.php
@@ -36,7 +36,7 @@ class RuleInvokerTest extends TestCase
             [
                 'count' => 2,
                 'errorField' => 'player_id',
-                'message' => function ($entity, $options) {
+                'message' => static function ($entity, $options) {
                     return 'Player count should be ' . $options['count'] . ' not ' . $entity->get('players');
                 },
             ],

--- a/tests/TestCase/Datasource/RulesCheckerTest.php
+++ b/tests/TestCase/Datasource/RulesCheckerTest.php
@@ -37,7 +37,7 @@ class RulesCheckerTest extends TestCase
 
         $rules = new RulesChecker();
         $rules->add(
-            function () {
+            static function () {
                 return false;
             },
             'ruleName',
@@ -67,7 +67,7 @@ class RulesCheckerTest extends TestCase
 
         $rules = new RulesChecker();
         $rules->addDelete(
-            function () {
+            static function () {
                 return false;
             },
             'ruleName',
@@ -94,7 +94,7 @@ class RulesCheckerTest extends TestCase
 
         $rules = new RulesChecker();
         $rules->addUpdate(
-            function () {
+            static function () {
                 return false;
             },
             'ruleName',
@@ -121,7 +121,7 @@ class RulesCheckerTest extends TestCase
 
         $rules = new RulesChecker();
         $rules->addCreate(
-            function () {
+            static function () {
                 return false;
             },
             'ruleName',
@@ -148,7 +148,7 @@ class RulesCheckerTest extends TestCase
 
         $rules = new RulesChecker();
         $rules->add(
-            function () {
+            static function () {
                 return false;
             },
             'ruleName',
@@ -170,7 +170,7 @@ class RulesCheckerTest extends TestCase
 
         $rules = new RulesChecker();
         $rules->add(
-            function () {
+            static function () {
                 return 'worst thing ever';
             },
             ['errorField' => 'name'],
@@ -191,7 +191,7 @@ class RulesCheckerTest extends TestCase
 
         $rules = new RulesChecker();
         $rules->add(
-            function () {
+            static function () {
                 return false;
             },
             ['message' => 'this is bad', 'errorField' => 'name'],
@@ -211,7 +211,7 @@ class RulesCheckerTest extends TestCase
         ]);
 
         $rules = new RulesChecker();
-        $rules->add(function () {
+        $rules->add(static function () {
             return false;
         });
 
@@ -228,7 +228,7 @@ class RulesCheckerTest extends TestCase
 
         $rules = new RulesChecker();
         $rules->add(
-            function () {
+            static function () {
                 return false;
             },
             'ruleName',
@@ -244,7 +244,7 @@ class RulesCheckerTest extends TestCase
     {
         $rules = new RulesChecker();
         $rules->addCreate(
-            function () {
+            static function () {
                 return false;
             },
             'ruleName',
@@ -261,7 +261,7 @@ class RulesCheckerTest extends TestCase
     {
         $rules = new RulesChecker();
         $rules->addUpdate(
-            function () {
+            static function () {
                 return false;
             },
             'ruleName',
@@ -278,7 +278,7 @@ class RulesCheckerTest extends TestCase
     {
         $rules = new RulesChecker();
         $rules->addDelete(
-            function () {
+            static function () {
                 return false;
             },
             'ruleName',

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -841,7 +841,7 @@ EXPECTED;
      */
     public function testEditorUrlClosure(): void
     {
-        Debugger::addEditor('open', function (string $file, int $line) {
+        Debugger::addEditor('open', static function (string $file, int $line) {
             return "{$file}/{$line}";
         });
         Debugger::setEditor('open');

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -293,7 +293,7 @@ class ErrorTrapTest extends TestCase
     {
         $trap = new ErrorTrap(['errorRenderer' => TextErrorRenderer::class]);
         $trap->register();
-        $trap->getEventManager()->on('Error.beforeRender', function ($event, PhpError $error): void {
+        $trap->getEventManager()->on('Error.beforeRender', static function ($event, PhpError $error): void {
             $event->setResult("This ain't so bad");
         });
 

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -72,7 +72,7 @@ class ExceptionTrapTest extends TestCase
 
     public function testConfigExceptionRendererFactory(): void
     {
-        $trap = new ExceptionTrap(['exceptionRenderer' => function ($err, $req) {
+        $trap = new ExceptionTrap(['exceptionRenderer' => static function ($err, $req) {
             return new WebExceptionRenderer($err, $req);
         }]);
         $error = new InvalidArgumentException('nope');
@@ -299,7 +299,7 @@ class ExceptionTrapTest extends TestCase
     public function testBeforeRenderEventExceptionChanged(): void
     {
         $trap = new ExceptionTrap(['exceptionRenderer' => TextExceptionRenderer::class]);
-        $trap->getEventManager()->on('Exception.beforeRender', function ($event, Throwable $error, ?ServerRequest $req): void {
+        $trap->getEventManager()->on('Exception.beforeRender', static function ($event, Throwable $error, ?ServerRequest $req): void {
             $event->setData('exception', new NotFoundException());
         });
         $error = new InvalidArgumentException('nope', 100);
@@ -314,7 +314,7 @@ class ExceptionTrapTest extends TestCase
     public function testBeforeRenderEventReturnResponse(): void
     {
         $trap = new ExceptionTrap(['exceptionRenderer' => TextExceptionRenderer::class]);
-        $trap->getEventManager()->on('Exception.beforeRender', function (EventInterface $event, Throwable $error, ?ServerRequest $req): void {
+        $trap->getEventManager()->on('Exception.beforeRender', static function (EventInterface $event, Throwable $error, ?ServerRequest $req): void {
             $event->setResult('Here B Erroz');
         });
 

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -114,7 +114,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $middleware = new ErrorHandlerMiddleware(new ExceptionTrap([
             'exceptionRenderer' => $factory,
         ]));
-        $handler = new TestRequestHandler(function (): void {
+        $handler = new TestRequestHandler(static function (): void {
             throw new LogicException('Something bad');
         });
         $middleware->process($request, $handler);
@@ -127,7 +127,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
     {
         $request = ServerRequestFactory::fromGlobals();
         $middleware = new ErrorHandlerMiddleware();
-        $handler = new TestRequestHandler(function (): void {
+        $handler = new TestRequestHandler(static function (): void {
             throw new NotFoundException('whoops');
         });
         $result = $middleware->process($request, $handler);
@@ -145,7 +145,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $middleware = new ErrorHandlerMiddleware(new ExceptionTrap([
             'exceptionRenderer' => WebExceptionRenderer::class,
         ]));
-        $handler = new TestRequestHandler(function (): void {
+        $handler = new TestRequestHandler(static function (): void {
             throw new NotFoundException('whoops');
         });
         $result = $middleware->process($request, $handler);
@@ -161,7 +161,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
     {
         $request = ServerRequestFactory::fromGlobals();
         $middleware = new ErrorHandlerMiddleware();
-        $handler = new TestRequestHandler(function (): void {
+        $handler = new TestRequestHandler(static function (): void {
             throw new RedirectException('http://example.org/login');
         });
         $result = $middleware->process($request, $handler);
@@ -181,7 +181,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
     {
         $request = ServerRequestFactory::fromGlobals();
         $middleware = new ErrorHandlerMiddleware();
-        $handler = new TestRequestHandler(function (): void {
+        $handler = new TestRequestHandler(static function (): void {
             $err = new RedirectException('http://example.org/login', 301, ['Constructor' => 'yes', 'Method' => 'yes']);
             throw $err;
         });
@@ -207,7 +207,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $request = $request->withHeader('Accept', 'application/json');
 
         $middleware = new ErrorHandlerMiddleware();
-        $handler = new TestRequestHandler(function (): void {
+        $handler = new TestRequestHandler(static function (): void {
             throw new NotFoundException('whoops');
         });
         $result = $middleware->process($request, $handler);
@@ -240,7 +240,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             'HTTP_REFERER' => '/other/path',
         ]);
         $middleware = new ErrorHandlerMiddleware(['log' => true, 'trace' => true]);
-        $handler = new TestRequestHandler(function (): void {
+        $handler = new TestRequestHandler(static function (): void {
             throw new NotFoundException('Kaboom!');
         });
         $result = $middleware->process($request, $handler);
@@ -270,7 +270,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             'HTTP_REFERER' => '/other/path',
         ]);
         $middleware = new ErrorHandlerMiddleware(['log' => true, 'trace' => true]);
-        $handler = new TestRequestHandler(function ($req): void {
+        $handler = new TestRequestHandler(static function ($req): void {
             $previous = new RecordNotFoundException('Previous logged');
             throw new NotFoundException('Kaboom!', null, $previous);
         });
@@ -304,7 +304,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             'log' => true,
             'skipLog' => [NotFoundException::class],
         ]);
-        $handler = new TestRequestHandler(function (): void {
+        $handler = new TestRequestHandler(static function (): void {
             throw new NotFoundException('Kaboom!');
         });
         $result = $middleware->process($request, $handler);
@@ -321,7 +321,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
     {
         $request = ServerRequestFactory::fromGlobals();
         $middleware = new ErrorHandlerMiddleware(['log' => true]);
-        $handler = new TestRequestHandler(function (): void {
+        $handler = new TestRequestHandler(static function (): void {
             throw new MissingControllerException(['controller' => 'Articles']);
         });
         $result = $middleware->process($request, $handler);
@@ -343,13 +343,13 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $middleware = new ErrorHandlerMiddleware(new ExceptionTrap([
             'exceptionRenderer' => WebExceptionRenderer::class,
         ]));
-        $handler = new TestRequestHandler(function (): void {
+        $handler = new TestRequestHandler(static function (): void {
             throw new NotFoundException('whoops');
         });
 
         EventManager::instance()->on(
             'Exception.beforeRender',
-            function (EventInterface $event, Throwable $e, ServerRequestInterface $req): void {
+            static function (EventInterface $event, Throwable $e, ServerRequestInterface $req): void {
                 $event->setResult('Response string from event');
             },
         );
@@ -366,7 +366,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
     {
         $request = ServerRequestFactory::fromGlobals();
 
-        $factory = function () {
+        $factory = static function () {
             return new class implements ExceptionRendererInterface
             {
                 public function render(): ResponseInterface|string
@@ -382,7 +382,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $middleware = new ErrorHandlerMiddleware(new ExceptionTrap([
             'exceptionRenderer' => $factory,
         ]));
-        $handler = new TestRequestHandler(function (): void {
+        $handler = new TestRequestHandler(static function (): void {
             throw new ServiceUnavailableException('whoops');
         });
         $response = $middleware->process($request, $handler);

--- a/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
+++ b/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
@@ -916,7 +916,7 @@ class WebExceptionRendererTest extends TestCase
     public function testRenderShutdownEvents(): void
     {
         $fired = [];
-        $listener = function (EventInterface $event) use (&$fired): void {
+        $listener = static function (EventInterface $event) use (&$fired): void {
             $fired[] = $event->getName();
         };
         $events = EventManager::instance();
@@ -936,7 +936,7 @@ class WebExceptionRendererTest extends TestCase
     public function testSubclassTriggerShutdownEvents(): void
     {
         $fired = [];
-        $listener = function (EventInterface $event) use (&$fired): void {
+        $listener = static function (EventInterface $event) use (&$fired): void {
             $fired[] = $event->getName();
         };
         $events = EventManager::instance();

--- a/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
+++ b/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
@@ -33,12 +33,12 @@ class ConditionDecoratorTest extends TestCase
      */
     public function testCanTriggerIf(): void
     {
-        $callable = function (EventInterface $event) {
+        $callable = static function (EventInterface $event) {
             return 'success';
         };
 
         $decorator = new ConditionDecorator($callable, [
-            'if' => function (EventInterface $event) {
+            'if' => static function (EventInterface $event) {
                 return $event->getData('canTrigger');
             },
         ]);
@@ -61,19 +61,19 @@ class ConditionDecoratorTest extends TestCase
      */
     public function testCascadingEvents(): void
     {
-        $callable = function (EventInterface $event) {
+        $callable = static function (EventInterface $event) {
             $event->setData('counter', $event->getData('counter') + 1);
 
             return $event;
         };
 
         $listener1 = new ConditionDecorator($callable, [
-            'if' => function (EventInterface $event) {
+            'if' => static function (EventInterface $event) {
                 return false;
             },
         ]);
 
-        $listener2 = function (EventInterface $event): void {
+        $listener2 = static function (EventInterface $event): void {
             $event->setData('counter', $event->getData('counter') + 1);
             $event->setResult(false);
         };
@@ -96,7 +96,7 @@ class ConditionDecoratorTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cake\Event\Decorator\ConditionDecorator the `if` condition is not a callable!');
-        $callable = function (EventInterface $event) {
+        $callable = static function (EventInterface $event) {
             return 'success';
         };
 

--- a/tests/TestCase/Event/Decorator/SubjectFilterDecoratorTest.php
+++ b/tests/TestCase/Event/Decorator/SubjectFilterDecoratorTest.php
@@ -32,7 +32,7 @@ class SubjectFilterDecoratorTest extends TestCase
     public function testCanTrigger(): void
     {
         $event = new Event('decorator.test', $this);
-        $callable = function (EventInterface $event) {
+        $callable = static function (EventInterface $event) {
             return 'success';
         };
 

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -182,7 +182,7 @@ class EventManagerTest extends TestCase
     public function testOffFromAll(): void
     {
         $manager = new EventManager();
-        $callable = function (): void {
+        $callable = static function (): void {
         };
         $manager->on('fake.event', $callable);
         $manager->on('another.event', $callable);
@@ -778,7 +778,7 @@ class EventManagerTest extends TestCase
 
         $eventManager->unsetEventList();
 
-        $func = function (): void {
+        $func = static function (): void {
         };
         $eventManager->on('foo', $func);
 
@@ -810,13 +810,13 @@ class EventManagerTest extends TestCase
             $eventManager->__debugInfo(),
         );
 
-        $eventManager->on('bar', function (): void {
+        $eventManager->on('bar', static function (): void {
         });
-        $eventManager->on('bar', function (): void {
+        $eventManager->on('bar', static function (): void {
         });
-        $eventManager->on('bar', function (): void {
+        $eventManager->on('bar', static function (): void {
         });
-        $eventManager->on('baz', function (): void {
+        $eventManager->on('baz', static function (): void {
         });
 
         $this->assertSame(
@@ -843,7 +843,7 @@ class EventManagerTest extends TestCase
         $eventList = new EventList();
         $eventManager = new EventManager();
         $eventManager->setEventList($eventList);
-        $eventManager->on('example', function (): void {
+        $eventManager->on('example', static function (): void {
         });
         $eventManager->dispatch('example');
 
@@ -876,7 +876,7 @@ class EventManagerTest extends TestCase
                 return [];
             }
         };
-        $callable = function (): void {
+        $callable = static function (): void {
         };
 
         $returnValue = $eventManager->on($listener);
@@ -920,11 +920,11 @@ class EventManagerTest extends TestCase
     public function testEventWithoutSubjectWorksWithReturningListener(): void
     {
         $eventManager = new EventManager();
-        $eventManager->on('example', function (): string {
+        $eventManager->on('example', static function (): string {
             return 'example event called';
         });
         $result = '';
-        $this->deprecated(function () use (&$eventManager, &$result): void {
+        $this->deprecated(static function () use (&$eventManager, &$result): void {
             $result = $eventManager->dispatch(new Event('example'));
         });
         $this->assertEquals('example event called', $result->getResult());

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -62,7 +62,7 @@ class BaseApplicationTest extends TestCase
 
             public function events(EventManagerInterface $eventManager): EventManagerInterface
             {
-                $eventManager->on('testTrue', function ($event) {
+                $eventManager->on('testTrue', static function ($event) {
                     return true;
                 });
 
@@ -213,7 +213,7 @@ class BaseApplicationTest extends TestCase
         $app = $this->app;
         $app->addPlugin('Named');
         // Remove the deprecated() wrapping once plugin class is added to TestPluginTwo
-        $this->deprecated(function () use ($app): void {
+        $this->deprecated(static function () use ($app): void {
             $app->pluginBootstrap();
         });
         $this->assertTrue(
@@ -282,7 +282,7 @@ class BaseApplicationTest extends TestCase
     public function testBuildContainerEventReplaceContainer(): void
     {
         $app = $this->app;
-        $app->getEventManager()->on('Application.buildContainer', function (EventInterface $event): void {
+        $app->getEventManager()->on('Application.buildContainer', static function (EventInterface $event): void {
             $new = new Container();
             $new->add('testing', 'yes');
 
@@ -325,7 +325,7 @@ class BaseApplicationTest extends TestCase
 
             public function events(EventManagerInterface $eventManager): EventManagerInterface
             {
-                $eventManager->on('testTrue', function ($event) {
+                $eventManager->on('testTrue', static function ($event) {
                     return true;
                 });
 

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -92,7 +92,7 @@ class StreamTest extends TestCase
         $stream = new Stream();
         $request = new Request('http://throw_exception/');
 
-        $currentHandler = set_error_handler(function (): void {
+        $currentHandler = set_error_handler(static function (): void {
         });
         restore_error_handler();
 
@@ -101,7 +101,7 @@ class StreamTest extends TestCase
         } catch (Exception) {
         }
 
-        $newHandler = set_error_handler(function (): void {
+        $newHandler = set_error_handler(static function (): void {
         });
         restore_error_handler();
 

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -901,7 +901,7 @@ class ClientTest extends TestCase
         $client = new Client();
         $client->getEventManager()->on(
             'HttpClient.beforeSend',
-            function (ClientEvent $event, Request $request, array $adapterOptions, int $redirects) use (&$eventTriggered): void {
+            static function (ClientEvent $event, Request $request, array $adapterOptions, int $redirects) use (&$eventTriggered): void {
                 $eventTriggered = true;
             },
         );
@@ -919,7 +919,7 @@ class ClientTest extends TestCase
 
         $client->getEventManager()->on(
             'HttpClient.beforeSend',
-            function (ClientEvent $event, Request $request, array $adapterOptions, int $redirects): void {
+            static function (ClientEvent $event, Request $request, array $adapterOptions, int $redirects): void {
                 $event->setRequest(new Request('http://bar.test'));
                 $event->setAdapterOptions(['some' => 'value']);
             },
@@ -946,7 +946,7 @@ class ClientTest extends TestCase
 
         $client->getEventManager()->on(
             'HttpClient.beforeSend',
-            function (ClientEvent $event, Request $request, array $adapterOptions, int $redirects): void {
+            static function (ClientEvent $event, Request $request, array $adapterOptions, int $redirects): void {
                 $event->setResult(new Response(body: 'short circuit'));
             },
         );
@@ -968,7 +968,7 @@ class ClientTest extends TestCase
 
         $client->getEventManager()->on(
             'HttpClient.afterSend',
-            function (ClientEvent $event, Request $request, array $adapterOptions, int $redirects): void {
+            static function (ClientEvent $event, Request $request, array $adapterOptions, int $redirects): void {
                 $event->setResult(new Response(body: 'modified response'));
             },
         );
@@ -1160,7 +1160,7 @@ class ClientTest extends TestCase
     {
         $one = new Response(['HTTP/1.0 200'], 'one');
         Client::addMockResponse('GET', 'http://example.com/info', $one, [
-            'match' => function ($request) {
+            'match' => static function ($request) {
                 return false;
             },
         ]);
@@ -1253,7 +1253,7 @@ class ClientTest extends TestCase
     {
         $stub = new Response(['HTTP/1.0 200'], 'hello world');
         Client::addMockResponse('POST', 'http://example.com/path', $stub, [
-            'match' => function () {
+            'match' => static function () {
                 return false;
             },
         ]);
@@ -1272,7 +1272,7 @@ class ClientTest extends TestCase
     {
         $stub = new Response(['HTTP/1.0 200'], 'hello world');
         Client::addMockResponse('POST', 'http://example.com/path', $stub, [
-            'match' => function ($request) {
+            'match' => static function ($request) {
                 return 'invalid';
             },
         ]);

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -406,7 +406,7 @@ class CookieCollectionTest extends TestCase
      */
     public function testCookieSizeWarning(): void
     {
-        $this->expectWarningMessageMatches('/The cookie `default` exceeds the recommended maximum cookie length of 4096 bytes.*/', function (): void {
+        $this->expectWarningMessageMatches('/The cookie `default` exceeds the recommended maximum cookie length of 4096 bytes.*/', static function (): void {
             $string = Security::insecureRandomBytes(9000);
             $collection = new CookieCollection();
             $collection = $collection

--- a/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
@@ -134,7 +134,7 @@ class BodyParserMiddlewareTest extends TestCase
     public function testAddParserReturn(): void
     {
         $parser = new BodyParserMiddleware(['json' => false]);
-        $f1 = function (string $body) {
+        $f1 = static function (string $body) {
             return json_decode($body, true);
         };
         $this->assertSame($parser, $parser->addParser(['application/json'], $f1));
@@ -147,10 +147,10 @@ class BodyParserMiddlewareTest extends TestCase
     {
         $parser = new BodyParserMiddleware(['json' => false]);
 
-        $f1 = function (string $body) {
+        $f1 = static function (string $body) {
             return json_decode($body, true);
         };
-        $f2 = function (string $body) {
+        $f2 = static function (string $body) {
             return ['overridden'];
         };
         $parser->addParser(['application/json'], $f1);
@@ -413,7 +413,7 @@ XML;
             ],
             'input' => 'lol',
         ]);
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(static function ($req) {
             return new Response();
         });
         $this->expectException(BadRequestException::class);

--- a/tests/TestCase/Http/Middleware/CspMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CspMiddlewareTest.php
@@ -35,7 +35,7 @@ class CspMiddlewareTest extends TestCase
      */
     protected function _getRequestHandler(): RequestHandlerInterface
     {
-        return new TestRequestHandler(function ($request) {
+        return new TestRequestHandler(static function ($request) {
             return new Response();
         });
     }

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -77,7 +77,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
      */
     protected function _getRequestHandler(): RequestHandlerInterface
     {
-        return new TestRequestHandler(function () {
+        return new TestRequestHandler(static function () {
             return new Response();
         });
     }
@@ -94,7 +94,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
         /** @var \Cake\Http\ServerRequest $updatedRequest */
         $updatedRequest = null;
-        $handler = new TestRequestHandler(function ($request) use (&$updatedRequest) {
+        $handler = new TestRequestHandler(static function ($request) use (&$updatedRequest) {
             $updatedRequest = $request;
 
             return new Response();
@@ -126,7 +126,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
         /** @var \Cake\Http\ServerRequest $updatedRequest */
         $updatedRequest = null;
-        $handler = new TestRequestHandler(function ($request) use (&$updatedRequest) {
+        $handler = new TestRequestHandler(static function ($request) use (&$updatedRequest) {
             $updatedRequest = $request;
 
             return new Response();
@@ -162,7 +162,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
         /** @var \Cake\Http\ServerRequest $updatedRequest */
         $updatedRequest = null;
-        $handler = new TestRequestHandler(function ($request) use (&$updatedRequest) {
+        $handler = new TestRequestHandler(static function ($request) use (&$updatedRequest) {
             $updatedRequest = $request;
 
             return new Response();
@@ -223,7 +223,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'GET'],
         ]);
-        $handler = new TestRequestHandler(function () {
+        $handler = new TestRequestHandler(static function () {
             return new RedirectResponse('/');
         });
 
@@ -241,7 +241,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
             'environment' => ['REQUEST_METHOD' => 'GET'],
         ]);
         $request = $request->withAttribute('csrfToken', 'not-good');
-        $handler = new TestRequestHandler(function () {
+        $handler = new TestRequestHandler(static function () {
             return new RedirectResponse('/');
         });
 
@@ -258,7 +258,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'GET'],
         ]);
-        $handler = new TestRequestHandler(function () {
+        $handler = new TestRequestHandler(static function () {
             return new DiactorosResponse();
         });
 

--- a/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
@@ -125,7 +125,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
     public function testEncodeResponseSetCookieHeader(): void
     {
         $request = new ServerRequest(['url' => '/cookies/nom']);
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(static function ($req) {
             return (new Response())->withAddedHeader('Set-Cookie', 'secret=be%20quiet')
                 ->withAddedHeader('Set-Cookie', 'plain=in%20clear')
                 ->withAddedHeader('Set-Cookie', 'ninja=shuriken');
@@ -148,7 +148,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
     public function testEncodeResponseCookieData(): void
     {
         $request = new ServerRequest(['url' => '/cookies/nom']);
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(static function ($req) {
             return (new Response())->withCookie(new Cookie('secret', 'be quiet'))
                 ->withCookie(new Cookie('plain', 'in clear'))
                 ->withCookie(new Cookie('ninja', 'shuriken'));

--- a/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
@@ -53,7 +53,7 @@ class HttpsEnforcerMiddlewareTest extends TestCase
         $request = new ServerRequest();
         $request = $request->withUri($uri);
 
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(static function ($req) {
             return new Response(['body' => 'success']);
         });
 
@@ -70,7 +70,7 @@ class HttpsEnforcerMiddlewareTest extends TestCase
         $request = new ServerRequest();
         $request = $request->withUri($uri);
 
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(static function ($req) {
             return new Response(['body' => 'success']);
         });
 
@@ -87,7 +87,7 @@ class HttpsEnforcerMiddlewareTest extends TestCase
         $request = new ServerRequest();
         $request = $request->withUri($uri);
 
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(static function ($req) {
             return new Response(['body' => 'success']);
         });
 
@@ -104,7 +104,7 @@ class HttpsEnforcerMiddlewareTest extends TestCase
         $request = new ServerRequest();
         $request = $request->withUri($uri);
 
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(static function ($req) {
             return new Response(['body' => 'success']);
         });
 
@@ -121,7 +121,7 @@ class HttpsEnforcerMiddlewareTest extends TestCase
         $request = new ServerRequest();
         $request = $request->withUri($uri)->withMethod('GET');
 
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(static function ($req) {
             return new Response();
         });
 
@@ -156,7 +156,7 @@ class HttpsEnforcerMiddlewareTest extends TestCase
             'method' => 'GET',
         ]);
 
-        $handler = new TestRequestHandler(function () {
+        $handler = new TestRequestHandler(static function () {
             return new Response();
         });
 
@@ -179,7 +179,7 @@ class HttpsEnforcerMiddlewareTest extends TestCase
         $request = new ServerRequest();
         $request = $request->withUri($uri);
 
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(static function ($req) {
             return new Response();
         });
 
@@ -198,7 +198,7 @@ class HttpsEnforcerMiddlewareTest extends TestCase
         $request = new ServerRequest();
         $request = $request->withUri($uri)->withMethod('POST');
 
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(static function ($req) {
             return new Response();
         });
 
@@ -217,7 +217,7 @@ class HttpsEnforcerMiddlewareTest extends TestCase
         $request = new ServerRequest();
         $request = $request->withUri($uri);
 
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(static function ($req) {
             return new Response(['body' => 'skipped']);
         });
 
@@ -241,7 +241,7 @@ class HttpsEnforcerMiddlewareTest extends TestCase
         ];
         $request = ServerRequestFactory::fromGlobals($server);
 
-        $handler = new TestRequestHandler(function () {
+        $handler = new TestRequestHandler(static function () {
             return new Response();
         });
 

--- a/tests/TestCase/Http/Middleware/SecurityHeadersMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SecurityHeadersMiddlewareTest.php
@@ -36,7 +36,7 @@ class SecurityHeadersMiddlewareTest extends TestCase
         $request = ServerRequestFactory::fromGlobals([
             'REQUEST_URI' => '/',
         ]);
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(static function ($req) {
             return new Response();
         });
 

--- a/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
@@ -63,7 +63,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
      */
     protected function _getRequestHandler(): RequestHandlerInterface
     {
-        return new TestRequestHandler(function () {
+        return new TestRequestHandler(static function () {
             return new Response();
         });
     }
@@ -80,7 +80,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
 
         /** @var \Cake\Http\ServerRequest|null $updatedRequest */
         $updatedRequest = null;
-        $handler = new TestRequestHandler(function ($request) use (&$updatedRequest) {
+        $handler = new TestRequestHandler(static function ($request) use (&$updatedRequest) {
             $updatedRequest = $request;
 
             return new Response();

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -56,7 +56,7 @@ class MiddlewareQueueTest extends TestCase
 
     public function testConstructorAddingMiddleware(): void
     {
-        $cb = function (): void {
+        $cb = static function (): void {
         };
         $queue = new MiddlewareQueue([$cb]);
         $this->assertCount(1, $queue);
@@ -69,7 +69,7 @@ class MiddlewareQueueTest extends TestCase
     public function testGet(): void
     {
         $queue = new MiddlewareQueue();
-        $cb = function (): void {
+        $cb = static function (): void {
         };
         $queue->add($cb);
         $this->assertSame($cb, $queue->current()->getCallable());
@@ -93,7 +93,7 @@ class MiddlewareQueueTest extends TestCase
     public function testAddReturn(): void
     {
         $queue = new MiddlewareQueue();
-        $cb = function (): void {
+        $cb = static function (): void {
         };
         $this->assertSame($queue, $queue->add($cb));
     }
@@ -103,9 +103,9 @@ class MiddlewareQueueTest extends TestCase
      */
     public function testAddOrdering(): void
     {
-        $one = function (): void {
+        $one = static function (): void {
         };
-        $two = function (): void {
+        $two = static function (): void {
         };
 
         $queue = new MiddlewareQueue();
@@ -127,7 +127,7 @@ class MiddlewareQueueTest extends TestCase
      */
     public function testPrependReturn(): void
     {
-        $cb = function (): void {
+        $cb = static function (): void {
         };
         $queue = new MiddlewareQueue();
         $this->assertSame($queue, $queue->prepend($cb));
@@ -138,9 +138,9 @@ class MiddlewareQueueTest extends TestCase
      */
     public function testPrependOrdering(): void
     {
-        $one = function (): void {
+        $one = static function (): void {
         };
-        $two = function (): void {
+        $two = static function (): void {
         };
 
         $queue = new MiddlewareQueue();
@@ -175,7 +175,7 @@ class MiddlewareQueueTest extends TestCase
      */
     public function testAddingPrependingUsingArray(): void
     {
-        $one = function (): void {
+        $one = static function (): void {
         };
 
         $queue = new MiddlewareQueue();
@@ -192,11 +192,11 @@ class MiddlewareQueueTest extends TestCase
      */
     public function testInsertAt(): void
     {
-        $one = function (): void {
+        $one = static function (): void {
         };
-        $two = function (): void {
+        $two = static function (): void {
         };
-        $three = function (): void {
+        $three = static function (): void {
         };
         $four = new SampleMiddleware();
 
@@ -224,9 +224,9 @@ class MiddlewareQueueTest extends TestCase
      */
     public function testInsertAtOutOfBounds(): void
     {
-        $one = function (): void {
+        $one = static function (): void {
         };
-        $two = function (): void {
+        $two = static function (): void {
         };
 
         $queue = new MiddlewareQueue();
@@ -243,9 +243,9 @@ class MiddlewareQueueTest extends TestCase
      */
     public function testInsertAtNegative(): void
     {
-        $one = function (): void {
+        $one = static function (): void {
         };
-        $two = function (): void {
+        $two = static function (): void {
         };
         $three = new SampleMiddleware();
 
@@ -265,10 +265,10 @@ class MiddlewareQueueTest extends TestCase
      */
     public function testInsertBefore(): void
     {
-        $one = function (): void {
+        $one = static function (): void {
         };
         $two = new SampleMiddleware();
-        $three = function (): void {
+        $three = static function (): void {
         };
         $four = new DumbMiddleware();
 
@@ -306,10 +306,10 @@ class MiddlewareQueueTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('No middleware matching `InvalidClassName` could be found.');
-        $one = function (): void {
+        $one = static function (): void {
         };
         $two = new SampleMiddleware();
-        $three = function (): void {
+        $three = static function (): void {
         };
         $queue = new MiddlewareQueue();
         $queue->add($one)->add($two)->insertBefore('InvalidClassName', $three);
@@ -321,9 +321,9 @@ class MiddlewareQueueTest extends TestCase
     public function testInsertAfter(): void
     {
         $one = new SampleMiddleware();
-        $two = function (): void {
+        $two = static function (): void {
         };
-        $three = function (): void {
+        $three = static function (): void {
         };
         $four = new DumbMiddleware();
         $queue = new MiddlewareQueue();
@@ -363,9 +363,9 @@ class MiddlewareQueueTest extends TestCase
     public function testInsertAfterInvalid(): void
     {
         $one = new SampleMiddleware();
-        $two = function (): void {
+        $two = static function (): void {
         };
-        $three = function (): void {
+        $three = static function (): void {
         };
         $queue = new MiddlewareQueue();
         $queue->add($one)->add($two)->insertAfter('InvalidClass', $three);

--- a/tests/TestCase/Http/ResponseEmitterTest.php
+++ b/tests/TestCase/Http/ResponseEmitterTest.php
@@ -50,7 +50,7 @@ class ResponseEmitterTest extends TestCase
 
         $this->emitter->expects($this->any())
             ->method('setCookie')
-            ->willReturnCallback(function ($cookie) {
+            ->willReturnCallback(static function ($cookie) {
                 if (is_string($cookie)) {
                     $cookie = Cookie::createFromHeaderString($cookie, ['path' => '']);
                 }
@@ -243,7 +243,7 @@ class ResponseEmitterTest extends TestCase
      */
     public function testEmitResponseCallbackStream(): void
     {
-        $stream = new CallbackStream(function (): void {
+        $stream = new CallbackStream(static function (): void {
             echo 'It worked';
         });
         $response = (new Response())
@@ -342,7 +342,7 @@ class ResponseEmitterTest extends TestCase
      */
     public function testEmitResponseBodyRangeCallbackStream(): void
     {
-        $stream = new CallbackStream(function () {
+        $stream = new CallbackStream(static function () {
             return 'It worked';
         });
         $response = (new Response())

--- a/tests/TestCase/Http/RunnerTest.php
+++ b/tests/TestCase/Http/RunnerTest.php
@@ -61,13 +61,13 @@ class RunnerTest extends TestCase
 
         $this->queue = new MiddlewareQueue();
 
-        $this->ok = function ($request, $handler) {
+        $this->ok = static function ($request, $handler) {
             return $handler->handle($request->withAttribute('ok', true));
         };
-        $this->pass = function ($request, $handler) {
+        $this->pass = static function ($request, $handler) {
             return $handler->handle($request->withAttribute('pass', true));
         };
-        $this->fail = function ($request, $handler): void {
+        $this->fail = static function ($request, $handler): void {
             throw new RuntimeException('A bad thing');
         };
     }
@@ -91,17 +91,17 @@ class RunnerTest extends TestCase
     public function testRunSequencing(): void
     {
         $log = [];
-        $one = function ($request, $handler) use (&$log) {
+        $one = static function ($request, $handler) use (&$log) {
             $log[] = 'one';
 
             return $handler->handle($request);
         };
-        $two = function ($request, $handler) use (&$log) {
+        $two = static function ($request, $handler) use (&$log) {
             $log[] = 'two';
 
             return $handler->handle($request);
         };
-        $three = function ($request, $handler) use (&$log) {
+        $three = static function ($request, $handler) use (&$log) {
             $log[] = 'three';
 
             return $handler->handle($request);
@@ -136,7 +136,7 @@ class RunnerTest extends TestCase
         $attributes = [];
 
         $this->queue
-            ->add(function ($request, $handler) use (&$attributes) {
+            ->add(static function ($request, $handler) use (&$attributes) {
                 try {
                     return $handler->handle($request);
                 } catch (Throwable) {

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -43,7 +43,7 @@ class ServerRequestTest extends TestCase
     public function testCustomArgsDetector(): void
     {
         $request = new ServerRequest();
-        $request->addDetector('controller', function ($request, $name) {
+        $request->addDetector('controller', static function ($request, $name) {
             return $request->getParam('controller') === $name;
         });
 
@@ -748,12 +748,12 @@ class ServerRequestTest extends TestCase
     {
         $request = new ServerRequest();
 
-        ServerRequest::addDetector('closure', function ($request) {
+        ServerRequest::addDetector('closure', static function ($request) {
             return true;
         });
         $this->assertTrue($request->is('closure'));
 
-        ServerRequest::addDetector('get', function ($request) {
+        ServerRequest::addDetector('get', static function ($request) {
             return $request->getEnv('REQUEST_METHOD') === 'GET';
         });
         $request = $request->withEnv('REQUEST_METHOD', 'GET');
@@ -800,7 +800,7 @@ class ServerRequestTest extends TestCase
         $request->clearDetectorCache();
         $this->assertFalse($request->isIndex());
 
-        ServerRequest::addDetector('withParams', function ($request, array $params) {
+        ServerRequest::addDetector('withParams', static function ($request, array $params) {
             foreach ($params as $name => $value) {
                 if ($request->getParam($name) != $value) {
                     return false;
@@ -818,7 +818,7 @@ class ServerRequestTest extends TestCase
         $request->clearDetectorCache();
         $this->assertFalse($request->isWithParams(['controller' => 'Pages', 'action' => 'index']));
 
-        ServerRequest::addDetector('callme', function ($request) {
+        ServerRequest::addDetector('callme', static function ($request) {
             return $request->getAttribute('return');
         });
         $request = $request->withAttribute('return', true);

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -263,7 +263,7 @@ class ServerTest extends TestCase
     {
         $GLOBALS['mockedHeadersSent'] = false;
         $response = new LaminasResponse('php://memory', 200, ['x-testing' => 'source header']);
-        $response = $response->withBody(new CallbackStream(function (): void {
+        $response = $response->withBody(new CallbackStream(static function (): void {
             echo 'body content';
         }));
 
@@ -285,7 +285,7 @@ class ServerTest extends TestCase
         $called = false;
 
         $server->getEventManager()->on('Server.buildMiddleware', function (EventInterface $event, MiddlewareQueue $middlewareQueue) use (&$called): void {
-            $middlewareQueue->add(function ($request, $handler) use (&$called) {
+            $middlewareQueue->add(static function ($request, $handler) use (&$called) {
                 $called = true;
 
                 return $handler->handle($request);

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -59,7 +59,7 @@ class SessionTest extends TestCase
     {
         $_SESSION = null;
 
-        $this->deprecated(function (): void {
+        $this->deprecated(static function (): void {
             $config = [
                 'cookie' => 'test',
                 'checkAgent' => false,

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -38,7 +38,7 @@ class DateTest extends TestCase
         parent::setUp();
 
         Cache::clear('_cake_translations_');
-        I18n::setTranslator('cake', function () {
+        I18n::setTranslator('cake', static function () {
             $package = new Package();
             $package->setMessages([
                 '{0} ago' => '{0} ago (translated)',

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -169,7 +169,7 @@ class I18nTest extends TestCase
      */
     public function testCreateCustomTranslationPackage(): void
     {
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'Cow' => 'Le moo',
@@ -201,7 +201,7 @@ class I18nTest extends TestCase
             }
         };
 
-        I18n::config('custom', function ($domain, $locale) use ($loader) {
+        I18n::config('custom', static function ($domain, $locale) use ($loader) {
             return new $loader(
                 $domain,
                 $locale,
@@ -295,7 +295,7 @@ class I18nTest extends TestCase
      */
     public function testGetTranslatorByDefaultLocale(): void
     {
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'Cow' => 'Le moo',
@@ -395,7 +395,7 @@ class I18nTest extends TestCase
      */
     public function testBasicDomainFunction(): void
     {
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'Cow' => 'Le moo',
@@ -434,7 +434,7 @@ class I18nTest extends TestCase
      */
     public function testBasicDomainPluralFunction(): void
     {
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'Cow' => 'Le Moo',
@@ -461,7 +461,7 @@ class I18nTest extends TestCase
      */
     public function testBasicContextFunction(): void
     {
-        I18n::setTranslator('default', function (): Package {
+        I18n::setTranslator('default', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'letter' => [
@@ -517,7 +517,7 @@ class I18nTest extends TestCase
      */
     public function testBasicContextFunctionNoString(): void
     {
-        I18n::setTranslator('default', function (): Package {
+        I18n::setTranslator('default', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'letter' => [
@@ -539,7 +539,7 @@ class I18nTest extends TestCase
      */
     public function testBasicContextFunctionInvalidContext(): void
     {
-        I18n::setTranslator('default', function (): Package {
+        I18n::setTranslator('default', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'letter' => [
@@ -561,7 +561,7 @@ class I18nTest extends TestCase
      */
     public function testPluralContextFunction(): void
     {
-        I18n::setTranslator('default', function (): Package {
+        I18n::setTranslator('default', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'letter' => [
@@ -613,7 +613,7 @@ class I18nTest extends TestCase
      */
     public function testDomainContextFunction(): void
     {
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'letter' => [
@@ -666,7 +666,7 @@ class I18nTest extends TestCase
      */
     public function testDomainPluralContextFunction(): void
     {
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'letter' => [
@@ -788,7 +788,7 @@ class I18nTest extends TestCase
      */
     public function testFallbackLoaderFactory(): void
     {
-        I18n::config(TranslatorRegistry::FALLBACK_LOADER, function (string $name, string $locale) {
+        I18n::config(TranslatorRegistry::FALLBACK_LOADER, static function (string $name, string $locale) {
             $package = new Package('default');
 
             if ($name === 'custom') {
@@ -816,7 +816,7 @@ class I18nTest extends TestCase
      */
     public function testFallbackTranslator(): void
     {
-        I18n::setTranslator('default', function (): Package {
+        I18n::setTranslator('default', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'Dog' => 'Le bark',
@@ -825,7 +825,7 @@ class I18nTest extends TestCase
             return $package;
         }, 'fr_FR');
 
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'Cow' => 'Le moo',
@@ -846,14 +846,14 @@ class I18nTest extends TestCase
     {
         I18n::useFallback(false);
 
-        I18n::setTranslator('default', function (): Package {
+        I18n::setTranslator('default', static function (): Package {
             $package = new Package('default');
             $package->setMessages(['Dog' => 'Le bark']);
 
             return $package;
         }, 'fr_FR');
 
-        I18n::setTranslator('custom', function (): Package {
+        I18n::setTranslator('custom', static function (): Package {
             $package = new Package('default');
             $package->setMessages(['Cow' => 'Le moo']);
 
@@ -871,7 +871,7 @@ class I18nTest extends TestCase
      */
     public function testFallbackTranslatorWithFactory(): void
     {
-        I18n::setTranslator('default', function (): Package {
+        I18n::setTranslator('default', static function (): Package {
             $package = new Package('default');
             $package->setMessages([
                 'Dog' => 'Le bark',

--- a/tests/TestCase/I18n/Parser/PoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/PoFileParserTest.php
@@ -167,7 +167,7 @@ class PoFileParserTest extends TestCase
         $file = $this->path . 'en' . DS . 'context.po';
         $messages = $parser->parse($file);
 
-        I18n::setTranslator('default', function () use ($messages) {
+        I18n::setTranslator('default', static function () use ($messages) {
             $package = new Package('default');
             $package->setMessages($messages);
 
@@ -201,7 +201,7 @@ class PoFileParserTest extends TestCase
         $file = $this->path . 'en' . DS . 'context.po';
         $messages = $parser->parse($file);
 
-        I18n::setTranslator('default', function () use ($messages) {
+        I18n::setTranslator('default', static function () use ($messages) {
             $package = new Package('default');
             $package->setMessages($messages);
 

--- a/tests/TestCase/Log/Engine/BaseLogTest.php
+++ b/tests/TestCase/Log/Engine/BaseLogTest.php
@@ -73,7 +73,7 @@ class BaseLogTest extends TestCase
             'array' => ['arr'],
             'array-obj' => new ArrayObject(['x' => 'y']),
             'debug-info' => ConnectionManager::get('test'),
-            'obj' => function (): void {
+            'obj' => static function (): void {
             },
             'to-string' => new Response(['body' => 'response body']),
             'to-array' => new TypeMap(['my-type']),

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -415,7 +415,7 @@ class LogTest extends TestCase
             'scopes' => false,
         ]);
 
-        $this->deprecated(function (): void {
+        $this->deprecated(static function (): void {
             Log::write('debug', 'debug message', 'orders');
         });
         $this->assertFileDoesNotExist(LOGS . 'debug.log');

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -149,7 +149,7 @@ class BelongsToManyTest extends TestCase
         $assoc->setSort(['id' => 'ASC']);
         $this->assertSame(['id' => 'ASC'], $assoc->getSort());
 
-        $closure = function () {
+        $closure = static function () {
             return ['id' => 'ASC'];
         };
         $assoc->setSort($closure);
@@ -182,7 +182,7 @@ class BelongsToManyTest extends TestCase
         $result = $articles->get(1, ...['contain' => 'Tags']);
         $this->assertSame([2, 1], array_column($result['tags'], 'id'));
 
-        $assoc->setSort(function () {
+        $assoc->setSort(static function () {
             return ['Tags.id' => 'DESC'];
         });
         $result = $articles->get(1, ...['contain' => 'Tags']);
@@ -503,7 +503,7 @@ class BelongsToManyTest extends TestCase
         $this->article->getAssociation($articleTag->getAlias());
 
         $counter = 0;
-        $articleTag->getEventManager()->on('Model.beforeDelete', function () use (&$counter): void {
+        $articleTag->getEventManager()->on('Model.beforeDelete', static function () use (&$counter): void {
             $counter++;
         });
 
@@ -530,8 +530,8 @@ class BelongsToManyTest extends TestCase
         $association->junction($articleTag);
         $this->article->getAssociation($articleTag->getAlias());
 
-        $articleTag->getEventManager()->on('Model.buildRules', function ($event, $rules): void {
-            $rules->addDelete(function () {
+        $articleTag->getEventManager()->on('Model.buildRules', static function ($event, $rules): void {
+            $rules->addDelete(static function () {
                 return false;
             });
         });
@@ -1048,8 +1048,8 @@ class BelongsToManyTest extends TestCase
     {
         $articles = $this->getTableLocator()->get('Articles');
         $tags = $this->getTableLocator()->get('Tags');
-        $tags->getEventManager()->on('Model.buildRules', function (EventInterface $event, RulesChecker $rules): void {
-            $rules->add(function () {
+        $tags->getEventManager()->on('Model.buildRules', static function (EventInterface $event, RulesChecker $rules): void {
+            $rules->add(static function () {
                 return false;
             }, 'rule', ['errorField' => 'name', 'message' => 'Bad data']);
         });
@@ -1128,7 +1128,7 @@ class BelongsToManyTest extends TestCase
         $tag1 = $tags->find()->where(['Tags.name' => 'tag1'])->firstOrFail();
         $tag2 = $tags->find()->where(['Tags.name' => 'tag2'])->firstOrFail();
 
-        $findArticle = function ($article) use ($articles) {
+        $findArticle = static function ($article) use ($articles) {
             return $articles->find()
                 ->where(['CompositeKeyArticles.author_id' => $article->author_id])
                 ->contain('Tags')
@@ -1490,7 +1490,7 @@ class BelongsToManyTest extends TestCase
         $table->belongsToMany('Tags');
         $result = $table
             ->find()
-            ->contain(['Tags' => function (SelectQuery $q) {
+            ->contain(['Tags' => static function (SelectQuery $q) {
                 return $q->select(['id']);
             }])
             ->first();
@@ -1523,7 +1523,7 @@ class BelongsToManyTest extends TestCase
         $table->belongsToMany('Tags');
         $result = $table
             ->find()
-            ->contain(['Tags' => function (SelectQuery $q) {
+            ->contain(['Tags' => static function (SelectQuery $q) {
                 return $q->select(['two' => $q->expr('1 + 1')])->enableAutoFields();
             }])
             ->first();
@@ -1592,7 +1592,7 @@ class BelongsToManyTest extends TestCase
             'conditions' => ['SpecialTags.highlighted' => true],
             'through' => 'SpecialTags',
         ]);
-        $query = $table->find()->matching('Tags', function (SelectQuery $q) {
+        $query = $table->find()->matching('Tags', static function (SelectQuery $q) {
             return $q->where(['Tags.name' => 'tag1']);
         });
         $results = $query->toArray();
@@ -1610,7 +1610,7 @@ class BelongsToManyTest extends TestCase
             'conditions' => [new QueryExpression("name LIKE 'tag%'")],
             'through' => 'SpecialTags',
         ]);
-        $query = $table->find()->matching('Tags', function (SelectQuery $q) {
+        $query = $table->find()->matching('Tags', static function (SelectQuery $q) {
             return $q->where(['Tags.name' => 'tag1']);
         });
         $results = $query->toArray();
@@ -1628,7 +1628,7 @@ class BelongsToManyTest extends TestCase
             'conditions' => ['SpecialTags.highlighted' => true],
             'through' => 'SpecialTags',
         ]);
-        $query = $table->Tags->find()->matching('Articles', function (SelectQuery $query) {
+        $query = $table->Tags->find()->matching('Articles', static function (SelectQuery $query) {
             return $query->where(['Articles.id' => 1]);
         });
         // The inner join on special_tags excludes the results.
@@ -1653,7 +1653,7 @@ class BelongsToManyTest extends TestCase
         ]);
 
         $results = $table->find()
-            ->contain('SpecialTags', function ($query) {
+            ->contain('SpecialTags', static function ($query) {
                 return $query->orderBy(['SpecialTags.tag_id']);
             })
             ->where(['id' => 2])
@@ -1716,7 +1716,7 @@ class BelongsToManyTest extends TestCase
             'bindingKey' => 'name',
         ]);
         $query = $table->find()
-            ->matching('Articles', function ($q) {
+            ->matching('Articles', static function ($q) {
                 return $q->where(['Articles.id >' => 0]);
             });
         $results = $query->all();

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -401,7 +401,7 @@ class BelongsToTest extends TestCase
         });
         $association = new BelongsTo('Companies', $config);
         $query = $this->client->selectQuery();
-        $association->attachTo($query, ['queryBuilder' => function ($q) {
+        $association->attachTo($query, ['queryBuilder' => static function ($q) {
             return $q->applyOptions(['something' => 'more']);
         }]);
         $this->assertTrue($called, 'Listener should be called.');

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -179,7 +179,7 @@ class HasManyTest extends TestCase
         $assoc->setSort(['id' => 'ASC']);
         $this->assertSame(['id' => 'ASC'], $assoc->getSort());
 
-        $closure = function () {
+        $closure = static function () {
             return ['id' => 'ASC'];
         };
         $assoc->setSort($closure);
@@ -212,7 +212,7 @@ class HasManyTest extends TestCase
         $result = $authors->get(1, ...['contain' => 'Articles']);
         $this->assertSame([3, 1], array_column($result['articles'], 'id'));
 
-        $assoc->setSort(function () {
+        $assoc->setSort(static function () {
             return ['Articles.id' => 'DESC'];
         });
         $result = $authors->get(1, ...['contain' => 'Articles']);
@@ -463,7 +463,7 @@ class HasManyTest extends TestCase
             ->with('all')
             ->willReturn($query);
 
-        $queryBuilder = function ($query) {
+        $queryBuilder = static function ($query) {
             return $query->select(['author_id'])->join('comments')->where(['comments.id' => 1]);
         };
         $association->eagerLoader(compact('keys', 'query', 'queryBuilder'));
@@ -661,8 +661,8 @@ class HasManyTest extends TestCase
         ];
         $association = new HasMany('Articles', $config);
         $articles = $association->getTarget();
-        $articles->getEventManager()->on('Model.buildRules', function ($event, $rules): void {
-            $rules->addDelete(function () {
+        $articles->getEventManager()->on('Model.buildRules', static function ($event, $rules): void {
+            $rules->addDelete(static function () {
                 return false;
             });
         });
@@ -1198,7 +1198,7 @@ class HasManyTest extends TestCase
         $authors->Articles
             ->setDependent(true)
             ->setSaveStrategy('replace')
-            ->setConditions(function () {
+            ->setConditions(static function () {
                 return ['published' => 'Y'];
             });
 

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -320,7 +320,7 @@ class HasOneTest extends TestCase
         );
         $association = new HasOne('Profiles', $config);
         $query = $this->user->find();
-        $association->attachTo($query, ['queryBuilder' => function ($q) {
+        $association->attachTo($query, ['queryBuilder' => static function ($q) {
             return $q->applyOptions(['something' => 'more']);
         }]);
         $this->assertTrue($this->listenerCalled, 'Event not fired');
@@ -432,8 +432,8 @@ class HasOneTest extends TestCase
         ];
         $association = new HasOne('Profiles', $config);
         $profiles = $association->getTarget();
-        $profiles->getEventManager()->on('Model.buildRules', function ($event, $rules): void {
-            $rules->addDelete(function () {
+        $profiles->getEventManager()->on('Model.buildRules', static function ($event, $rules): void {
+            $rules->addDelete(static function () {
                 return false;
             });
         });

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -465,7 +465,7 @@ class CounterCacheBehaviorTest extends TestCase
 
         $this->post->addBehavior('CounterCache', [
             'Users' => [
-                'posts_published' => function (EventInterface $event, EntityInterface $entity, Table $table) {
+                'posts_published' => static function (EventInterface $event, EntityInterface $entity, Table $table) {
                     return $table->getConnection()->selectQuery(4);
                 },
             ],
@@ -627,7 +627,7 @@ class CounterCacheBehaviorTest extends TestCase
         $this->post->addBehavior('CounterCache', [
             'Users' => [
                 'post_count',
-                'dummy' => function (): void {
+                'dummy' => static function (): void {
                     throw new Exception('Closures are never called by "updateCounterCache()"');
                 },
             ],

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -87,13 +87,13 @@ class TranslateBehaviorEavTest extends TestCase
      */
     protected function _extractTranslations($data): CollectionInterface
     {
-        return (new Collection($data))->map(function (EntityInterface $row) {
+        return (new Collection($data))->map(static function (EntityInterface $row) {
             $translations = $row->get('_translations');
             if (!$translations) {
                 return [];
             }
 
-            return array_map(function (EntityInterface $entity) {
+            return array_map(static function (EntityInterface $entity) {
                 return $entity->toArray();
             }, $translations);
         });
@@ -198,7 +198,7 @@ class TranslateBehaviorEavTest extends TestCase
         $table->getBehavior('Translate')->setLocale('eng');
         $results = $table->find('translations')
             ->limit(1)
-            ->formatResults(function ($results) {
+            ->formatResults(static function ($results) {
                 foreach ($results as $res) {
                     $res->first = 'val';
                 }
@@ -630,7 +630,7 @@ class TranslateBehaviorEavTest extends TestCase
         $table->getBehavior('Translate')->setLocale('eng');
         $comments->getBehavior('Translate')->setLocale('eng');
 
-        $results = $table->find()->contain(['Comments' => function ($q) {
+        $results = $table->find()->contain(['Comments' => static function ($q) {
             return $q->select(['id', 'comment', 'article_id']);
         }]);
 
@@ -664,7 +664,7 @@ class TranslateBehaviorEavTest extends TestCase
         $comments->addBehavior('Translate', ['fields' => ['comment']]);
 
         $results = $table->find('translations')->contain([
-            'Comments' => function ($q) {
+            'Comments' => static function ($q) {
                 return $q->find('translations')->select(['id', 'comment', 'article_id']);
             },
         ]);
@@ -705,7 +705,7 @@ class TranslateBehaviorEavTest extends TestCase
         $table->getBehavior('Translate')->setLocale('cze');
         $comments->getBehavior('Translate')->setLocale('eng');
         $results = $table->find('translations')->contain([
-            'Comments' => function ($q) {
+            'Comments' => static function ($q) {
                 return $q->find('translations')->select(['id', 'comment', 'article_id']);
             },
         ]);
@@ -760,7 +760,7 @@ class TranslateBehaviorEavTest extends TestCase
         $results = $table->find()
             ->select(['title', 'body'])
             ->orderBy(['title' => 'asc'])
-            ->contain(['Authors' => function (SelectQuery $q) {
+            ->contain(['Authors' => static function (SelectQuery $q) {
                 return $q->select(['id', 'name']);
             }]);
 
@@ -784,7 +784,7 @@ class TranslateBehaviorEavTest extends TestCase
                 '_locale' => 'eng',
             ],
         ];
-        $results = array_map(function (EntityInterface $r) {
+        $results = array_map(static function (EntityInterface $r) {
             return $r->toArray();
         }, $results->toArray());
         $this->assertEquals($expected, $results);
@@ -2061,7 +2061,7 @@ class TranslateBehaviorEavTest extends TestCase
         $result = $table
             ->find()
             ->contain([
-                'Articles' => function ($query) {
+                'Articles' => static function ($query) {
                     return $query->matching('Tags');
                 },
                 'Articles.Tags',
@@ -2084,7 +2084,7 @@ class TranslateBehaviorEavTest extends TestCase
         $table->getBehavior('Translate')->setLocale('fra');
 
         $articles = $table->find()->all();
-        $articles->each(function ($article): void {
+        $articles->each(static function ($article): void {
             $article->published = 'N';
         });
 

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -361,7 +361,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $table->addBehavior('Translate');
         $table->getBehavior('Translate')->setLocale('eng');
 
-        $query = $table->find()->select()->where(function (ExpressionInterface $exp) {
+        $query = $table->find()->select()->where(static function (ExpressionInterface $exp) {
             return $exp->lt(new QueryExpression('1'), 50);
         });
 
@@ -675,7 +675,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
             ->find()
             ->where(['Comments.id' => 1])
             ->contain([
-                'Articles' => function ($q) {
+                'Articles' => static function ($q) {
                     return $q->find('translations');
                 }]);
         $record = $query->firstOrFail();
@@ -1224,7 +1224,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $table->getBehavior('Translate')->setLocale('fra');
 
         $articles = $table->find()->all();
-        $articles->each(function ($article): void {
+        $articles->each(static function ($article): void {
             $article->published = 'N';
         });
 

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -193,7 +193,7 @@ class TreeBehaviorTest extends TestCase
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', [
-            'scope' => function ($query) {
+            'scope' => static function ($query) {
                 return $query->where(['menu' => 'main-menu']);
             },
         ]);
@@ -256,7 +256,7 @@ class TreeBehaviorTest extends TestCase
         $query = $table->find('treeList');
 
         $result = null;
-        $query->clause('order')->iterateParts(function ($dir, $field) use (&$result): void {
+        $query->clause('order')->iterateParts(static function ($dir, $field) use (&$result): void {
             $result = $field;
         });
         $this->assertSame('MenuLinkTrees.lft', $result);
@@ -1449,7 +1449,7 @@ class TreeBehaviorTest extends TestCase
         $displayField = $table->getDisplayField();
 
         $options = [
-            'valuePath' => function ($item, $key, $iterator) use ($primaryKey, $displayField) {
+            'valuePath' => static function ($item, $key, $iterator) use ($primaryKey, $displayField) {
                 return sprintf(
                     '%s:%s - %s:%s',
                     str_pad((string)$item->lft, 2, ' ', STR_PAD_LEFT),

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -315,7 +315,7 @@ class EagerLoaderTest extends TestCase
      */
     public function testContainClosure(): void
     {
-        $builder = function ($query): void {
+        $builder = static function ($query): void {
         };
         $loader = new EagerLoader();
         $loader->contain([
@@ -346,7 +346,7 @@ class EagerLoaderTest extends TestCase
      */
     public function testContainSecondSignature(): void
     {
-        $builder = function ($query): void {
+        $builder = static function ($query): void {
         };
         $loader = new EagerLoader();
         $loader->contain('clients', $builder);
@@ -366,7 +366,7 @@ class EagerLoaderTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $builder = function ($query): void {
+        $builder = static function ($query): void {
         };
         $loader = new EagerLoader();
         $loader->contain(['clients'], $builder);
@@ -386,12 +386,12 @@ class EagerLoaderTest extends TestCase
     {
         $loader = new EagerLoader();
         $loader->contain([
-            'clients' => function ($query) {
+            'clients' => static function ($query) {
                 return $query->select(['a']);
             },
         ]);
         $loader->contain([
-            'clients' => function ($query) {
+            'clients' => static function ($query) {
                 return $query->select(['b']);
             },
         ]);

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -56,7 +56,7 @@ class EntityTest extends TestCase
 
     public function testEntitySetDeprecated(): void
     {
-        $this->deprecated(function (): void {
+        $this->deprecated(static function (): void {
             $entity = new Entity();
             $entity->set(['foo' => 'bar']);
         });

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -349,7 +349,7 @@ class MarshallerTest extends TestCase
         $users->hasOne('Articles', [
             'foreignKey' => 'author_id',
         ]);
-        $articles->getEventManager()->on('Model.beforeMarshal', function ($event, $data, $options): void {
+        $articles->getEventManager()->on('Model.beforeMarshal', static function ($event, $data, $options): void {
             // Blank the association, so it doesn't become dirty.
             unset($data['not_a_real_field']);
         });
@@ -1878,7 +1878,7 @@ class MarshallerTest extends TestCase
         $entity->clean();
 
         // Adding a forced join to have another table with the same column names
-        $this->articles->Tags->getEventManager()->on('Model.beforeFind', function ($e, $query): void {
+        $this->articles->Tags->getEventManager()->on('Model.beforeFind', static function ($e, $query): void {
             $left = new IdentifierExpression('Tags.id');
             $right = new IdentifierExpression('a.id');
             $query->leftJoin(['a' => 'tags'], $query->expr()->eq($left, $right));
@@ -1935,7 +1935,7 @@ class MarshallerTest extends TestCase
         ]);
 
         $this->articles->Tags->getEventManager()
-            ->on('Model.beforeFind', function (EventInterface $event, $query) use (&$called): void {
+            ->on('Model.beforeFind', static function (EventInterface $event, $query) use (&$called): void {
                 $called = true;
 
                 $query->where(['Tags.id >=' => 1]);
@@ -2607,7 +2607,7 @@ class MarshallerTest extends TestCase
             ['id' => 1, 'comment' => 'Changed 1', 'user_id' => 1],
             ['id' => 2, 'comment' => 'Changed 2', 'user_id' => 2],
         ];
-        $this->comments->getEventManager()->on('Model.beforeFind', function (EventInterface $event, $query): void {
+        $this->comments->getEventManager()->on('Model.beforeFind', static function (EventInterface $event, $query): void {
             $query->contain(['Articles']);
         });
         $marshall = new Marshaller($this->comments);
@@ -3391,28 +3391,28 @@ class MarshallerTest extends TestCase
 
         $this->articles->Users->getEventManager()->on(
             'Model.beforeMarshal',
-            function ($e, $data, $options): void {
+            static function ($e, $data, $options): void {
                 $data['secret'] = 'h45h3d';
             },
         );
 
         $this->articles->Comments->getEventManager()->on(
             'Model.beforeMarshal',
-            function ($e, $data): void {
+            static function ($e, $data): void {
                 $data['comment'] .= ' (modified)';
             },
         );
 
         $this->articles->Tags->getEventManager()->on(
             'Model.beforeMarshal',
-            function ($e, $data): void {
+            static function ($e, $data): void {
                 $data['tag'] .= ' (modified)';
             },
         );
 
         $this->articles->Tags->junction()->getEventManager()->on(
             'Model.beforeMarshal',
-            function ($e, $data): void {
+            static function ($e, $data): void {
                 $data['modified_by'] = 1;
             },
         );

--- a/tests/TestCase/ORM/Query/CaseExpressionQueryTest.php
+++ b/tests/TestCase/ORM/Query/CaseExpressionQueryTest.php
@@ -30,7 +30,7 @@ class CaseExpressionQueryTest extends TestCase
     {
         $query = $this->getTableLocator()->get('Products')
             ->find()
-            ->select(function (SelectQuery $query) {
+            ->select(static function (SelectQuery $query) {
                 return [
                     'name',
                     'price',
@@ -70,7 +70,7 @@ class CaseExpressionQueryTest extends TestCase
     {
         $query = $this->getTableLocator()->get('Products')
             ->find()
-            ->select(function (SelectQuery $query) {
+            ->select(static function (SelectQuery $query) {
                 $expression = $query->expr()
                     ->case()
                     ->when(['Products.price <' => 20])

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -164,8 +164,8 @@ class QueryRegressionTest extends TestCase
         $tags->belongsToMany('Authors');
 
         $query = $articles->find()
-            ->matching('Tags', function ($q) {
-                return $q->matching('Authors', function ($q) {
+            ->matching('Tags', static function ($q) {
+                return $q->matching('Authors', static function ($q) {
                     return $q->where(['Authors.name' => 'larry']);
                 });
             });
@@ -287,7 +287,7 @@ class QueryRegressionTest extends TestCase
         $articles->belongsToMany('Tags');
         $tags->belongsToMany('Articles');
 
-        $sub = $articles->Tags->find()->select(['Tags.id'])->matching('Articles', function ($q) {
+        $sub = $articles->Tags->find()->select(['Tags.id'])->matching('Articles', static function ($q) {
             return $q->where(['Articles.id' => 1]);
         });
 
@@ -382,7 +382,7 @@ class QueryRegressionTest extends TestCase
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsTo('Authors');
 
-        $articles->getEventManager()->on('Model.beforeFind', function (EventInterface $event, $query) {
+        $articles->getEventManager()->on('Model.beforeFind', static function (EventInterface $event, $query) {
             return $query->contain('Authors');
         });
 
@@ -637,7 +637,7 @@ class QueryRegressionTest extends TestCase
         $table->belongsTo('Authors', ['joinType' => 'inner']);
         $count = $table
             ->find()
-            ->contain(['Authors' => function ($q) {
+            ->contain(['Authors' => static function ($q) {
                 return $q->where(['Authors.id' => 1]);
             }])
             ->count();
@@ -679,7 +679,7 @@ class QueryRegressionTest extends TestCase
         $this->assertNotFalse($result);
 
         $table->getEventManager()
-            ->on('Model.beforeFind', function (EventInterface $event, $query): void {
+            ->on('Model.beforeFind', static function (EventInterface $event, $query): void {
                 $query->contain(['Authors']);
             });
 
@@ -830,7 +830,7 @@ class QueryRegressionTest extends TestCase
         $table->belongsTo('Authors');
         $article = $table->find()
             ->contain('Authors')
-            ->matching('Authors', function ($q) {
+            ->matching('Authors', static function ($q) {
                 return $q->where(['Authors.id' => 1]);
             })
             ->first();
@@ -850,7 +850,7 @@ class QueryRegressionTest extends TestCase
         $table->articles->belongsToMany('tags');
 
         $result = $table->find()
-            ->matching('articles.tags', function ($q) {
+            ->matching('articles.tags', static function ($q) {
                 return $q->where(['tags.id' => 2]);
             })
             ->contain('articles');
@@ -873,7 +873,7 @@ class QueryRegressionTest extends TestCase
 
         $result = $comments
             ->find()
-            ->matching('Articles.Tags', function ($q) {
+            ->matching('Articles.Tags', static function ($q) {
                 return $q->where(['Tags.id' => 2]);
             })
             ->contain('Articles')
@@ -902,7 +902,7 @@ class QueryRegressionTest extends TestCase
 
         $result = $comments
             ->find()
-            ->matching('Articles.Tags', function ($q) {
+            ->matching('Articles.Tags', static function ($q) {
                 return $q->where(['Tags.id' => 2]);
             })
             ->contain('Articles.Authors')
@@ -936,10 +936,10 @@ class QueryRegressionTest extends TestCase
 
         $result = $comments->find()
             ->contain(['Articles', 'Users'])
-            ->matching('Articles', function ($q) {
+            ->matching('Articles', static function ($q) {
                 return $q->where(['Articles.id >=' => 1]);
             })
-            ->matching('Users', function ($q) {
+            ->matching('Users', static function ($q) {
                 return $q->where(['Users.id >=' => 1]);
             })
             ->orderBy(['Comments.id' => 'ASC'])
@@ -1003,7 +1003,7 @@ class QueryRegressionTest extends TestCase
         $table->hasMany('Comments');
 
         $query = $table->find()->contain([
-            'Comments' => function ($q) {
+            'Comments' => static function ($q) {
                 return $q->select([
                     'concat' => $q->func()->concat(['red', 'blue']),
                     'user_id',
@@ -1028,7 +1028,7 @@ class QueryRegressionTest extends TestCase
         $table->hasMany('Comments');
         $results = $table->find()
             ->select(['Users.id'])
-            ->matching('Comments', function ($q) {
+            ->matching('Comments', static function ($q) {
                 return $q->where(['Comments.id' => 1]);
             })
             ->all()
@@ -1046,14 +1046,14 @@ class QueryRegressionTest extends TestCase
         $table->belongsToMany('Tags');
 
         $rows = $table->find()
-            ->matching('Tags', function ($q) {
+            ->matching('Tags', static function ($q) {
                 return $q->where([]);
             })
             ->all();
         $this->assertNotEmpty($rows);
 
         $rows = $table->find()
-            ->matching('Tags', function ($q) {
+            ->matching('Tags', static function ($q) {
                 return $q->where(null);
             })
             ->all();
@@ -1067,7 +1067,7 @@ class QueryRegressionTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Comments');
         $ratio = $table->find()
-            ->select(function ($query) use ($table) {
+            ->select(static function ($query) use ($table) {
                 $allCommentsCount = $table->find()->select($query->func()->count('*'));
                 $countToFloat = $query->expr([$query->func()->count('*'), '1.0'])->setConjunction('*');
 
@@ -1096,8 +1096,8 @@ class QueryRegressionTest extends TestCase
         $table->Articles->belongsTo('Authors');
         $table->Articles->Authors->belongsToMany('Tags');
 
-        $query = $table->find()->where(['Comments.id' => 5])->contain(['Articles' => function ($q) {
-            return $q->contain(['Authors' => function ($q) {
+        $query = $table->find()->where(['Comments.id' => 5])->contain(['Articles' => static function ($q) {
+            return $q->contain(['Authors' => static function ($q) {
                 return $q->contain('Tags');
             }]);
         }]);
@@ -1175,7 +1175,7 @@ class QueryRegressionTest extends TestCase
             'through' => 'SpecialTags',
         ]);
         $query = $table->find()
-            ->contain(['Tags' => function ($q) {
+            ->contain(['Tags' => static function ($q) {
                 return $q->where(['SpecialTags.highlighted_time >' => new DateTime('2014-06-01 00:00:00')]);
             }])
             ->where(['Articles.id' => 2]);
@@ -1269,7 +1269,7 @@ class QueryRegressionTest extends TestCase
         $Tags->belongsToMany('Articles');
 
         $query = $Tags->find()
-            ->notMatching('Articles', function ($q) {
+            ->notMatching('Articles', static function ($q) {
                 return $q ->where(['ArticlesTags.tag_id !=' => 3 ]);
             })
             ->where([
@@ -1394,7 +1394,7 @@ class QueryRegressionTest extends TestCase
             ->find()
             ->select(['name' => 'Authors.name', 'tag' => 'Tags.name'])
             ->matching('Articles.SpecialTags.Tags')
-            ->matching('Articles.SpecialTags.Authors', function ($q) {
+            ->matching('Articles.SpecialTags.Authors', static function ($q) {
                 return $q->where(['Authors.id' => 2]);
             })
             ->distinct()
@@ -1519,9 +1519,9 @@ class QueryRegressionTest extends TestCase
         $articles->hasMany('articlesTags');
         $tags = $articles->getAssociation('articlesTags')->getTarget()->belongsTo('tags');
 
-        $tags->getTarget()->getEventManager()->on('Model.beforeFind', function ($e, $query): void {
-            $query->formatResults(function ($results) {
-                return $results->map(function (Entity $tag) {
+        $tags->getTarget()->getEventManager()->on('Model.beforeFind', static function ($e, $query): void {
+            $query->formatResults(static function ($results) {
+                return $results->map(static function (Entity $tag) {
                     $tag->name .= ' - visited';
 
                     return $tag;
@@ -1531,7 +1531,7 @@ class QueryRegressionTest extends TestCase
 
         $query = $table->find()->contain(['articles.articlesTags.tags']);
 
-        $query->mapReduce(function ($row, $key, $mr): void {
+        $query->mapReduce(static function ($row, $key, $mr): void {
             foreach ((array)$row->articles as $article) {
                 foreach ((array)$article->articles_tags as $articleTag) {
                     $mr->emit($articleTag->tag->name);
@@ -1552,7 +1552,7 @@ class QueryRegressionTest extends TestCase
 
         $query = $table
             ->find()
-            ->select(function (SelectQuery $q) use ($table) {
+            ->select(static function (SelectQuery $q) use ($table) {
                 return [
                     'value' => $q
                         ->func()
@@ -1579,14 +1579,14 @@ class QueryRegressionTest extends TestCase
 
         $query = $table
             ->find()
-            ->select(function (SelectQuery $q) use ($table) {
+            ->select(static function (SelectQuery $q) use ($table) {
                 return [
                     'value' => $q->func()->UPPER([
                         $table
                             ->getAssociation('Authors')
                             ->find()
                             ->select(['Authors.name'])
-                            ->where(function (QueryExpression $exp) {
+                            ->where(static function (QueryExpression $exp) {
                                 return $exp->equalFields('Authors.id', 'Articles.author_id');
                             }),
                     ]),
@@ -1606,7 +1606,7 @@ class QueryRegressionTest extends TestCase
 
         $query = $table
             ->find()
-            ->select(function (SelectQuery $q) use ($table) {
+            ->select(static function (SelectQuery $q) use ($table) {
                 return [
                     'value' => $q
                         ->func()
@@ -1642,14 +1642,14 @@ class QueryRegressionTest extends TestCase
 
         $query = $table
             ->find()
-            ->select(function (SelectQuery $q) use ($table) {
+            ->select(static function (SelectQuery $q) use ($table) {
                 return [
                     'value' => $q->func()->coalesce([
                         $table
                             ->getAssociation('Authors')
                             ->find()
                             ->select(['Authors.name'])
-                            ->where(function (QueryExpression $exp) {
+                            ->where(static function (QueryExpression $exp) {
                                 return $exp->equalFields('Authors.id', 'Articles.author_id');
                             }),
                         '1',
@@ -1671,7 +1671,7 @@ class QueryRegressionTest extends TestCase
 
         $query = $table
             ->find()
-            ->select(function (SelectQuery $q) use ($table) {
+            ->select(static function (SelectQuery $q) use ($table) {
                 return [
                     'value' => $q->func()->concat([
                         $table
@@ -1698,14 +1698,14 @@ class QueryRegressionTest extends TestCase
 
         $query = $table
             ->find()
-            ->select(function (SelectQuery $q) use ($table) {
+            ->select(static function (SelectQuery $q) use ($table) {
                 return [
                     'value' => $q->func()->concat([
                         $table
                             ->getAssociation('Authors')
                             ->find()
                             ->select(['Authors.name'])
-                            ->where(function (QueryExpression $exp) {
+                            ->where(static function (QueryExpression $exp) {
                                 return $exp->equalFields('Authors.id', 'Articles.author_id');
                             }),
                         ' appended',
@@ -1756,7 +1756,7 @@ class QueryRegressionTest extends TestCase
 
         // Test with both order and limit - both should be preserved
         $query = $authors->find()
-            ->contain(['Articles' => function ($q) {
+            ->contain(['Articles' => static function ($q) {
                 return $q->orderBy(['Articles.id' => 'DESC'])
                     ->limit(2);
             }])
@@ -1788,7 +1788,7 @@ class QueryRegressionTest extends TestCase
 
         // Test with only order (no limit) - order should be preserved
         $query = $authors->find()
-            ->contain(['Articles' => function ($q) {
+            ->contain(['Articles' => static function ($q) {
                 return $q->orderBy(['Articles.title' => 'ASC']);
             }])
             ->where(['Authors.id' => 1]);
@@ -1804,7 +1804,7 @@ class QueryRegressionTest extends TestCase
 
         // Test with only limit (no order) - limit should be respected
         $query = $authors->find()
-            ->contain(['Articles' => function ($q) {
+            ->contain(['Articles' => static function ($q) {
                 return $q->limit(1);
             }])
             ->where(['Authors.id' => 1]);

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -730,7 +730,7 @@ class SelectQueryTest extends TestCase
         $results = $query->setRepository($table)
             ->select()
             ->disableHydration()
-            ->matching('Comments', function ($q) {
+            ->matching('Comments', static function ($q) {
                 return $q->where(['Comments.user_id' => 4]);
             })
             ->toArray();
@@ -767,7 +767,7 @@ class SelectQueryTest extends TestCase
         $table->hasMany('Comments');
 
         $result = $query->setRepository($table)
-            ->matching('Comments', function ($q) {
+            ->matching('Comments', static function ($q) {
                 return $q->where(['Comments.user_id' => 4]);
             })
             ->first();
@@ -793,7 +793,7 @@ class SelectQueryTest extends TestCase
         $table->belongsToMany('Tags');
 
         $results = $query->setRepository($table)->select()
-            ->matching('Tags', function ($q) {
+            ->matching('Tags', static function ($q) {
                 return $q->where(['Tags.id' => 3]);
             })
             ->enableHydration(false)
@@ -820,7 +820,7 @@ class SelectQueryTest extends TestCase
 
         $query = new SelectQuery($table);
         $results = $query->select()
-            ->matching('Tags', function ($q) {
+            ->matching('Tags', static function ($q) {
                 return $q->where(['Tags.name' => 'tag2']);
             })
             ->enableHydration(false)
@@ -860,7 +860,7 @@ class SelectQueryTest extends TestCase
         $results = $query->setRepository($table)
             ->select()
             ->enableHydration(false)
-            ->matching('articles.tags', function ($q) {
+            ->matching('articles.tags', static function ($q) {
                 return $q->where(['tags.id' => 2]);
             })
             ->toArray();
@@ -1080,9 +1080,9 @@ class SelectQueryTest extends TestCase
      */
     public function testMapReduceOnlyMapper(): void
     {
-        $mapper1 = function (): void {
+        $mapper1 = static function (): void {
         };
-        $mapper2 = function (): void {
+        $mapper2 = static function (): void {
         };
         $query = new SelectQuery($this->table);
         $this->assertSame($query, $query->mapReduce($mapper1));
@@ -1107,13 +1107,13 @@ class SelectQueryTest extends TestCase
      */
     public function testMapReduceBothMethods(): void
     {
-        $mapper1 = function (): void {
+        $mapper1 = static function (): void {
         };
-        $mapper2 = function (): void {
+        $mapper2 = static function (): void {
         };
-        $reducer1 = function (): void {
+        $reducer1 = static function (): void {
         };
-        $reducer2 = function (): void {
+        $reducer2 = static function (): void {
         };
         $query = new SelectQuery($this->table);
         $this->assertSame($query, $query->mapReduce($mapper1, $reducer1));
@@ -1137,13 +1137,13 @@ class SelectQueryTest extends TestCase
      */
     public function testOverwriteMapReduce(): void
     {
-        $mapper1 = function (): void {
+        $mapper1 = static function (): void {
         };
-        $mapper2 = function (): void {
+        $mapper2 = static function (): void {
         };
-        $reducer1 = function (): void {
+        $reducer1 = static function (): void {
         };
-        $reducer2 = function (): void {
+        $reducer2 = static function (): void {
         };
         $query = new SelectQuery($this->table);
         $this->assertEquals($query, $query->mapReduce($mapper1, $reducer1));
@@ -1167,14 +1167,14 @@ class SelectQueryTest extends TestCase
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
         $query = new SelectQuery($table);
         $query->select(['a' => 'id'])->limit(2)->orderBy(['id' => 'ASC']);
-        $query->mapReduce(function ($v, $k, $mr): void {
+        $query->mapReduce(static function ($v, $k, $mr): void {
             $mr->emit($v['a']);
         });
         $query->mapReduce(
-            function ($v, $k, $mr): void {
+            static function ($v, $k, $mr): void {
                 $mr->emitIntermediate($v, $k);
             },
-            function ($v, $k, $mr): void {
+            static function ($v, $k, $mr): void {
                 $mr->emit($v[0] + 1);
             },
         );
@@ -1230,10 +1230,10 @@ class SelectQueryTest extends TestCase
      */
     public function testFirstMapReduce(): void
     {
-        $map = function ($row, $key, $mapReduce): void {
+        $map = static function ($row, $key, $mapReduce): void {
             $mapReduce->emitIntermediate($row['id'], 'id');
         };
-        $reduce = function ($values, $key, $mapReduce): void {
+        $reduce = static function ($values, $key, $mapReduce): void {
             $mapReduce->emit(array_sum($values));
         };
 
@@ -1381,8 +1381,8 @@ class SelectQueryTest extends TestCase
 
         $articlesTags
             ->getEventManager()
-            ->on('Model.beforeFind', function (EventInterface $event, $query): void {
-                $query->formatResults(function ($results) {
+            ->on('Model.beforeFind', static function (EventInterface $event, $query): void {
+                $query->formatResults(static function ($results) {
                     foreach ($results as $result) {
                         $result->beforeFind = true;
                     }
@@ -1652,7 +1652,7 @@ class SelectQueryTest extends TestCase
                 'Articles.title',
                 'tag_count' => $counter,
             ])
-            ->matching('Authors', function ($q) {
+            ->matching('Authors', static function ($q) {
                 return $q->where(['Authors.id' => 1]);
             })
             ->count();
@@ -1685,7 +1685,7 @@ class SelectQueryTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
         $table->getEventManager()
-            ->on('Model.beforeFind', function (EventInterface $event, $query): void {
+            ->on('Model.beforeFind', static function (EventInterface $event, $query): void {
                 $query
                     ->limit(1)
                     ->orderBy(['Articles.title' => 'DESC']);
@@ -1704,7 +1704,7 @@ class SelectQueryTest extends TestCase
         $callCount = 0;
         $table = $this->getTableLocator()->get('Articles');
         $table->getEventManager()
-            ->on('Model.beforeFind', function (EventInterface $event, $query) use (&$callCount): void {
+            ->on('Model.beforeFind', static function (EventInterface $event, $query) use (&$callCount): void {
                 $valueBinder = new ValueBinder();
                 $query->sql($valueBinder);
                 $callCount++;
@@ -1928,7 +1928,7 @@ class SelectQueryTest extends TestCase
 
         $query
             ->select(['id', 'title'])
-            ->formatResults(function ($results) {
+            ->formatResults(static function ($results) {
                 return $results->combine('id', 'title');
             })
             ->cache('my_key', $cacher);
@@ -1971,7 +1971,7 @@ class SelectQueryTest extends TestCase
             ->select()
             ->disableBufferedResults()
             ->contain([
-                'articles' => function ($q) {
+                'articles' => static function ($q) {
                     return $q->where(['articles.id' => 1]);
                 },
             ]);
@@ -1996,7 +1996,7 @@ class SelectQueryTest extends TestCase
         $query = new SelectQuery($table);
         $query
             ->select()
-            ->contain('articles', function ($q) {
+            ->contain('articles', static function ($q) {
                 return $q->where(['articles.id' => 1]);
             });
 
@@ -2016,7 +2016,7 @@ class SelectQueryTest extends TestCase
         $query = new SelectQuery($table);
         $query
             ->select()
-            ->contain('articles', function ($q) {
+            ->contain('articles', static function ($q) {
                 return $q->select(['test' => '(SELECT 20)'])
                     ->enableAutoFields(true);
             });
@@ -2038,7 +2038,7 @@ class SelectQueryTest extends TestCase
             ->contain([
                 'Articles' => [
                     'foreignKey' => false,
-                    'queryBuilder' => function ($q) {
+                    'queryBuilder' => static function ($q) {
                         return $q->where(['articles.id' => 1]);
                     },
                 ],
@@ -2059,7 +2059,7 @@ class SelectQueryTest extends TestCase
             ->contain([
                 'Articles' => [
                     'foreignKey' => false,
-                    'queryBuilder' => function ($q) {
+                    'queryBuilder' => static function ($q) {
                         return $q->where(['Articles.id' => 1]);
                     },
                 ],
@@ -2075,7 +2075,7 @@ class SelectQueryTest extends TestCase
             ->contain([
                 'Authors' => [
                     'foreignKey' => false,
-                    'queryBuilder' => function ($q) {
+                    'queryBuilder' => static function ($q) {
                         return $q->where(['Authors.id' => 1]);
                     },
                 ],
@@ -2091,7 +2091,7 @@ class SelectQueryTest extends TestCase
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsTo('Authors', [
-            'conditions' => function ($exp, $query) {
+            'conditions' => static function ($exp, $query) {
                 return $exp;
             },
         ]);
@@ -2105,9 +2105,9 @@ class SelectQueryTest extends TestCase
      */
     public function testFormatResults(): void
     {
-        $callback1 = function (): void {
+        $callback1 = static function (): void {
         };
-        $callback2 = function (): void {
+        $callback2 = static function (): void {
         };
         $table = $this->getTableLocator()->get('authors');
         $query = new SelectQuery($table);
@@ -2134,7 +2134,7 @@ class SelectQueryTest extends TestCase
 
         $query = $this->getTableLocator()->get('Authors')
             ->find()
-            ->formatResults(function ($results, $query) use (&$resultFormatterQuery) {
+            ->formatResults(static function ($results, $query) use (&$resultFormatterQuery) {
                 $resultFormatterQuery = $query;
 
                 return $results;
@@ -2159,10 +2159,10 @@ class SelectQueryTest extends TestCase
 
         $authors->getEventManager()->on(
             'Model.beforeFind',
-            function ($event, SelectQuery $targetQuery) use (&$resultFormatterTargetQuery, &$resultFormatterSourceQuery): void {
+            static function ($event, SelectQuery $targetQuery) use (&$resultFormatterTargetQuery, &$resultFormatterSourceQuery): void {
                 $resultFormatterTargetQuery = $targetQuery;
 
-                $targetQuery->formatResults(function ($results, $query) use (&$resultFormatterSourceQuery) {
+                $targetQuery->formatResults(static function ($results, $query) use (&$resultFormatterSourceQuery) {
                     $resultFormatterSourceQuery = $query;
 
                     return $results;
@@ -2196,13 +2196,13 @@ class SelectQueryTest extends TestCase
 
         $sourceQuery = $articles
             ->find()
-            ->contain('Authors', function (SelectQuery $targetQuery) use (
+            ->contain('Authors', static function (SelectQuery $targetQuery) use (
                 &$resultFormatterTargetQuery,
                 &$resultFormatterSourceQuery,
             ) {
                 $resultFormatterTargetQuery = $targetQuery;
 
-                return $targetQuery->formatResults(function ($results, $query) use (&$resultFormatterSourceQuery) {
+                return $targetQuery->formatResults(static function ($results, $query) use (&$resultFormatterSourceQuery) {
                     $resultFormatterSourceQuery = $query;
 
                     return $results;
@@ -2231,10 +2231,10 @@ class SelectQueryTest extends TestCase
 
         $tags->getEventManager()->on(
             'Model.beforeFind',
-            function ($event, SelectQuery $targetQuery) use (&$resultFormatterTargetQuery, &$resultFormatterSourceQuery): void {
+            static function ($event, SelectQuery $targetQuery) use (&$resultFormatterTargetQuery, &$resultFormatterSourceQuery): void {
                 $resultFormatterTargetQuery = $targetQuery;
 
-                $targetQuery->formatResults(function ($results, $query) use (&$resultFormatterSourceQuery) {
+                $targetQuery->formatResults(static function ($results, $query) use (&$resultFormatterSourceQuery) {
                     $resultFormatterSourceQuery = $query;
 
                     return $results;
@@ -2268,13 +2268,13 @@ class SelectQueryTest extends TestCase
 
         $sourceQuery = $articles
             ->find()
-            ->contain('Tags', function (SelectQuery $targetQuery) use (
+            ->contain('Tags', static function (SelectQuery $targetQuery) use (
                 &$resultFormatterTargetQuery,
                 &$resultFormatterSourceQuery,
             ) {
                 $resultFormatterTargetQuery = $targetQuery;
 
-                return $targetQuery->formatResults(function ($results, $query) use (&$resultFormatterSourceQuery) {
+                return $targetQuery->formatResults(static function ($results, $query) use (&$resultFormatterSourceQuery) {
                     $resultFormatterSourceQuery = $query;
 
                     return $results;
@@ -2316,7 +2316,7 @@ class SelectQueryTest extends TestCase
             return $results->indexBy('id');
         });
 
-        $query->formatResults(function ($results) {
+        $query->formatResults(static function ($results) {
             return $results->extract('name');
         });
 
@@ -2408,17 +2408,17 @@ class SelectQueryTest extends TestCase
 
         $query = $table->find()
             ->contain([
-                'authors' => function ($q) {
+                'authors' => static function ($q) {
                     return $q
-                        ->formatResults(function ($authors) {
-                            return $authors->map(function ($author) {
+                        ->formatResults(static function ($authors) {
+                            return $authors->map(static function ($author) {
                                 $author->idCopy = $author->id;
 
                                 return $author;
                             });
                         })
-                        ->formatResults(function ($authors) {
-                            return $authors->map(function ($author) {
+                        ->formatResults(static function ($authors) {
+                            return $authors->map(static function ($author) {
                                 $author->idCopy += 2;
 
                                 return $author;
@@ -2427,7 +2427,7 @@ class SelectQueryTest extends TestCase
                 },
             ]);
 
-        $query->formatResults(function ($results) {
+        $query->formatResults(static function ($results) {
             return $results->combine('id', 'author.idCopy');
         });
         $results = $query->toArray();
@@ -2444,17 +2444,17 @@ class SelectQueryTest extends TestCase
         $table->belongsTo('Articles');
         $table->getAssociation('Articles')->getTarget()->belongsTo('Authors');
 
-        $builder = function ($q) {
+        $builder = static function ($q) {
             return $q
-                ->formatResults(function ($results) {
-                    return $results->map(function ($result) {
+                ->formatResults(static function ($results) {
+                    return $results->map(static function ($result) {
                         $result->idCopy = $result->id;
 
                         return $result;
                     });
                 })
-                ->formatResults(function ($results) {
-                    return $results->map(function ($result) {
+                ->formatResults(static function ($results) {
+                    return $results->map(static function ($result) {
                         $result->idCopy += 2;
 
                         return $result;
@@ -2465,8 +2465,8 @@ class SelectQueryTest extends TestCase
             ->contain(['Articles' => $builder, 'Articles.Authors' => $builder])
             ->orderBy(['ArticlesTags.article_id' => 'ASC']);
 
-        $query->formatResults(function ($results) {
-            return $results->map(function ($row) {
+        $query->formatResults(static function ($results) {
+            return $results->map(static function ($row) {
                 return sprintf(
                     '%s - %s - %s',
                     $row->tag_id,
@@ -2493,9 +2493,9 @@ class SelectQueryTest extends TestCase
         $articles->getAssociation('articlesTags')->getTarget()->belongsTo('tags');
 
         $query = $table->find()->contain([
-            'articles.articlesTags.tags' => function ($q) {
-                return $q->formatResults(function ($results) {
-                    return $results->map(function ($tag) {
+            'articles.articlesTags.tags' => static function ($q) {
+                return $q->formatResults(static function ($results) {
+                    return $results->map(static function ($tag) {
                         $tag->name .= ' - visited';
 
                         return $tag;
@@ -2504,7 +2504,7 @@ class SelectQueryTest extends TestCase
             },
         ]);
 
-        $query->mapReduce(function ($row, $key, $mr): void {
+        $query->mapReduce(static function ($row, $key, $mr): void {
             foreach ((array)$row->articles as $article) {
                 foreach ((array)$article->articles_tags as $articleTag) {
                     $mr->emit($articleTag->tag->name);
@@ -2563,7 +2563,7 @@ class SelectQueryTest extends TestCase
 
         // First, let's test with a regular field to ensure our fix works
         $query = $table->find()
-            ->contain(['Authors' => function ($q) {
+            ->contain(['Authors' => static function ($q) {
                 // Select only the name field (not the primary key)
                 return $q->select(['Authors.name']);
             }])
@@ -2597,7 +2597,7 @@ class SelectQueryTest extends TestCase
         $query = $table->find()
             ->orderBy(['Articles.id' => 'ASC'])
             ->contain([
-                'Articles' => function ($q) {
+                'Articles' => static function ($q) {
                     return $q->contain('Authors');
                 },
             ]);
@@ -2618,8 +2618,8 @@ class SelectQueryTest extends TestCase
         $articles->hasMany('articlesTags');
         $articles->getAssociation('articlesTags')->getTarget()->belongsTo('tags');
 
-        $query = $table->find()->matching('articles.articlesTags', function ($q) {
-            return $q->matching('tags', function ($q) {
+        $query = $table->find()->matching('articles.articlesTags', static function ($q) {
+            return $q->matching('tags', static function ($q) {
                 return $q->where(['tags.name' => 'tag3']);
             });
         });
@@ -2641,10 +2641,10 @@ class SelectQueryTest extends TestCase
             ->enableHydration(false)
             ->matching('articles')
             ->applyOptions(['foo' => 'bar'])
-            ->formatResults(function ($results) {
+            ->formatResults(static function ($results) {
                 return $results;
             })
-            ->mapReduce(function ($item, $key, $mr): void {
+            ->mapReduce(static function ($item, $key, $mr): void {
                 $mr->emit($item);
             });
 
@@ -2880,7 +2880,7 @@ class SelectQueryTest extends TestCase
             ->enableAutoFields()
             ->enableHydration(false)
             ->contain([
-                'Authors' => function ($q) {
+                'Authors' => static function ($q) {
                     return $q->select(['computed' => '(SELECT 2 + 20)'])
                         ->enableAutoFields();
                 },
@@ -2969,7 +2969,7 @@ class SelectQueryTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
         $table->getEventManager()
-            ->on('Model.beforeFind', function (EventInterface $event, $query): void {
+            ->on('Model.beforeFind', static function (EventInterface $event, $query): void {
                 $query
                     ->limit(5)
                     ->orderBy(['Articles.title' => 'DESC']);
@@ -3127,7 +3127,7 @@ class SelectQueryTest extends TestCase
         $resultWithArticles = $table->find('all')
             ->where(['id' => 1])
             ->contain([
-                'Articles' => function ($q) {
+                'Articles' => static function ($q) {
                     return $q->find('published');
                 },
             ]);
@@ -3143,7 +3143,7 @@ class SelectQueryTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $query = $table->find()->where(['id >' => 1]);
-        $query->where(function (ExpressionInterface $exp) {
+        $query->where(static function (ExpressionInterface $exp) {
             return $exp->add('author_id = :author');
         });
         $query->bind(':author', 1, 'integer');
@@ -3212,7 +3212,7 @@ class SelectQueryTest extends TestCase
 
         $result = $query->setRepository($table)
             ->select()
-            ->matching('articles.tags', function ($q) {
+            ->matching('articles.tags', static function ($q) {
                 return $q->where(['tags.id' => 2]);
             })
             ->contain('articles')
@@ -3233,7 +3233,7 @@ class SelectQueryTest extends TestCase
         $table->belongsToMany('tags');
 
         $result = $table->find()
-            ->matching('tags', function ($q) {
+            ->matching('tags', static function ($q) {
                 return $q->where(['tags.id' => 2]);
             })
             ->contain('tags')
@@ -3304,7 +3304,7 @@ class SelectQueryTest extends TestCase
         $table->belongsTo('authors');
         $result = $table
             ->find()
-            ->select(function ($q) {
+            ->select(static function ($q) {
                 return ['foo' => $q->expr('1 + 1')];
             })
             ->select($table)
@@ -3314,7 +3314,7 @@ class SelectQueryTest extends TestCase
 
         $expected = $table
             ->find()
-            ->select(function ($q) {
+            ->select(static function ($q) {
                 return ['foo' => $q->expr('1 + 1')];
             })
             ->enableAutoFields()
@@ -3399,7 +3399,7 @@ class SelectQueryTest extends TestCase
                 'authors.id',
                 'tagged_articles' => 'count(tags.id)',
             ])
-            ->leftJoinWith('articles.tags', function ($q) {
+            ->leftJoinWith('articles.tags', static function ($q) {
                 return $q->where(['tags.name' => 'tag3']);
             })
             ->groupBy(['authors.id']);
@@ -3423,7 +3423,7 @@ class SelectQueryTest extends TestCase
         $articles->belongsToMany('tags');
         $results = $table
             ->find()
-            ->leftJoinWith('articles.tags', function ($q) {
+            ->leftJoinWith('articles.tags', static function ($q) {
                 return $q
                     ->select(['articles.id', 'articles.title', 'tags.name'])
                     ->where(['tags.name' => 'tag3']);
@@ -3453,7 +3453,7 @@ class SelectQueryTest extends TestCase
 
         $results = $table
             ->find()
-            ->leftJoinWith('authors', function ($q) {
+            ->leftJoinWith('authors', static function ($q) {
                 return $q->enableAutoFields();
             })
             ->all();
@@ -3560,7 +3560,7 @@ class SelectQueryTest extends TestCase
         $table->hasMany('articles');
         $results = $table
             ->find()
-            ->innerJoinWith('articles', function ($q) {
+            ->innerJoinWith('articles', static function ($q) {
                 return $q->where(['articles.title' => 'Third Article']);
             });
         $expected = [
@@ -3582,7 +3582,7 @@ class SelectQueryTest extends TestCase
         $articles->belongsToMany('tags');
         $results = $table
             ->find()
-            ->innerJoinWith('articles.tags', function ($q) {
+            ->innerJoinWith('articles.tags', static function ($q) {
                 return $q->where(['tags.name' => 'tag3']);
             });
         $expected = [
@@ -3604,7 +3604,7 @@ class SelectQueryTest extends TestCase
         $results = $table
             ->find()
             ->enableAutoFields()
-            ->innerJoinWith('articles', function ($q) {
+            ->innerJoinWith('articles', static function ($q) {
                 return $q->select(['id', 'author_id', 'title', 'body', 'published']);
             })
             ->toArray();
@@ -3628,7 +3628,7 @@ class SelectQueryTest extends TestCase
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('`Articles` association cannot contain() associations when using JOIN strategy');
         $comments->find()
-            ->innerJoinWith('Articles', function (SelectQuery $q) {
+            ->innerJoinWith('Articles', static function (SelectQuery $q) {
                 return $q
                     ->contain('ArticlesTranslations')
                     ->where(['ArticlesTranslations.title' => 'Titel #1']);
@@ -3658,7 +3658,7 @@ class SelectQueryTest extends TestCase
 
         $results = $table->find()
             ->enableHydration(false)
-            ->notMatching('articles', function ($q) {
+            ->notMatching('articles', static function ($q) {
                 return $q->where(['articles.author_id' => 1]);
             })
             ->orderBy(['authors.id'])
@@ -3681,7 +3681,7 @@ class SelectQueryTest extends TestCase
 
         $results = $table->find()
             ->enableHydration(false)
-            ->notMatching('tags', function ($q) {
+            ->notMatching('tags', static function ($q) {
                 return $q->where(['tags.name' => 'tag2']);
             });
 
@@ -3718,7 +3718,7 @@ class SelectQueryTest extends TestCase
         $results = $table->find()
             ->enableHydration(false)
             ->select('authors.id')
-            ->notMatching('articles.tags', function ($q) {
+            ->notMatching('articles.tags', static function ($q) {
                 return $q->where(['tags.name' => 'tag3']);
             })
             ->distinct(['authors.id']);
@@ -3727,7 +3727,7 @@ class SelectQueryTest extends TestCase
 
         $results = $table->find()
             ->enableHydration(false)
-            ->notMatching('articles.tags', function ($q) {
+            ->notMatching('articles.tags', static function ($q) {
                 return $q->where(['tags.name' => 'tag3']);
             })
             ->matching('articles')
@@ -3748,8 +3748,8 @@ class SelectQueryTest extends TestCase
 
         $results = $table->find()
             ->enableHydration(false)
-            ->matching('articles', function (SelectQuery $q) {
-                return $q->notMatching('tags', function (SelectQuery $q) {
+            ->matching('articles', static function (SelectQuery $q) {
+                return $q->notMatching('tags', static function (SelectQuery $q) {
                     return $q->where(['tags.name' => 'tag3']);
                 });
             })
@@ -3803,7 +3803,7 @@ class SelectQueryTest extends TestCase
         $result = $table
             ->find()
             ->contain([
-                'Comments' => function (SelectQuery $query) use ($table) {
+                'Comments' => static function (SelectQuery $query) use ($table) {
                     return $query->selectAllExcept($table->Comments, ['published']);
                 },
             ])
@@ -3915,7 +3915,7 @@ class SelectQueryTest extends TestCase
 
         $cteQuery = $table
             ->find()
-            ->select(function (SelectQuery $query) use ($table) {
+            ->select(static function (SelectQuery $query) use ($table) {
                 $columns = $table->getSchema()->columns();
 
                 return array_combine($columns, $columns) + [
@@ -3930,7 +3930,7 @@ class SelectQueryTest extends TestCase
 
         $query = $table
             ->find()
-            ->with(function (CommonTableExpression $cte) use ($cteQuery) {
+            ->with(static function (CommonTableExpression $cte) use ($cteQuery) {
                 return $cte
                     ->name('cte')
                     ->query($cteQuery);

--- a/tests/TestCase/ORM/ResultSetFactoryTest.php
+++ b/tests/TestCase/ORM/ResultSetFactoryTest.php
@@ -213,7 +213,7 @@ class ResultSetFactoryTest extends TestCase
         $this->assertSame('TestPlugin.Comments', $result->getSource());
         $this->assertSame('TestPlugin.Authors', $result->author->getSource());
 
-        $result = $comments->find()->matching('Authors', function ($q) {
+        $result = $comments->find()->matching('Authors', static function ($q) {
             return $q->where(['Authors.id' => 1]);
         })->first();
         $this->assertSame('TestPlugin.Comments', $result->getSource());

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -246,7 +246,7 @@ class ResultSetTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Comments');
         $query = $table->find()
-            ->formatResults(function ($results) {
+            ->formatResults(static function ($results) {
                 return $results;
             });
         $res = $query->all();

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -122,7 +122,7 @@ class LinkConstraintTest extends TestCase
         $Articles = $this->getTableLocator()->get('Articles');
         $Articles->hasMany('Comments');
 
-        $Articles->getEventManager()->on('Model.beforeRules', function (Event $event): void {
+        $Articles->getEventManager()->on('Model.beforeRules', static function (Event $event): void {
             $event->getSubject()->setPrimaryKey(['id', 'nonexistent']);
         });
 
@@ -614,12 +614,12 @@ class LinkConstraintTest extends TestCase
         $Articles = $this->getTableLocator()->get('Articles');
         $Articles->hasOne('Comments', [
             'foreignKey' => false,
-            'conditions' => function (QueryExpression $exp, SelectQuery $query) {
+            'conditions' => static function (QueryExpression $exp, SelectQuery $query) {
                 $connection = $query->getConnection();
                 $subQuery = $connection
                     ->selectQuery(['RecentComments.id'])
                     ->from(['RecentComments' => 'comments'])
-                    ->where(function (QueryExpression $exp) {
+                    ->where(static function (QueryExpression $exp) {
                         return $exp->eq(
                             new IdentifierExpression('Articles.id'),
                             new IdentifierExpression('RecentComments.article_id'),
@@ -650,12 +650,12 @@ class LinkConstraintTest extends TestCase
         $Articles = $this->getTableLocator()->get('Articles');
         $Articles->hasOne('Comments', [
             'foreignKey' => false,
-            'conditions' => function (QueryExpression $exp, SelectQuery $query) {
+            'conditions' => static function (QueryExpression $exp, SelectQuery $query) {
                 $connection = $query->getConnection();
                 $subQuery = $connection
                     ->selectQuery(['RecentComments.id'])
                     ->from(['RecentComments' => 'comments'])
-                    ->where(function (QueryExpression $exp) {
+                    ->where(static function (QueryExpression $exp) {
                         return $exp->eq(
                             new IdentifierExpression('Articles.id'),
                             new IdentifierExpression('RecentComments.article_id'),
@@ -749,7 +749,7 @@ class LinkConstraintTest extends TestCase
     {
         $Articles = $this->getTableLocator()->get('Articles');
         $Articles->hasOne('Comments', [
-            'conditions' => function (QueryExpression $exp) {
+            'conditions' => static function (QueryExpression $exp) {
                 return $exp->notEq(
                     new IdentifierExpression('Comments.published'),
                     new IdentifierExpression('Articles.published'),
@@ -785,7 +785,7 @@ class LinkConstraintTest extends TestCase
     {
         $Articles = $this->getTableLocator()->get('Articles');
         $Articles->hasOne('Comments', [
-            'conditions' => function (QueryExpression $exp) {
+            'conditions' => static function (QueryExpression $exp) {
                 return $exp->eq(
                     new IdentifierExpression('Comments.published'),
                     new IdentifierExpression('Articles.published'),

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -101,7 +101,7 @@ class RulesCheckerIntegrationTest extends TestCase
             ->getTarget()
             ->rulesChecker()
             ->add(
-                function (EntityInterface $entity) {
+                static function (EntityInterface $entity) {
                     return false;
                 },
                 ['errorField' => 'title', 'message' => 'This is an error'],
@@ -191,7 +191,7 @@ class RulesCheckerIntegrationTest extends TestCase
             ->getTarget()
             ->rulesChecker()
             ->add(
-                function (Entity $article) {
+                static function (Entity $article) {
                     return is_numeric($article->title);
                 },
                 ['errorField' => 'title', 'message' => 'This is an error'],
@@ -229,7 +229,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $table->getAssociation('tags')
             ->junction()
             ->rulesChecker()
-            ->add(function (Entity $entity) {
+            ->add(static function (Entity $entity) {
                 return $entity->article_id > 4;
             });
 
@@ -266,7 +266,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $table->getAssociation('tags')
             ->junction()
             ->rulesChecker()
-            ->add(function (Entity $entity) {
+            ->add(static function (Entity $entity) {
                 return $entity->tag_id > 4;
             });
 
@@ -293,7 +293,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $table = $this->getTableLocator()->get('Authors');
         $rules = $table->rulesChecker();
         $rules->add(
-            function () {
+            static function () {
                 return false;
             },
             'ruleName',
@@ -769,7 +769,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules = $table->rulesChecker();
         $rules->add($rules->isUnique(['author_id']));
 
-        $table->Authors->getEventManager()->on('Model.beforeFind', function (EventInterface $event, $query): void {
+        $table->Authors->getEventManager()->on('Model.beforeFind', static function (EventInterface $event, $query): void {
             $query->leftJoin(['a2' => 'authors']);
         });
 
@@ -809,7 +809,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules = $table->rulesChecker();
         $rules->add($rules->existsIn('author_id', 'Authors'));
 
-        $table->Authors->getEventManager()->on('Model.beforeFind', function (EventInterface $event, $query): void {
+        $table->Authors->getEventManager()->on('Model.beforeFind', static function (EventInterface $event, $query): void {
             $query->leftJoin(['a2' => 'authors']);
         });
 
@@ -1090,7 +1090,7 @@ class RulesCheckerIntegrationTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $rules = $table->rulesChecker();
-        $rules->addDelete(function ($entity) {
+        $rules->addDelete(static function ($entity) {
             return false;
         });
 
@@ -1148,7 +1148,7 @@ class RulesCheckerIntegrationTest extends TestCase
 
         $table = $this->getTableLocator()->get('Authors');
         $rules = $table->rulesChecker();
-        $rules->add(function () {
+        $rules->add(static function () {
             return 'So much nope';
         }, ['errorField' => 'name']);
 
@@ -1167,7 +1167,7 @@ class RulesCheckerIntegrationTest extends TestCase
 
         $table = $this->getTableLocator()->get('Authors');
         $rules = $table->rulesChecker();
-        $rules->add(function () {
+        $rules->add(static function () {
             return 'So much nope';
         });
 
@@ -1691,7 +1691,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rulesChecker = $Comments->rulesChecker();
 
         Closure::bind(
-            function () use ($rulesChecker): void {
+            static function () use ($rulesChecker): void {
                 $rulesChecker->{'_useI18n'} = false;
             },
             null,
@@ -1736,7 +1736,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rulesChecker = $Comments->rulesChecker();
 
         Closure::bind(
-            function () use ($rulesChecker): void {
+            static function () use ($rulesChecker): void {
                 $rulesChecker->{'_useI18n'} = false;
             },
             null,

--- a/tests/TestCase/ORM/TableRegressionTest.php
+++ b/tests/TestCase/ORM/TableRegressionTest.php
@@ -46,7 +46,7 @@ class TableRegressionTest extends TestCase
         $table = $this->getTableLocator()->get('Authors');
         $table->getEventManager()->on(
             'Model.afterSave',
-            function () use ($table): void {
+            static function () use ($table): void {
                 $table->getConnection()->rollback();
             },
         );

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -757,7 +757,7 @@ class TableTest extends TestCase
         ]);
         $table->getEventManager()->on(
             'Model.beforeFind',
-            function (EventInterface $event, $query, $options): void {
+            static function (EventInterface $event, $query, $options): void {
                 $query->limit(1);
             },
         );
@@ -779,14 +779,14 @@ class TableTest extends TestCase
         $expected = ['One', 'Two', 'Three'];
         $table->getEventManager()->on(
             'Model.beforeFind',
-            function (EventInterface $event, $query, $options) use ($expected): void {
+            static function (EventInterface $event, $query, $options) use ($expected): void {
                 $query->setResult($expected);
                 $event->stopPropagation();
             },
         );
 
         $query = $table->find('all')
-            ->formatResults(function (ResultSet $results) {
+            ->formatResults(static function (ResultSet $results) {
                 return $results;
             });
         $query->limit(1);
@@ -1604,7 +1604,7 @@ class TableTest extends TestCase
         $expected = ['id', 'username'];
         $this->assertSame($expected, $query->clause('select'));
 
-        $query = $table->find('list', valueField: function ($row) {
+        $query = $table->find('list', valueField: static function ($row) {
             return $row->username;
         });
         $this->assertEmpty($query->clause('select'));
@@ -2314,7 +2314,7 @@ class TableTest extends TestCase
             'created' => new DateTime('2013-10-10 00:00'),
             'updated' => new DateTime('2013-10-10 00:00'),
         ]);
-        $listener1 = function ($event, $entity, $options): void {
+        $listener1 = static function ($event, $entity, $options): void {
             $options['crazy'] = true;
         };
         $listener2 = function ($event, $entity, $options): void {
@@ -2341,7 +2341,7 @@ class TableTest extends TestCase
             'created' => new DateTime('2013-10-10 00:00'),
             'updated' => new DateTime('2013-10-10 00:00'),
         ]);
-        $listener = function (EventInterface $event, $entity): void {
+        $listener = static function (EventInterface $event, $entity): void {
             $event->stopPropagation();
             $event->setResult($entity);
         };
@@ -2364,7 +2364,7 @@ class TableTest extends TestCase
             'created' => new DateTime('2013-10-10 00:00'),
             'updated' => new DateTime('2013-10-10 00:00'),
         ]);
-        $listener = function (EventInterface $event, $entity): void {
+        $listener = static function (EventInterface $event, $entity): void {
             $event->stopPropagation();
         };
         $table->getEventManager()->on('Model.beforeSave', $listener);
@@ -2382,7 +2382,7 @@ class TableTest extends TestCase
             'created' => new DateTime('2013-10-10 00:00'),
             'updated' => new DateTime('2013-10-10 00:00'),
         ]);
-        $listener = function (EventInterface $event, $entity): void {
+        $listener = static function (EventInterface $event, $entity): void {
             $event->stopPropagation();
             $event->setResult(1);
         };
@@ -2442,7 +2442,7 @@ class TableTest extends TestCase
         $table->getEventManager()->on('Model.afterSave', $listener);
 
         $calledAfterCommit = false;
-        $listenerAfterCommit = function ($e, $entity, $options) use (&$calledAfterCommit): void {
+        $listenerAfterCommit = static function ($e, $entity, $options) use (&$calledAfterCommit): void {
             $calledAfterCommit = true;
         };
         $table->getEventManager()->on('Model.afterSaveCommit', $listenerAfterCommit);
@@ -2466,7 +2466,7 @@ class TableTest extends TestCase
         ]);
 
         $called = false;
-        $listener = function ($e, $entity, $options) use (&$called): void {
+        $listener = static function ($e, $entity, $options) use (&$called): void {
             $called = true;
         };
         $table->getEventManager()->on('Model.afterSaveCommit', $listener);
@@ -2490,7 +2490,7 @@ class TableTest extends TestCase
         ]);
 
         $called = false;
-        $listener = function ($e, $entity, $options) use (&$called): void {
+        $listener = static function ($e, $entity, $options) use (&$called): void {
             $called = true;
         };
         $table->getEventManager()->on('Model.afterSaveCommit', $listener);
@@ -2532,13 +2532,13 @@ class TableTest extends TestCase
             ->willReturn(0);
 
         $called = false;
-        $listener = function ($e, $entity, $options) use (&$called): void {
+        $listener = static function ($e, $entity, $options) use (&$called): void {
             $called = true;
         };
         $table->getEventManager()->on('Model.afterSave', $listener);
 
         $calledAfterCommit = false;
-        $listenerAfterCommit = function ($e, $entity, $options) use (&$calledAfterCommit): void {
+        $listenerAfterCommit = static function ($e, $entity, $options) use (&$calledAfterCommit): void {
             $calledAfterCommit = true;
         };
         $table->getEventManager()->on('Model.afterSaveCommit', $listenerAfterCommit);
@@ -2565,13 +2565,13 @@ class TableTest extends TestCase
         $table->belongsTo('authors');
 
         $calledForArticle = false;
-        $listenerForArticle = function ($e, $entity, $options) use (&$calledForArticle): void {
+        $listenerForArticle = static function ($e, $entity, $options) use (&$calledForArticle): void {
             $calledForArticle = true;
         };
         $table->getEventManager()->on('Model.afterSaveCommit', $listenerForArticle);
 
         $calledForAuthor = false;
-        $listenerForAuthor = function ($e, $entity, $options) use (&$calledForAuthor): void {
+        $listenerForAuthor = static function ($e, $entity, $options) use (&$calledForAuthor): void {
             $calledForAuthor = true;
         };
         $table->authors->getEventManager()->on('Model.afterSaveCommit', $listenerForAuthor);
@@ -2925,7 +2925,7 @@ class TableTest extends TestCase
         ];
 
         $timesCalled = 0;
-        $listener = function ($e, $entity, $options) use (&$timesCalled): void {
+        $listener = static function ($e, $entity, $options) use (&$timesCalled): void {
             $timesCalled++;
         };
         $table = $this->getTableLocator()
@@ -3022,7 +3022,7 @@ class TableTest extends TestCase
             new Entity(['name' => 'jose']),
         ];
 
-        $table->getEventManager()->on('Model.beforeSave', function (EventInterface $event, EntityInterface $entity): void {
+        $table->getEventManager()->on('Model.beforeSave', static function (EventInterface $event, EntityInterface $entity): void {
             if ($entity->name === 'jose') {
                 throw new Exception('Oh noes');
             }
@@ -3116,7 +3116,7 @@ class TableTest extends TestCase
 
             public function buildRules(RulesChecker $rules): RulesChecker
             {
-                return $rules->add(function () {
+                return $rules->add(static function () {
                     return 'Xyz';
                 });
             }
@@ -3192,8 +3192,8 @@ class TableTest extends TestCase
             ->setCascadeCallbacks(true);
 
         $articles = $table->getAssociation('Articles')->getTarget();
-        $articles->getEventManager()->on('Model.buildRules', function ($event, $rules): void {
-            $rules->addDelete(function ($entity) {
+        $articles->getEventManager()->on('Model.buildRules', static function ($event, $rules): void {
+            $rules->addDelete(static function ($entity) {
                 if ($entity->author_id === 3) {
                     return false;
                 }
@@ -3323,8 +3323,8 @@ class TableTest extends TestCase
     {
         $sections = $this->getTableLocator()->get('Sections');
         $sectionsMembers = $this->getTableLocator()->get('SectionsMembers');
-        $sectionsMembers->getEventManager()->on('Model.buildRules', function ($event, $rules): void {
-            $rules->addDelete(function () {
+        $sectionsMembers->getEventManager()->on('Model.buildRules', static function ($event, $rules): void {
+            $rules->addDelete(static function () {
                 return false;
             });
         });
@@ -3409,7 +3409,7 @@ class TableTest extends TestCase
         $table->getEventManager()->on('Model.afterDelete', $listener);
 
         $calledAfterCommit = false;
-        $listenerAfterCommit = function ($e, $entity, $options) use (&$calledAfterCommit): void {
+        $listenerAfterCommit = static function ($e, $entity, $options) use (&$calledAfterCommit): void {
             $calledAfterCommit = true;
         };
         $table->getEventManager()->on('Model.afterDeleteCommit', $listenerAfterCommit);
@@ -3428,13 +3428,13 @@ class TableTest extends TestCase
         $table->Articles->setDependent(true);
 
         $called = false;
-        $listener = function ($e, $entity, $options) use (&$called): void {
+        $listener = static function ($e, $entity, $options) use (&$called): void {
             $called = true;
         };
         $table->getEventManager()->on('Model.afterDeleteCommit', $listener);
 
         $called2 = false;
-        $listener = function ($e, $entity, $options) use (&$called2): void {
+        $listener = static function ($e, $entity, $options) use (&$called2): void {
             $called2 = true;
         };
         $table->Articles->getEventManager()->on('Model.afterDeleteCommit', $listener);
@@ -3456,7 +3456,7 @@ class TableTest extends TestCase
         $mock = $this->getMockBuilder(EventManager::class)->getMock();
         $mock->expects($this->any())
             ->method('dispatch')
-            ->willReturnCallback(function (EventInterface $event) {
+            ->willReturnCallback(static function (EventInterface $event) {
                 $event->stopPropagation();
 
                 return $event;
@@ -3478,7 +3478,7 @@ class TableTest extends TestCase
         $mock = $this->getMockBuilder(EventManager::class)->getMock();
         $mock->expects($this->any())
             ->method('dispatch')
-            ->willReturnCallback(function (EventInterface $event) {
+            ->willReturnCallback(static function (EventInterface $event) {
                 $event->stopPropagation();
                 $event->setResult('got stopped');
 
@@ -5035,7 +5035,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $tags->junction()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
+            static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             },
         );
@@ -5069,7 +5069,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $tags->junction()->getEventManager()->on(
             'Model.beforeSave',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
+            static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             },
         );
@@ -5105,7 +5105,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $tags->junction()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
+            static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             },
         );
@@ -5136,13 +5136,13 @@ class TableTest extends TestCase
         $actualDeleteOptions = null;
         $tags->junction()->getEventManager()->on(
             'Model.beforeSave',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualSaveOptions): void {
+            static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualSaveOptions): void {
                 $actualSaveOptions = $options->getArrayCopy();
             },
         );
         $tags->junction()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualDeleteOptions): void {
+            static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualDeleteOptions): void {
                 $actualDeleteOptions = $options->getArrayCopy();
             },
         );
@@ -5194,7 +5194,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $articles->getTarget()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
+            static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             },
         );
@@ -5229,7 +5229,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $articles->getTarget()->getEventManager()->on(
             'Model.beforeSave',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
+            static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             },
         );
@@ -5271,7 +5271,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $articles->getTarget()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
+            static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             },
         );
@@ -5306,13 +5306,13 @@ class TableTest extends TestCase
         $actualDeleteOptions = null;
         $articles->getTarget()->getEventManager()->on(
             'Model.beforeSave',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualSaveOptions): void {
+            static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualSaveOptions): void {
                 $actualSaveOptions = $options->getArrayCopy();
             },
         );
         $articles->getTarget()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualDeleteOptions): void {
+            static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualDeleteOptions): void {
                 $actualDeleteOptions = $options->getArrayCopy();
             },
         );
@@ -5366,7 +5366,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $tags->junction()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
+            static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             },
         );
@@ -5396,7 +5396,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $articles->getTarget()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
+            static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             },
         );
@@ -5869,7 +5869,7 @@ class TableTest extends TestCase
     public function testFindOrCreateTransactions(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
-        $articles->getEventManager()->on('Model.afterSaveCommit', function (EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
+        $articles->getEventManager()->on('Model.afterSaveCommit', static function (EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
             $entity->afterSaveCommit = true;
         });
 
@@ -5993,7 +5993,7 @@ class TableTest extends TestCase
     public function testInitializeEvent(): void
     {
         $count = 0;
-        $cb = function (EventInterface $event) use (&$count): void {
+        $cb = static function (EventInterface $event) use (&$count): void {
             $count++;
         };
         EventManager::instance()->on('Model.initialize', $cb);
@@ -6022,7 +6022,7 @@ class TableTest extends TestCase
     public function testBuildValidatorEvent(): void
     {
         $count = 0;
-        $cb = function (EventInterface $event) use (&$count): void {
+        $cb = static function (EventInterface $event) use (&$count): void {
             $count++;
         };
         EventManager::instance()->on('Model.buildValidator', $cb);
@@ -6167,7 +6167,7 @@ class TableTest extends TestCase
         $afterSaveCount = 0;
         $eventManager->on(
             'Model.buildRules',
-            function (EventInterface $event, RulesChecker $rules) use (&$buildRulesCount): void {
+            static function (EventInterface $event, RulesChecker $rules) use (&$buildRulesCount): void {
                 $buildRulesCount++;
             },
         );
@@ -6188,13 +6188,13 @@ class TableTest extends TestCase
         );
         $eventManager->on(
             'Model.beforeSave',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$beforeSaveCount): void {
+            static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$beforeSaveCount): void {
                 $beforeSaveCount++;
             },
         );
         $eventManager->on(
             'Model.afterSave',
-            $afterSaveCallback = function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$afterSaveCount): void {
+            $afterSaveCallback = static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$afterSaveCount): void {
                 $afterSaveCount++;
             },
         );
@@ -6209,13 +6209,13 @@ class TableTest extends TestCase
         $afterDeleteCount = 0;
         $eventManager->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$beforeDeleteCount): void {
+            static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$beforeDeleteCount): void {
                 $beforeDeleteCount++;
             },
         );
         $eventManager->on(
             'Model.afterDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$afterDeleteCount): void {
+            static function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$afterDeleteCount): void {
                 $afterDeleteCount++;
             },
         );
@@ -6300,7 +6300,7 @@ class TableTest extends TestCase
         $counter = 0;
         $userTable->Comments
             ->getEventManager()
-            ->on('Model.afterSave', function (EventInterface $event, $entity) use (&$counter): void {
+            ->on('Model.afterSave', static function (EventInterface $event, $entity) use (&$counter): void {
                 if ($entity->isDirty()) {
                     $counter++;
                 }
@@ -6334,7 +6334,7 @@ class TableTest extends TestCase
         $counter = 0;
         $table->Tags->junction()
             ->getEventManager()
-            ->on('Model.afterSave', function (EventInterface $event, $entity) use (&$counter): void {
+            ->on('Model.afterSave', static function (EventInterface $event, $entity) use (&$counter): void {
                 if ($entity->isDirty()) {
                     $counter++;
                 }
@@ -6419,7 +6419,7 @@ class TableTest extends TestCase
         $entity = $table->get(1);
         $options = [
             'SiteArticles' => ['fields' => ['title', 'author_id']],
-            'Articles.Tags' => function ($q) {
+            'Articles.Tags' => static function ($q) {
                 return $q->where(['Tags.name' => 'tag2']);
             },
         ];
@@ -6457,8 +6457,8 @@ class TableTest extends TestCase
 
         $entity = $table->get(2);
         $result = $table->loadInto($entity, [
-            'Articles' => function (SelectQuery $q) {
-                return $q->innerJoinWith('Authors', function ($q) {
+            'Articles' => static function (SelectQuery $q) {
+                return $q->innerJoinWith('Authors', static function ($q) {
                     return $q->where(['Authors.name' => 'mariano']);
                 });
             },

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -86,7 +86,7 @@ class RoutingMiddlewareTest extends TestCase
     {
         $this->builder->connect('/testpath', ['controller' => 'Articles', 'action' => 'index'], ['routeClass' => HeaderRedirectRoute::class]);
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/testpath']);
-        $handler = new TestRequestHandler(function ($request) {
+        $handler = new TestRequestHandler(static function ($request) {
             return new Response();
         });
         $middleware = new RoutingMiddleware($this->app());
@@ -344,7 +344,7 @@ class RoutingMiddlewareTest extends TestCase
         $this->builder->applyMiddleware('first');
         $this->builder->connect('/', ['controller' => 'Home']);
 
-        $this->builder->scope('/api', function (RouteBuilder $routes): void {
+        $this->builder->scope('/api', static function (RouteBuilder $routes): void {
             $routes->applyMiddleware('second');
             $routes->connect('/articles', ['controller' => 'Articles']);
         });
@@ -381,7 +381,7 @@ class RoutingMiddlewareTest extends TestCase
         $this->builder->applyMiddleware('first');
         $this->builder->connect('/', ['controller' => 'Home']);
 
-        $this->builder->scope('/api', function (RouteBuilder $routes): void {
+        $this->builder->scope('/api', static function (RouteBuilder $routes): void {
             $routes->applyMiddleware('second');
             $routes->connect('/articles', ['controller' => 'Articles']);
         });
@@ -419,12 +419,12 @@ class RoutingMiddlewareTest extends TestCase
             return $handler->handle($request);
         });
 
-        $this->builder->scope('/api', function (RouteBuilder $routes): void {
+        $this->builder->scope('/api', static function (RouteBuilder $routes): void {
             $routes->applyMiddleware('first');
             $routes->connect('/ping', ['controller' => 'Pings']);
         });
 
-        $this->builder->scope('/api', function (RouteBuilder $routes): void {
+        $this->builder->scope('/api', static function (RouteBuilder $routes): void {
             $routes->applyMiddleware('second');
             $routes->connect('/version', ['controller' => 'Version']);
         });
@@ -466,11 +466,11 @@ class RoutingMiddlewareTest extends TestCase
             {
             }
         };
-        $this->builder->scope('/', function (RouteBuilder $routes): void {
+        $this->builder->scope('/', static function (RouteBuilder $routes): void {
             $routes->connect('/testpath', ['controller' => 'Articles', 'action' => 'index']);
         });
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/testpath']);
-        $handler = new TestRequestHandler(function ($request) {
+        $handler = new TestRequestHandler(static function ($request) {
             return new Response('php://memory', 200);
         });
         $middleware = new RoutingMiddleware($app);
@@ -484,11 +484,11 @@ class RoutingMiddlewareTest extends TestCase
     public function testAppWithContainerApplicationInterface(): void
     {
         $app = $this->app();
-        $this->builder->scope('/', function (RouteBuilder $routes): void {
+        $this->builder->scope('/', static function (RouteBuilder $routes): void {
             $routes->connect('/testpath', ['controller' => 'Articles', 'action' => 'index']);
         });
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/testpath']);
-        $handler = new TestRequestHandler(function ($request) {
+        $handler = new TestRequestHandler(static function ($request) {
             return new Response('php://memory', 200);
         });
         $middleware = new RoutingMiddleware($app);

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -549,7 +549,7 @@ class RouteBuilderTest extends TestCase
     public function testResourcesPathOption(): void
     {
         $routes = new RouteBuilder($this->collection, '/api');
-        $routes->resources('Articles', ['path' => 'posts'], function (RouteBuilder $routes): void {
+        $routes->resources('Articles', ['path' => 'posts'], static function (RouteBuilder $routes): void {
             $routes->resources('Comments');
         });
         $all = $this->collection->routes();
@@ -620,7 +620,7 @@ class RouteBuilderTest extends TestCase
         $routes->resources(
             'NetworkObjects',
             ['inflect' => 'dasherize'],
-            function (RouteBuilder $routes): void {
+            static function (RouteBuilder $routes): void {
                 $routes->resources('Attributes');
             },
         );
@@ -701,7 +701,7 @@ class RouteBuilderTest extends TestCase
     public function testResourcesInScope(): void
     {
         $builder = Router::createRouteBuilder('/');
-        $builder->scope('/api', ['prefix' => 'Api'], function (RouteBuilder $routes): void {
+        $builder->scope('/api', ['prefix' => 'Api'], static function (RouteBuilder $routes): void {
             $routes->setExtensions(['json']);
             $routes->resources('Articles');
         });
@@ -911,7 +911,7 @@ class RouteBuilderTest extends TestCase
     public function testScopeWithAction(): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
-        $routes->scope('/prices', ['controller' => 'Prices', 'action' => 'view'], function (RouteBuilder $routes): void {
+        $routes->scope('/prices', ['controller' => 'Prices', 'action' => 'view'], static function (RouteBuilder $routes): void {
             $routes->connect('/shared', ['shared' => true]);
             $routes->get('/exclusive', ['exclusive' => true]);
         });
@@ -978,7 +978,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testRegisterMiddleware(): void
     {
-        $func = function (): void {
+        $func = static function (): void {
         };
         $routes = new RouteBuilder($this->collection, '/api');
         $result = $routes->registerMiddleware('test', $func);
@@ -993,7 +993,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testMiddlewareGroup(): void
     {
-        $func = function (): void {
+        $func = static function (): void {
         };
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->registerMiddleware('test', $func);
@@ -1012,7 +1012,7 @@ class RouteBuilderTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Cannot add middleware group 'test'. A middleware by this name has already been registered.");
-        $func = function (): void {
+        $func = static function (): void {
         };
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->registerMiddleware('test', $func);
@@ -1035,7 +1035,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testApplyMiddleware(): void
     {
-        $func = function (): void {
+        $func = static function (): void {
         };
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->registerMiddleware('test', $func)
@@ -1050,7 +1050,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testApplyMiddlewareMerges(): void
     {
-        $func = function (): void {
+        $func = static function (): void {
         };
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->registerMiddleware('test', $func)
@@ -1066,7 +1066,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testApplyMiddlewareUnique(): void
     {
-        $func = function (): void {
+        $func = static function (): void {
         };
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->registerMiddleware('test', $func)
@@ -1083,7 +1083,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testApplyMiddlewareAttachToRoutes(): void
     {
-        $func = function (): void {
+        $func = static function (): void {
         };
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->registerMiddleware('test', $func)
@@ -1160,7 +1160,7 @@ class RouteBuilderTest extends TestCase
     public function testHttpMethodIntegration(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
-        $routes->scope('/', function (RouteBuilder $routes): void {
+        $routes->scope('/', static function (RouteBuilder $routes): void {
             $routes->get('/faq/{page}', ['controller' => 'Pages', 'action' => 'faq'], 'faq')
                 ->setPatterns(['page' => '[a-z0-9_]+'])
                 ->setHost('docs.example.com');

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -812,11 +812,11 @@ class RouteCollectionTest extends TestCase
      */
     public function testRegisterMiddleware(): void
     {
-        $result = $this->collection->registerMiddleware('closure', function (): void {
+        $result = $this->collection->registerMiddleware('closure', static function (): void {
         });
         $this->assertSame($result, $this->collection);
 
-        $callable = function (): void {
+        $callable = static function (): void {
         };
         $result = $this->collection->registerMiddleware('callable', $callable);
         $this->assertSame($result, $this->collection);
@@ -832,10 +832,10 @@ class RouteCollectionTest extends TestCase
      */
     public function testMiddlewareGroup(): void
     {
-        $this->collection->registerMiddleware('closure', function (): void {
+        $this->collection->registerMiddleware('closure', static function (): void {
         });
 
-        $callable = function (): void {
+        $callable = static function (): void {
         };
         $this->collection->registerMiddleware('callable', $callable);
 
@@ -849,7 +849,7 @@ class RouteCollectionTest extends TestCase
      */
     public function testMiddlewareGroupOverwrite(): void
     {
-        $stub = function (): void {
+        $stub = static function (): void {
         };
         $this->collection->registerMiddleware('closure', $stub);
         $this->collection->registerMiddleware('callable', $stub);

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -105,7 +105,7 @@ class RouterTest extends TestCase
         Configure::write('App.base', '/cakephp');
         Router::fullBaseUrl('http://example.com');
         Router::createRouteBuilder('/')
-            ->scope('/', function (RouteBuilder $routes): void {
+            ->scope('/', static function (RouteBuilder $routes): void {
                 $routes->get('/{controller}', ['action' => 'index']);
             });
 
@@ -213,7 +213,7 @@ class RouterTest extends TestCase
     public function testGenerateUrlResourceRoute(): void
     {
         Router::createRouteBuilder('/')
-            ->scope('/', function (RouteBuilder $routes): void {
+            ->scope('/', static function (RouteBuilder $routes): void {
                 $routes->resources('Posts');
             });
 
@@ -878,8 +878,8 @@ class RouterTest extends TestCase
     public function testUrlGenerationPrefixedPlugin(): void
     {
         $routes = Router::createRouteBuilder('/');
-        $routes->prefix('admin', function (RouteBuilder $routes): void {
-            $routes->plugin('MyPlugin', function (RouteBuilder $routes): void {
+        $routes->prefix('admin', static function (RouteBuilder $routes): void {
+            $routes->plugin('MyPlugin', static function (RouteBuilder $routes): void {
                 $routes->fallbacks('InflectedRoute');
             });
         });
@@ -900,8 +900,8 @@ class RouterTest extends TestCase
     public function testUrlGenerationMultiplePrefixes(): void
     {
         $routes = Router::createRouteBuilder('/');
-        $routes->prefix('admin', function (RouteBuilder $routes): void {
-            $routes->prefix('backoffice', function (RouteBuilder $routes): void {
+        $routes->prefix('admin', static function (RouteBuilder $routes): void {
+            $routes->prefix('backoffice', static function (RouteBuilder $routes): void {
                 $routes->fallbacks('InflectedRoute');
             });
         });
@@ -1095,13 +1095,13 @@ class RouterTest extends TestCase
         Router::setRequest($request);
 
         $calledCount = 0;
-        Router::addUrlFilter(function ($url, $request) use (&$calledCount) {
+        Router::addUrlFilter(static function ($url, $request) use (&$calledCount) {
             $calledCount++;
             $url['lang'] = $request->getParam('lang');
 
             return $url;
         });
-        Router::addUrlFilter(function ($url, $request) use (&$calledCount) {
+        Router::addUrlFilter(static function ($url, $request) use (&$calledCount) {
             $calledCount++;
             $url[] = '1234';
 
@@ -1134,7 +1134,7 @@ class RouterTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        Router::addUrlFilter(function ($url, $request): void {
+        Router::addUrlFilter(static function ($url, $request): void {
             throw new RuntimeException('nope');
         });
         Router::url(['controller' => 'Posts', 'action' => 'index', 'lang' => 'en']);
@@ -1162,7 +1162,7 @@ class RouterTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        Router::addUrlFilter(function (): void {
+        Router::addUrlFilter(static function (): void {
             throw new Exception();
         });
         Router::url(['controller' => 'Posts', 'action' => 'index', 'lang' => 'en']);
@@ -1725,11 +1725,11 @@ class RouterTest extends TestCase
         Router::extensions(['json']);
 
         $routes = Router::createRouteBuilder('/');
-        $routes->scope('/', function (RouteBuilder $routes): void {
+        $routes->scope('/', static function (RouteBuilder $routes): void {
             $routes->setExtensions('rss');
             $routes->connect('/', ['controller' => 'Pages', 'action' => 'index']);
 
-            $routes->scope('/api', function (RouteBuilder $routes): void {
+            $routes->scope('/api', static function (RouteBuilder $routes): void {
                 $routes->setExtensions('xml');
                 $routes->connect('/docs', ['controller' => 'ApiDocs', 'action' => 'index']);
             });
@@ -1744,7 +1744,7 @@ class RouterTest extends TestCase
     public function testResourcesInScope(): void
     {
         $routes = Router::createRouteBuilder('/');
-        $routes->scope('/api', ['prefix' => 'Api'], function (RouteBuilder $routes): void {
+        $routes->scope('/api', ['prefix' => 'Api'], static function (RouteBuilder $routes): void {
             $routes->setExtensions(['json']);
             $routes->resources('Articles');
         });
@@ -3547,7 +3547,7 @@ class RouterTest extends TestCase
      */
     protected function _connectDefaultRoutes(): void
     {
-        Router::scope('/', function (RouteBuilder $routes): void {
+        Router::scope('/', static function (RouteBuilder $routes): void {
             $routes->fallbacks('InflectedRoute');
         });
     }

--- a/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
@@ -133,7 +133,7 @@ class FixtureHelperTest extends TestCase
         ConnectionManager::alias('test', 'test2');
 
         $numCalls = 0;
-        (new FixtureHelper())->runPerConnection(function () use (&$numCalls): void {
+        (new FixtureHelper())->runPerConnection(static function () use (&$numCalls): void {
             ++$numCalls;
         }, [$fixture1, $fixture2]);
         $this->assertSame(2, $numCalls);

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -76,12 +76,12 @@ class IntegrationTestTraitTest extends TestCase
             $routes->options('/options/{controller}/{action}', []);
             $routes->connect('/{controller}/{action}/*', []);
 
-            $routes->scope('/cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes): void {
+            $routes->scope('/cookie-csrf/', ['csrf' => 'cookie'], static function (RouteBuilder $routes): void {
                 $routes->registerMiddleware('cookieCsrf', new CsrfProtectionMiddleware());
                 $routes->applyMiddleware('cookieCsrf');
                 $routes->connect('/posts/{action}', ['controller' => 'Posts']);
             });
-            $routes->scope('/session-csrf/', ['csrf' => 'session'], function (RouteBuilder $routes): void {
+            $routes->scope('/session-csrf/', ['csrf' => 'session'], static function (RouteBuilder $routes): void {
                 $routes->registerMiddleware('sessionCsrf', new SessionCsrfProtectionMiddleware());
                 $routes->applyMiddleware('sessionCsrf');
                 $routes->connect('/posts/{action}/', ['controller' => 'Posts']);
@@ -321,7 +321,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testExceptionsInMiddlewareJsonView(): void
     {
         Router::reload();
-        Configure::write('TestApp.routes', function (RouteBuilder $routes): void {
+        Configure::write('TestApp.routes', static function (RouteBuilder $routes): void {
             $routes->connect('/json_response/api_get_data', [
                 'controller' => 'JsonResponse',
                 'action' => 'apiGetData',
@@ -1057,8 +1057,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testPostSessionCsrfSuccessWithSetCookieName(): void
     {
-        Configure::write('TestApp.routes', function (RouteBuilder $routes): void {
-            $routes->scope('/custom-cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes): void {
+        Configure::write('TestApp.routes', static function (RouteBuilder $routes): void {
+            $routes->scope('/custom-cookie-csrf/', ['csrf' => 'cookie'], static function (RouteBuilder $routes): void {
                 $routes->registerMiddleware('cookieCsrf', new CsrfProtectionMiddleware(
                     [
                         'cookieName' => 'customCsrfToken',
@@ -1083,8 +1083,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testPostSessionCsrfFailureWithSetCookieName(): void
     {
-        Configure::write('TestApp.routes', function (RouteBuilder $routes): void {
-            $routes->scope('/custom-cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes): void {
+        Configure::write('TestApp.routes', static function (RouteBuilder $routes): void {
+            $routes->scope('/custom-cookie-csrf/', ['csrf' => 'cookie'], static function (RouteBuilder $routes): void {
                 $routes->registerMiddleware('cookieCsrf', new CsrfProtectionMiddleware(
                     [
                         'cookieName' => 'customCsrfToken',
@@ -2020,7 +2020,7 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testHandleWithMockServices(): void
     {
-        $this->mockService(stdClass::class, function () {
+        $this->mockService(stdClass::class, static function () {
             return json_decode('{"mock":true}');
         });
         $this->get('/dependencies/requiredDep');
@@ -2033,7 +2033,7 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testHandleWithMockServicesFromReflectionContainer(): void
     {
-        $this->mockService(ReflectionDependency::class, function () {
+        $this->mockService(ReflectionDependency::class, static function () {
             return new ReflectionDependency();
         });
         $this->get('/dependencies/reflectionDep');
@@ -2046,10 +2046,10 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testHandleWithMockServicesOverwrite(): void
     {
-        $this->mockService(stdClass::class, function () {
+        $this->mockService(stdClass::class, static function () {
             return json_decode('{"first":true}');
         });
-        $this->mockService(stdClass::class, function () {
+        $this->mockService(stdClass::class, static function () {
             return json_decode('{"second":true}');
         });
         $this->get('/dependencies/requiredDep');
@@ -2062,7 +2062,7 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testHandleWithMockServicesUnset(): void
     {
-        $this->mockService(stdClass::class, function () {
+        $this->mockService(stdClass::class, static function () {
             return json_decode('{"first":true}');
         });
         $this->removeMockService(stdClass::class);

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -155,7 +155,7 @@ class TestCaseTest extends TestCase
      */
     public function testCaptureError(): void
     {
-        $error = $this->captureError(E_USER_WARNING, function (): void {
+        $error = $this->captureError(E_USER_WARNING, static function (): void {
             trigger_error('Something bad', E_USER_WARNING);
         });
         $this->assertEquals('Something bad', $error->getMessage());
@@ -170,7 +170,7 @@ class TestCaseTest extends TestCase
     public function testCaptureErrorNoError(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->captureError(E_USER_WARNING, function (): void {
+        $this->captureError(E_USER_WARNING, static function (): void {
             // nothing
         });
     }
@@ -197,7 +197,7 @@ class TestCaseTest extends TestCase
      */
     public function testDeprecated(): void
     {
-        $this->deprecated(function (): void {
+        $this->deprecated(static function (): void {
             trigger_error('deprecation message', E_USER_DEPRECATED);
         });
     }
@@ -225,7 +225,7 @@ class TestCaseTest extends TestCase
     public function testDeprecatedWithNoDeprecation(): void
     {
         try {
-            $this->deprecated(function (): void {
+            $this->deprecated(static function (): void {
             });
 
             $this->fail();
@@ -243,13 +243,13 @@ class TestCaseTest extends TestCase
          * setting stackframe = 0 and having same method
          * to have same deprecation message and same line for all cases
          */
-        $fun = function (): void {
+        $fun = static function (): void {
             deprecationWarning('5.0.0', 'Test same deprecation message', 0);
         };
-        $this->deprecated(function () use ($fun): void {
+        $this->deprecated(static function () use ($fun): void {
             $fun();
         });
-        $this->deprecated(function () use ($fun): void {
+        $this->deprecated(static function () use ($fun): void {
             $fun();
         });
     }

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -88,7 +88,7 @@ class TextTest extends TestCase
     public function testUuidGenerationWithClosure(): void
     {
         $customUuid = 'custom-uuid-12345678-1234-1234-1234-123456789012';
-        Configure::write('Text.uuidGenerator', function () use ($customUuid) {
+        Configure::write('Text.uuidGenerator', static function () use ($customUuid) {
             return $customUuid;
         });
 
@@ -1849,7 +1849,7 @@ HTML;
     public function testStrlen(): void
     {
         $method = new ReflectionMethod(Text::class, '_strlen');
-        $strlen = function () use ($method) {
+        $strlen = static function () use ($method) {
             return $method->invokeArgs(null, func_get_args());
         };
 
@@ -1872,7 +1872,7 @@ HTML;
     public function testSubstr(): void
     {
         $method = new ReflectionMethod(Text::class, '_substr');
-        $substr = function () use ($method) {
+        $substr = static function () use ($method) {
             return $method->invokeArgs(null, func_get_args());
         };
 

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -3003,7 +3003,7 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::numElements($array, Validation::COMPARE_GREATER, 3));
         $this->assertFalse(Validation::numElements($array, Validation::COMPARE_LESS, 1));
 
-        $callable = function () {
+        $callable = static function () {
             return '';
         };
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -744,7 +744,7 @@ class ValidatorTest extends TestCase
         $validator->allowEmptyString(
             'title',
             'very required',
-            function ($context) {
+            static function ($context) {
                 return $context['data']['otherField'] === true;
             },
         )
@@ -3070,7 +3070,7 @@ class ValidatorTest extends TestCase
 
         $nestedValidator = new Validator();
         $nestedValidator->add('nested_field', 'custom', [
-            'rule' => function ($value, $context) use (&$contextCapture) {
+            'rule' => static function ($value, $context) use (&$contextCapture) {
                 $contextCapture = $context;
                 // Access parent data through context
                 if (isset($context['parentContext'])) {
@@ -3120,7 +3120,7 @@ class ValidatorTest extends TestCase
 
         $nestedValidator = new Validator();
         $nestedValidator->add('item_name', 'custom', [
-            'rule' => function ($value, $context) use (&$contextCaptures) {
+            'rule' => static function ($value, $context) use (&$contextCaptures) {
                 $contextCaptures[] = $context;
                 // Validate based on index
                 if (isset($context['nestedManyIndex']) && $context['nestedManyIndex'] === 0) {

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -818,7 +818,7 @@ class EntityContextTest extends TestCase
         $articles = $this->getTableLocator()->get('Articles');
 
         $validator = $articles->getValidator();
-        $validator->notEmptyString('title', 'nope', function ($context) {
+        $validator->notEmptyString('title', 'nope', static function ($context) {
             return $context['providers']['entity']->isRequired();
         });
         $articles->setValidator('default', $validator);
@@ -844,7 +844,7 @@ class EntityContextTest extends TestCase
 
         $comments = $this->getTableLocator()->get('Comments');
         $validator = $comments->getValidator();
-        $validator->allowEmptyString('comment', null, function ($context) {
+        $validator->allowEmptyString('comment', null, static function ($context) {
             return $context['providers']['entity']->isNew();
         });
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -226,7 +226,7 @@ class FormHelperTest extends TestCase
         $this->Form->widget('test', ['val' => 1]);
 
         $widget->shouldHaveReceived('render')
-            ->withArgs(function (array $data) {
+            ->withArgs(static function (array $data) {
                 return $data === ['val' => 1];
             })
             ->once();
@@ -249,7 +249,7 @@ class FormHelperTest extends TestCase
         $this->Form->widget('test', ['val' => 1, 'name' => 'test', 'secure' => true]);
 
         $widget->shouldHaveReceived('render')
-            ->withArgs(function (array $data) {
+            ->withArgs(static function (array $data) {
                 return $data === ['val' => 1, 'name' => 'test'];
             })
             ->once();
@@ -303,7 +303,7 @@ class FormHelperTest extends TestCase
     {
         $entity = new Article();
         $stub = new StubContext();
-        $this->Form->addContextProvider('orm', function ($request, $data) use ($stub) {
+        $this->Form->addContextProvider('orm', static function ($request, $data) use ($stub) {
             return $stub;
         });
         $this->Form->create($entity);
@@ -318,7 +318,7 @@ class FormHelperTest extends TestCase
     {
         $entity = new Article();
         $stub = new StubContext();
-        $this->Form->addContextProvider('newshiny', function ($request, $data) use ($stub) {
+        $this->Form->addContextProvider('newshiny', static function ($request, $data) use ($stub) {
             if ($data['entity'] instanceof Entity) {
                 return $stub;
             }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -701,7 +701,7 @@ class ViewTest extends TestCase
     public function testElementCallbacks(): void
     {
         $count = 0;
-        $callback = function (EventInterface $event, $file) use (&$count): void {
+        $callback = static function (EventInterface $event, $file) use (&$count): void {
             $count++;
         };
         $events = $this->View->getEventManager();
@@ -1664,7 +1664,7 @@ TEXT;
 
         $e = null;
         try {
-            $this->View->cache(function (): void {
+            $this->View->cache(static function (): void {
                 ob_start();
 
                 throw new Exception('Exception with open buffers');

--- a/tests/test_app/Plugin/TestPlugin/config/routes.php
+++ b/tests/test_app/Plugin/TestPlugin/config/routes.php
@@ -5,7 +5,7 @@ use Cake\Routing\RouteBuilder;
 
 Configure::write('PluginTest.test_plugin.routes', 'loaded plugin routes');
 
-return function (RouteBuilder $routes): void {
+return static function (RouteBuilder $routes): void {
     $routes->get(
         '/test_plugin',
         ['controller' => 'TestPlugin', 'plugin' => 'TestPlugin', 'action' => 'index'],

--- a/tests/test_app/Plugin/TestPlugin/src/Plugin.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Plugin.php
@@ -23,7 +23,7 @@ class Plugin extends BasePlugin
 {
     public function events(EventManagerInterface $event): EventManagerInterface
     {
-        $event->on('TestPlugin.load', function (): void {
+        $event->on('TestPlugin.load', static function (): void {
         });
 
         return $event;
@@ -31,7 +31,7 @@ class Plugin extends BasePlugin
 
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
-        $middlewareQueue->add(function ($request, $handler) {
+        $middlewareQueue->add(static function ($request, $handler) {
             return $handler->handle($request);
         });
 

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -59,7 +59,7 @@ class Application extends BaseApplication
 
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
-        $middlewareQueue->add(function ($request, $handler) {
+        $middlewareQueue->add(static function ($request, $handler) {
             return $handler->handle($request)->withHeader('X-Middleware', 'true');
         });
         $middlewareQueue->add(new ErrorHandlerMiddleware(Configure::read('Error', [])));
@@ -81,7 +81,7 @@ class Application extends BaseApplication
 
         $routes->registerMiddleware('dumb', new DumbMiddleware());
         $routes->registerMiddleware('sample', new SampleMiddleware());
-        $routes->scope('/app', function (RouteBuilder $routes): void {
+        $routes->scope('/app', static function (RouteBuilder $routes): void {
             $routes->applyMiddleware('dumb', 'sample');
             $routes->connect('/articles', ['controller' => 'Articles']);
             $routes->connect('/articles/{action}/*', ['controller' => 'Articles']);

--- a/tests/test_app/TestApp/ApplicationWithPluginRoutes.php
+++ b/tests/test_app/TestApp/ApplicationWithPluginRoutes.php
@@ -41,7 +41,7 @@ class ApplicationWithPluginRoutes extends BaseApplication
      */
     public function routes(RouteBuilder $routes): void
     {
-        $routes->scope('/app', function (RouteBuilder $routes): void {
+        $routes->scope('/app', static function (RouteBuilder $routes): void {
             $routes->connect('/articles', ['controller' => 'Articles']);
         });
         $routes->loadPlugin('TestPlugin');

--- a/tests/test_app/TestApp/Collection/CountableIterator.php
+++ b/tests/test_app/TestApp/Collection/CountableIterator.php
@@ -13,7 +13,7 @@ class CountableIterator extends IteratorIterator implements Countable
      */
     public function __construct($items)
     {
-        $f = function () use ($items) {
+        $f = static function () use ($items) {
             foreach ($items as $e) {
                 yield $e;
             }

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -37,13 +37,13 @@ class PostsController extends AppController
         $this->loadComponent('Flash');
         $this->loadComponent('FormProtection');
 
-        $this->middleware(function ($request, $handler) {
+        $this->middleware(static function ($request, $handler) {
             return $handler->handle($request->withAttribute('for-all', true));
         });
-        $this->middleware(function ($request, $handler) {
+        $this->middleware(static function ($request, $handler) {
             return $handler->handle($request->withAttribute('index-only', true));
         }, ['only' => 'index']);
-        $this->middleware(function ($request, $handler) {
+        $this->middleware(static function ($request, $handler) {
             return $handler->handle($request->withAttribute('all-except-index', true));
         }, ['except' => ['index']]);
     }

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -179,7 +179,7 @@ class RequestActionController extends AppController
     public function uploaded_files()
     {
         $files = Hash::flatten($this->request->getUploadedFiles());
-        $names = collection($files)->map(function (UploadedFileInterface $file) {
+        $names = collection($files)->map(static function (UploadedFileInterface $file) {
             return $file->getClientFilename();
         });
 

--- a/tests/test_app/TestApp/Database/Type/OrderedUuidType.php
+++ b/tests/test_app/TestApp/Database/Type/OrderedUuidType.php
@@ -30,7 +30,7 @@ class OrderedUuidType extends BaseType implements ExpressionTypeInterface
         if ($value instanceof UuidValue) {
             $value = $value->value;
         }
-        $substr = function ($start, $length = null) use ($value) {
+        $substr = static function ($start, $length = null) use ($value) {
             return new FunctionExpression(
                 'SUBSTR',
                 $length === null ? [$value, $start] : [$value, $start, $length],

--- a/tests/test_app/TestApp/Http/EventApplication.php
+++ b/tests/test_app/TestApp/Http/EventApplication.php
@@ -24,7 +24,7 @@ class EventApplication extends BaseApplication
 {
     public function events(EventManagerInterface $eventManager): EventManagerInterface
     {
-        $eventManager->on('My.event', function (): void {
+        $eventManager->on('My.event', static function (): void {
         });
 
         return $eventManager;

--- a/tests/test_app/TestApp/Http/MiddlewareApplication.php
+++ b/tests/test_app/TestApp/Http/MiddlewareApplication.php
@@ -17,13 +17,13 @@ class MiddlewareApplication extends BaseApplication
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
         $middlewareQueue
-            ->add(function ($request, $handler) {
+            ->add(static function ($request, $handler) {
                 return $handler->handle($request)->withHeader('X-First', 'first');
             })
-            ->add(function ($request, $handler) {
+            ->add(static function ($request, $handler) {
                 return $handler->handle($request)->withHeader('X-Second', 'second');
             })
-            ->add(function ($request, $handler) {
+            ->add(static function ($request, $handler) {
                 $response = $handler->handle($request);
 
                 if ($request->hasHeader('X-pass')) {

--- a/tests/test_app/TestApp/Http/TestRequestHandler.php
+++ b/tests/test_app/TestApp/Http/TestRequestHandler.php
@@ -25,7 +25,7 @@ class TestRequestHandler implements RequestHandlerInterface
 
     public function __construct(?callable $callable = null)
     {
-        $this->callable = $callable ?: function ($request) {
+        $this->callable = $callable ?: static function ($request) {
             return new Response();
         };
     }

--- a/tests/test_app/TestApp/Model/Table/ArticlesTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTable.php
@@ -72,8 +72,8 @@ class ArticlesTable extends Table
 
     public function findSlugged(SelectQuery $query): SelectQuery
     {
-        return $query->formatResults(function ($results) {
-            return $results->indexBy(function ($row) {
+        return $query->formatResults(static function ($results) {
+            return $results->indexBy(static function ($row) {
                 return Text::slug($row['title']);
             });
         });

--- a/tests/test_app/TestApp/Model/Table/AuthorsTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthorsTable.php
@@ -54,8 +54,8 @@ class AuthorsTable extends Table
      */
     public function findFormatted(SelectQuery $query, array $options = []): SelectQuery
     {
-        return $query->formatResults(function ($results) {
-            return $results->map(function ($author) {
+        return $query->formatResults(static function ($results) {
+            return $results->map(static function ($author) {
                 $author->formatted = $author->name . '!!';
 
                 return $author;

--- a/tests/test_app/TestApp/Model/Table/TagsTable.php
+++ b/tests/test_app/TestApp/Model/Table/TagsTable.php
@@ -33,8 +33,8 @@ class TagsTable extends Table
     public function findSlugged(SelectQuery $query): SelectQuery
     {
         return $query->applyOptions(['preserveKeys' => true])
-            ->formatResults(function ($results) {
-                return $results->indexBy(function ($record) {
+            ->formatResults(static function ($results) {
+                return $results->indexBy(static function ($record) {
                     return Text::slug($record->name);
                 });
             });

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -15,9 +15,9 @@
 
 use Cake\Routing\RouteBuilder;
 
-return function (RouteBuilder $routes): void {
+return static function (RouteBuilder $routes): void {
     $routes->setExtensions('json');
-    $routes->scope('/', function (RouteBuilder $routes): void {
+    $routes->scope('/', static function (RouteBuilder $routes): void {
         $routes->connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
         $routes->connect(
             '/some_alias',

--- a/tests/test_app/invalid_routes/routes.php
+++ b/tests/test_app/invalid_routes/routes.php
@@ -8,7 +8,7 @@ use Cake\Routing\RouteBuilder;
  * Application requests should have InvalidArgument error rendered.
  */
 
-return function (RouteBuilder $routes): void {
+return static function (RouteBuilder $routes): void {
     $routes->setRouteClass('DoesNotExist');
     $routes->get('/', ['controller' => 'Pages']);
 };


### PR DESCRIPTION
Refs #18926.

Given @othercorey's reservations about making arrow functions static, I haven't added the rule for it.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
