### PR TITLE
Fix default value for boolean type in SQLite getting columns schema

### DIFF
--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -313,7 +313,7 @@ class SqliteSchemaDialect extends SchemaDialect
             return null;
         }
 
-        if (strtolower($type) === TableSchemaInterface::TYPE_BOOLEAN) {
+        if ($type !== null && strtolower($type) === TableSchemaInterface::TYPE_BOOLEAN) {
             return is_numeric($default) ? (int)$default : filter_var($default, FILTER_VALIDATE_BOOLEAN);
         }
 

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -307,14 +307,18 @@ class SqliteSchemaDialect extends SchemaDialect
      * @param string|null $type The column type.
      * @return string|int|bool|null
      */
-    protected function _defaultValue(string|int|null $default, ?string $type = null): string|int|bool|null
+    protected function _defaultValue(string|int|null $default, ?string $type = null): string|int|null
     {
         if ($default === 'NULL' || $default === null) {
             return null;
         }
 
         if ($type !== null && strtolower($type) === TableSchemaInterface::TYPE_BOOLEAN) {
-            return is_numeric($default) ? (int)$default : filter_var($default, FILTER_VALIDATE_BOOLEAN);
+            if ($default === '0' || $default === '1') {
+                return (int)$default;
+            }
+
+            return (int)filter_var($default, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
         }
 
         // Remove quotes

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -305,7 +305,7 @@ class SqliteSchemaDialect extends SchemaDialect
      *
      * @param string|int|null $default The default value.
      * @param string|null $type The column type.
-     * @return string|int|bool|null
+     * @return string|int|null
      */
     protected function _defaultValue(string|int|null $default, ?string $type = null): string|int|null
     {

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -213,7 +213,7 @@ class SqliteSchemaDialect extends SchemaDialect
         $field = $this->_convertColumn($row['type']);
         $field += [
             'null' => !$row['notnull'],
-            'default' => $this->_defaultValue($row['dflt_value']),
+            'default' => $this->_defaultValue($row['dflt_value'], $row['type']),
         ];
         $primary = $schema->getConstraint('primary');
 
@@ -278,7 +278,7 @@ class SqliteSchemaDialect extends SchemaDialect
             $field += [
                 'name' => $name,
                 'null' => !$row['notnull'],
-                'default' => $this->_defaultValue($row['dflt_value']),
+                'default' => $this->_defaultValue($row['dflt_value'], $row['type']),
                 'comment' => null,
                 'length' => null,
             ];
@@ -304,12 +304,17 @@ class SqliteSchemaDialect extends SchemaDialect
      * We need to remove those.
      *
      * @param string|int|null $default The default value.
-     * @return string|int|null
+     * @param string|null $type The column type.
+     * @return string|int|bool|null
      */
-    protected function _defaultValue(string|int|null $default): string|int|null
+    protected function _defaultValue(string|int|null $default, ?string $type = null): string|int|bool|null
     {
         if ($default === 'NULL' || $default === null) {
             return null;
+        }
+
+        if (strtolower($type) === TableSchemaInterface::TYPE_BOOLEAN) {
+            return is_numeric($default) ? (int)$default : filter_var($default, FILTER_VALIDATE_BOOLEAN);
         }
 
         // Remove quotes

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -83,7 +83,7 @@ class SqliteSchemaDialectTest extends TestCase
             ],
             [
                 'BOOLEAN',
-                ['type' => 'boolean', 'length' => null],
+                ['type' => 'boolean', 'length' => null, 'default' => 0],
             ],
             [
                 'BIGINT',
@@ -452,7 +452,7 @@ SQL;
             'reviewed' => [
                 'type' => 'boolean',
                 'null' => true,
-                'default' => true,
+                'default' => 1,
                 'length' => null,
                 'precision' => null,
                 'comment' => null,
@@ -853,6 +853,14 @@ SQL;
                 'type' => 'boolean',
                 'null' => true,
                 'default' => 0,
+                'length' => null,
+                'comment' => null,
+            ],
+            [
+                'name' => 'reviewed',
+                'type' => 'boolean',
+                'null' => true,
+                'default' => true,
                 'length' => null,
                 'comment' => null,
             ],

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -293,6 +293,7 @@ body TEXT,
 author_id INT(11) NOT NULL,
 unique_id UNSIGNED INTEGER NOT NULL,
 published BOOLEAN DEFAULT 0,
+reviewed BOOLEAN DEFAULT TRUE,
 created DATETIME,
 field1 VARCHAR(10) DEFAULT NULL,
 field2 VARCHAR(10) DEFAULT 'NULL',
@@ -448,6 +449,14 @@ SQL;
                 'precision' => null,
                 'comment' => null,
             ],
+            'reviewed' => [
+                'type' => 'boolean',
+                'null' => true,
+                'default' => true,
+                'length' => null,
+                'precision' => null,
+                'comment' => null,
+            ],
             'created' => [
                 'type' => 'datetime',
                 'null' => true,
@@ -488,7 +497,11 @@ SQL;
         $this->assertInstanceOf(TableSchema::class, $result);
         $this->assertEquals(['id'], $result->getPrimaryKey());
         foreach ($expected as $field => $definition) {
-            $this->assertEquals($definition, $result->getColumn($field));
+            $testColumn = $result->getColumn($field);
+            $this->assertNotEmpty($testColumn);
+            ksort($testColumn);
+            ksort($definition);
+            $this->assertSame($definition, $testColumn);
         }
     }
 


### PR DESCRIPTION
This PR fixes an issue with default value of boolean type columns for SQLite database.

Building a table with `TableSchema` for example:

```php
$s = new TableSchema('examples');
$s->addColumn('field1', [
    'type' => 'boolean',
    'null' => true,
    'default' => true,
]);
```
will produce

```SQL
CREATE TABLE "examples" ("field1" BOOLEAN DEFAULT TRUE)
```
Once the table was created reading the schema we obtain an inconsistency columns for default value. 

```php
$schema = new SchemaCollection($connection);
$result = $schema->describe('examples');
debug($result->getColumn('field1'));
```

output

```
########## DEBUG ##########
[
  'type' => 'boolean',
  'length' => null,
  'null' => true,
  'default' => 'TRUE',
  'comment' => null,
  'precision' => null
]
###########################
```

The default is a string `'TRUE'` but I expect a boolean `true` instead.

The same happens defining default as INT, for example `0`. The results in this case will be `'default' => '0'`.

---

**Side note**

To change code just in one place I modified the `protected function _defaultValue` signature. I think that it shouldn't have serious impact but let me know in case.