### PR TITLE
Paginator: Implement combined sorting key.

### DIFF
--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -576,6 +576,9 @@ class NumericPaginator implements PaginatorInterface
             // Parse sort and direction parameters
             $sortParams = $this->parseSortParams($options);
 
+            // Update options with parsed sort key (handles combined format)
+            $options['sort'] = $sortParams['sortKey'];
+
             if ($builder !== null) {
                 // Use builder to resolve sort key
                 $order = $builder->resolve(
@@ -718,6 +721,8 @@ class NumericPaginator implements PaginatorInterface
      * Parse sort parameters from options.
      *
      * Extracts and normalizes sort key and direction from pagination options.
+     * Supports both traditional format (?sort=field&direction=asc) and
+     * combined format (?sort=field-asc).
      *
      * @param array<string, mixed> $options The options array
      * @return array{sortKey: string, direction: string, directionSpecified: bool}
@@ -727,6 +732,13 @@ class NumericPaginator implements PaginatorInterface
         $sortKey = $options['sort'];
         $direction = isset($options['direction']) ? strtolower($options['direction']) : SortField::ASC;
         $directionSpecified = isset($options['direction']);
+
+        // Check for combined sort-direction format (e.g., 'title-asc' or 'title-desc')
+        if (preg_match('/^(.+)-(asc|desc)$/i', $sortKey, $matches)) {
+            $sortKey = $matches[1];
+            $direction = strtolower($matches[2]);
+            $directionSpecified = true;
+        }
 
         // Validate direction
         if (!in_array($direction, [SortField::ASC, SortField::DESC], true)) {

--- a/src/Datasource/Paging/SortableFieldsBuilder.php
+++ b/src/Datasource/Paging/SortableFieldsBuilder.php
@@ -233,6 +233,7 @@ final class SortableFieldsBuilder
     protected function resolveArrayMapping(array $fields, string $direction, bool $directionSpecified): array
     {
         $order = [];
+        $shouldInvert = $directionSpecified && $direction === SortField::DESC;
 
         foreach ($fields as $key => $value) {
             if ($value instanceof SortField) {
@@ -243,11 +244,22 @@ final class SortableFieldsBuilder
             } elseif (is_int($key)) {
                 // Numeric array: ['field1', 'field2'] - use requested direction
                 $order[$value] = $direction;
-            } elseif (!$directionSpecified) {
-                // Default direction: 'field' => 'asc'
-                $order[$key] = $value;
+            } elseif (is_string($key) && is_string($value)) {
+                // Associative array with default directions per field
+                // Format: ['field1' => 'ASC', 'field2' => 'DESC']
+                $defaultDirection = strtolower($value);
+
+                if ($shouldInvert) {
+                    // Invert the direction when toggling to desc
+                    $fieldDirection = $defaultDirection === SortField::ASC ? SortField::DESC : SortField::ASC;
+                } else {
+                    // Use default direction (for asc or no direction specified)
+                    $fieldDirection = $defaultDirection;
+                }
+
+                $order[$key] = $fieldDirection;
             } else {
-                // Toggleable with default
+                // Fallback for other cases
                 $order[$key] = $direction;
             }
         }

--- a/src/Datasource/Paging/SortableFieldsBuilder.php
+++ b/src/Datasource/Paging/SortableFieldsBuilder.php
@@ -244,7 +244,7 @@ final class SortableFieldsBuilder
             } elseif (is_int($key)) {
                 // Numeric array: ['field1', 'field2'] - use requested direction
                 $order[$value] = $direction;
-            } elseif (is_string($key) && is_string($value)) {
+            } elseif (is_string($value)) {
                 // Associative array with default directions per field
                 // Format: ['field1' => 'ASC', 'field2' => 'DESC']
                 $defaultDirection = strtolower($value);

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -61,6 +61,7 @@ class PaginatorHelper extends Helper
      * - `url['?']['direction']` Direction of the sorting (default: 'asc').
      * - `url['?']['page']` Page number to use in links.
      * - `escape` Defines if the title field for the link should be escaped (default: true).
+     * - `sortFormat` Format for sort URLs: 'separate' (default, ?sort=x&direction=y) or 'combined' (?sort=x-y).
      * - `routePlaceholders` An array specifying which paging params should be
      *   passed as route placeholders instead of query string parameters. The array
      *   can have values `'sort'`, `'direction'`, `'page'`.
@@ -71,7 +72,9 @@ class PaginatorHelper extends Helper
      */
     protected array $_defaultConfig = [
         'params' => [],
-        'options' => [],
+        'options' => [
+            'sortFormat' => 'separate',
+        ],
         'templates' => [
             'nextActive' => '<li class="next"><a rel="next" href="{{url}}">{{text}}</a></li>',
             'nextDisabled' => '<li class="next disabled"><a>{{text}}</a></li>',
@@ -433,7 +436,12 @@ class PaginatorHelper extends Helper
             $title = $title[$dir];
         }
 
-        $paging = ['sort' => $key, 'direction' => $dir, 'page' => 1];
+        $sortFormat = $this->getConfig('options.sortFormat', 'separate');
+        if ($sortFormat === 'combined') {
+            $paging = ['sort' => $key . '-' . $dir, 'page' => 1];
+        } else {
+            $paging = ['sort' => $key, 'direction' => $dir, 'page' => 1];
+        }
 
         $vars = [
             'text' => $options['escape'] ? h($title) : $title,

--- a/tests/TestCase/Datasource/Paging/NumericPaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/NumericPaginatorTest.php
@@ -368,44 +368,44 @@ class NumericPaginatorTest extends TestCase
             'PaginatorPosts.body' => 'desc', // Uses default
         ], $pagingParams['completeSort']);
 
-       // Test 'custom' with asc direction (should use defaults)
+       // Test 'custom' with asc direction (should use defaults as-is)
         $params = ['sort' => 'custom', 'direction' => 'asc'];
         $result = $this->Paginator->paginate($table, $params, $settings);
         $pagingParams = $result->pagingParams();
 
         $this->assertEquals([
-            'PaginatorPosts.title' => 'asc', // Default was asc, stays asc
-            'PaginatorPosts.body' => 'asc', // Default was desc, flips to asc
+            'PaginatorPosts.title' => 'asc', // Default is asc
+            'PaginatorPosts.body' => 'desc', // Default is desc
         ], $pagingParams['completeSort']);
 
-       // Test 'custom' with desc direction (should flip defaults)
+       // Test 'custom' with desc direction (should invert all defaults)
         $params = ['sort' => 'custom', 'direction' => 'desc'];
         $result = $this->Paginator->paginate($table, $params, $settings);
         $pagingParams = $result->pagingParams();
 
         $this->assertEquals([
-            'PaginatorPosts.title' => 'desc', // Default was asc, flips to desc
-            'PaginatorPosts.body' => 'desc', // Default was desc, stays desc
+            'PaginatorPosts.title' => 'desc', // Default was asc, inverted to desc
+            'PaginatorPosts.body' => 'asc', // Default was desc, inverted to asc
         ], $pagingParams['completeSort']);
 
-       // Test 'locked' with asc direction
+       // Test 'locked' with asc direction (uses defaults)
         $params = ['sort' => 'locked', 'direction' => 'asc'];
         $result = $this->Paginator->paginate($table, $params, $settings);
         $pagingParams = $result->pagingParams();
 
         $this->assertEquals([
             'PaginatorPosts.id' => 'desc', // Locked, never changes
-            'PaginatorPosts.author_id' => 'asc', // Default asc, stays asc
+            'PaginatorPosts.author_id' => 'asc', // Default asc
         ], $pagingParams['completeSort']);
 
-       // Test 'locked' with desc direction
+       // Test 'locked' with desc direction (inverts toggleable fields)
         $params = ['sort' => 'locked', 'direction' => 'desc'];
         $result = $this->Paginator->paginate($table, $params, $settings);
         $pagingParams = $result->pagingParams();
 
         $this->assertEquals([
             'PaginatorPosts.id' => 'desc', // Locked, never changes
-            'PaginatorPosts.author_id' => 'desc', // Default asc, flips to desc
+            'PaginatorPosts.author_id' => 'desc', // Default asc, inverted to desc
         ], $pagingParams['completeSort']);
     }
 
@@ -524,5 +524,122 @@ class NumericPaginatorTest extends TestCase
         $this->assertEquals('simple_author', $pagingParams['sort']);
         $this->assertEquals('desc', $pagingParams['direction']);
         $this->assertEquals(['PaginatorPosts.author_id' => 'desc'], $pagingParams['completeSort']);
+    }
+
+    /**
+     * Test combined sort-direction parameter format (e.g., 'title-asc')
+     */
+    public function testCombinedSortDirectionFormat(): void
+    {
+        $table = $this->getTableLocator()->get('PaginatorPosts');
+
+        // Test ascending with combined format
+        $params = ['sort' => 'title-asc'];
+        $result = $this->Paginator->paginate($table, $params);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertEquals('title', $pagingParams['sort']);
+        $this->assertEquals('asc', $pagingParams['direction']);
+        $this->assertEquals(['PaginatorPosts.title' => 'asc'], $pagingParams['completeSort']);
+
+        // Test descending with combined format
+        $params = ['sort' => 'body-desc'];
+        $result = $this->Paginator->paginate($table, $params);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertEquals('body', $pagingParams['sort']);
+        $this->assertEquals('desc', $pagingParams['direction']);
+        $this->assertEquals(['PaginatorPosts.body' => 'desc'], $pagingParams['completeSort']);
+
+        // Test that traditional format still works
+        $params = ['sort' => 'title', 'direction' => 'desc'];
+        $result = $this->Paginator->paginate($table, $params);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertEquals('title', $pagingParams['sort']);
+        $this->assertEquals('desc', $pagingParams['direction']);
+        $this->assertEquals(['PaginatorPosts.title' => 'desc'], $pagingParams['completeSort']);
+
+        // Test combined format with hyphenated field names
+        $params = ['sort' => 'author_id-desc'];
+        $result = $this->Paginator->paginate($table, $params);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertEquals('author_id', $pagingParams['sort']);
+        $this->assertEquals('desc', $pagingParams['direction']);
+        $this->assertEquals(['PaginatorPosts.author_id' => 'desc'], $pagingParams['completeSort']);
+    }
+
+    /**
+     * Test combined sort format with sortableFields
+     */
+    public function testCombinedSortFormatWithSortableFields(): void
+    {
+        $table = $this->getTableLocator()->get('PaginatorPosts');
+        $settings = [
+            'sortableFields' => [
+                'name' => 'PaginatorPosts.title',
+                'content' => 'PaginatorPosts.body',
+                'newest' => [
+                    SortField::desc('PaginatorPosts.id', locked: true),
+                    'PaginatorPosts.title',
+                ],
+                'custom' => [
+                    'PaginatorPosts.author_id' => 'asc', // Toggleable default
+                    'PaginatorPosts.body' => 'desc', // Toggleable default
+                ],
+            ],
+        ];
+
+        // Test simple mapping with combined format
+        $params = ['sort' => 'name-desc'];
+        $result = $this->Paginator->paginate($table, $params, $settings);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertEquals('name', $pagingParams['sort']);
+        $this->assertEquals('desc', $pagingParams['direction']);
+        $this->assertEquals(['PaginatorPosts.title' => 'desc'], $pagingParams['completeSort']);
+
+        // Test that unmapped fields with combined format are still rejected
+        $params = ['sort' => 'unmapped-asc'];
+        $result = $this->Paginator->paginate($table, $params, $settings);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertNull($pagingParams['sort']);
+        $this->assertNull($pagingParams['direction']);
+        $this->assertEquals([], $pagingParams['completeSort']);
+
+        // Test multi-field mapping with combined format (locked field)
+        $params = ['sort' => 'newest-asc']; // Direction should apply to non-locked fields
+        $result = $this->Paginator->paginate($table, $params, $settings);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertEquals('newest', $pagingParams['sort']);
+        $this->assertEquals([
+            'PaginatorPosts.id' => 'desc', // Locked direction
+            'PaginatorPosts.title' => 'asc', // Uses combined format direction
+        ], $pagingParams['completeSort']);
+
+        // Test toggleable defaults with combined format - asc (uses defaults)
+        $params = ['sort' => 'custom-asc'];
+        $result = $this->Paginator->paginate($table, $params, $settings);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertEquals('custom', $pagingParams['sort']);
+        $this->assertEquals([
+            'PaginatorPosts.author_id' => 'asc', // Default is asc
+            'PaginatorPosts.body' => 'desc', // Default is desc
+        ], $pagingParams['completeSort']);
+
+        // Test toggleable defaults with combined format - desc (inverts all)
+        $params = ['sort' => 'custom-desc'];
+        $result = $this->Paginator->paginate($table, $params, $settings);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertEquals('custom', $pagingParams['sort']);
+        $this->assertEquals([
+            'PaginatorPosts.author_id' => 'desc', // Default asc, inverted to desc
+            'PaginatorPosts.body' => 'asc', // Default desc, inverted to asc
+        ], $pagingParams['completeSort']);
     }
 }

--- a/tests/TestCase/Datasource/Paging/SortableFieldsBuilderTest.php
+++ b/tests/TestCase/Datasource/Paging/SortableFieldsBuilderTest.php
@@ -303,8 +303,8 @@ class SortableFieldsBuilderTest extends TestCase
         // Direction 'desc' specified - invert all defaults
         $result = $builder->resolve('custom', 'desc', true);
         $expected = [
-            'title' => 'desc',   // default asc, inverted to desc
-            'created' => 'asc',  // default desc, inverted to asc
+            'title' => 'desc', // default asc, inverted to desc
+            'created' => 'asc', // default desc, inverted to asc
         ];
         $this->assertSame($expected, $result);
     }

