### PR TITLE
Add support for arbitrary columns

### DIFF
--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -674,6 +674,7 @@ class MysqlSchemaDialect extends SchemaDialect
                     if ($isKnownLength) {
                         $length = array_search($column['length'], TableSchema::$columnLengths);
                         assert(is_string($length));
+                        unset($column['length']);
                         $out .= ' ' . strtoupper($length) . 'BLOB';
                         break;
                     }
@@ -684,9 +685,9 @@ class MysqlSchemaDialect extends SchemaDialect
                     }
 
                     if ($column['length'] > 2) {
-                        $out .= ' VARBINARY(' . $column['length'] . ')';
+                        $out .= ' VARBINARY';
                     } else {
-                        $out .= ' BINARY(' . $column['length'] . ')';
+                        $out .= ' BINARY';
                     }
                     break;
             }
@@ -697,7 +698,12 @@ class MysqlSchemaDialect extends SchemaDialect
             TableSchemaInterface::TYPE_SMALLINTEGER,
             TableSchemaInterface::TYPE_TINYINTEGER,
             TableSchemaInterface::TYPE_STRING,
+            TableSchemaInterface::TYPE_BINARY,
         ];
+        if (!isset($typeMap[$column['type']]) && !isset($specialMap[$column['type']])) {
+            $out .= ' ' . strtoupper($column['type']);
+            $hasLength[] = $column['type'];
+        }
         if (in_array($column['type'], $hasLength, true) && isset($column['length'])) {
             $out .= '(' . $column['length'] . ')';
         }

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -757,7 +757,7 @@ class SqliteSchemaDialect extends SchemaDialect
         ];
         $typeMap = [
             TableSchemaInterface::TYPE_BINARY_UUID => ' BINARY(16)',
-            TableSchemaInterface::TYPE_BINARY=> ' BLOB',
+            TableSchemaInterface::TYPE_BINARY => ' BLOB',
             TableSchemaInterface::TYPE_UUID => ' CHAR(36)',
             TableSchemaInterface::TYPE_CHAR => ' CHAR',
             TableSchemaInterface::TYPE_STRING => ' VARCHAR',

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -818,7 +818,10 @@ class SqliteSchemaDialect extends SchemaDialect
         if ($column['type'] === TableSchemaInterface::TYPE_TEXT && $column['length'] !== TableSchema::LENGTH_TINY) {
             $out .= ' TEXT';
             $foundType = true;
-        } elseif ($column['type'] === TableSchemaInterface::TYPE_TEXT && $column['length'] === TableSchema::LENGTH_TINY) {
+        } elseif (
+            $column['type'] === TableSchemaInterface::TYPE_TEXT &&
+            $column['length'] === TableSchema::LENGTH_TINY
+        ) {
             $out .= ' VARCHAR';
             $hasLength[] = $column['type'];
             $foundType = true;

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -757,8 +757,10 @@ class SqliteSchemaDialect extends SchemaDialect
         ];
         $typeMap = [
             TableSchemaInterface::TYPE_BINARY_UUID => ' BINARY(16)',
+            TableSchemaInterface::TYPE_BINARY=> ' BLOB',
             TableSchemaInterface::TYPE_UUID => ' CHAR(36)',
             TableSchemaInterface::TYPE_CHAR => ' CHAR',
+            TableSchemaInterface::TYPE_STRING => ' VARCHAR',
             TableSchemaInterface::TYPE_TINYINTEGER => ' TINYINT',
             TableSchemaInterface::TYPE_SMALLINTEGER => ' SMALLINT',
             TableSchemaInterface::TYPE_INTEGER => ' INTEGER',
@@ -799,49 +801,34 @@ class SqliteSchemaDialect extends SchemaDialect
             $out .= ' UNSIGNED';
         }
 
+        $foundType = false;
         if (isset($typeMap[$column['type']])) {
             $out .= $typeMap[$column['type']];
+            $foundType = true;
         }
 
-        if ($column['type'] === TableSchemaInterface::TYPE_TEXT && $column['length'] !== TableSchema::LENGTH_TINY) {
-            $out .= ' TEXT';
-        }
-
-        if ($column['type'] === TableSchemaInterface::TYPE_CHAR) {
-            $out .= '(' . $column['length'] . ')';
-        }
-
-        if (
-            $column['type'] === TableSchemaInterface::TYPE_STRING ||
-            (
-                $column['type'] === TableSchemaInterface::TYPE_TEXT &&
-                $column['length'] === TableSchema::LENGTH_TINY
-            )
-        ) {
-            $out .= ' VARCHAR';
-
-            if (isset($column['length'])) {
-                $out .= '(' . $column['length'] . ')';
-            }
-        }
-
-        if ($column['type'] === TableSchemaInterface::TYPE_BINARY) {
-            if (isset($column['length'])) {
-                $out .= ' BLOB(' . $column['length'] . ')';
-            } else {
-                $out .= ' BLOB';
-            }
-        }
-
-        $integerTypes = [
+        $hasLength = [
+            TableSchemaInterface::TYPE_BINARY,
+            TableSchemaInterface::TYPE_STRING,
+            TableSchemaInterface::TYPE_CHAR,
             TableSchemaInterface::TYPE_TINYINTEGER,
             TableSchemaInterface::TYPE_SMALLINTEGER,
             TableSchemaInterface::TYPE_INTEGER,
         ];
-        if (
-            in_array($column['type'], $integerTypes, true) &&
-            isset($column['length']) && !$autoIncrement
-        ) {
+        if ($column['type'] === TableSchemaInterface::TYPE_TEXT && $column['length'] !== TableSchema::LENGTH_TINY) {
+            $out .= ' TEXT';
+            $foundType = true;
+        } elseif ($column['type'] === TableSchemaInterface::TYPE_TEXT && $column['length'] === TableSchema::LENGTH_TINY) {
+            $out .= ' VARCHAR';
+            $hasLength[] = $column['type'];
+            $foundType = true;
+        }
+        if (!$foundType) {
+            $out .= ' ' . strtoupper($column['type']);
+            $hasLength[] = $column['type'];
+        }
+
+        if (in_array($column['type'], $hasLength, true) && isset($column['length']) && !$autoIncrement) {
             $out .= '(' . (int)$column['length'] . ')';
         }
 

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -677,11 +677,14 @@ class SqlserverSchemaDialect extends SchemaDialect
             unset($column['default']);
         }
 
-        if ($column['type'] === TableSchemaInterface::TYPE_TEXT && $column['length'] !== TableSchema::LENGTH_TINY) {
+        if ($column['type'] === TableSchemaInterface::TYPE_STRING && !isset($column['length'])) {
+            $column['length'] = TableSchema::LENGTH_TINY;
+        } elseif (
+            $column['type'] === TableSchemaInterface::TYPE_TEXT &&
+            $column['length'] !== TableSchema::LENGTH_TINY
+        ) {
             $out .= ' NVARCHAR(MAX)';
             $foundType = true;
-        } elseif ($column['type'] === TableSchemaInterface::TYPE_CHAR) {
-            // $out .= '(' . $column['length'] . ')';
         }
 
         if ($column['type'] === TableSchemaInterface::TYPE_BINARY) {
@@ -707,6 +710,7 @@ class SqlserverSchemaDialect extends SchemaDialect
         }
         if (!$foundType) {
             $out .= ' ' . strtoupper($column['type']);
+            $hasLength[] = $column['type'];
         }
         if (in_array($column['type'], $hasLength, true) && isset($column['length'])) {
             $out .= '(' . $column['length'] . ')';
@@ -734,10 +738,7 @@ class SqlserverSchemaDialect extends SchemaDialect
 
         if (
             $column['type'] === TableSchemaInterface::TYPE_DECIMAL &&
-            (
-                isset($column['length']) ||
-                isset($column['precision'])
-            )
+            (isset($column['length']) || isset($column['precision']))
         ) {
             $out .= '(' . (int)$column['length'] . ',' . (int)$column['precision'] . ')';
         }

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -634,6 +634,7 @@ class SqlserverSchemaDialect extends SchemaDialect
             TableSchemaInterface::TYPE_BINARY_UUID => ' UNIQUEIDENTIFIER',
             TableSchemaInterface::TYPE_BOOLEAN => ' BIT',
             TableSchemaInterface::TYPE_CHAR => ' NCHAR',
+            TableSchemaInterface::TYPE_STRING => ' NVARCHAR',
             TableSchemaInterface::TYPE_FLOAT => ' FLOAT',
             TableSchemaInterface::TYPE_DECIMAL => ' DECIMAL',
             TableSchemaInterface::TYPE_DATE => ' DATE',
@@ -652,10 +653,17 @@ class SqlserverSchemaDialect extends SchemaDialect
             TableSchemaInterface::TYPE_POLYGON => ' GEOGRAPHY',
         ];
 
+        $foundType = false;
         if (isset($typeMap[$column['type']])) {
             $out .= $typeMap[$column['type']];
+            $foundType = true;
         }
 
+        $hasLength = [
+            TableSchemaInterface::TYPE_CHAR,
+            TableSchemaInterface::TYPE_STRING,
+            TableSchemaInterface::TYPE_BINARY,
+        ];
         $autoIncrementTypes = [
             TableSchemaInterface::TYPE_TINYINTEGER,
             TableSchemaInterface::TYPE_SMALLINTEGER,
@@ -663,20 +671,17 @@ class SqlserverSchemaDialect extends SchemaDialect
             TableSchemaInterface::TYPE_BIGINTEGER,
         ];
         $autoIncrement = (bool)($column['autoIncrement'] ?? false);
-        if (
-            in_array($column['type'], $autoIncrementTypes, true) &&
-            $autoIncrement
-        ) {
+        if (in_array($column['type'], $autoIncrementTypes, true) && $autoIncrement) {
             $out .= ' IDENTITY(1, 1)';
+            $foundType = true;
             unset($column['default']);
         }
 
         if ($column['type'] === TableSchemaInterface::TYPE_TEXT && $column['length'] !== TableSchema::LENGTH_TINY) {
             $out .= ' NVARCHAR(MAX)';
-        }
-
-        if ($column['type'] === TableSchemaInterface::TYPE_CHAR) {
-            $out .= '(' . $column['length'] . ')';
+            $foundType = true;
+        } elseif ($column['type'] === TableSchemaInterface::TYPE_CHAR) {
+            // $out .= '(' . $column['length'] . ')';
         }
 
         if ($column['type'] === TableSchemaInterface::TYPE_BINARY) {
@@ -688,24 +693,23 @@ class SqlserverSchemaDialect extends SchemaDialect
             }
 
             if ($column['length'] === 1) {
-                $out .= ' BINARY(1)';
+                $out .= ' BINARY';
             } else {
                 $out .= ' VARBINARY';
-
-                $out .= sprintf('(%s)', $column['length']);
             }
+            $foundType = true;
         }
 
-        if (
-            $column['type'] === TableSchemaInterface::TYPE_STRING ||
-            (
-                $column['type'] === TableSchemaInterface::TYPE_TEXT &&
-                $column['length'] === TableSchema::LENGTH_TINY
-            )
-        ) {
-            $type = ' NVARCHAR';
-            $length = $column['length'] ?? TableSchema::LENGTH_TINY;
-            $out .= sprintf('%s(%d)', $type, $length);
+        if ($column['type'] === TableSchemaInterface::TYPE_TEXT && $column['length'] === TableSchema::LENGTH_TINY) {
+            $out .= ' NVARCHAR';
+            $hasLength[] = $column['type'];
+            $foundType = true;
+        }
+        if (!$foundType) {
+            $out .= ' ' . strtoupper($column['type']);
+        }
+        if (in_array($column['type'], $hasLength, true) && isset($column['length'])) {
+            $out .= '(' . $column['length'] . ')';
         }
 
         $hasCollate = [

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -937,6 +937,12 @@ SQL;
     public static function columnSqlProvider(): array
     {
         return [
+            // Unknown column type is preserved.
+            [
+                'title',
+                ['type' => 'foobar', 'length' => 25, 'null' => true, 'default' => null],
+                '`title` FOOBAR(25)',
+            ],
             // strings
             [
                 'title',

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -983,6 +983,12 @@ SQL;
     public static function columnSqlProvider(): array
     {
         return [
+            // Unknown column type is preserved.
+            [
+                'title',
+                ['type' => 'foobar', 'length' => 25, 'null' => true, 'default' => null],
+                '"title" FOOBAR(25) DEFAULT NULL',
+            ],
             // strings
             [
                 'title',

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -957,6 +957,12 @@ SQL;
     public static function columnSqlProvider(): array
     {
         return [
+            // Unknown column type is preserved.
+            [
+                'title',
+                ['type' => 'foobar', 'length' => 25, 'null' => true, 'default' => null],
+                '"title" FOOBAR(25)',
+            ],
             // strings
             [
                 'title',

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -730,6 +730,12 @@ SQL;
     public static function columnSqlProvider(): array
     {
         return [
+            // Unknown column type is preserved.
+            [
+                'title',
+                ['type' => 'foobar', 'length' => 25, 'null' => true, 'default' => null],
+                '[title] FOOBAR(25)',
+            ],
             // strings
             [
                 'title',

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -734,7 +734,7 @@ SQL;
             [
                 'title',
                 ['type' => 'foobar', 'length' => 25, 'null' => true, 'default' => null],
-                '[title] FOOBAR(25)',
+                '[title] FOOBAR(25) DEFAULT NULL',
             ],
             // strings
             [


### PR DESCRIPTION
Should application schema or migrations use types that aren't known, we shouldn't generate invalid SQL. Instead we can try to do what the developer asked and let them sort out why their column type didn't work.
