### PR TITLE
Fix limitControl() to keep current filters when switching the limit s…

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1181,12 +1181,10 @@ class PaginatorHelper extends Helper
             $scope .= '.';
         }
 
-        $url = $this->_View->getRequest()->getPath();
-        $out = $this->Form->create(null, ['type' => 'get', 'url' => $url]);
+        $out = $this->Form->create(null, ['type' => 'get', 'url' => $this->_View->getRequest()->getPath()]);
 
         // Add hidden fields to preserve query parameters
         $out .= $this->generateHiddenFields($hiddenFields);
-
         $out .= $this->Form->control($scope . 'limit', $options + [
             'type' => 'select',
             'label' => __('View'),
@@ -1195,6 +1193,7 @@ class PaginatorHelper extends Helper
             'options' => $limits,
             'onChange' => 'this.form.submit()',
         ]);
+
         $out .= $this->Form->end();
 
         return $out;

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1153,26 +1153,40 @@ class PaginatorHelper extends Helper
         $scope = $this->param('scope');
         assert($scope === null || is_string($scope));
 
-        $url = null;
         $currentPage = $this->paginated()->currentPage();
+        $query = $this->_View->getRequest()->getQueryParams();
 
-        if ($currentPage > 1) {
-            $query = $this->_View->getRequest()->getQueryParams();
-
-            if ($scope) {
-                $query[$scope]['page'] = 1;
-            } else {
-                $query['page'] = 1;
+        // Prepare query params to preserve as hidden fields
+        $hiddenFields = $query;
+        if ($scope) {
+            // Remove limit and page from scoped params
+            unset($hiddenFields[$scope]['limit'], $hiddenFields[$scope]['page']);
+            if (isset($hiddenFields[$scope]) && empty($hiddenFields[$scope])) {
+                unset($hiddenFields[$scope]);
             }
-
-            $url = $this->_View->getRequest()->getPath();
-            $url .= '?' . http_build_query($query);
+            // Set page to 1 if not on first page
+            if ($currentPage > 1) {
+                $hiddenFields[$scope]['page'] = 1;
+            }
+        } else {
+            // Remove pagination params that will be handled separately
+            unset($hiddenFields['limit'], $hiddenFields['page'], $hiddenFields['sort'], $hiddenFields['direction']);
+            // Set page to 1 if not on first page
+            if ($currentPage > 1) {
+                $hiddenFields['page'] = 1;
+            }
         }
 
         if ($scope) {
             $scope .= '.';
         }
+
+        $url = $this->_View->getRequest()->getPath();
         $out = $this->Form->create(null, ['type' => 'get', 'url' => $url]);
+
+        // Add hidden fields to preserve query parameters
+        $out .= $this->generateHiddenFields($hiddenFields);
+
         $out .= $this->Form->control($scope . 'limit', $options + [
             'type' => 'select',
             'label' => __('View'),
@@ -1182,6 +1196,39 @@ class PaginatorHelper extends Helper
             'onChange' => 'this.form.submit()',
         ]);
         $out .= $this->Form->end();
+
+        return $out;
+    }
+
+    /**
+     * Recursively generate hidden form fields for nested arrays.
+     *
+     * This handles query parameters with arbitrary nesting levels by converting
+     * nested arrays into dot-notation field names.
+     *
+     * Example:
+     * ['filter' => ['date' => ['start' => '2024-01-01']]]
+     * becomes: hidden field "filter.date.start" with value "2024-01-01"
+     *
+     * @param array $data The data to convert to hidden fields
+     * @param string $prefix The current key prefix for nested fields
+     * @return string HTML for hidden form fields
+     */
+    protected function generateHiddenFields(array $data, string $prefix = ''): string
+    {
+        $out = '';
+
+        foreach ($data as $key => $value) {
+            $fieldName = $prefix === '' ? $key : "{$prefix}.{$key}";
+
+            if (is_array($value)) {
+                // Recursively handle nested arrays
+                $out .= $this->generateHiddenFields($value, $fieldName);
+            } else {
+                // Generate hidden field for scalar values
+                $out .= $this->Form->hidden($fieldName, ['value' => $value]);
+            }
+        }
 
         return $out;
     }

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1181,9 +1181,8 @@ class PaginatorHelper extends Helper
             $scope .= '.';
         }
 
