### PR TITLE
Add optional constant for commands to allow custom CLI grouping

### DIFF
--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -103,8 +103,8 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
             $prefix = 'app';
             if ($namespace === 'Cake') {
                 $prefix = 'cakephp';
-            } elseif (defined("$class::GROUP")) {
-                $prefix = constant("$class::GROUP");
+            } elseif (method_exists($class, 'getGroup')) {
+                $prefix = $class::getGroup();
             } elseif (in_array($namespace, $plugins, true)) {
                 $prefix = Inflector::underscore($namespace);
             }

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -103,6 +103,8 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
             $prefix = 'app';
             if ($namespace === 'Cake') {
                 $prefix = 'cakephp';
+            } elseif (defined("$class::GROUP")) {
+                $prefix = constant("$class::GROUP");
             } elseif (in_array($namespace, $plugins, true)) {
                 $prefix = Inflector::underscore($namespace);
             }

--- a/tests/TestCase/Console/Command/HelpCommandTest.php
+++ b/tests/TestCase/Console/Command/HelpCommandTest.php
@@ -91,6 +91,8 @@ class HelpCommandTest extends TestCase
         $this->assertOutputContains('To run a command', 'more info present');
         $this->assertOutputContains('To get help', 'more info present');
         $this->assertOutputContains('This is a demo command', 'command description missing');
+        $this->assertOutputContains('<info>custom_group</info>');
+        $this->assertOutputContains('- grouped');
     }
 
     /**

--- a/tests/test_app/TestApp/Command/GroupedCommand.php
+++ b/tests/test_app/TestApp/Command/GroupedCommand.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+
+class GroupedCommand extends Command
+{
+    public static function getGroup(): string
+    {
+        return 'custom_group';
+    }
+
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        $io->out('Grouped Command!');
+    }
+}


### PR DESCRIPTION
Add optional GROUP constant for commands to allow custom CLI grouping

Commands under App\Command can now define a public const GROUP
to appear under a custom group in the bin/cake help output 
instead of the default "app" group.

This change is fully backward-compatible and does not affect
existing commands without a GROUP.