### PR TITLE
Fix up regression on iterator memory usage.

### DIFF
--- a/src/Collection/Iterator/ExtractIterator.php
+++ b/src/Collection/Iterator/ExtractIterator.php
@@ -80,26 +80,6 @@ class ExtractIterator extends Collection
      */
     public function unwrap(): Iterator
     {
-        $iterator = $this->getInnerIterator();
-
-        if ($iterator instanceof CollectionInterface) {
-            $iterator = $iterator->unwrap();
-        }
-
-        if ($iterator::class !== ArrayIterator::class) {
-            return $this;
-        }
-
-        // ArrayIterator can be traversed strictly.
-        // Let's do that for performance gains
-
-        $callback = $this->_extractor;
-        $res = [];
-
-        foreach ($iterator->getArrayCopy() as $k => $v) {
-            $res[$k] = $callback($v);
-        }
-
-        return new ArrayIterator($res);
+        return $this;
     }
 }

--- a/src/Collection/Iterator/ExtractIterator.php
+++ b/src/Collection/Iterator/ExtractIterator.php
@@ -16,9 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Collection\Iterator;
 
-use ArrayIterator;
 use Cake\Collection\Collection;
-use Cake\Collection\CollectionInterface;
 use Iterator;
 
 /**


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/17744#issuecomment-3413709683

 The issue is in ExtractIterator::unwrap() (src/Collection/Iterator/ExtractIterator.php:81-104).

  Root cause: When extract() is called on a large query result and then any operation triggers unwrap() (like iteration, toArray(), toList(), etc.), the method eagerly materializes the entire result set into memory at line
  99:
```php
  foreach ($iterator->getArrayCopy() as $k => $v) {
      $res[$k] = $callback($v);
  }
```
  This "optimization" was intended to improve performance for small ArrayIterator instances, but it backfires with large result sets containing hydrated entities, causing memory exhaustion.

  **Proposed Solution**

  Remove the eager materialization optimization from ExtractIterator::unwrap(). Make it always return the lazy iterator, allowing extraction to happen on-demand:
```php
  public function unwrap(): Iterator
  {
      return $this;
  }
```
  Previous behavior (CakePHP 5): When the inner iterator was an ArrayIterator, the method would eagerly materialize the entire result set into memory by calling getArrayCopy() and processing all items at once. This caused
  memory exhaustion with large datasets (60,000+ hydrated entities).

  New behavior (restored from CakePHP 4): The method now always returns the lazy iterator, ensuring extraction happens on-demand, one item at a time.

**Impact**

  This fix resolves the memory exhaustion issue reported in #17744 without breaking any existing functionality. Users can now call ->extract() on large query results without needing workarounds like ->disableHydration() or
  ->limit().

Unless we are fine with ->disableHydration() requirement and document it as such?