### PR TITLE
Add CastExpression, implement TypedResultInterface

### DIFF
--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -18,16 +18,19 @@ namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Type\ExpressionTypeCasterTrait;
+use Cake\Database\TypedResultInterface;
+use Cake\Database\TypedResultTrait;
 use Cake\Database\ValueBinder;
 use Closure;
 
 /**
  * An expression object that represents a SQL BETWEEN snippet
  */
-class BetweenExpression implements ExpressionInterface, FieldInterface
+class BetweenExpression implements ExpressionInterface, FieldInterface, TypedResultInterface
 {
     use ExpressionTypeCasterTrait;
     use FieldTrait;
+    use TypedResultTrait;
 
     /**
      * The first value in the expression
@@ -69,6 +72,7 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
         $this->from = $from;
         $this->to = $to;
         $this->type = $type;
+        $this->returnType = 'boolean';
     }
 
     /**

--- a/src/Database/Expression/CastExpression.php
+++ b/src/Database/Expression/CastExpression.php
@@ -1,0 +1,149 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         6.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+use Cake\Database\ExpressionInterface;
+use Cake\Database\TypedResultInterface;
+use Cake\Database\TypedResultTrait;
+use Cake\Database\ValueBinder;
+use Closure;
+
+/**
+ * Represents a SQL CAST expression in a SQL statement.
+ *
+ * This class represents a SQL CAST operation that converts an expression
+ * to a specific database type. For example: CAST(field AS INTEGER)
+ */
+class CastExpression implements ExpressionInterface, TypedResultInterface
+{
+    use TypedResultTrait;
+
+    /**
+     * The value to be cast
+     *
+     * @var \Cake\Database\ExpressionInterface|string
+     */
+    protected ExpressionInterface|string $value;
+
+    /**
+     * The target SQL data type
+     *
+     * @var string
+     */
+    protected string $type;
+
+    /**
+     * Constructor
+     *
+     * @param \Cake\Database\ExpressionInterface|string $value The value or expression to cast
+     * @param string $type The SQL data type to cast to (e.g., 'INTEGER', 'VARCHAR', 'DATE')
+     * @param string $returnType The abstract return type. Defaults to 'string'.
+     */
+    public function __construct(
+        ExpressionInterface|string $value,
+        string $type,
+        string $returnType = 'string',
+    ) {
+        $this->value = $value;
+        $this->type = $type;
+        $this->returnType = $returnType;
+    }
+
+    /**
+     * Sets the value to be cast
+     *
+     * @param \Cake\Database\ExpressionInterface|string $value The value to cast
+     * @return $this
+     */
+    public function setValue(ExpressionInterface|string $value): static
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Gets the value to be cast
+     *
+     * @return \Cake\Database\ExpressionInterface|string
+     */
+    public function getValue(): ExpressionInterface|string
+    {
+        return $this->value;
+    }
+
+    /**
+     * Sets the target SQL data type
+     *
+     * @param string $type The SQL data type
+     * @return $this
+     */
+    public function setType(string $type): static
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * Gets the target SQL data type
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function sql(ValueBinder $binder): string
+    {
+        $value = $this->value;
+        if ($value instanceof ExpressionInterface) {
+            $value = $value->sql($binder);
+        }
+
+        return sprintf('CAST(%s AS %s)', $value, $this->type);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function traverse(Closure $callback): static
+    {
+        if ($this->value instanceof ExpressionInterface) {
+            $callback($this->value);
+            $this->value->traverse($callback);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Clones the inner expression if it's an ExpressionInterface
+     *
+     * @return void
+     */
+    public function __clone(): void
+    {
+        if ($this->value instanceof ExpressionInterface) {
+            $this->value = clone $this->value;
+        }
+    }
+}

--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -19,6 +19,8 @@ namespace Cake\Database\Expression;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Type\ExpressionTypeCasterTrait;
+use Cake\Database\TypedResultInterface;
+use Cake\Database\TypedResultTrait;
 use Cake\Database\ValueBinder;
 use Closure;
 
@@ -27,10 +29,11 @@ use Closure;
  * involving a field an operator and a value. In its most common form the
  * string representation of a comparison is `field = value`
  */
-class ComparisonExpression implements ExpressionInterface, FieldInterface
+class ComparisonExpression implements ExpressionInterface, FieldInterface, TypedResultInterface
 {
     use ExpressionTypeCasterTrait;
     use FieldTrait;
+    use TypedResultTrait;
 
     /**
      * The value to be used in the right hand side of the operation
@@ -86,6 +89,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
         $this->setField($field);
         $this->setValue($value);
         $this->operator = $operator;
+        $this->returnType = 'boolean';
     }
 
     /**

--- a/src/Database/Expression/StringExpression.php
+++ b/src/Database/Expression/StringExpression.php
@@ -17,14 +17,18 @@ declare(strict_types=1);
 namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
+use Cake\Database\TypedResultInterface;
+use Cake\Database\TypedResultTrait;
 use Cake\Database\ValueBinder;
 use Closure;
 
 /**
  * String expression with collation.
  */
-class StringExpression implements ExpressionInterface
+class StringExpression implements ExpressionInterface, TypedResultInterface
 {
+    use TypedResultTrait;
+
     /**
      * @var string
      */

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -53,6 +53,7 @@ class TupleComparison extends ComparisonExpression
         $this->setField($fields);
         $this->operator = $conjunction;
         $this->setValue($values);
+        $this->returnType = 'boolean';
     }
 
     /**

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -45,14 +45,6 @@ class WhenThenExpression implements ExpressionInterface
     ];
 
     /**
-     * The type map to use when using an array of conditions for the
-     * `WHEN` value.
-     *
-     * @var \Cake\Database\TypeMap
-     */
-    protected TypeMap $typeMap;
-
-    /**
      * Then `WHEN` value.
      *
      * @var \Cake\Database\ExpressionInterface|object|scalar|null
@@ -94,9 +86,8 @@ class WhenThenExpression implements ExpressionInterface
      * @param \Cake\Database\TypeMap|null $typeMap The type map to use when using an array of conditions for the `WHEN`
      *  value.
      */
-    public function __construct(?TypeMap $typeMap = null)
+    public function __construct(protected ?TypeMap $typeMap = new TypeMap())
     {
-        $this->typeMap = $typeMap ?? new TypeMap();
     }
 
     /**

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -83,10 +83,10 @@ class WhenThenExpression implements ExpressionInterface
     /**
      * Constructor.
      *
-     * @param \Cake\Database\TypeMap|null $typeMap The type map to use when using an array of conditions for the `WHEN`
+     * @param \Cake\Database\TypeMap $typeMap The type map to use when using an array of conditions for the `WHEN`
      *  value.
      */
-    public function __construct(protected ?TypeMap $typeMap = new TypeMap())
+    public function __construct(protected TypeMap $typeMap = new TypeMap())
     {
     }
 

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database;
 
 use Cake\Database\Expression\AggregateExpression;
+use Cake\Database\Expression\CastExpression;
 use Cake\Database\Expression\FunctionExpression;
 use InvalidArgumentException;
 
@@ -127,20 +128,18 @@ class FunctionsBuilder
     }
 
     /**
-     * Returns a FunctionExpression representing a SQL CAST.
+     * Returns a CastExpression representing a SQL CAST.
      *
      * The `$type` parameter is a SQL type. The return type for the returned expression
      * is the default type name. Use `setReturnType()` to update it.
      *
      * @param \Cake\Database\ExpressionInterface|string $field Field or expression to cast.
      * @param string $dataType The SQL data type
-     * @return \Cake\Database\Expression\FunctionExpression
+     * @return \Cake\Database\Expression\CastExpression
      */
-    public function cast(ExpressionInterface|string $field, string $dataType): FunctionExpression
+    public function cast(ExpressionInterface|string $field, string $dataType): CastExpression
     {
-        $expression = new FunctionExpression('CAST', $this->toLiteralParam($field));
-
-        return $expression->setConjunction(' AS')->add([$dataType => 'literal']);
+        return new CastExpression($field, $dataType);
     }
 
     /**

--- a/tests/TestCase/Database/Expression/BetweenExpressionTest.php
+++ b/tests/TestCase/Database/Expression/BetweenExpressionTest.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         6.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\Expression;
+
+use Cake\Database\Expression\BetweenExpression;
+use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ValueBinder;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Tests BetweenExpression class
+ */
+class BetweenExpressionTest extends TestCase
+{
+    /**
+     * Tests basic BETWEEN SQL generation
+     */
+    public function testSimpleBetween(): void
+    {
+        $expr = new BetweenExpression('field', 1, 10, 'integer');
+        $binder = new ValueBinder();
+        $this->assertSame('field BETWEEN :c0 AND :c1', $expr->sql($binder));
+        $this->assertSame(1, $binder->bindings()[':c0']['value']);
+        $this->assertSame(10, $binder->bindings()[':c1']['value']);
+        $this->assertSame('integer', $binder->bindings()[':c0']['type']);
+        $this->assertSame('integer', $binder->bindings()[':c1']['type']);
+    }
+
+    /**
+     * Tests that return type is set to boolean
+     */
+    public function testReturnType(): void
+    {
+        $expr = new BetweenExpression('field', 1, 10, 'integer');
+        $this->assertSame('boolean', $expr->getReturnType());
+    }
+
+    /**
+     * Tests BETWEEN with identifier expression
+     */
+    public function testBetweenWithIdentifier(): void
+    {
+        $field = new IdentifierExpression('Users.age');
+        $expr = new BetweenExpression($field, 18, 65, 'integer');
+        $binder = new ValueBinder();
+        $this->assertSame('Users.age BETWEEN :c0 AND :c1', $expr->sql($binder));
+    }
+
+    /**
+     * Tests BETWEEN with expression values
+     */
+    public function testBetweenWithExpressionValues(): void
+    {
+        $from = new QueryExpression('MIN(age)');
+        $to = new QueryExpression('MAX(age)');
+        $expr = new BetweenExpression('value', $from, $to);
+        $binder = new ValueBinder();
+        $this->assertSame('value BETWEEN MIN(age) AND MAX(age)', $expr->sql($binder));
+    }
+
+    /**
+     * Tests traverse functionality
+     */
+    public function testTraverse(): void
+    {
+        $field = new IdentifierExpression('field');
+        $from = new QueryExpression('1');
+        $to = new QueryExpression('10');
+        $expr = new BetweenExpression($field, $from, $to);
+
+        $expressions = [];
+        $expr->traverse(function ($exp) use (&$expressions): void {
+            $expressions[] = $exp;
+        });
+
+        $this->assertCount(3, $expressions);
+        $this->assertSame($field, $expressions[0]);
+        $this->assertSame($from, $expressions[1]);
+        $this->assertSame($to, $expressions[2]);
+    }
+
+    /**
+     * Tests that cloning creates deep copies of expression parts
+     */
+    public function testClone(): void
+    {
+        $field = new IdentifierExpression('field');
+        $from = new QueryExpression('start');
+        $to = new QueryExpression('end');
+        $expr = new BetweenExpression($field, $from, $to);
+
+        $cloned = clone $expr;
+
+        $this->assertNotSame($expr->getField(), $cloned->getField());
+        $this->assertEquals($expr->getField(), $cloned->getField());
+    }
+}

--- a/tests/TestCase/Database/Expression/CastExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CastExpressionTest.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The Open Group Test Suite License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         6.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\Expression;
+
+use Cake\Database\Expression\CastExpression;
+use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\ValueBinder;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Tests CastExpression class
+ */
+class CastExpressionTest extends TestCase
+{
+    public function testConstructorWithString(): void
+    {
+        $cast = new CastExpression('field_name', 'INTEGER');
+
+        $this->assertSame('field_name', $cast->getValue());
+        $this->assertSame('INTEGER', $cast->getType());
+        $this->assertSame('string', $cast->getReturnType());
+    }
+
+    public function testConstructorWithExpression(): void
+    {
+        $identifier = new IdentifierExpression('Users.age');
+        $cast = new CastExpression($identifier, 'VARCHAR');
+
+        $this->assertSame($identifier, $cast->getValue());
+        $this->assertSame('VARCHAR', $cast->getType());
+    }
+
+    public function testConstructorWithReturnType(): void
+    {
+        $cast = new CastExpression('count_field', 'INTEGER', 'integer');
+
+        $this->assertSame('integer', $cast->getReturnType());
+    }
+
+    public function testSqlWithString(): void
+    {
+        $cast = new CastExpression('field_name', 'INTEGER');
+        $binder = new ValueBinder();
+
+        $this->assertSame('CAST(field_name AS INTEGER)', $cast->sql($binder));
+    }
+
+    public function testSqlWithExpression(): void
+    {
+        $identifier = new IdentifierExpression('Users.age');
+        $cast = new CastExpression($identifier, 'VARCHAR');
+        $binder = new ValueBinder();
+
+        $this->assertSame('CAST(Users.age AS VARCHAR)', $cast->sql($binder));
+    }
+
+    public function testSetValue(): void
+    {
+        $cast = new CastExpression('field1', 'INTEGER');
+        $identifier = new IdentifierExpression('field2');
+
+        $cast->setValue($identifier);
+
+        $this->assertSame($identifier, $cast->getValue());
+    }
+
+    public function testSetType(): void
+    {
+        $cast = new CastExpression('field', 'INTEGER');
+
+        $cast->setType('VARCHAR');
+
+        $this->assertSame('VARCHAR', $cast->getType());
+    }
+
+    public function testSetReturnType(): void
+    {
+        $cast = new CastExpression('field', 'INTEGER');
+
+        $cast->setReturnType('integer');
+
+        $this->assertSame('integer', $cast->getReturnType());
+    }
+
+    public function testTraverse(): void
+    {
+        $identifier = new IdentifierExpression('Users.age');
+        $cast = new CastExpression($identifier, 'INTEGER');
+
+        $expressions = [];
+        $cast->traverse(function ($exp) use (&$expressions): void {
+            $expressions[] = $exp;
+        });
+
+        $this->assertCount(1, $expressions);
+        $this->assertSame($identifier, $expressions[0]);
+    }
+
+    public function testClone(): void
+    {
+        $identifier = new IdentifierExpression('Users.age');
+        $cast = new CastExpression($identifier, 'INTEGER');
+
+        $cloned = clone $cast;
+
+        $this->assertNotSame($cast->getValue(), $cloned->getValue());
+        $this->assertEquals($cast->getValue(), $cloned->getValue());
+    }
+}

--- a/tests/TestCase/Database/Expression/ComparisonExpressionTest.php
+++ b/tests/TestCase/Database/Expression/ComparisonExpressionTest.php
@@ -49,6 +49,15 @@ class ComparisonExpressionTest extends TestCase
     }
 
     /**
+     * Tests that return type is set to boolean
+     */
+    public function testReturnType(): void
+    {
+        $expr = new ComparisonExpression('field', 'value', 'string', '=');
+        $this->assertSame('boolean', $expr->getReturnType());
+    }
+
+    /**
      * Tests that cloning Comparion instance clones it's value and field expressions.
      */
     public function testClone(): void

--- a/tests/TestCase/Database/Expression/TupleComparisonTest.php
+++ b/tests/TestCase/Database/Expression/TupleComparisonTest.php
@@ -42,6 +42,15 @@ class TupleComparisonTest extends TestCase
     }
 
     /**
+     * Tests that return type is set to boolean
+     */
+    public function testReturnType(): void
+    {
+        $f = new TupleComparison(['field1', 'field2'], [1, 2], ['integer', 'integer'], '=');
+        $this->assertSame('boolean', $f->getReturnType());
+    }
+
+    /**
      * Tests generating tuples in the fields side containing expressions
      */
     public function testTupleWithExpressionFields(): void

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database;
 
 use Cake\Database\Expression\AggregateExpression;
+use Cake\Database\Expression\CastExpression;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\FunctionsBuilder;
@@ -162,12 +163,12 @@ class FunctionsBuilderTest extends TestCase
     public function testCast(): void
     {
         $function = $this->functions->cast('field', 'varchar');
-        $this->assertInstanceOf(FunctionExpression::class, $function);
+        $this->assertInstanceOf(CastExpression::class, $function);
         $this->assertSame('CAST(field AS varchar)', $function->sql(new ValueBinder()));
         $this->assertSame('string', $function->getReturnType());
 
         $function = $this->functions->cast($this->functions->now(), 'varchar');
-        $this->assertInstanceOf(FunctionExpression::class, $function);
+        $this->assertInstanceOf(CastExpression::class, $function);
         $this->assertSame('CAST(NOW() AS varchar)', $function->sql(new ValueBinder()));
         $this->assertSame('string', $function->getReturnType());
     }


### PR DESCRIPTION
Part of the 6.x roadmap

Add a CastExpression and automatically cast function expressions when the type is known. This will require making sure all our expression classes have a returnType like FunctionExpression does (https://github.com/cakephp/cakephp/issues/7534)

The old implementation was hacky because it tried to force non-function syntax into FunctionExpression:
```php
  // Old CAST - abusing FunctionExpression
  $expression = new FunctionExpression('CAST', $this->toLiteralParam($field));
  $expression->setConjunction(' AS')  // Hack! Functions use ',' not ' AS'
             ->add([$dataType => 'literal']);
  // Generates: CAST(field AS type) - but as a fake "function"
```

Now:
```php
  // Casting with expressions:
  $query->select([
      'created_date' => $query->func()->cast(
          $query->func()->now(),  // Cast result of NOW()
          'DATE'
      ),
  ]);
```

 Out of scope - what's Still Possible (Future Work):

  The roadmap mentioned "automatically cast function expressions when the type is known." While I've built the foundation (CastExpression + TypedResultInterface), the automatic casting logic would require:
  - Query builder integration to detect type mismatches
  - Schema awareness to know expected types