### PR TITLE
Add generateKey() to rate limiter classes.

### DIFF
--- a/src/Http/RateLimit/FixedWindowRateLimiter.php
+++ b/src/Http/RateLimit/FixedWindowRateLimiter.php
@@ -47,7 +47,7 @@ class FixedWindowRateLimiter implements RateLimiterInterface
     {
         $now = time();
         $windowStart = (int)($now / $window) * $window;
-        $key = 'rate_limit_' . hash('xxh3', $identifier . '_' . $windowStart);
+        $key = $this->generateKey($identifier . '_' . $windowStart);
 
         $count = (int)$this->cache->get($key, 0);
         $allowed = $count + $cost <= $limit;
@@ -74,7 +74,17 @@ class FixedWindowRateLimiter implements RateLimiterInterface
         $now = time();
         $window = 3600; // Assume max window of 1 hour for reset
         $windowStart = (int)($now / $window) * $window;
-        $key = 'rate_limit_' . md5($identifier . '_' . $windowStart);
-        $this->cache->delete($key);
+        $this->cache->delete($this->generateKey($identifier . '_' . $windowStart));
+    }
+
+    /**
+     * Generate cache key for identifier
+     *
+     * @param string $identifier The identifier to rate limit
+     * @return string
+     */
+    protected function generateKey(string $identifier): string
+    {
+        return 'rate_limit_' . hash('xxh3', $identifier);
     }
 }

--- a/src/Http/RateLimit/SlidingWindowRateLimiter.php
+++ b/src/Http/RateLimit/SlidingWindowRateLimiter.php
@@ -46,7 +46,7 @@ class SlidingWindowRateLimiter implements RateLimiterInterface
     public function attempt(string $identifier, int $limit, int $window, int $cost = 1): array
     {
         $now = time();
-        $key = 'rate_limit_' . md5($identifier);
+        $key = $this->generateKey($identifier);
 
         $data = $this->cache->get($key, [
             'count' => 0,
@@ -86,7 +86,17 @@ class SlidingWindowRateLimiter implements RateLimiterInterface
      */
     public function reset(string $identifier): void
     {
-        $key = 'rate_limit_' . md5($identifier);
-        $this->cache->delete($key);
+        $this->cache->delete($this->generateKey($identifier));
+    }
+
+    /**
+     * Generate cache key for identifier
+     *
+     * @param string $identifier The identifier to rate limit
+     * @return string
+     */
+    protected function generateKey(string $identifier): string
+    {
+        return 'rate_limit_' . hash('xxh3', $identifier);
     }
 }

--- a/src/Http/RateLimit/TokenBucketRateLimiter.php
+++ b/src/Http/RateLimit/TokenBucketRateLimiter.php
@@ -46,7 +46,7 @@ class TokenBucketRateLimiter implements RateLimiterInterface
     public function attempt(string $identifier, int $limit, int $window, int $cost = 1): array
     {
         $now = microtime(true);
-        $key = 'rate_limit_' . md5($identifier);
+        $key = $this->generateKey($identifier);
 
         $data = $this->cache->get($key, [
             'tokens' => $limit,
@@ -87,7 +87,17 @@ class TokenBucketRateLimiter implements RateLimiterInterface
      */
     public function reset(string $identifier): void
     {
-        $key = 'rate_limit_' . md5($identifier);
-        $this->cache->delete($key);
+        $this->cache->delete($this->generateKey($identifier));
+    }
+
+    /**
+     * Generate cache key for identifier
+     *
+     * @param string $identifier The identifier to rate limit
+     * @return string
+     */
+    protected function generateKey(string $identifier): string
+    {
+        return 'rate_limit_' . hash('xxh3', $identifier);
     }
 }


### PR DESCRIPTION
This avoids code duplication and ensures consistent key generation.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
