### PR TITLE
Include prefix and plugin in MissingActionException

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -476,17 +476,13 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         $request = $this->request;
         $action = $request->getParam('action');
         $controller = $this->name . 'Controller';
-        if ($request->getParam('prefix')) {
-            $controller = $request->getParam('prefix') . '/' . $controller;
-        }
-        if ($this->plugin) {
-            $controller = $this->plugin . '.' . $controller;
-        }
 
         if (!$this->isAction($action)) {
             throw new MissingActionException([
                 'controller' => $controller,
                 'action' => $action,
+                'prefix' => $request->getParam('prefix') ?? null,
+                'plugin' => $this->plugin ?? null,
             ]);
         }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -745,7 +745,7 @@ class ControllerTest extends TestCase
                 $e->getMessage(),
             );
             $this->assertEquals(
-                ['controller' => 'TestController', 'action' => 'missing'],
+                ['controller' => 'TestController', 'action' => 'missing', 'prefix' => null, 'plugin' => null],
                 $e->getAttributes(),
             );
         }


### PR DESCRIPTION
Refactor action handling to include prefix and plugin parameters in the MissingActionException.

https://prnt.sc/OXloL_n2vjM5