### PR TITLE
5.3 Add check constraints

### DIFF
--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -103,6 +103,7 @@ class Mysql extends Driver
             'window' => '8.0.0',
             'intersect' => '8.0.31',
             'intersect-all' => '8.0.31',
+            'check-constraints' => '8.0.16',
         ],
         'mariadb' => [
             'json' => '10.2.7',
@@ -110,6 +111,7 @@ class Mysql extends Driver
             'window' => '10.2.0',
             'intersect' => '10.3.0',
             'intersect-all' => '10.5.0',
+            'check-constraints' => '10.2.1',
         ],
     ];
 
@@ -254,6 +256,7 @@ class Mysql extends Driver
             DriverFeatureEnum::WINDOW => $versionCompare(),
             DriverFeatureEnum::INTERSECT => $versionCompare(),
             DriverFeatureEnum::INTERSECT_ALL => $versionCompare(),
+            DriverFeatureEnum::CHECK_CONSTRAINTS => $versionCompare(),
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => true,
             DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => true,
         };

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -211,6 +211,7 @@ class Postgres extends Driver
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => true,
             DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION => false,
             DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => true,
+            DriverFeatureEnum::CHECK_CONSTRAINTS => true,
         };
     }
 

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -208,6 +208,7 @@ class Sqlite extends Driver
             DriverFeatureEnum::INTERSECT_ALL => false,
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => false,
             DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => false,
+            DriverFeatureEnum::CHECK_CONSTRAINTS => true,
         };
     }
 

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -289,6 +289,7 @@ class Sqlserver extends Driver
             DriverFeatureEnum::JSON => false,
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => false,
             DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => false,
+            DriverFeatureEnum::CHECK_CONSTRAINTS => false,
         };
     }
 

--- a/src/Database/DriverFeatureEnum.php
+++ b/src/Database/DriverFeatureEnum.php
@@ -67,4 +67,9 @@ enum DriverFeatureEnum: string
      * Support for optimizer hints in comment form after statement keyword (SELECT <hint>, etc)
      */
     case OPTIMIZER_HINT_COMMENT = 'optimizer-hint-comment';
+
+    /**
+     * Support for CHECK constraints.
+     */
+    case CHECK_CONSTRAINTS = 'check-constraints';
 }

