### PR TITLE
Silence annoying unset part.

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,16 +11,12 @@ parameters:
 	paths:
 		- src/
 	ignoreErrors:
-		-
-			identifier: missingType.iterableValue
-		-
-			identifier: missingType.generics
-		-
-			identifier: include.fileNotFound
-		-
-			identifier: method.internalClass
-		-
-			identifier: new.internalClass
+		- identifier: missingType.iterableValue
+		- identifier: missingType.generics
+		- identifier: include.fileNotFound
+		- identifier: method.internalClass
+		- identifier: new.internalClass
+		- identifier: unset.possiblyHookedProperty
 
 services:
 	-


### PR DESCRIPTION
Locally, you get 8 of those errors in PHP 8.4+
```
 ------ ------------------------------------------------------------------------------------------------------- 
  Line   Console/ConsoleOutput.php                                                                              
 ------ ------------------------------------------------------------------------------------------------------- 
  388    Cannot unset property Cake\Console\ConsoleOutput::$_output because it might have hooks in a subclass.  
         🪪 unset.possiblyHookedProperty                                                                        
 ------ ------------------------------------------------------------------------------------------------------- 
```

I wonder if that helps to keep the noise out.