### PR TITLE
Fix Query::bind() to make the count query

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1691,6 +1691,7 @@ abstract class Query implements ExpressionInterface, Stringable
      */
     public function bind(string|int $param, mixed $value, string|int|null $type = null)
     {
+        $this->_dirty();
         $this->getValueBinder()->bind($param, $value, $type);
 
         return $this;


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/15175

Given that this has been the case forever, this might be a bit more behavior changing to some existing apps.
Targeting ~~5.next~~ 5.x