### PR TITLE
Deprecate long defunct/removed relicts.

### DIFF
--- a/src/TestSuite/Fixture/TruncateFixtureStrategy.php
+++ b/src/TestSuite/Fixture/TruncateFixtureStrategy.php
@@ -16,43 +16,26 @@ declare(strict_types=1);
  */
 namespace Cake\TestSuite\Fixture;
 
+use function Cake\Core\deprecationWarning;
+
 /**
- * Fixture strategy that truncates all fixture ables at the end of test.
+ * Fixture strategy that truncates all fixture tables at the end of test.
+ *
+ * @deprecated 5.2.10 Use {@link \Cake\TestSuite\Fixture\TruncateStrategy} instead.
+ *   Will be removed in 5.3.0.
  */
-class TruncateFixtureStrategy implements FixtureStrategyInterface
+class TruncateFixtureStrategy extends TruncateStrategy
 {
-    /**
-     * @var \Cake\TestSuite\Fixture\FixtureHelper
-     */
-    protected FixtureHelper $helper;
-
-    /**
-     * @var array<\Cake\Datasource\FixtureInterface>
-     */
-    protected array $fixtures = [];
-
     /**
      * Initialize strategy.
      */
     public function __construct()
     {
-        $this->helper = new FixtureHelper();
-    }
+        deprecationWarning(
+            '5.2.10',
+            'TruncateFixtureStrategy is deprecated. Use TruncateStrategy instead.',
+        );
 
-    /**
-     * @inheritDoc
-     */
-    public function setupTest(array $fixtureNames): void
-    {
-        $this->fixtures = $this->helper->loadFixtures($fixtureNames);
-        $this->helper->insert($this->fixtures);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function teardownTest(): void
-    {
-        $this->helper->truncate($this->fixtures);
+        parent::__construct();
     }
 }

--- a/src/TestSuite/Fixture/TruncateStrategy.php
+++ b/src/TestSuite/Fixture/TruncateStrategy.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\TestSuite\Fixture;
 
 /**
- * Fixture strategy that truncates all fixture ables at the end of test.
+ * Fixture strategy that truncates all fixture tables at the end of test.
  */
 class TruncateStrategy implements FixtureStrategyInterface
 {

--- a/tests/TestCase/TestSuite/Fixture/TransactionFixtureStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TransactionFixtureStrategyTest.php
@@ -20,9 +20,22 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\TransactionFixtureStrategy;
 use Cake\TestSuite\TestCase;
 
+/**
+ * @deprecated 5.2.10 Will be removed in 5.3.0
+ */
 class TransactionFixtureStrategyTest extends TestCase
 {
     protected array $fixtures = ['core.Articles'];
+
+    /**
+     * Tests that deprecation warning is triggered.
+     */
+    public function testDeprecationWarning(): void
+    {
+        $this->deprecated(function (): void {
+            new TransactionFixtureStrategy();
+        });
+    }
 
     /**
      * Tests truncation strategy.
@@ -38,7 +51,9 @@ class TransactionFixtureStrategyTest extends TestCase
         $this->assertEmpty($rows->fetchAll());
         $rows->closeCursor();
 
-        $strategy = new TransactionFixtureStrategy();
+        $this->deprecated(function () use (&$strategy): void {
+            $strategy = new TransactionFixtureStrategy();
+        });
         $strategy->setupTest(['core.Articles']);
         $rows = $connection->selectQuery()->select('*')->from('articles')->execute();
         $this->assertNotEmpty($rows->fetchAll());

--- a/tests/TestCase/TestSuite/Fixture/TruncateFixtureStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TruncateFixtureStrategyTest.php
@@ -20,9 +20,22 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\TruncateFixtureStrategy;
 use Cake\TestSuite\TestCase;
 
+/**
+ * @deprecated 5.2.10 Will be removed in 5.3.0
+ */
 class TruncateFixtureStrategyTest extends TestCase
 {
     protected array $fixtures = ['core.Articles'];
+
+    /**
+     * Tests that deprecation warning is triggered.
+     */
+    public function testDeprecationWarning(): void
+    {
+        $this->deprecated(function (): void {
+            new TruncateFixtureStrategy();
+        });
+    }
 
     /**
      * Tests truncation strategy.
@@ -38,7 +51,9 @@ class TruncateFixtureStrategyTest extends TestCase
         $this->assertEmpty($rows->fetchAll());
         $rows->closeCursor();
 
-        $strategy = new TruncateFixtureStrategy();
+        $this->deprecated(function () use (&$strategy): void {
+            $strategy = new TruncateFixtureStrategy();
+        });
         $strategy->setupTest(['core.Articles']);
         $rows = $connection->selectQuery()->select('*')->from('articles')->execute();
         $this->assertNotEmpty($rows->fetchAll());


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/19041

The use statement and class name switch in case anyone was using should be fully automatable via rector I assume.