### PR TITLE
5.next: Add ExistsInNullable

### DIFF
--- a/src/ORM/Rule/ExistsInNullable.php
+++ b/src/ORM/Rule/ExistsInNullable.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\ORM\Rule;
+
+use Cake\ORM\Association;
+use Cake\ORM\Table;
+
+/**
+ * ExistsIn rule with allowNullableNulls enabled by default.
+ *
+ * This rule accepts composite foreign keys where one or more nullable columns are null.
+ */
+class ExistsInNullable extends ExistsIn
+{
+    /**
+     * Constructor.
+     *
+     * @param array<string>|string $fields The field or fields to check existence as primary key.
+     * @param \Cake\ORM\Table|\Cake\ORM\Association|string $repository The repository where the
+     * field will be looked for, or the association name for the repository.
+     * @param array<string, mixed> $options The options that modify the rule's behavior.
+     */
+    public function __construct(array|string $fields, Table|Association|string $repository, array $options = [])
+    {
+        $options += ['allowNullableNulls' => true];
+        parent::__construct($fields, $repository, $options);
+    }
+}

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -19,6 +19,7 @@ namespace Cake\ORM;
 use Cake\Datasource\RuleInvoker;
 use Cake\Datasource\RulesChecker as BaseRulesChecker;
 use Cake\ORM\Rule\ExistsIn;
+use Cake\ORM\Rule\ExistsInNullable;
 use Cake\ORM\Rule\IsUnique;
 use Cake\ORM\Rule\LinkConstraint;
 use Cake\ORM\Rule\ValidCount;
@@ -121,6 +122,62 @@ class RulesChecker extends BaseRulesChecker
         $errorField = is_string($field) ? $field : current($field);
 
         return $this->_addError(new ExistsIn($field, $table, $options), '_existsIn', compact('errorField', 'message'));
