### PR TITLE
Fix failing with FormProtector when debug disabled

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -742,7 +742,13 @@ trait IntegrationTestTrait
             $tokenData = $formProtector->buildTokenData($url, 'cli');
 
             $data['_Token'] = $tokenData;
-            $data['_Token']['debug'] = 'FormProtector debug data would be added here';
+
+            /** @see \Cake\Form\FormProtector::extractToken() */
+            if (Configure::read('debug')) {
+                $data['_Token']['debug'] = 'FormProtector debug data would be added here';
+            } elseif (isset($data['_Token']['debug'])) {
+                unset($data['_Token']['debug']);
+            }
         }
 
         if ($this->_csrfToken === true) {

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -982,6 +982,26 @@ class IntegrationTestTraitTest extends TestCase
     }
 
     /**
+     * Test that security token does not include debug field when debug mode is disabled
+     */
+    public function testPostSecuredFormWithDebugDisabled(): void
+    {
+        $originalDebug = Configure::read('debug');
+        Configure::write('debug', false);
+
+        $this->enableSecurityToken();
+        $data = [
+            'title' => 'Some title',
+            'body' => 'Some text',
+        ];
+        $this->post('/posts/securePost', $data);
+        $this->assertResponseOk();
+        $this->assertResponseContains('Request was accepted');
+
+        Configure::write('debug', $originalDebug);
+    }
+
+    /**
      * Test posting to a secured form action action.
      */
     public function testPostSecuredFormFailure(): void


### PR DESCRIPTION
Replaces https://github.com/cakephp/cakephp/pull/17490