### PR TITLE
Add InstanceConfigTrait::deleteConfig().

### DIFF
--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -190,7 +190,7 @@ trait InstanceConfigTrait
      *
      * @return void
      */
-    protected function initCfg(): void
+    private function initCfg(): void
     {
         if (!$this->_configInitialized) {
             $this->_config = $this->_defaultConfig;

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -72,11 +72,7 @@ trait InstanceConfigTrait
      */
     public function setConfig(array|string $key, mixed $value = null, bool $merge = true)
     {
-        if (!$this->_configInitialized) {
-            $this->_config = $this->_defaultConfig;
-            $this->_configInitialized = true;
-        }
-
+        $this->initCfg();
         $this->_configWrite($key, $value, $merge);
 
         return $this;
@@ -117,10 +113,7 @@ trait InstanceConfigTrait
      */
     public function getConfig(?string $key = null, mixed $default = null): mixed
     {
-        if (!$this->_configInitialized) {
-            $this->_config = $this->_defaultConfig;
-            $this->_configInitialized = true;
-        }
+        $this->initCfg();
 
         return $this->_configRead($key) ?? $default;
     }
@@ -172,14 +165,37 @@ trait InstanceConfigTrait
      */
     public function configShallow(array|string $key, mixed $value = null)
     {
+        $this->initCfg();
+        $this->_configWrite($key, $value, 'shallow');
+
+        return $this;
+    }
+
+    /**
+     * Deletes a config key.
+     *
+     * @param string $key Key to delete. It can be a dot separated string to delete nested keys.
+     * @return $this
+     */
+    public function deleteConfig(string $key)
+    {
+        $this->initCfg();
+        $this->_configDelete($key);
+
+        return $this;
+    }
+
+    /**
+     * Initializes the config with the default config.
+     *
+     * @return void
+     */
+    protected function initCfg(): void
+    {
         if (!$this->_configInitialized) {
             $this->_config = $this->_defaultConfig;
             $this->_configInitialized = true;
         }
-
-        $this->_configWrite($key, $value, 'shallow');
-
-        return $this;
     }
 
     /**

--- a/tests/TestCase/Core/InstanceConfigTraitTest.php
+++ b/tests/TestCase/Core/InstanceConfigTraitTest.php
@@ -414,18 +414,43 @@ class InstanceConfigTraitTest extends TestCase
         $object->setConfig('throw.me', 'an exception');
     }
 
+    public function testDeleteUsingSetConfig(): void
+    {
+        $this->object->setConfig('some');
+        $this->assertNull(
+            $this->object->getConfig('some'),
+            'setting a new key to null should have no effect',
+        );
+
+        $this->object->setConfig('a.nested');
+        $this->assertNull(
+            $this->object->getConfig('a.nested'),
+            'should delete the existing value',
+        );
+
+        $this->assertSame(
+            [
+                'a' => [
+                    'other' => 'value',
+                ],
+            ],
+            $this->object->getConfig(),
+            'deleted keys should not be present',
+        );
+    }
+
     /**
      * testDeleteSimple
      */
     public function testDeleteSimple(): void
     {
-        $this->object->setConfig('foo');
+        $this->object->deleteConfig('foo');
         $this->assertNull(
             $this->object->getConfig('foo'),
             'setting a new key to null should have no effect',
         );
 
-        $this->object->setConfig('some');
+        $this->object->deleteConfig('some');
         $this->assertNull(
             $this->object->getConfig('some'),
             'should delete the existing value',
@@ -445,13 +470,13 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testDeleteNested(): void
     {
-        $this->object->setConfig('new.foo');
+        $this->object->deleteConfig('new.foo');
         $this->assertNull(
             $this->object->getConfig('new.foo'),
             'setting a new key to null should have no effect',
         );
 
-        $this->object->setConfig('a.nested');
+        $this->object->deleteConfig('a.nested');
         $this->assertNull(
             $this->object->getConfig('a.nested'),
             'should delete the existing value',
@@ -467,7 +492,7 @@ class InstanceConfigTraitTest extends TestCase
             'deleted keys should not be present',
         );
 
-        $this->object->setConfig('a.other');
+        $this->object->deleteConfig('a.other');
         $this->assertNull(
             $this->object->getConfig('a.other'),
             'should delete the existing value',
@@ -487,7 +512,7 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testDeleteArray(): void
     {
-        $this->object->setConfig('a');
+        $this->object->deleteConfig('a');
         $this->assertNull(
             $this->object->getConfig('a'),
             'should delete the existing value',
@@ -508,6 +533,6 @@ class InstanceConfigTraitTest extends TestCase
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Cannot unset `a.nested.value.whoops`');
-        $this->object->setConfig('a.nested.value.whoops');
+        $this->object->deleteConfig('a.nested.value.whoops');
     }
 }


### PR DESCRIPTION
Currently you have to call setConfig() with null value to delete a config, which is not very ergonomic.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
