### PR TITLE
5.3 Fix a regression in fixture names

### DIFF
--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -43,12 +43,26 @@ class TestFixture implements FixtureInterface
     public string $connection = 'test';
 
     /**
-     * Full Table Name
+     * The physical database table name to use.
+     *
+     * If set, tableAlias must initially be empty.
+     * $tableAlias will then be inflected as Inflector::camelize($table).
      *
      * @var string
      */
     public string $table = '';
 
+    /**
+     * The ORM table alias to use.
+     *
+     * If set, table must initially be empty.
+     * $table will be read from the ORM table loaded via the alias.
+     *
+     * If both table and tableAlias are empty, the alias,
+     * will be inflected from the class name with Inflector::pluralize()
+     *
+     * @var string
+     */
     public string $tableAlias = '';
 
     /**
@@ -136,7 +150,7 @@ class TestFixture implements FixtureInterface
         [, $class] = namespaceSplit(static::class);
         preg_match('/^(.*)Fixture$/', $class, $matches);
 
-        return $matches[1] ?? $class;
+        return Inflector::pluralize($matches[1] ?? $class);
     }
 
     /**

--- a/tests/Fixture/SpecialPkFixture.php
+++ b/tests/Fixture/SpecialPkFixture.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Custom fixture with a name that inflects differently
+ * with 5.3 than it did with 5.2
+ */
+class SpecialPkFixture extends TestFixture
+{
+}


### PR DESCRIPTION
I found this as a change I was working on in migrations failed.

https://github.com/cakephp/migrations/pull/918

is currently failing because a table does not exist, and the table in question comes from a fixture named `SpecialPk`. Previously that fixture would use `special_pks` as its table name.