### PR TITLE
Add missing return type of beforeRedirect()

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -1072,7 +1072,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * @param array|string $url A string or array-based URL pointing to another location within the app,
      *     or an absolute URL
      * @param \Cake\Http\Response $response The response object.
-     * @return \Cake\Http\Response|null|void
+     * @return \Cake\Http\Response|false|null|void
      * @link https://book.cakephp.org/4/en/controllers.html#request-life-cycle-callbacks
      */
     public function beforeRedirect(EventInterface $event, $url, Response $response)


### PR DESCRIPTION
According to the cookbook: https://book.cakephp.org/4/en/controllers/components.html#beforeRedirect

> Is invoked when the controller’s redirect method is called but before any further action. If this method returns false the controller will not continue on to redirect the request.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
