### PR TITLE
add workflows to make sure docs keep in sync with core changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,15 @@
-<!---
+### Summary
 
 Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.
 
-Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.
+Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request.
 
--->
+In particular, make sure existing tests still pass, and add tests for all new behavior.
+
+When fixing a bug, you may want to add a test to verify the fix.
+
+### Documentation
+
+- [ ] Documentation PR created
+  (add link here: https://github.com/cakephp/docs/pull/____)
+- [ ] No docs needed

--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -1,0 +1,20 @@
+# This GitHub Actions workflow adds a label to newly opened pull requests.
+name: Add labels
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ["needs documentation"]
+            })

--- a/.github/workflows/cleanup-labels.yml
+++ b/.github/workflows/cleanup-labels.yml
@@ -1,0 +1,30 @@
+# This GitHub Actions workflow removes specific labels from issues when they are merged/closed.
+name: Cleanup labels
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  remove-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                name: "needs documentation"
+              });
+              console.log("✅ Removed 'needs documentation' label from closed PR");
+            } catch (error) {
+              if (error.status === 404) {
+                console.log("ℹ️ Label not present, nothing to clean up");
+              } else {
+                throw error;
+              }
+            }

--- a/.github/workflows/needs-docs.yml
+++ b/.github/workflows/needs-docs.yml
@@ -1,0 +1,30 @@
+# Enforce that PRs labeled with "needs documentation" have a linked docs PR.
+name: Documentation needed triage
+
+on:
+  pull_request:
+    # Do NOT run on "opened" aka created PRs, since it won't have labels yet.
+    types: [synchronize, labeled, unlabeled, edited]
+
+jobs:
+  check-docs-triage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request
+            const labels = pr.labels.map(l => l.name)
+
+            // Rule: Must either have no "needs documentation" label
+            // OR have a linked docs PR in the description
+            const hasLabel = labels.includes("needs documentation")
+            const hasDocsLink = /\bhttps:\/\/github\.com\/cakephp\/docs\/pull\/\d+\b/.test(pr.body || "")
+
+            if (hasLabel && !hasDocsLink) {
+              core.setFailed("PR has `needs documentation` label but no linked docs PR.")
+            } else {
+              console.log("Documentation triage condition satisfied ✅")
+            }


### PR DESCRIPTION
This is my attempt to automate our outdated docs problem. The workflows should be rather self-explanatory.

The new PR template would look like this:

---

### Summary

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request.

In particular, make sure existing tests still pass, and add tests for all new behavior.

When fixing a bug, you may want to add a test to verify the fix.

### Documentation

- [ ] Documentation PR created
  (add link here: https://github.com/cakephp/docs/pull/8102)
- [ ] No docs needed
