### PR TITLE
Use builder config for PaginatorHelper::sort()

### DIFF
--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -390,6 +390,14 @@ class NumericPaginator implements PaginatorInterface
             ? $data['options']['limit']
             : null;
 
+        // Add sortableFields configuration for view helpers
+        if (isset($data['options']['sortableFields'])) {
+            $sortableFields = $data['options']['sortableFields'];
+            if ($sortableFields instanceof SortableFieldsBuilder) {
+                $this->pagingParams['sortableFields'] = $sortableFields->toArray();
+            }
+        }
+
         return $this->pagingParams;
     }
 
@@ -574,6 +582,11 @@ class NumericPaginator implements PaginatorInterface
         $builder = $sortableFields instanceof SortableFieldsBuilder
             ? $sortableFields
             : SortableFieldsBuilder::create($sortableFields);
+
+        // Store the converted builder for later use in paging params
+        if ($builder !== null) {
+            $options['sortableFields'] = $builder;
+        }
 
         $sortAllowed = $builder !== null;
 

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -18,6 +18,7 @@ namespace Cake\View\Helper;
 
 use Cake\Core\Exception\CakeException;
 use Cake\Datasource\Paging\PaginatedInterface;
+use Cake\Datasource\Paging\SortField;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Cake\View\Helper;
@@ -401,6 +402,27 @@ class PaginatorHelper extends Helper
             }
 
             $title = __(Inflector::humanize((string)preg_replace('/_id$/', '', $title)));
+        }
+
+        if (!isset($options['direction']) || !isset($options['lock'])) {
+            $sortableFields = $this->param('sortableFields');
+            if ($sortableFields && isset($sortableFields[$key])) {
+                $fieldConfig = $sortableFields[$key];
+
+                // Handle array of SortField objects
+                if (is_array($fieldConfig) && isset($fieldConfig[0]) && $fieldConfig[0] instanceof SortField) {
+                    /** @var \Cake\Datasource\Paging\SortField $sortField */
+                    $sortField = $fieldConfig[0];
+
+                    if (!isset($options['direction'])) {
+                        // Get the default direction (asc if not set, or the locked direction)
+                        $options['direction'] = $sortField->getDirection(SortField::ASC, false);
+                    }
+                    if (!isset($options['lock'])) {
+                        $options['lock'] = $sortField->isLocked();
+                    }
+                }
+            }
         }
 
         $defaultDir = isset($options['direction']) ? strtolower($options['direction']) : 'asc';


### PR DESCRIPTION
This completes the new paginator builder.
Instead of having to manually keep the helper usage in sync with the builder config, e.g.
```diff
 			<tr>
 				<th><?= $this->Paginator->sort('title', 'Title') ?></th>
-				<th><?= $this->Paginator->sort('price', 'Price') ?> / <?= $this->Paginator->sort('expensive', 'Expensive') ?></th>
+				<th><?= $this->Paginator->sort('price', 'Price', ['direction' => 'asc', 'lock' => true]) ?> / <?= $this->Paginator->sort('expensive', 'Expensive', ['direction' => 'desc', 'lock' => true]) ?></th>
 				<th><?= $this->Paginator->sort('stock', 'Stock') ?> / <?= $this->Paginator->sort('availability', 'Availability') ?></th>
 				<th><?= $this->Paginator->sort('created', 'Created') ?></th>
-				<th><?= $this->Paginator->sort('modified', 'Modified') ?></th>
+				<th><?= $this->Paginator->sort('modified', 'Modified', ['direction' => 'desc']) ?></th>
 			</tr>
```

it can now automatically re-use the config.
So the sort() calls are now properly defaulting to the direction and lock.