### PR TITLE
Reset direction for combined.

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -438,7 +438,7 @@ class PaginatorHelper extends Helper
 
         $sortFormat = $this->getConfig('options.sortFormat', 'separate');
         if ($sortFormat === 'combined') {
-            $paging = ['sort' => $key . '-' . $dir, 'page' => 1];
+            $paging = ['sort' => $key . '-' . $dir, 'direction' => null, 'page' => 1];
         } else {
             $paging = ['sort' => $key, 'direction' => $dir, 'page' => 1];
         }

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -737,6 +737,35 @@ class PaginatorHelperTest extends TestCase
     }
 
     /**
+     * Test that combined format removes direction parameter
+     */
+    public function testSortLinksCombinedFormatResetsDirection(): void
+    {
+        $request = new ServerRequest([
+            'url' => '/accounts/',
+            'params' => [
+                'plugin' => null,
+                'controller' => 'Accounts',
+                'action' => 'index',
+                'pass' => [],
+            ],
+            'base' => '',
+            'webroot' => '/',
+        ]);
+        Router::setRequest($request);
+        $this->Paginator = new PaginatorHelper($this->View);
+
+        $this->setPaginatedResult([
+            'alias' => 'Articles',
+            'direction' => 'desc',
+        ]);
+        $this->Paginator->setConfig('options.sortFormat', 'combined');
+        $result = $this->Paginator->sort('title');
+        $this->assertStringNotContainsString('direction=', $result);
+        $this->assertStringContainsString('sort=title-asc', $result);
+    }
+
+    /**
      * Test that generated URLs work without sort defined within the request
      */
     public function testDefaultSortAndNoSort(): void


### PR DESCRIPTION
Small URL adjustment fix.

Resets the direction (removes it) instead of having relicts like

    /sandbox/cake-examples/paginate-combined-sort?sort=expensive-desc&direction=asc
    
Expected:

    /sandbox/cake-examples/paginate-combined-sort?sort=expensive-desc

