### PR TITLE
5.next: Fix up allowNullableNull default.

### DIFF
--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -52,18 +52,19 @@ class ExistsIn
      * Constructor.
      *
      * Available option for $options is 'allowNullableNulls' flag.
-     * Set to true to accept composite foreign keys where one or more nullable columns are null.
+     * When true (default), accepts composite foreign keys where one or more nullable columns are null.
      *
      * @param array<string>|string $fields The field or fields to check existence as primary key.
      * @param \Cake\ORM\Table|\Cake\ORM\Association|string $repository The repository where the
      * field will be looked for, or the association name for the repository.
      * @param array<string, mixed> $options The options that modify the rule's behavior.
      *     Options 'allowNullableNulls' will make the rule pass if given foreign keys are set to `null`.
-     *     Notice: allowNullableNulls cannot pass by database columns set to `NOT NULL`.
+     *     Only applies to columns that are nullable in the database schema.
+     *     Columns set to `NOT NULL` in the database will still fail validation if null.
      */
     public function __construct(array|string $fields, Table|Association|string $repository, array $options = [])
     {
-        $options += ['allowNullableNulls' => false];
+        $options += ['allowNullableNulls' => true];
         $this->_options = $options;
 
         $this->_fields = (array)$fields;

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM;
 
+use Cake\Core\Configure;
 use Cake\Datasource\RuleInvoker;
 use Cake\Datasource\RulesChecker as BaseRulesChecker;
 use Cake\ORM\Rule\ExistsIn;
@@ -90,6 +91,9 @@ class RulesChecker extends BaseRulesChecker
      * 'message' sets a custom error message.
      * Set 'allowNullableNulls' to true to accept composite foreign keys where one or more nullable columns are null.
      *
+     * The default value for 'allowNullableNulls' can be controlled via the configuration option
+     * `ORM.allowNullableNulls`. When not explicitly set, defaults to `false` for backwards compatibility.
+     *
      * @param array<string>|string $field The field or list of fields to check for existence by
      * primary key lookup in the other table.
      * @param \Cake\ORM\Table|\Cake\ORM\Association|string $table The table name where the fields existence will be checked.
@@ -107,6 +111,10 @@ class RulesChecker extends BaseRulesChecker
             $options = $message + ['message' => null];
             $message = $options['message'];
             unset($options['message']);
+        }
+
+        if (!isset($options['allowNullableNulls'])) {
+            $options['allowNullableNulls'] = Configure::read('ORM.allowNullableNulls', false);
         }
 
         if (!$message) {

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM;
 
 use ArrayObject;
+use Cake\Core\Configure;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Datasource\ConnectionManager;
@@ -879,7 +880,7 @@ class RulesCheckerIntegrationTest extends TestCase
     }
 
     /**
-     * Tests that allowNullableNulls is true by default
+     * Tests that allowNullableNulls is false by default (for BC)
      */
     public function testExistsInAllowNullableNullsDefaultValue(): void
     {
@@ -894,7 +895,8 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules = $table->rulesChecker();
 
         $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors'));
-        $this->assertInstanceOf(Entity::class, $table->save($entity));
+        // Default is false, so this should fail
+        $this->assertFalse($table->save($entity));
     }
 
     /**
@@ -1081,6 +1083,55 @@ class RulesCheckerIntegrationTest extends TestCase
 
         $this->assertInstanceOf(Entity::class, $result[1]);
         $this->assertEmpty($result[1]->getErrors());
+    }
+
+    /**
+     * Tests Configure-based default for allowNullableNulls set to true
+     */
+    public function testExistsInWithConfigureDefault(): void
+    {
+        Configure::write('ORM.allowNullableNulls', true);
+
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => null,
+            'site_id' => 1,
+            'name' => 'New Site Article without Author',
+        ]);
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors'));
+        $this->assertInstanceOf(Entity::class, $table->save($entity));
+
+        Configure::delete('ORM.allowNullableNulls');
+    }
+
+    /**
+     * Tests Configure-based default can be overridden explicitly
+     */
+    public function testExistsInWithConfigureDefaultOverride(): void
+    {
+        Configure::write('ORM.allowNullableNulls', true);
+
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => null,
+            'site_id' => 1,
+            'name' => 'New Site Article without Author',
+        ]);
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        // Explicitly override the Configure default
+        $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', [
+            'allowNullableNulls' => false,
+        ]));
+        $this->assertFalse($table->save($entity));
+
+        Configure::delete('ORM.allowNullableNulls');
     }
 
     /**

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -879,7 +879,7 @@ class RulesCheckerIntegrationTest extends TestCase
     }
 
     /**
-     * Tests new allowNullableNulls flag with author id set to null
+     * Tests that allowNullableNulls is true by default
      */
     public function testExistsInAllowNullableNullsDefaultValue(): void
     {
@@ -894,7 +894,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules = $table->rulesChecker();
 
         $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors'));
-        $this->assertFalse($table->save($entity));
+        $this->assertInstanceOf(Entity::class, $table->save($entity));
     }
 
     /**


### PR DESCRIPTION
This is currently a hidden and not so easy to trace issue

  When you have a nullable foreign key like company_id, the existsIn rule will fail for null values by default (when checking composite keys where only some are null), which is counterintuitive since:
  1. NULL values are semantically valid for optional relationships
  2. The rule is pointless for NULL anyway (always fails)
  3. It forces you to manually add ['allowNullableNulls' => true] everywhere

  So:

  Changing the default to true would be more ergonomic because:
  - Single field case: Already handled by _fieldsAreNull() check (lines 126-128), which passes when ALL fields are null
  - Composite key case: Currently requires manual allowNullableNulls => true to allow partial nulls
  - Database constraint: If a field is truly required, it should be NOT NULL at the database level anyway

And you can still set it manually, if needed. 

This seems to me to be a saner default now.
We can add this to the migration changelog for 5.next.