--- a/src/Database/Schema/CheckConstraint.php
+++ b/src/Database/Schema/CheckConstraint.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Schema;
+
+use InvalidArgumentException;
+
+/**
+ * Check constraint value object
+ *
+ * Models a check constraint.
+ */
+class CheckConstraint extends Constraint
+{
+    protected string $type = self::CHECK;
+
+    /**
+     * Constructor
+     *
+     * @param string $name Constraint name.
+     * @param string $expression The check constraint expression (e.g., "age >= 18")
+     */
+    public function __construct(
+        protected string $name,
+        protected string $expression,
+    ) {
+    }
+
+    /**
+     * Set the check constraint expression.
+     *
+     * @param string $expression The SQL expression for the check constraint
+     * @return $this
+     * @throws \InvalidArgumentException
+     */
+    public function setExpression(string $expression)
+    {
+        if (trim($expression) === '') {
+            throw new InvalidArgumentException('Check constraint expression cannot be empty');
+        }
+
+        $this->expression = $expression;
+
+        return $this;
+    }
+
+    /**
+     * Get the check constraint expression.
+     *
+     * @return string
+     */
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+    /**
+     * Converts a constraint to an array that is compatible
+     * with the constructor.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'expression' => $this->expression,
+        ];
+    }
+}

--- a/src/Database/Schema/CheckConstraint.php
+++ b/src/Database/Schema/CheckConstraint.php
@@ -52,7 +52,7 @@ class CheckConstraint extends Constraint
             throw new InvalidArgumentException('Check constraint expression cannot be empty');
         }
 
-        $this->expression = $expression;
+        $this->expression = trim($expression);
 
         return $this;
     }

--- a/src/Database/Schema/CheckConstraint.php
+++ b/src/Database/Schema/CheckConstraint.php
@@ -77,6 +77,7 @@ class CheckConstraint extends Constraint
     {
         return [
             'name' => $this->name,
+            'type' => $this->type,
             'expression' => $this->expression,
         ];
     }

--- a/src/Database/Schema/Constraint.php
+++ b/src/Database/Schema/Constraint.php
@@ -41,6 +41,11 @@ class Constraint
     public const FOREIGN = TableSchema::CONSTRAINT_FOREIGN;
 
     /**
+     * @var string
+     */
+    public const CHECK = TableSchema::CONSTRAINT_CHECK;
+
+    /**
      * Constructor
      *
      * @param string $name The name of the constraint.

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -890,7 +890,6 @@ class MysqlSchemaDialect extends SchemaDialect
      */
     public function constraintSql(TableSchema $schema, string $name): string
     {
-        //
         $data = $schema->getConstraint($name);
         assert($data !== null);
         if ($data['type'] === TableSchema::CONSTRAINT_PRIMARY) {

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -571,6 +571,35 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    public function describeCheckConstraints(string $tableName): array
+    {
+        [$schema, $name] = $this->splitTablename($tableName);
+        $sql = "SELECT
+        cc.CONSTRAINT_NAME AS name,
+        cc.CHECK_CLAUSE AS expression
+        FROM INFORMATION_SCHEMA.CHECK_CONSTRAINTS AS cc
+        INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON (
+            tc.CONSTRAINT_SCHEMA = cc.CONSTRAINT_SCHEMA
+            AND tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
+        )
+        WHERE tc.CONSTRAINT_SCHEMA = ? AND tc.TABLE_NAME = ? AND tc.CONSTRAINT_TYPE = 'CHECK'";
+
+        $constraints = [];
+        $statement = $this->_driver->execute($sql, [$schema, $name]);
+        foreach ($statement->fetchAll('assoc') as $row) {
+            $constraints[] = [
+                'name' => $row['name'],
+                'type' => TableSchema::CONSTRAINT_CHECK,
+                'expression' => $row['expression'],
+            ];
+        }
+
+        return $constraints;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function truncateTableSql(TableSchema $schema): array
     {
         return [sprintf('TRUNCATE TABLE `%s`', $schema->name())];
@@ -871,9 +900,10 @@ class MysqlSchemaDialect extends SchemaDialect
         $out = '';
         if ($data['type'] === TableSchema::CONSTRAINT_UNIQUE) {
             $out = 'UNIQUE KEY ';
-        }
-        if ($data['type'] === TableSchema::CONSTRAINT_FOREIGN) {
+        } elseif ($data['type'] === TableSchema::CONSTRAINT_FOREIGN) {
             $out = 'CONSTRAINT ';
+        } elseif ($data['type'] === TableSchema::CONSTRAINT_CHECK) {
+            return 'CONSTRAINT ' . $this->_driver->quoteIdentifier($name) . ' CHECK (' . $data['expression'] . ')';
         }
         $out .= $this->_driver->quoteIdentifier($name);
 

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -578,7 +578,8 @@ class MysqlSchemaDialect extends SchemaDialect
         }
 
         [$schema, $name] = $this->splitTablename($tableName);
-        $sql = "SELECT
+        $sql = <<<SQL
+        SELECT
         cc.CONSTRAINT_NAME AS name,
         cc.CHECK_CLAUSE AS expression
         FROM INFORMATION_SCHEMA.CHECK_CONSTRAINTS AS cc
@@ -586,7 +587,8 @@ class MysqlSchemaDialect extends SchemaDialect
             tc.CONSTRAINT_SCHEMA = cc.CONSTRAINT_SCHEMA
             AND tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
         )
-        WHERE tc.CONSTRAINT_SCHEMA = ? AND tc.TABLE_NAME = ? AND tc.CONSTRAINT_TYPE = 'CHECK'";
+        WHERE tc.CONSTRAINT_SCHEMA = ? AND tc.TABLE_NAME = ? AND tc.CONSTRAINT_TYPE = 'CHECK'
+SQL;
 
         $constraints = [];
         $statement = $this->_driver->execute($sql, [$schema, $name]);

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -573,6 +573,10 @@ class MysqlSchemaDialect extends SchemaDialect
      */
     public function describeCheckConstraints(string $tableName): array
     {
+        if (!$this->_driver->supports(DriverFeatureEnum::CHECK_CONSTRAINTS)) {
+            return [];
+        }
+
         [$schema, $name] = $this->splitTablename($tableName);
         $sql = "SELECT
         cc.CONSTRAINT_NAME AS name,
@@ -886,6 +890,7 @@ class MysqlSchemaDialect extends SchemaDialect
      */
     public function constraintSql(TableSchema $schema, string $name): string
     {
+        //
         $data = $schema->getConstraint($name);
         assert($data !== null);
         if ($data['type'] === TableSchema::CONSTRAINT_PRIMARY) {

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -603,6 +603,34 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    public function describeCheckConstraints(string $tableName): array
+    {
+        [$schema, $name] = $this->splitTablename($tableName);
+        $sql = 'SELECT
+        con.conname AS name,
+        pg_get_constraintdef(con.oid) AS expression
+        FROM pg_catalog.pg_constraint AS con
+        INNER JOIN pg_catalog.pg_namespace AS ns ON (ns.oid = con.connamespace)
+        INNER JOIN pg_catalog.pg_class AS cls ON (cls.oid = con.conrelid)
+        WHERE ns.nspname = ? AND cls.relname = ? AND con.contype = \'c\'';
+
+        $results = [];
+        $statement = $this->_driver->execute($sql, [$schema, $name]);
+        foreach ($statement->fetchAll('assoc') as $row) {
+            $expression = preg_replace('/^CHECK \(\((.*)\)\)$/i', '$1', $row['expression']);
+            $results[] = [
+                'name' => $row['name'],
+                'type' => TableSchema::CONSTRAINT_CHECK,
+                'expression' => $expression,
+            ];
+        }
+
+        return $results;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function describeOptions(string $tableName): array
     {
         return [];

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -950,9 +950,10 @@ class PostgresSchemaDialect extends SchemaDialect
         $out = 'CONSTRAINT ' . $this->_driver->quoteIdentifier($name);
         if ($data['type'] === TableSchema::CONSTRAINT_PRIMARY) {
             $out = 'PRIMARY KEY';
-        }
-        if ($data['type'] === TableSchema::CONSTRAINT_UNIQUE) {
+        } elseif ($data['type'] === TableSchema::CONSTRAINT_UNIQUE) {
             $out .= ' UNIQUE';
+        } elseif ($data['type'] === TableSchema::CONSTRAINT_CHECK) {
+            return $out . ' CHECK (' . $data['expression'] . ')';
         }
 
         return $this->_keySql($out, $data);

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -444,6 +444,9 @@ abstract class SchemaDialect
         foreach ($this->describeForeignKeys($name) as $key) {
             $table->addConstraint($key['name'], $key);
         }
+        foreach ($this->describeCheckConstraints($name) as $key) {
+            $table->addConstraint($key['name'], $key);
+        }
         $options = $this->describeOptions($name);
         if ($options) {
             $table->setOptions($options);
@@ -622,6 +625,22 @@ abstract class SchemaDialect
         }
 
         return $table->getOptions();
+    }
+
+    /**
+     * Get a list of check constraint metadata as an array.
+     *
+     * Each item in the array will contain the following keys:
+     *
+     * - name - The name of the constraint.
+     * - expression - The check constraint expression as a SQL fragment.
+     *
+     * @param string $tableName The name of the table to describe options on.
+     * @return array
+     */
+    public function describeCheckConstraints(string $tableName): array
+    {
+        return [];
     }
 
     /**

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -696,6 +696,36 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * @inheritDoc
      */
+    public function describeCheckConstraints(string $tableName): array
+    {
+        $constraints = [];
+        $createSql = $this->getCreateTableSql($tableName);
+
+        // Parse CHECK constraints from CREATE TABLE statement
+        // Match CONSTRAINT name CHECK (expression) or just CHECK (expression)
+        $pattern = '/(?:CONSTRAINT\s+([^\s]+)\s+)?CHECK\s*\(([^)]+(?:\([^)]*\)[^)]*)*)\)/is';
+
+        if (preg_match_all($pattern, $createSql, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $index => $match) {
+                $name = !empty($match[1])
+                    ? trim($match[1], '"`[]')
+                    : 'check_' . $index;
+                $expression = trim($match[2]);
+
+                $constraints[] = [
+                    'name' => $name,
+                    'type' => TableSchema::CONSTRAINT_CHECK,
+                    'expression' => $expression,
+                ];
+            }
+        }
+
+        return $constraints;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function describeOptions(string $tableName): array
     {
         return [];
@@ -890,25 +920,33 @@ class SqliteSchemaDialect extends SchemaDialect
         $data = $schema->getConstraint($name);
         assert($data !== null, 'Data does not exist');
 
-        $column = $schema->getColumn($data['columns'][0]);
-        assert($column !== null, 'Data does not exist');
+        $columns = '';
+        if (isset($data['columns'])) {
+            $column = $schema->getColumn($data['columns'][0]);
+            assert($column !== null, 'Data does not exist');
 
-        if (
-            $data['type'] === TableSchema::CONSTRAINT_PRIMARY &&
-            count($data['columns']) === 1 &&
-            $column['type'] === TableSchemaInterface::TYPE_INTEGER
-        ) {
-            return '';
+            if (
+                $data['type'] === TableSchema::CONSTRAINT_PRIMARY &&
+                count($data['columns']) === 1 &&
+                $column['type'] === TableSchemaInterface::TYPE_INTEGER
+            ) {
+                return '';
+            }
+
+            $aliased = array_map(
+                $this->_driver->quoteIdentifier(...),
+                $data['columns'],
+            );
+            $columns = implode(', ', $aliased);
         }
+
         $clause = '';
         $type = '';
         if ($data['type'] === TableSchema::CONSTRAINT_PRIMARY) {
             $type = 'PRIMARY KEY';
-        }
-        if ($data['type'] === TableSchema::CONSTRAINT_UNIQUE) {
+        } elseif ($data['type'] === TableSchema::CONSTRAINT_UNIQUE) {
             $type = 'UNIQUE';
-        }
-        if ($data['type'] === TableSchema::CONSTRAINT_FOREIGN) {
+        } elseif ($data['type'] === TableSchema::CONSTRAINT_FOREIGN) {
             $type = 'FOREIGN KEY';
 
             $clause = rtrim(sprintf(
@@ -919,17 +957,16 @@ class SqliteSchemaDialect extends SchemaDialect
                 $this->_foreignOnClause($data['delete']),
                 $data['deferrable'] ?? null,
             ));
+        } elseif ($data['type'] === TableSchema::CONSTRAINT_CHECK) {
+            $type = 'CHECK';
+            $columns = $data['expression'];
         }
-        $columns = array_map(
-            $this->_driver->quoteIdentifier(...),
-            $data['columns'],
-        );
 
         return sprintf(
             'CONSTRAINT %s %s (%s)%s',
             $this->_driver->quoteIdentifier($name),
             $type,
-            implode(', ', $columns),
+            $columns,
             $clause,
         );
     }

--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -335,7 +335,7 @@ interface TableSchemaInterface extends SchemaInterface
      * Add a constraint.
      *
      * Used to add constraints to a table. For example primary keys, unique
-     * keys and foreign keys.
+     * keys, check constraints and foreign keys.
      *
      * ### Attributes
      *
@@ -344,6 +344,7 @@ interface TableSchemaInterface extends SchemaInterface
      * - `references` The table, column a foreign key references.
      * - `update` The behavior on update. Options are 'restrict', 'setNull', 'cascade', 'noAction'.
      * - `delete` The behavior on delete. Options are 'restrict', 'setNull', 'cascade', 'noAction'.
+     * - `expression` The SQL expression for check constraints.
      *
      * The default for 'update' & 'delete' is 'cascade'.
      *

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -347,7 +347,8 @@ SQL;
                 KEY `author_idx` (`author_id`),
                 CONSTRAINT `length_idx` UNIQUE KEY(`title`(4)),
                 FOREIGN KEY `author_idx` (`author_id`) REFERENCES `schema_authors`(`id`) ON UPDATE CASCADE ON DELETE RESTRICT,
-                UNIQUE INDEX `unique_id_idx` (`unique_id`)
+                UNIQUE INDEX `unique_id_idx` (`unique_id`),
+                CONSTRAINT `unique_id_check` CHECK (`unique_id` > 0)
             ) ENGINE=InnoDB COLLATE=utf8_general_ci
 SQL;
         $connection->execute($table);
@@ -695,7 +696,7 @@ SQL;
         $result = $dialect->describe('schema_articles');
         $this->assertInstanceOf(TableSchema::class, $result);
 
-        $this->assertCount(4, $result->constraints());
+        $this->assertCount(5, $result->constraints());
         $expected = [
             'primary' => [
                 'type' => 'primary',
@@ -728,6 +729,10 @@ SQL;
                 'columns' => ['author_id'],
                 'length' => [],
             ],
+            'unique_id_check' => [
+                'type' => 'check',
+                'expression' => '(`unique_id` > 0)',
+            ],
         ];
 
         $this->assertEquals($expected['primary'], $result->getConstraint('primary'));
@@ -740,6 +745,11 @@ SQL;
         $this->assertEquals('length_idx', $key->getName());
         $this->assertEquals($expected['length_idx']['columns'], $key->getColumns());
         $this->assertEquals(['title' => 4], $key->getLength());
+
+        $this->assertEquals($expected['unique_id_check'], $result->getConstraint('unique_id_check'));
+        $key = $result->constraint('unique_id_check');
+        $this->assertEquals('unique_id_check', $key->getName());
+        $this->assertEquals($expected['unique_id_check']['expression'], $key->getExpression());
 
         if (ConnectionManager::get('test')->getDriver()->isMariadb()) {
             $this->assertEquals($expected['schema_articles_ibfk_1'], $result->getConstraint('author_idx'));
@@ -1411,6 +1421,11 @@ SQL;
                 ['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'noAction'],
                 'CONSTRAINT `author_id_idx` FOREIGN KEY (`author_id`) ' .
                 'REFERENCES `authors` (`id`) ON UPDATE NO ACTION ON DELETE RESTRICT',
+            ],
+            [
+                'author_id_check',
+                ['type' => 'check', 'expression' => 'author_id > 0'],
+                'CONSTRAINT `author_id_check` CHECK (author_id > 0)',
             ],
         ];
     }

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -347,8 +347,7 @@ SQL;
                 KEY `author_idx` (`author_id`),
                 CONSTRAINT `length_idx` UNIQUE KEY(`title`(4)),
                 FOREIGN KEY `author_idx` (`author_id`) REFERENCES `schema_authors`(`id`) ON UPDATE CASCADE ON DELETE RESTRICT,
-                UNIQUE INDEX `unique_id_idx` (`unique_id`),
-                CONSTRAINT `unique_id_check` CHECK (`unique_id` > 0)
+                UNIQUE INDEX `unique_id_idx` (`unique_id`)
             ) ENGINE=InnoDB COLLATE=utf8_general_ci
 SQL;
         $connection->execute($table);
@@ -696,7 +695,7 @@ SQL;
         $result = $dialect->describe('schema_articles');
         $this->assertInstanceOf(TableSchema::class, $result);
 
-        $this->assertCount(5, $result->constraints());
+        $this->assertCount(4, $result->constraints());
         $expected = [
             'primary' => [
                 'type' => 'primary',
@@ -729,10 +728,6 @@ SQL;
                 'columns' => ['author_id'],
                 'length' => [],
             ],
-            'unique_id_check' => [
-                'type' => 'check',
-                'expression' => '(`unique_id` > 0)',
-            ],
         ];
 
         $this->assertEquals($expected['primary'], $result->getConstraint('primary'));
@@ -745,11 +740,6 @@ SQL;
         $this->assertEquals('length_idx', $key->getName());
         $this->assertEquals($expected['length_idx']['columns'], $key->getColumns());
         $this->assertEquals(['title' => 4], $key->getLength());
-
-        $this->assertEquals($expected['unique_id_check'], $result->getConstraint('unique_id_check'));
-        $key = $result->constraint('unique_id_check');
-        $this->assertEquals('unique_id_check', $key->getName());
-        $this->assertEquals($expected['unique_id_check']['expression'], $key->getExpression());
 
         if (ConnectionManager::get('test')->getDriver()->isMariadb()) {
             $this->assertEquals($expected['schema_articles_ibfk_1'], $result->getConstraint('author_idx'));
@@ -901,6 +891,36 @@ SQL;
         $this->assertNotEmpty($index);
         $this->assertEquals('index', $index['type']);
         $this->assertEquals([], $index['columns']);
+    }
+
+    public function testDescribeTableCheckConstraints(): void
+    {
+        $this->_needsConnection();
+        $connection = ConnectionManager::get('test');
+        $driver = $connection->getDriver();
+        $this->skipIf(!$driver->supports(DriverFeatureEnum::CHECK_CONSTRAINTS), 'This test requires check constraint support');
+
+        $connection->execute('DROP TABLE IF EXISTS schema_constraints');
+        $table = <<<SQL
+CREATE TABLE schema_constraints (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    age INT,
+    CONSTRAINT age_check CHECK (age >= 18)
+) Engine=InnoDB;
+SQL;
+        $connection->execute($table);
+
+        $schema = new SchemaCollection($connection);
+        $result = $schema->describe('schema_constraints');
+
+        $constraint = $result->getConstraint('age_check');
+        $this->assertEquals('(`age` >= 18)', $constraint['expression']);
+
+        $key = $result->constraint('age_check');
+        $this->assertEquals('age_check', $key->getName());
+        $this->assertEquals('(`age` >= 18)', $key->getExpression());
+
+        $connection->execute('DROP TABLE IF EXISTS schema_constraints');
     }
 
     /**

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -21,6 +21,7 @@ use Cake\Database\Driver;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\DriverFeatureEnum;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\Schema\CheckConstraint;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\ForeignKey;
 use Cake\Database\Schema\MysqlSchemaDialect;
@@ -695,7 +696,6 @@ SQL;
         $result = $dialect->describe('schema_articles');
         $this->assertInstanceOf(TableSchema::class, $result);
 
-        $this->assertCount(4, $result->constraints());
         $expected = [
             'primary' => [
                 'type' => 'primary',
@@ -914,11 +914,12 @@ SQL;
         $result = $schema->describe('schema_constraints');
 
         $constraint = $result->getConstraint('age_check');
-        $this->assertEquals('(`age` >= 18)', $constraint['expression']);
+        $this->assertStringContainsString('`age` >= 18', $constraint['expression']);
 
         $key = $result->constraint('age_check');
+        assert($key instanceof CheckConstraint);
         $this->assertEquals('age_check', $key->getName());
-        $this->assertEquals('(`age` >= 18)', $key->getExpression());
+        $this->assertStringContainsString('`age` >= 18', $key->getExpression());
 
         $connection->execute('DROP TABLE IF EXISTS schema_constraints');
     }

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -20,6 +20,7 @@ use Cake\Database\Connection;
 use Cake\Database\Driver;
 use Cake\Database\Driver\Postgres;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\Schema\CheckConstraint;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\ForeignKey;
 use Cake\Database\Schema\PostgresSchemaDialect;
@@ -97,7 +98,8 @@ CONSTRAINT "author_idx_immediate" FOREIGN KEY ("author_id")
     DEFERRABLE INITIALLY IMMEDIATE,
 CONSTRAINT "author_idx_not" FOREIGN KEY ("author_id")
     REFERENCES "schema_authors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
-    NOT DEFERRABLE
+    NOT DEFERRABLE,
+CONSTRAINT "author_id_value_check" CHECK (author_id > 0)
 )
 SQL;
         $connection->execute($table);
@@ -784,6 +786,23 @@ SQL;
         $this->assertConstraint($constraint, 'reverse_constraint', $result);
     }
 
+    public function testDescribeTableCheckConstraints(): void
+    {
+        $connection = ConnectionManager::get('test');
+        $this->_createTables($connection);
+
+        $schema = new SchemaCollection($connection);
+        $result = $schema->describe('schema_articles');
+
+        $constraint = $result->getConstraint('author_id_value_check');
+        $this->assertSame('author_id > 0', $constraint['expression']);
+
+        $constraint = $result->constraint('author_id_value_check');
+        assert($constraint instanceof CheckConstraint);
+        $this->assertSame('author_id_value_check', $constraint->getName());
+        $this->assertSame('author_id > 0', $constraint->getExpression());
+    }
+
     /**
      * Test describing a table with indexes
      */
@@ -796,7 +815,7 @@ SQL;
         $result = $dialect->describe('schema_articles');
         $this->assertInstanceOf(TableSchema::class, $result);
 
-        $this->assertCount(6, $result->constraints());
+        $this->assertCount(7, $result->constraints());
         $expected = [
             'primary' => [
                 'type' => 'primary',
@@ -838,6 +857,10 @@ SQL;
                     'unique_id',
                 ],
                 'length' => [],
+            ],
+            'author_id_value_check' => [
+                'type' => 'check',
+                'expression' => 'author_id > 0',
             ],
         ];
         foreach ($expected as $name => $expectedItem) {

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -1442,6 +1442,11 @@ SQL;
                 'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
                 'REFERENCES "authors" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED',
             ],
+            [
+                'author_id_check',
+                ['type' => 'check', 'expression' => 'author_id > 0'],
+                'CONSTRAINT "author_id_check" CHECK (author_id > 0)',
+            ],
         ];
     }
 

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -598,7 +598,7 @@ SQL;
                 ],
                 'length' => [],
             ],
-            'author_id_value_check' => [
+            'author_value_chk' => [
                 'type' => 'check',
                 'expression' => 'author_id > 0',
             ],
@@ -610,6 +610,11 @@ SQL;
         $this->assertInstanceOf(Constraint::class, $primary);
         $this->assertSame('primary', $primary->getName());
         $this->assertSame($expected['primary']['columns'], $primary->getColumns());
+
+        $check = $result->constraint('author_value_chk');
+        $this->assertInstanceOf(CheckConstraint::class, $check);
+        $this->assertSame('author_value_chk', $check->getName());
+        $this->assertSame($expected['author_value_chk']['expression'], $check->getExpression());
 
         $this->assertEquals(
             $expected['author_fk'],
@@ -633,6 +638,7 @@ SQL;
             $result->getConstraint('title_idx'),
         );
         $this->assertEquals($expected['unique_id_idx'], $result->getConstraint('unique_id_idx'));
+
         // Compare with describeIndexes() & constraint() result
         $this->assertEquals($expected['unique_id_idx'] + ['name' => 'unique_id_idx'], $indexes[0]);
         $unique = $result->constraint('unique_id_idx');

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -20,6 +20,7 @@ use Cake\Database\Connection;
 use Cake\Database\Driver;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\Schema\CheckConstraint;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\Constraint;
 use Cake\Database\Schema\ForeignKey;
@@ -301,6 +302,7 @@ field2 VARCHAR(10) DEFAULT 'NULL',
 location POINT_TEXT,
 CONSTRAINT "title_idx" UNIQUE ("title", "body")
 CONSTRAINT "author_fk" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON UPDATE CASCADE ON DELETE RESTRICT
+CONSTRAINT "author_value_chk" CHECK (author_id > 0)
 );
 SQL;
         $connection->execute($table);
@@ -596,8 +598,12 @@ SQL;
                 ],
                 'length' => [],
             ],
