### PR TITLE
Add Table container for delegating Table classes

### DIFF
--- a/src/ORM/Locator/TableContainer.php
+++ b/src/ORM/Locator/TableContainer.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\ORM\Locator;
+
+use Cake\ORM\Table;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Dependency injection container for Tables. Will create Tables
+ * as if fetchTable() was called with default options.
+ *
+ * Register as a delegate in your Application::services() function
+ * before any auto-wire delegates.
+ */
+class TableContainer implements ContainerInterface
+{
+    use LocatorAwareTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function get(string $id): Table
+    {
+        return $this->fetchTable($id);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has(string $id): bool
+    {
+        return str_ends_with($id, 'Table') && is_subclass_of($id, Table::class);
+    }
+}

--- a/tests/TestCase/ORM/Locator/TableContainerTest.php
+++ b/tests/TestCase/ORM/Locator/TableContainerTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\ORM\Locator;
+
+use Cake\Core\Container;
+use Cake\ORM\Locator\TableContainer;
+use Cake\TestSuite\TestCase;
+use League\Container\Exception\NotFoundException;
+use TestApp\Model\Table\ArticlesTable;
+use TestApp\Model\Table\FakeTable;
+
+class TableContainerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        static::setAppNamespace();
+    }
+
+    public function testTableContainer(): void
+    {
+        $container = new Container();
+        $container->delegate(new TableContainer());
+
+        $table = $container->get(ArticlesTable::class);
+        $this->assertInstanceOf(ArticlesTable::class, $table);
+        $this->assertSame($table, $container->get(ArticlesTable::class));
+    }
+
+    public function testTableContainerMissingTable(): void
+    {
+        $container = new Container();
+        $container->delegate(new TableContainer());
+
+        $this->expectException(NotFoundException::class);
+        $container->get(FakeTable::class);
+    }
+}

--- a/tests/test_app/TestApp/Model/Table/FakeTable.php
+++ b/tests/test_app/TestApp/Model/Table/FakeTable.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Model\Table;
+
+class FakeTable
+{
+}


### PR DESCRIPTION
This allows Table instances to be injected into controllers and actions. Users can add the delegate to custom containers where needed.


