### PR TITLE
Add more ergonomic map input for classnames

### DIFF
--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -362,8 +362,24 @@ class StringTemplate
         if (!is_array($new)) {
             $new = $new !== '' ? explode(' ', $new) : [];
         }
+        $remove = [];
+        $add = [];
+        foreach ($new as $key => $value) {
+            if (is_string($key)) {
+                if ($value) {
+                    $add[] = $key;
+                } elseif (!$value) {
+                    $remove[] = $key;
+                }
+            } else {
+                $add[] = $value;
+            }
+        }
+        // Remove any classes and then add.
+        $update = array_diff($existing, $remove);
+        $update = array_merge($update, $add);
 
-        return array_values(array_unique(array_merge($existing, $new)));
+        return array_values(array_unique($update));
     }
 
     /**

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -368,7 +368,7 @@ class StringTemplate
             if (is_string($key)) {
                 if ($value) {
                     $add[] = $key;
-                } elseif (!$value) {
+                } else {
                     $remove[] = $key;
                 }
             } else {

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -390,6 +390,31 @@ class StringTemplateTest extends TestCase
     }
 
     /**
+     * Test addClassNames method with various input types.
+     */
+    public function testAddClassNamesMap(): void
+    {
+        // Falsey values remove, truthy values add.
+        $result = $this->template->addClassNames(['existing'], ['new' => true, 'no' => false, 'nullish' => null]);
+        $this->assertSame(['existing', 'new'], $result);
+
+        $result = $this->template->addClassNames(['clear', 'one'], ['new' => true, 'clear' => false]);
+        $this->assertSame(['one', 'new'], $result);
+
+        $result = $this->template->addClassNames(['clear', 'one'], ['new' => true, 'clear' => null]);
+        $this->assertSame(['one', 'new'], $result);
+
+        $result = $this->template->addClassNames(['clear', 'one'], ['new' => true, 'clear' => 0]);
+        $this->assertSame(['one', 'new'], $result);
+
+        $result = $this->template->addClassNames('one', ['new' => 1]);
+        $this->assertSame(['one', 'new'], $result);
+
+        $result = $this->template->addClassNames('one', ['new' => 'hotdog']);
+        $this->assertSame(['one', 'new'], $result);
+    }
+
+    /**
      * Test addClass method with deprecated string input
      *
      * @deprecated Tests deprecated addClass method with string input


### PR DESCRIPTION
This makes it much simpler to pass entity 'state' into classnames and drive styling and interaction hooks.

Refs #18999
