### PR TITLE
Update signature of HttpException::setHeader()

### DIFF
--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -186,7 +186,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
 
             if (!$hasDefinition) {
                 // No user-defined configuration - add auto-wired arguments
-                $constructor = (new ReflectionClass($class))->getConstructor();
+                $constructor = new ReflectionClass($class)->getConstructor();
                 if ($constructor !== null) {
                     $args = $this->reflectArguments($constructor, ['config' => $config]);
                     $this->container->add($class)->addArguments($args);

--- a/src/Http/Exception/HttpException.php
+++ b/src/Http/Exception/HttpException.php
@@ -41,12 +41,12 @@ class HttpException extends CakeException implements HttpErrorCodeInterface
      * Set a single HTTP response header.
      *
      * @param non-empty-string $header Header name
-     * @param array<string>|string|null $value Header value
+     * @param array<string>|string $value Header value
      * @return void
      */
-    public function setHeader(string $header, array|string|null $value = null): void
+    public function setHeader(string $header, array|string $value): void
     {
-        $this->headers[$header] = $value ?? '';
+        $this->headers[$header] = $value;
     }
 
     /**


### PR DESCRIPTION
It now matches that of MessageInterface::withHeader()

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