+    }
+
+    /**
+     * Returns a callable that can be used as a rule for checking that the value provided in a
+     * field exists as the primary key of another table. Accepts composite foreign keys where
+     * one or more nullable columns are null.
+     *
+     * This is a convenience wrapper around `ExistsIn` with `allowNullableNulls` set to `true` by default.
+     *
+     * ### Example:
+     *
+     * ```
+     * $rules->add($rules->existsInNullable(['author_id', 'site_id'], 'SiteAuthors'));
+     * ```
+     *
+     * This is equivalent to:
+     *
+     * ```
+     * $rules->add($rules->existsIn(['author_id', 'site_id'], 'SiteAuthors', ['allowNullableNulls' => true]));
+     * ```
+     *
+     * @param array<string>|string $field The field or fields to check existence as primary key.
+     * @param \Cake\ORM\Table|\Cake\ORM\Association|string $table The table object or association name for the table
+     *   where the fields existence will be checked.
+     * @param array<string, mixed>|string|null $message The error message to show in case the rule does not pass. Can
+     *   also be an array of options. When an array, the 'message' key can be used to provide a message.
+     * @return \Cake\Datasource\RuleInvoker
+     * @since 5.3.0
+     */
+    public function existsInNullable(
+        array|string $field,
+        Table|Association|string $table,
+        array|string|null $message = null,
+    ): RuleInvoker {
+        $options = [];
+        if (is_array($message)) {
+            $options = $message + ['message' => null];
+            $message = $options['message'];
+            unset($options['message']);
+        }
+
+        if (!$message) {
+            if ($this->_useI18n) {
+                $message = __d('cake', 'This value does not exist');
+            } else {
+                $message = 'This value does not exist';
+            }
+        }
+
+        $errorField = is_string($field) ? $field : current($field);
+
+        return $this->_addError(
+            new ExistsInNullable($field, $table, $options),
+            '_existsIn',
+            compact('errorField', 'message'),
+        );
     }
 
     /**

--- a/tests/TestCase/ORM/Rule/ExistsInNullableTest.php
+++ b/tests/TestCase/ORM/Rule/ExistsInNullableTest.php
@@ -1,0 +1,278 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\ORM\Rule;
+
+use Cake\ORM\Entity;
+use Cake\ORM\Rule\ExistsIn;
+use Cake\ORM\Rule\ExistsInNullable;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Tests the ExistsInNullable rule
+ */
+class ExistsInNullableTest extends TestCase
+{
+    /**
+     * Fixtures to be loaded
+     *
+     * @var array<string>
+     */
+    protected array $fixtures = [
+        'core.SiteArticles',
+        'core.SiteAuthors',
+    ];
+
+    /**
+     * Test that allowNullableNulls is true by default
+     */
+    public function testAllowNullableNullsDefaultValue(): void
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => null,
+            'site_id' => 1,
+            'name' => 'New Site Article without Author',
+        ]);
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add(new ExistsInNullable(['author_id', 'site_id'], 'SiteAuthors'));
+        $this->assertInstanceOf(Entity::class, $table->save($entity));
+    }
+
+    /**
+     * Test that allowNullableNulls can be explicitly overridden to false
+     */
+    public function testAllowNullableNullsCanBeOverridden(): void
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => null,
+            'site_id' => 1,
+            'name' => 'New Site Article without Author',
+        ]);
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add(new ExistsInNullable(['author_id', 'site_id'], 'SiteAuthors', [
+            'allowNullableNulls' => false,
+        ]));
+        $this->assertFalse($table->save($entity));
+    }
+
+    /**
+     * Test with all foreign keys set
+     */
+    public function testAllKeysSet(): void
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => 1,
+            'site_id' => 1,
+            'name' => 'New Site Article with Author',
+        ]);
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add(new ExistsInNullable(['author_id', 'site_id'], 'SiteAuthors'));
+        $this->assertInstanceOf(Entity::class, $table->save($entity));
+    }
+
+    /**
+     * Test with invalid foreign key
+     */
+    public function testInvalidKey(): void
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => 99999999,
+            'site_id' => 1,
+            'name' => 'New Site Article with Author',
+        ]);
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add(
+            new ExistsInNullable(['author_id', 'site_id'], 'SiteAuthors'),
+            '_existsIn',
+            ['errorField' => 'author_id', 'message' => 'will error'],
+        );
+        $this->assertFalse($table->save($entity));
+        $this->assertEquals(['author_id' => ['_existsIn' => 'will error']], $entity->getErrors());
+    }
+
+    /**
+     * Test with all invalid foreign keys
+     */
+    public function testInvalidKeys(): void
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => 99999999,
+            'site_id' => 99999999,
+            'name' => 'New Site Article with Author',
+        ]);
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add(
+            new ExistsInNullable(['author_id', 'site_id'], 'SiteAuthors'),
+            '_existsIn',
+            ['errorField' => 'author_id', 'message' => 'will error'],
+        );
+        $this->assertFalse($table->save($entity));
+        $this->assertEquals(['author_id' => ['_existsIn' => 'will error']], $entity->getErrors());
+    }
+
+    /**
+     * Test with saveMany
+     */
+    public function testSaveMany(): void
+    {
+        $entities = [
+            new Entity([
+                'id' => 1,
+                'author_id' => null,
+                'site_id' => 1,
+                'name' => 'New Site Article without Author',
+            ]),
+            new Entity([
+                'id' => 2,
+                'author_id' => 1,
+                'site_id' => 1,
+                'name' => 'New Site Article with Author',
+            ]),
+        ];
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add(new ExistsInNullable(['author_id', 'site_id'], 'SiteAuthors', [
+            'message' => 'will error with array_combine warning',
+        ]));
+        /** @var iterable<\Cake\ORM\Entity> $result */
+        $result = $table->saveMany($entities);
+        $this->assertCount(2, $result);
+        /** @var array<\Cake\ORM\Entity> $result */
+        $result = iterator_to_array($result);
+
+        $this->assertInstanceOf(Entity::class, $result[0]);
+        $this->assertEmpty($result[0]->getErrors());
+
+        $this->assertInstanceOf(Entity::class, $result[1]);
+        $this->assertEmpty($result[1]->getErrors());
+    }
+
+    /**
+     * Test using ExistsInNullable directly with table object
+     */
+    public function testWithTableObject(): void
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => null,
+            'site_id' => 1,
+            'name' => 'New Site Article without Author',
+        ]);
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $authorsTable = $this->getTableLocator()->get('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add(new ExistsInNullable(['author_id', 'site_id'], $authorsTable));
+        $this->assertInstanceOf(Entity::class, $table->save($entity));
+    }
+
+    /**
+     * Test with custom message
+     */
+    public function testCustomMessage(): void
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => 99999999,
+            'site_id' => 1,
+            'name' => 'New Site Article with Author',
+        ]);
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add(
+            new ExistsInNullable(['author_id', 'site_id'], 'SiteAuthors'),
+            '_existsIn',
+            ['errorField' => 'author_id', 'message' => 'Custom error message'],
+        );
+        $this->assertFalse($table->save($entity));
+        $this->assertEquals(['author_id' => ['_existsIn' => 'Custom error message']], $entity->getErrors());
+    }
+
+    /**
+     * Test using rulesChecker existsInNullable method
+     */
+    public function testUsingRulesCheckerMethod(): void
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => null,
+            'site_id' => 1,
+            'name' => 'New Site Article without Author',
+        ]);
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        /** @var \Cake\ORM\RulesChecker $rules */
+        $rules = $table->rulesChecker();
+
+        $rules->add($rules->existsInNullable(['author_id', 'site_id'], 'SiteAuthors'));
+        $this->assertInstanceOf(Entity::class, $table->save($entity));
+    }
+
+    /**
+     * Test using rulesChecker existsInNullable method with custom message
+     */
+    public function testUsingRulesCheckerMethodWithCustomMessage(): void
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => 99999999,
+            'site_id' => 1,
+            'name' => 'New Site Article with invalid author',
+        ]);
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        /** @var \Cake\ORM\RulesChecker $rules */
+        $rules = $table->rulesChecker();
+
+        $rules->add($rules->existsInNullable(['author_id', 'site_id'], 'SiteAuthors', 'Custom message via method'));
+        $this->assertFalse($table->save($entity));
+        $this->assertEquals(['author_id' => ['_existsIn' => 'Custom message via method']], $entity->getErrors());
+    }
+
+    /**
+     * Test that ExistsInNullable extends ExistsIn
+     */
+    public function testExtendsExistsIn(): void
+    {
+        $rule = new ExistsInNullable(['author_id', 'site_id'], 'SiteAuthors');
+
+        $this->assertInstanceOf(ExistsIn::class, $rule);
+    }
+}

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -1084,6 +1084,84 @@ class RulesCheckerIntegrationTest extends TestCase
     }
 
     /**
+     * Tests existsInNullable helper method with null value
+     */
+    public function testExistsInNullableMethod(): void
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => null,
+            'site_id' => 1,
+            'name' => 'New Site Article without Author',
+        ]);
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add($rules->existsInNullable(['author_id', 'site_id'], 'SiteAuthors'));
+        $this->assertInstanceOf(Entity::class, $table->save($entity));
+    }
+
+    /**
+     * Tests existsInNullable helper method with valid values
+     */
+    public function testExistsInNullableMethodWithValidValues(): void
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => 1,
+            'site_id' => 1,
+            'name' => 'New Site Article with Author',
+        ]);
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add($rules->existsInNullable(['author_id', 'site_id'], 'SiteAuthors'));
+        $this->assertInstanceOf(Entity::class, $table->save($entity));
+    }
+
+    /**
+     * Tests existsInNullable helper method with invalid values
+     */
+    public function testExistsInNullableMethodWithInvalidValues(): void
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => 99999999,
+            'site_id' => 1,
+            'name' => 'New Site Article with Invalid Author',
+        ]);
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add($rules->existsInNullable(['author_id', 'site_id'], 'SiteAuthors'));
+        $this->assertFalse($table->save($entity));
+        $this->assertEquals(['author_id' => ['_existsIn' => 'This value does not exist']], $entity->getErrors());
+    }
+
+    /**
+     * Tests existsInNullable helper method with custom message
+     */
+    public function testExistsInNullableMethodWithCustomMessage(): void
+    {
+        $entity = new Entity([
+            'id' => 10,
+            'author_id' => 99999999,
+            'site_id' => 1,
+            'name' => 'New Site Article',
+        ]);
+        $table = $this->getTableLocator()->get('SiteArticles');
+        $table->belongsTo('SiteAuthors');
+        $rules = $table->rulesChecker();
+
+        $rules->add($rules->existsInNullable(['author_id', 'site_id'], 'SiteAuthors', 'Custom nullable message'));
+        $this->assertFalse($table->save($entity));
+        $this->assertEquals(['author_id' => ['_existsIn' => 'Custom nullable message']], $entity->getErrors());
+    }
+
+    /**
      * Tests using rules to prevent delete operations
      */
     public function testDeleteRules(): void


### PR DESCRIPTION
Alternative to https://github.com/cakephp/cakephp/pull/18964

```php
 public function buildRules(RulesChecker $rules): RulesChecker
  {
      // Allows null values in nullable composite foreign keys
      $rules->add($rules->existsInNullable(['author_id', 'site_id'], 'SiteAuthors'));
      return $rules;
  }
 ```
 
This is OK if we want to keep the ExistsIn and ExistsInNullable around for easier reusability.
If we only want ExistsIn with the switched config value in 6.x, then I would recommend going with a config flag instead.


TODO:
- [ ] bake update to switch default one in use
- [ ] docs update