### PR TITLE
Fix prefixed templates.

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1483,8 +1483,8 @@ class View implements EventDispatcherInterface
         }
         $layoutPaths = $this->_getSubPaths(static::TYPE_LAYOUT . DIRECTORY_SEPARATOR . $subDir);
 
-        foreach ($this->_paths($plugin) as $path) {
-            foreach ($layoutPaths as $layoutPath) {
+        foreach ($layoutPaths as $layoutPath) {
+            foreach ($this->_paths($plugin) as $path) {
                 yield $path . $layoutPath;
             }
         }
@@ -1520,8 +1520,8 @@ class View implements EventDispatcherInterface
     protected function getElementPaths(?string $plugin): Generator
     {
         $elementPaths = $this->_getSubPaths(static::TYPE_ELEMENT);
-        foreach ($this->_paths($plugin) as $path) {
-            foreach ($elementPaths as $subDir) {
+        foreach ($elementPaths as $subDir) {
+            foreach ($this->_paths($plugin) as $path) {
                 yield $path . $subDir . DIRECTORY_SEPARATOR;
             }
         }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -672,6 +672,31 @@ class ViewTest extends TestCase
     }
 
     /**
+     * Test that prefix-specific plugin templates take precedence over non-prefixed app overrides.
+     *
+     * This test ensures that when:
+     * - A plugin provides a prefix-specific element (Admin/element/foo.php)
+     * - The app provides a non-prefixed override (templates/plugin/Plugin/element/foo.php)
+     *
+     * The plugin's prefixed version is used in the prefixed context, not the app's non-prefixed override.
+     * The expected resolution order is:
+     * 1. App prefix-element
+     * 2. Plugin prefix-element (should win in this test)
+     * 3. App element
+     * 4. Plugin element
+     */
+    public function testPrefixedPluginElementTakesPrecedenceOverNonPrefixedAppOverride(): void
+    {
+        $this->View->setRequest($this->View->getRequest()->withParam('prefix', 'Admin'));
+        $result = $this->View->element('TestPlugin.prefix_override_test');
+        $this->assertSame('plugin - admin prefixed', $result);
+
+        $this->View->setRequest($this->View->getRequest()->withParam('prefix', null));
+        $result = $this->View->element('TestPlugin.prefix_override_test');
+        $this->assertSame('app override - non-prefixed', $result);
+    }
+
+    /**
      * Test loading missing view element
      */
     public function testElementMissing(): void

--- a/tests/test_app/Plugin/TestPlugin/templates/Admin/element/prefix_override_test.php
+++ b/tests/test_app/Plugin/TestPlugin/templates/Admin/element/prefix_override_test.php
@@ -1,0 +1,1 @@
+plugin - admin prefixed

--- a/tests/test_app/Plugin/TestPlugin/templates/element/prefix_override_test.php
+++ b/tests/test_app/Plugin/TestPlugin/templates/element/prefix_override_test.php
@@ -1,0 +1,1 @@
+plugin - non-prefixed

--- a/tests/test_app/templates/plugin/TestPlugin/element/prefix_override_test.php
+++ b/tests/test_app/templates/plugin/TestPlugin/element/prefix_override_test.php
@@ -1,0 +1,1 @@
+app override - non-prefixed


### PR DESCRIPTION
 Previously, when using routing prefixes (like "Admin"), CakePHP had an incorrect template resolution order:

  Old (incorrect) order:
  1. App prefix-element
  2. App element ← Used incorrectly for admin context
  3. Plugin prefix-element
  4. Plugin element

  This meant that if:
  - A plugin provided Admin/element/articles.php
  - The app had an override at templates/plugin/Plugin/element/articles.php

  The app's non-prefixed override would be used even in Admin context, ignoring the plugin's Admin-specific template.

###  The Solution

  The fix swaps the loop order to prioritize prefix-specific paths over non-prefixed ones:

  New (correct) order:
  1. App prefix-element
  2. Plugin prefix-element ← Now checked before app non-prefix
  3. App element
  4. Plugin element


 The change ensures that prefix-specific templates are always checked before falling back to non-prefixed versions, following the principle of specificity and least surprise.

Resolves https://github.com/cakephp/cakephp/issues/16982