### PR TITLE
Deprecate unused options parameter in constructor

### DIFF
--- a/src/Http/Client/Auth/Digest.php
+++ b/src/Http/Client/Auth/Digest.php
@@ -87,6 +87,8 @@ class Digest
     /**
      * Constructor
      *
+     * Deprecated: $options list is unused and will be removed in 6.0.     
+     *
      * @param \Cake\Http\Client $client Http client object.
      * @param array|null $options Options list.
      */


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/19004

This communicates the dead option and warns about usage via soft deprecation.

With the merge upstream this becomes also clear to be removed.