### PR TITLE
Update docblock to point out that CakePHP expects the association name for RulesChecker::existsIn

### DIFF
--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -91,8 +91,9 @@ class RulesChecker extends BaseRulesChecker
      * Set 'allowNullableNulls' to true to accept composite foreign keys where one or more nullable columns are null.
      *
      * @param array<string>|string $field The field or list of fields to check for existence by
-     * primary key lookup in the other table.
-     * @param \Cake\ORM\Table|\Cake\ORM\Association|string $table The table name where the fields existence will be checked.
+     *   primary key lookup in the other table.
+     * @param \Cake\ORM\Table|\Cake\ORM\Association|string $table The table object or association name for the table
+     *   where the fields existence will be checked.
      * @param array<string, mixed>|string|null $message The error message to show in case the rule does not pass. Can
      *   also be an array of options. When an array, the 'message' key can be used to provide a message.
      * @return \Cake\Datasource\RuleInvoker


### PR DESCRIPTION
This is a follow up of #18919

The parameter name of `Table|Association|string $table` could be misleading as CakePHP expects the association name - not the table name.

Changing the parameters name would be a breaking change for all that are using named parameters. For this reason only the docblock was updated. This is not ideal as IDEs will show the parameter name `table` but better than nothing.

<img width="582" height="71" alt="grafik" src="https://github.com/user-attachments/assets/6df4b9d8-9144-4537-aafe-91d7ab4934aa" />


