### PR TITLE
Fix up Form getError() not handling dot notation.

### DIFF
--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -211,12 +211,22 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
     /**
      * Returns validation errors for the given field
      *
-     * @param string $field Field name to get the errors from.
+     * Supports dot notation for nested fields. For example:
+     * - `$form->getError('Common.field_name')`
+     * - `$form->getError('parent.level.deep_field')`
+     *
+     * @param string $field Field name to get the errors from. Supports dot notation for nested fields.
      * @return array The validation errors for the given field.
      */
     public function getError(string $field): array
     {
-        return $this->_errors[$field] ?? [];
+        if (isset($this->_errors[$field])) {
+            return $this->_errors[$field];
+        }
+
+        $error = Hash::get($this->_errors, $field);
+
+        return is_array($error) ? $error : [];
     }
 
     /**

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -274,4 +274,72 @@ class FormTest extends TestCase
         $this->assertArrayHasKey('_validator', $result);
         $this->assertArrayHasKey('_data', $result);
     }
+
+    /**
+     * Test getError() with nested field validation using dot notation
+     */
+    public function testGetErrorNestedFields(): void
+    {
+        $form = new Form();
+
+        $nestedValidator = new Validator();
+        $nestedValidator->add('field_name', 'notBlank', [
+            'rule' => 'notBlank',
+            'message' => 'This field is required',
+        ]);
+
+        $form->getValidator()->addNested('Common', $nestedValidator);
+
+        $data = [
+            'Common' => [
+                'field_name' => '',
+            ],
+        ];
+
+        $form->validate($data);
+
+        // Test accessing nested errors using dot notation
+        $error = $form->getError('Common.field_name');
+        $this->assertNotEmpty($error);
+        $this->assertSame('This field is required', $error['notBlank']);
+
+        // Test accessing parent level errors
+        $commonErrors = $form->getError('Common');
+        $this->assertNotEmpty($commonErrors);
+        $this->assertArrayHasKey('field_name', $commonErrors);
+    }
+
+    /**
+     * Test getError() with deeply nested fields
+     */
+    public function testGetErrorDeeplyNestedFields(): void
+    {
+        $form = new Form();
+
+        $deepValidator = new Validator();
+        $deepValidator->add('deep_field', 'notBlank', [
+            'rule' => 'notBlank',
+            'message' => 'Deep field is required',
+        ]);
+
+        $midValidator = new Validator();
+        $midValidator->addNested('level', $deepValidator);
+
+        $form->getValidator()->addNested('parent', $midValidator);
+
+        $data = [
+            'parent' => [
+                'level' => [
+                    'deep_field' => '',
+                ],
+            ],
+        ];
+
+        $form->validate($data);
+
+        // Test accessing deeply nested errors using dot notation
+        $error = $form->getError('parent.level.deep_field');
+        $this->assertNotEmpty($error);
+        $this->assertSame('Deep field is required', $error['notBlank']);
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/12977

Since other places handle this already, this seems to be a fix to make it consistent.