### PR TITLE
Fix error being raised from exec() with input

### DIFF
--- a/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
@@ -29,7 +29,6 @@ use Cake\Console\TestSuite\Constraint\ExitCode;
 use Cake\Core\ConsoleApplicationInterface;
 use Cake\Core\TestSuite\ContainerStubTrait;
 use Cake\Error\Debugger;
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\After;
 
 /**

--- a/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
@@ -86,12 +86,8 @@ trait ConsoleIntegrationTestTrait
 
         $this->_out ??= new StubConsoleOutput();
         $this->_err ??= new StubConsoleOutput();
-        if ($this->_in === null) {
+        if ($this->_in === null || $input) {
             $this->_in = new StubConsoleInput($input);
-        } elseif ($input) {
-            throw new InvalidArgumentException(
-                'You can use `$input` only if `$_in` property is null and will be reset.',
-            );
         }
         $this->_out->clear();
         $this->_err->clear();

--- a/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -174,6 +174,20 @@ class ConsoleIntegrationTestTraitTest extends TestCase
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
     }
 
+    /**
+     * tests exec with input
+     */
+    public function testExecWithInputOnSecondCall(): void
+    {
+        $this->exec('integration "test"');
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+
+        // This exec() call should work.
+        $this->exec('bridge', ['cake', 'blue']);
+        $this->assertOutputContains('You may pass');
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+    }
+
     public function testExecWithMockServiceDependencies(): void
     {
         $this->mockService(stdClass::class, function () {


### PR DESCRIPTION
ConsoleIntegrationTestTrait should not raise an error when exec() is given an input list for the second or greater call.

This exception was added back in #14345. I think these changes still account for that use case as well.