-        $out = $this->Form->create(null, ['type' => 'get', 'url' => $this->_View->getRequest()->getPath()]);
+        $out = $this->Form->create(null, ['type' => 'get', 'url' => []]);
 
-        // Add hidden fields to preserve query parameters
         $out .= $this->generateHiddenFields($hiddenFields);
         $out .= $this->Form->control($scope . 'limit', $options + [
             'type' => 'select',

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -3068,62 +3068,6 @@ class PaginatorHelperTest extends TestCase
     }
 
     /**
-     * Test to demonstrate how nested query strings are parsed from URLs.
-     * This shows the structure of deeply nested params when accessed via getQuery().
-     */
-    public function testNestedQueryStringStructure(): void
-    {
-        // Simulate a URL with various nesting levels:
-        // ?status=active&filter[category]=tech&filter[date][start]=2024-01-01&filter[date][end]=2024-12-31
-        $request = new ServerRequest([
-            'url' => '/posts?status=active&filter[category]=tech&filter[date][start]=2024-01-01&filter[date][end]=2024-12-31',
-            'params' => [
-                'plugin' => null, 'controller' => 'Posts', 'action' => 'index', 'pass' => [],
-            ],
-            'query' => [
-                'status' => 'active',
-                'filter' => [
-                    'category' => 'tech',
-                    'date' => [
-                        'start' => '2024-01-01',
-                        'end' => '2024-12-31',
-                    ],
-                ],
-            ],
-            'base' => '',
-            'webroot' => '/',
-        ]);
-
-        // Verify the structure
-        $query = $request->getQueryParams();
-
-        // Level 1: Simple value
-        $this->assertSame('active', $query['status']);
-
-        // Level 2: Array with simple value
-        $this->assertIsArray($query['filter']);
-        $this->assertSame('tech', $query['filter']['category']);
-
-        // Level 3: Nested array with values
-        $this->assertIsArray($query['filter']['date']);
-        $this->assertSame('2024-01-01', $query['filter']['date']['start']);
-        $this->assertSame('2024-12-31', $query['filter']['date']['end']);
-
-        // Show what the structure looks like
-        $expected = [
-            'status' => 'active',
-            'filter' => [
-                'category' => 'tech',
-                'date' => [
-                    'start' => '2024-01-01',
-                    'end' => '2024-12-31',
-                ],
-            ],
-        ];
-        $this->assertSame($expected, $query);
-    }
-
-    /**
      * Test limitControl with deeply nested query parameters (3+ levels).
      * This verifies the recursive implementation handles arbitrary nesting.
      */

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2863,7 +2863,7 @@ class PaginatorHelperTest extends TestCase
 
         $out = $this->Paginator->limitControl([1 => 1]);
         $expected = [
-            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/batches']],
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/Batches/index']],
             ['input' => ['type' => 'hidden', 'name' => 'owner', 'value' => 'billy']],
             ['input' => ['type' => 'hidden', 'name' => 'expected', 'value' => '1']],
             ['input' => ['type' => 'hidden', 'name' => 'page', 'value' => '1']],
@@ -3005,7 +3005,7 @@ class PaginatorHelperTest extends TestCase
 
         $out = $this->Paginator->limitControl([20 => 20, 50 => 50]);
         $expected = [
-            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/users']],
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/Users/index']],
             ['input' => ['type' => 'hidden', 'name' => 'status', 'value' => 'active']],
             ['input' => ['type' => 'hidden', 'name' => 'role', 'value' => 'admin']],
             ['div' => ['class' => 'input select']],
@@ -3047,7 +3047,7 @@ class PaginatorHelperTest extends TestCase
         $out = $this->Paginator->limitControl([25 => 25, 100 => 100]);
         $expected = [
             // Should only have category as hidden field, not sort/direction/page/limit
-            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/posts']],
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/Posts/index']],
             ['input' => ['type' => 'hidden', 'name' => 'category', 'value' => 'tech']],
             ['div' => ['class' => 'input select']],
             ['label' => ['for' => 'limit']],
@@ -3096,7 +3096,7 @@ class PaginatorHelperTest extends TestCase
 
         $out = $this->Paginator->limitControl([20 => 20, 50 => 50]);
         $expected = [
-            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/posts']],
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/Posts/index']],
             ['input' => ['type' => 'hidden', 'name' => 'filter[date][start]', 'value' => '2024-01-01']],
             ['input' => ['type' => 'hidden', 'name' => 'filter[date][end]', 'value' => '2024-12-31']],
             ['input' => ['type' => 'hidden', 'name' => 'filter[status]', 'value' => 'active']],

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2863,7 +2863,10 @@ class PaginatorHelperTest extends TestCase
 
         $out = $this->Paginator->limitControl([1 => 1]);
         $expected = [
-            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/batches?owner=billy&amp;expected=1&amp;page=1']],
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/batches']],
+            ['input' => ['type' => 'hidden', 'name' => 'owner', 'value' => 'billy']],
+            ['input' => ['type' => 'hidden', 'name' => 'expected', 'value' => '1']],
+            ['input' => ['type' => 'hidden', 'name' => 'page', 'value' => '1']],
             ['div' => ['class' => 'input select']],
             ['label' => ['for' => 'limit']],
             'View',
@@ -2962,7 +2965,8 @@ class PaginatorHelperTest extends TestCase
 
         $out = $this->Paginator->limitControl([25 => 25, 50 => 50]);
         $expected = [
-            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/?article%5Bpage%5D=1']],
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
+            ['input' => ['type' => 'hidden', 'name' => 'article[page]', 'value' => '1']],
             ['div' => ['class' => 'input select']],
             ['label' => ['for' => 'article-limit']],
             'View',
@@ -2970,6 +2974,195 @@ class PaginatorHelperTest extends TestCase
             ['select' => ['name' => 'article[limit]', 'id' => 'article-limit', 'onChange' => 'this.form.submit()']],
             ['option' => ['value' => '25', 'selected' => 'selected']],
             '25',
+            '/option',
+            ['option' => ['value' => '50']],
+            '50',
+            '/option',
+            '/select',
+            '/div',
+            '/form',
+        ];
+        $this->assertHtml($expected, $out);
+    }
+
+    /**
+     * test the limitControl() method preserves query strings on page 1
+     */
+    public function testLimitControlPreservesQueryStringsOnPageOne(): void
+    {
+        $request = new ServerRequest([
+            'url' => '/users?status=active&role=admin',
+            'params' => [
+                'plugin' => null, 'controller' => 'Users', 'action' => 'index', 'pass' => [],
+            ],
+            'query' => ['status' => 'active', 'role' => 'admin'],
+            'base' => '',
+            'webroot' => '/',
+        ]);
+        Router::setRequest($request);
+        $this->View->setRequest($request);
+        $this->setPaginatedResult(['perPage' => 20, 'currentPage' => 1]);
+
+        $out = $this->Paginator->limitControl([20 => 20, 50 => 50]);
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/users']],
+            ['input' => ['type' => 'hidden', 'name' => 'status', 'value' => 'active']],
+            ['input' => ['type' => 'hidden', 'name' => 'role', 'value' => 'admin']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.submit()']],
+            ['option' => ['value' => '20', 'selected' => 'selected']],
+            '20',
+            '/option',
+            ['option' => ['value' => '50']],
+            '50',
+            '/option',
+            '/select',
+            '/div',
+            '/form',
+        ];
+        $this->assertHtml($expected, $out);
+    }
+
+    /**
+     * test the limitControl() method excludes pagination params but preserves other query strings
+     */
+    public function testLimitControlExcludesPaginationParams(): void
+    {
+        $request = new ServerRequest([
+            'url' => '/posts?category=tech&sort=title&direction=asc&page=1&limit=25',
+            'params' => [
+                'plugin' => null, 'controller' => 'Posts', 'action' => 'index', 'pass' => [],
+            ],
+            'query' => ['category' => 'tech', 'sort' => 'title', 'direction' => 'asc', 'page' => '1', 'limit' => '25'],
+            'base' => '',
+            'webroot' => '/',
+        ]);
+        Router::setRequest($request);
+        $this->View->setRequest($request);
+        $this->setPaginatedResult(['perPage' => 25, 'currentPage' => 1]);
+
+        $out = $this->Paginator->limitControl([25 => 25, 100 => 100]);
+        $expected = [
+            // Should only have category as hidden field, not sort/direction/page/limit
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/posts']],
+            ['input' => ['type' => 'hidden', 'name' => 'category', 'value' => 'tech']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.submit()']],
+            ['option' => ['value' => '25', 'selected' => 'selected']],
+            '25',
+            '/option',
+            ['option' => ['value' => '100']],
+            '100',
+            '/option',
+            '/select',
+            '/div',
+            '/form',
+        ];
+        $this->assertHtml($expected, $out);
+    }
+
+    /**
+     * Test to demonstrate how nested query strings are parsed from URLs.
+     * This shows the structure of deeply nested params when accessed via getQuery().
+     */
+    public function testNestedQueryStringStructure(): void
+    {
+        // Simulate a URL with various nesting levels:
+        // ?status=active&filter[category]=tech&filter[date][start]=2024-01-01&filter[date][end]=2024-12-31
+        $request = new ServerRequest([
+            'url' => '/posts?status=active&filter[category]=tech&filter[date][start]=2024-01-01&filter[date][end]=2024-12-31',
+            'params' => [
+                'plugin' => null, 'controller' => 'Posts', 'action' => 'index', 'pass' => [],
+            ],
+            'query' => [
+                'status' => 'active',
+                'filter' => [
+                    'category' => 'tech',
+                    'date' => [
+                        'start' => '2024-01-01',
+                        'end' => '2024-12-31',
+                    ],
+                ],
+            ],
+            'base' => '',
+            'webroot' => '/',
+        ]);
+
+        // Verify the structure
+        $query = $request->getQueryParams();
+
+        // Level 1: Simple value
+        $this->assertSame('active', $query['status']);
+
+        // Level 2: Array with simple value
+        $this->assertIsArray($query['filter']);
+        $this->assertSame('tech', $query['filter']['category']);
+
+        // Level 3: Nested array with values
+        $this->assertIsArray($query['filter']['date']);
+        $this->assertSame('2024-01-01', $query['filter']['date']['start']);
+        $this->assertSame('2024-12-31', $query['filter']['date']['end']);
+
+        // Show what the structure looks like
+        $expected = [
+            'status' => 'active',
+            'filter' => [
+                'category' => 'tech',
+                'date' => [
+                    'start' => '2024-01-01',
+                    'end' => '2024-12-31',
+                ],
+            ],
+        ];
+        $this->assertSame($expected, $query);
+    }
+
+    /**
+     * Test limitControl with deeply nested query parameters (3+ levels).
+     * This verifies the recursive implementation handles arbitrary nesting.
+     */
+    public function testLimitControlWithDeeplyNestedParams(): void
+    {
+        $request = new ServerRequest([
+            'url' => '/posts?filter[date][start]=2024-01-01&filter[date][end]=2024-12-31&filter[status]=active',
+            'params' => [
+                'plugin' => null, 'controller' => 'Posts', 'action' => 'index', 'pass' => [],
+            ],
+            'query' => [
+                'filter' => [
+                    'date' => [
+                        'start' => '2024-01-01',
+                        'end' => '2024-12-31',
+                    ],
+                    'status' => 'active',
+                ],
+            ],
+            'base' => '',
+            'webroot' => '/',
+        ]);
+        Router::setRequest($request);
+        $this->View->setRequest($request);
+        $this->setPaginatedResult(['perPage' => 20, 'currentPage' => 1]);
+
+        $out = $this->Paginator->limitControl([20 => 20, 50 => 50]);
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/posts']],
+            ['input' => ['type' => 'hidden', 'name' => 'filter[date][start]', 'value' => '2024-01-01']],
+            ['input' => ['type' => 'hidden', 'name' => 'filter[date][end]', 'value' => '2024-12-31']],
+            ['input' => ['type' => 'hidden', 'name' => 'filter[status]', 'value' => 'active']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.submit()']],
+            ['option' => ['value' => '20', 'selected' => 'selected']],
+            '20',
             '/option',
             ['option' => ['value' => '50']],
             '50',


### PR DESCRIPTION
…ize.

The problem is clear: it doesnt magically merge existing ones in the URL with the ones Form posted.
So `'action' => '/batches?owner=billy&amp;expected=1&amp;page=1'` is actually always `'action' => '/batches'`.

Resolves limitControl() when filters (e.g. Search plugin) are applied, but then would be resettet as a GET form result without all query string filters as hidden fields would make them removed.