--- a/tests/TestCase/Datasource/Paging/SortableFieldsBuilderTest.php
+++ b/tests/TestCase/Datasource/Paging/SortableFieldsBuilderTest.php
@@ -292,11 +292,19 @@ class SortableFieldsBuilderTest extends TestCase
         ];
         $this->assertSame($expected, $result);
 
-        // Direction specified - override defaults
+        // Direction 'asc' specified - use defaults as-is
+        $result = $builder->resolve('custom', 'asc', true);
+        $expected = [
+            'title' => 'asc',
+            'created' => 'desc',
+        ];
+        $this->assertSame($expected, $result);
+
+        // Direction 'desc' specified - invert all defaults
         $result = $builder->resolve('custom', 'desc', true);
         $expected = [
-            'title' => 'desc',
-            'created' => 'desc',
+            'title' => 'desc',   // default asc, inverted to desc
+            'created' => 'asc',  // default desc, inverted to asc
         ];
         $this->assertSame($expected, $result);
     }

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -663,6 +663,80 @@ class PaginatorHelperTest extends TestCase
     }
 
     /**
+     * Test sort links with combined format
+     */
+    public function testSortLinksCombinedFormat(): void
+    {
+        $request = new ServerRequest([
+            'url' => '/accounts/',
+            'params' => [
+                'plugin' => null,
+                'controller' => 'Accounts',
+                'action' => 'index',
+                'pass' => [],
+            ],
+            'base' => '',
+            'webroot' => '/',
+        ]);
+        Router::setRequest($request);
+
+        $this->setPaginatedResult([
+            'alias' => 'Articles',
+            'currentPage' => 1,
+            'count' => 9,
+            'totalCount' => 62,
+            'hasPrevPage' => false,
+            'hasNextPage' => true,
+            'pageCount' => 7,
+        ], false);
+        $this->Paginator->options(['url' => ['param']]);
+
+        // Test default format (separate)
+        $result = $this->Paginator->sort('title');
+        $expected = [
+            'a' => ['href' => '/Accounts/index/param?sort=title&amp;direction=asc'],
+            'Title',
+            '/a',
+        ];
+        $this->assertHtml($expected, $result);
+
+        // Test combined format
+        $this->Paginator->setConfig('options.sortFormat', 'combined');
+        $result = $this->Paginator->sort('title');
+        $expected = [
+            'a' => ['href' => '/Accounts/index/param?sort=title-asc'],
+            'Title',
+            '/a',
+        ];
+        $this->assertHtml($expected, $result);
+
+        // Test combined format with currently sorted field (toggles direction)
+        $this->setPaginatedResult([
+            'alias' => 'Articles',
+            'sort' => 'title',
+        ]);
+        $result = $this->Paginator->sort('title');
+        $expected = [
+            'a' => ['href' => '/Accounts/index/param?sort=title-desc', 'class' => 'asc'],
+            'Title',
+            '/a',
+        ];
+        $this->assertHtml($expected, $result);
+
+        // Test combined format with dot notation
+        $this->setPaginatedResult([
+            'alias' => 'Articles',
+        ]);
+        $result = $this->Paginator->sort('Articles.author');
+        $expected = [
+            'a' => ['href' => '/Accounts/index/param?sort=Articles.author-asc'],
+            'Articles Author',
+            '/a',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * Test that generated URLs work without sort defined within the request
      */
     public function testDefaultSortAndNoSort(): void


### PR DESCRIPTION
Reimplement and showcase initial idea of combined sort map, that also allows more complex use cases maybe:
https://github.com/cakephp/cakephp/pull/18898

If this is out of scope, fair enough. 

  1. Configuration
```
  // In your paginate() settings
  'sortableFields' => [
      'best-deal' => [
          'in_stock' => 'DESC',    // Field-level defaults
          'price' => 'ASC',
          'rating' => 'DESC'
      ],
      'name' => 'Users.full_name',   // Simple mapping
      'popular' => [
          'views' => 'DESC',
          'likes' => 'DESC'
      ]
  ]
```
  2. Enable Combined Format (One Line)
```
  // In AppView::initialize() or controller
  $this->Paginator->setConfig('options.sortFormat', 'combined');
```
or directly when loading the helper.

  3. Templates
```
  echo $this->Paginator->sort('best-deal', 'Best Deals');
  echo $this->Paginator->sort('name', 'Name');
  echo $this->Paginator->sort('popular', 'Most Popular');
```
  4. Auto-Generated URLs

  First click on "Best Deals":
  ?sort=best-deal-asc
  → ORDER BY in_stock DESC, price ASC, rating DESC

  Second click (toggle):
  ?sort=best-deal-desc
  → ORDER BY in_stock ASC, price DESC, rating ASC  (all inverted!)