### PR TITLE
Fix up permissions via umask.

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -64,7 +64,7 @@ class FileEngine extends CacheEngine
         'groups' => [],
         'lock' => true,
         'mask' => 0664,
-        'dirMask' => 0770,
+        'dirMask' => 0777,
         'path' => null,
         'prefix' => 'cake_',
         'serialize' => true,
@@ -364,7 +364,7 @@ class FileEngine extends CacheEngine
         $dir = $this->_config['path'] . $groups;
 
         if (!is_dir($dir)) {
-            mkdir($dir, $this->_config['dirMask'], true);
+            mkdir($dir, $this->_config['dirMask'] ^ umask(), true);
         }
 
         $path = new SplFileInfo($dir . $key);
@@ -411,7 +411,7 @@ class FileEngine extends CacheEngine
         $success = true;
         if (!is_dir($path)) {
             // phpcs:disable
-            $success = @mkdir($path, $this->_config['dirMask'], true);
+            $success = @mkdir($path, $this->_config['dirMask'] ^ umask(), true);
             // phpcs:enable
         }
 

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -880,7 +880,7 @@ class I18nExtractCommand extends Command
     protected function _isPathUsable(string $path): bool
     {
         if (!is_dir($path)) {
-            mkdir($path, 0755, true);
+            mkdir($path, 0777 ^ umask(), true);
         }
 
         return is_dir($path) && is_writable($path);

--- a/src/Command/I18nInitCommand.php
+++ b/src/Command/I18nInitCommand.php
@@ -75,7 +75,7 @@ class I18nInitCommand extends Command
         $sourceFolder = rtrim($response, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         $targetFolder = $sourceFolder . $language . DIRECTORY_SEPARATOR;
         if (!is_dir($targetFolder)) {
-            mkdir($targetFolder, 0755, true);
+            mkdir($targetFolder, 0777 ^ umask(), true);
         }
 
         $count = 0;

--- a/src/Command/PluginAssetsTrait.php
+++ b/src/Command/PluginAssetsTrait.php
@@ -219,11 +219,9 @@ trait PluginAssetsTrait
      */
     protected function _createDirectory(string $dir): bool
     {
-        $old = umask(0);
         // phpcs:disable
-        $result = @mkdir($dir, 0755, true);
+        $result = @mkdir($dir, 0777 ^ umask(), true);
         // phpcs:enable
-        umask($old);
 
         if ($result) {
             $this->io->out('Created directory ' . $dir);

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -54,7 +54,7 @@ class FileLog extends BaseLog
         'rotate' => 10,
         'size' => 10485760, // 10MB
         'mask' => null,
-        'dirMask' => 0770,
+        'dirMask' => 0777,
         'formatter' => [
             'className' => DefaultFormatter::class,
         ],
@@ -92,7 +92,7 @@ class FileLog extends BaseLog
 
         $this->_path = $this->getConfig('path', sys_get_temp_dir() . DIRECTORY_SEPARATOR);
         if (!is_dir($this->_path)) {
-            mkdir($this->_path, $this->_config['dirMask'], true);
+            mkdir($this->_path, $this->_config['dirMask'] ^ umask(), true);
         }
 
         if (!empty($this->_config['file'])) {

--- a/src/Utility/Filesystem.php
+++ b/src/Utility/Filesystem.php
@@ -161,11 +161,11 @@ class Filesystem
      * Create directory.
      *
      * @param string $dir Directory path.
-     * @param int $mode Octal mode passed to mkdir(). Defaults to 0755.
+     * @param int $mode Octal mode passed to mkdir(). Defaults to 0777.
      * @return void
      * @throws \Cake\Core\Exception\CakeException When directory creation fails.
      */
-    public function mkdir(string $dir, int $mode = 0755): void
+    public function mkdir(string $dir, int $mode = 0777): void
     {
         if (is_dir($dir)) {
             return;


### PR DESCRIPTION
Follow up on https://github.com/cakephp/cakephp/pull/18851#issuecomment-3217691939

With this the comment of @markstory is also included.

  ✅ Pros:

  1. Already proven pattern - ConsoleIo.php:654 already uses mkdir($directory, 0777 ^ umask(), true) successfully, and Filesystem.php:156 uses chmod($filename, 0666 & ~umask()) for files.
  2. Better cross-environment support - Would work across both:
    - Systems where developers can control umask (typically 0022, resulting in 0755)
    - Shared hosting with different umask settings
  3. Consistent implementation - Would unify 3 different approaches currently used:
    - FileLog: dirMask default 0770
    - FileEngine: dirMask default 0770
    - I18n commands: 0755
    - ConsoleIo: 0777 ^ umask()
    - Filesystem: 0755 default

I didnt add Configure yet as I dont know if we really need it.
The downside might be package/dependency issues.