### PR TITLE
Clean up parseFileSize() signature.

### DIFF
--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -106,7 +106,7 @@ class FileLog extends BaseLog
             if (is_numeric($this->config['size'])) {
                 $this->_size = (int)$this->config['size'];
             } else {
-                $this->_size = Text::parseFileSize($this->config['size']);
+                $this->_size = (int)Text::parseFileSize($this->config['size']);
             }
         }
     }

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -106,7 +106,7 @@ class FileLog extends BaseLog
             if (is_numeric($this->config['size'])) {
                 $this->_size = (int)$this->config['size'];
             } else {
-                $this->_size = (int)Text::parseFileSize($this->config['size']);
+                $this->_size = Text::parseFileSize($this->config['size']);
             }
         }
     }

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1007,12 +1007,12 @@ class Text
      * Converts filesize from human readable string to bytes
      *
      * @param string $size Size in human readable string like '5MB', '5M', '500B', '50kb' etc.
-     * @param mixed $default Value to be returned when invalid size was used, for example 'Unknown type'
-     * @return mixed Number of bytes as integer on success, `$default` on failure if not false
+     * @param int|string|null $default Value to be returned when invalid size was used, for example 'Unknown type'
+     * @return int|string Number of bytes as integer on success, `$default` on failure if not null
      * @throws \InvalidArgumentException On invalid Unit type.
      * @link https://book.cakephp.org/5/en/core-libraries/text.html#Cake\Utility\Text::parseFileSize
      */
-    public static function parseFileSize(string $size, mixed $default = false): mixed
+    public static function parseFileSize(string $size, int|string|null $default = null): int|string
     {
         if (ctype_digit($size)) {
             return (int)$size;
@@ -1037,7 +1037,7 @@ class Text
             return (int)$size;
         }
 
-        if ($default !== false) {
+        if ($default !== null) {
             return $default;
         }
         throw new InvalidArgumentException('No unit type.');

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1007,8 +1007,8 @@ class Text
      * Converts filesize from human readable string to bytes
      *
      * @param string $size Size in human readable string like '5MB', '5M', '500B', '50kb' etc.
-     * @param int|string|null $default Value to be returned when invalid size was used, for example 'Unknown type'
-     * @return int|string Number of bytes as integer on success, `$default` on failure if not null
+     * @param string|int|null $default Value to be returned when invalid size was used, for example 'Unknown type'
+     * @return string|int Number of bytes as integer on success, `$default` on failure if not null
      * @throws \InvalidArgumentException On invalid Unit type.
      * @link https://book.cakephp.org/5/en/core-libraries/text.html#Cake\Utility\Text::parseFileSize
      */

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1008,8 +1008,8 @@ class Text
      *
      * @param string $size Size in human readable string like '5MB', '5M', '500B', '50kb' etc.
      * @param string|int|null $default Value to be returned when invalid size was used, for example 'Unknown type'
-     * @return string|int Number of bytes as integer on success, `$default` on failure if not null
-     * @throws \InvalidArgumentException On invalid Unit type.
+     * @return ($default is null ? int : string|int) Number of bytes as integer on success, `$default` on failure if not null
+     * @throws \InvalidArgumentException When the size string cannot be parsed and no default is provided.
      * @link https://book.cakephp.org/5/en/core-libraries/text.html#Cake\Utility\Text::parseFileSize
      */
     public static function parseFileSize(string $size, int|string|null $default = null): int|string
@@ -1040,7 +1040,8 @@ class Text
         if ($default !== null) {
             return $default;
         }
-        throw new InvalidArgumentException('No unit type.');
+
+        throw new InvalidArgumentException('Size string could not be parsed.');
     }
 
     /**

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -410,8 +410,8 @@ class ExceptionTrapTest extends TestCase
             'exceptionRenderer' => TextExceptionRenderer::class,
         ]);
         $trap->increaseMemoryLimit(4 * 1024);
-        $initialBytes = Text::parseFileSize($initial, false);
-        $result = Text::parseFileSize(ini_get('memory_limit'), false);
+        $initialBytes = Text::parseFileSize($initial);
+        $result = Text::parseFileSize(ini_get('memory_limit'));
         $this->assertWithinRange($initialBytes + (4 * 1024 * 1024), $result, 1024);
     }
 

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1606,7 +1606,7 @@ HTML;
     public function testParseFileSizeException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        Text::parseFileSize('bogus', false);
+        Text::parseFileSize('bogus');
     }
 
     /**
@@ -1617,21 +1617,21 @@ HTML;
     public static function filesizes(): array
     {
         return [
-            [['size' => '512B', 'default' => false], 512],
-            [['size' => '1KB', 'default' => false], 1024],
-            [['size' => '1.5KB', 'default' => false], 1536],
-            [['size' => '1MB', 'default' => false], 1048576],
-            [['size' => '1mb', 'default' => false], 1048576],
-            [['size' => '1.5MB', 'default' => false], 1572864],
-            [['size' => '1GB', 'default' => false], 1073741824],
-            [['size' => '1.5GB', 'default' => false], 1610612736],
-            [['size' => '1K', 'default' => false], 1024],
-            [['size' => '1.5K', 'default' => false], 1536],
-            [['size' => '1M', 'default' => false], 1048576],
-            [['size' => '1m', 'default' => false], 1048576],
-            [['size' => '1.5M', 'default' => false], 1572864],
-            [['size' => '1G', 'default' => false], 1073741824],
-            [['size' => '1.5G', 'default' => false], 1610612736],
+            [['size' => '512B', 'default' => null], 512],
+            [['size' => '1KB', 'default' => null], 1024],
+            [['size' => '1.5KB', 'default' => null], 1536],
+            [['size' => '1MB', 'default' => null], 1048576],
+            [['size' => '1mb', 'default' => null], 1048576],
+            [['size' => '1.5MB', 'default' => null], 1572864],
+            [['size' => '1GB', 'default' => null], 1073741824],
+            [['size' => '1.5GB', 'default' => null], 1610612736],
+            [['size' => '1K', 'default' => null], 1024],
+            [['size' => '1.5K', 'default' => null], 1536],
+            [['size' => '1M', 'default' => null], 1048576],
+            [['size' => '1m', 'default' => null], 1048576],
+            [['size' => '1.5M', 'default' => null], 1572864],
+            [['size' => '1G', 'default' => null], 1073741824],
+            [['size' => '1.5G', 'default' => null], 1610612736],
             [['size' => '512', 'default' => 'Unknown type'], 512],
             [['size' => '2VB', 'default' => 'Unknown type'], 'Unknown type'],
         ];


### PR DESCRIPTION
It seems a bit too wide to also allow objects, arrays, and other types when the primary output is int, and secondary is string.

It was also the last method with false as default value, we so far use null everywhere else.