+            'author_id_value_check' => [
+                'type' => 'check',
+                'expression' => 'author_id > 0',
+            ],
         ];
-        $this->assertCount(4, $result->constraints());
+        $this->assertCount(5, $result->constraints());
         $this->assertEquals($expected['primary'], $result->getConstraint('primary'));
 
         $primary = $result->constraint('primary');
@@ -947,6 +953,23 @@ SQL;
                 $this->assertFalse($col->getIdentity());
             }
         }
+    }
+
+    public function testDescribeTableCheckConstraints(): void
+    {
+        $connection = ConnectionManager::get('test');
+        $this->_createTables($connection);
+
+        $schema = new SchemaCollection($connection);
+        $result = $schema->describe('schema_articles');
+
+        $constraint = $result->getConstraint('author_value_chk');
+        $this->assertSame('author_id > 0', $constraint['expression']);
+
+        $constraint = $result->constraint('author_value_chk');
+        assert($constraint instanceof CheckConstraint);
+        $this->assertSame('author_value_chk', $constraint->getName());
+        $this->assertSame('author_id > 0', $constraint->getExpression());
     }
 
     /**
@@ -1351,6 +1374,11 @@ SQL;
                 ],
                 'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
                 'REFERENCES "authors" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED',
+            ],
+            [
+                'author_id_check',
+                ['type' => 'check', 'expression' => 'author_id > 0'],
+                'CONSTRAINT "author_id_check" CHECK (author_id > 0)',
             ],
         ];
     }

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Database\Schema;
 
 use Cake\Database\Driver\Postgres;
 use Cake\Database\Exception\DatabaseException;
+use Cake\Database\Schema\CheckConstraint;
 use Cake\Database\Schema\ForeignKey;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\TypeFactory;
@@ -347,7 +348,6 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test adding an constraint.
-     * >
      */
     public function testAddConstraint(): void
     {
@@ -370,7 +370,6 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test adding an constraint with an overlapping unique index
-     * >
      */
     public function testAddConstraintOverwriteUniqueIndex(): void
     {
@@ -398,6 +397,31 @@ class TableSchemaTest extends TestCase
             'columns' => ['project_id', 'user_id'],
         ]);
         $this->assertEquals(['users_idx'], $table->constraints());
+    }
+
+    /**
+     * Test adding a check constraint.
+     */
+    public function testAddConstraintCheck(): void
+    {
+        $table = new TableSchema('articles');
+        $table->addColumn('age', [
+            'type' => 'integer',
+        ]);
+        $result = $table->addConstraint('age_check', [
+            'type' => 'check',
+            'expression' => 'age > 19',
+        ]);
+        $this->assertSame($result, $table);
+        $this->assertEquals(['age_check'], $table->constraints());
+
+        $check = $table->getConstraint('age_check');
+        $this->assertEquals('age > 19', $check['expression']);
+
+        $check = $table->constraint('age_check');
+        assert($check instanceof CheckConstraint);
+        $this->assertEquals('age_check', $check->getName());
+        $this->assertEquals('age > 19', $check->getExpression());
     }
 
     /**


### PR DESCRIPTION
Add support for reflection and generation of check constraints in the database reflection APIs. This replicates code that was added in cakephp/migrations#924

I'll revise migrations once this is merged.
