### PR TITLE
cleanup error package

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -85,13 +85,6 @@ class Debugger
     ];
 
     /**
-     * Holds current output data when outputFormat is false.
-     *
-     * @var array
-     */
-    protected array $_data = [];
-
-    /**
      * Constructor.
      */
     public function __construct()


### PR DESCRIPTION
while looking for all the underscore prefixed properties i noticed, that this property inside the Debugger was present but never used.

Any idea when/how this was used?