### PR TITLE
Fix Chronos::toQuarter(true) deprecation

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -689,3 +689,9 @@ parameters:
 			identifier: method.notFound
 			count: 1
 			path: src/View/Widget/DateTimeWidget.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Cake\\I18n\\DateTime and ''toQuarterRange'' will always evaluate to true\.#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/View/Helper/TimeHelper.php

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -223,7 +223,12 @@ class TimeHelper extends Helper
         ChronosDate|DateTimeInterface|string|int $dateString,
         bool $range = false,
     ): array|int {
-        return (new DateTime($dateString))->toQuarter($range);
+        $dt = new DateTime($dateString);
+        if ($range && method_exists($dt, 'toQuarterRange')) {
+            return $dt->toQuarterRange();
+        }
+
+        return $dt->toQuarter($range);
     }
 
     /**


### PR DESCRIPTION
In 5.3, we can require Chronos 3.3 and get rid of the method check.