### PR TITLE
Clarify non-interactive mode part.

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -161,7 +161,7 @@ class ConsoleOptionParser
                 'boolean' => true,
             ])->addOption('quiet', [
                 'short' => 'q',
-                'help' => 'Enable quiet output.',
+                'help' => 'Enable quiet output and non-interactive mode.',
                 'boolean' => true,
             ]);
         }


### PR DESCRIPTION
Some might not know that -q also makes the interactive prompts go away and uses the default set.
This would clarify it.