### PR TITLE
Expand types in TypeFactory and add fallback

### DIFF
--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -32,32 +32,37 @@ class TypeFactory
      * @phpstan-var array<string, class-string<\Cake\Database\TypeInterface>>
      */
     protected static array $_types = [
-        'tinyinteger' => Type\IntegerType::class,
-        'smallinteger' => Type\IntegerType::class,
-        'integer' => Type\IntegerType::class,
         'biginteger' => Type\IntegerType::class,
         'binary' => Type\BinaryType::class,
         'binaryuuid' => Type\BinaryUuidType::class,
         'boolean' => Type\BoolType::class,
+        'char' => Type\StringType::class,
+        'cidr' => Type\StringType::class,
+        'citext' => Type\StringType::class,
         'date' => Type\DateType::class,
         'datetime' => Type\DateTimeType::class,
         'datetimefractional' => Type\DateTimeFractionalType::class,
         'decimal' => Type\DecimalType::class,
         'float' => Type\FloatType::class,
+        'geometry' => Type\StringType::class,
+        'integer' => Type\IntegerType::class,
+        'inet' => Type\StringType::class,
         'json' => Type\JsonType::class,
+        'linestring' => Type\StringType::class,
+        'macaddr' => Type\StringType::class,
+        'nativeuuid' => Type\UuidType::class,
+        'point' => Type\StringType::class,
+        'polygon' => Type\StringType::class,
+        'smallinteger' => Type\IntegerType::class,
         'string' => Type\StringType::class,
-        'char' => Type\StringType::class,
         'text' => Type\StringType::class,
         'time' => Type\TimeType::class,
         'timestamp' => Type\DateTimeType::class,
         'timestampfractional' => Type\DateTimeFractionalType::class,
         'timestamptimezone' => Type\DateTimeTimezoneType::class,
+        'tinyinteger' => Type\IntegerType::class,
         'uuid' => Type\UuidType::class,
-        'nativeuuid' => Type\UuidType::class,
-        'linestring' => Type\StringType::class,
-        'geometry' => Type\StringType::class,
-        'point' => Type\StringType::class,
-        'polygon' => Type\StringType::class,
+        'year' => Type\StringType::class,
     ];
 
     /**
@@ -80,7 +85,7 @@ class TypeFactory
             return static::$_builtTypes[$name];
         }
         if (!isset(static::$_types[$name])) {
-            throw new InvalidArgumentException(sprintf('Unknown type `%s`', $name));
+            return static::$_builtTypes[$name] = new static::$_types['string']($name);
         }
 
         return static::$_builtTypes[$name] = new static::$_types[$name]($name);

--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -16,8 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Database;
 
-use InvalidArgumentException;
-
 /**
  * Factory for building database type classes.
  */
@@ -76,7 +74,6 @@ class TypeFactory
      * Returns a Type object capable of converting a type identified by name.
      *
      * @param string $name type identifier
-     * @throws \InvalidArgumentException If type identifier is unknown
      * @return \Cake\Database\TypeInterface
      */
     public static function build(string $name): TypeInterface

--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -62,7 +62,7 @@ class TypeFactory
         'timestamptimezone' => Type\DateTimeTimezoneType::class,
         'tinyinteger' => Type\IntegerType::class,
         'uuid' => Type\UuidType::class,
-        'year' => Type\StringType::class,
+        'year' => Type\IntegerType::class,
     ];
 
     /**

--- a/tests/TestCase/Database/TypeFactoryTest.php
+++ b/tests/TestCase/Database/TypeFactoryTest.php
@@ -21,7 +21,6 @@ use Cake\Database\Type\StringType;
 use Cake\Database\TypeFactory;
 use Cake\Database\TypeInterface;
 use Cake\TestSuite\TestCase;
-use InvalidArgumentException;
 use PDO;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Database\Type\BarType;

--- a/tests/TestCase/Database/TypeFactoryTest.php
+++ b/tests/TestCase/Database/TypeFactoryTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database;
 
 use Cake\Database\Driver;
+use Cake\Database\Type\StringType;
 use Cake\Database\TypeFactory;
 use Cake\Database\TypeInterface;
 use Cake\TestSuite\TestCase;
@@ -77,12 +78,27 @@ class TypeFactoryTest extends TestCase
     public static function basicTypesProvider(): array
     {
         return [
+            ['biginteger'],
+            ['binary'],
+            ['boolean'],
+            ['cidr'],
+            ['date'],
+            ['datetime'],
+            ['datetimefractional'],
+            ['decimal'],
+            ['float'],
+            ['inet'],
+            ['integer'],
+            ['macaddr'],
+            ['nativeuuid'],
+            ['point'],
+            ['smallinteger'],
             ['string'],
             ['text'],
-            ['smallinteger'],
+            ['time'],
             ['tinyinteger'],
-            ['integer'],
-            ['biginteger'],
+            ['uuid'],
+            ['year'],
         ];
     }
 
@@ -91,8 +107,10 @@ class TypeFactoryTest extends TestCase
      */
     public function testBuildUnknownType(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        TypeFactory::build('foo');
+        $type = TypeFactory::build('foo');
+        $this->assertSame('foo', $type->getName());
+        $this->assertSame('foo', $type->getBaseType());
+        $this->assertInstanceOf(StringType::class, $type);
     }
 
     /**


### PR DESCRIPTION
- Add new abstract types to TypeFactory.
- Replace an exception on unknown type name with a fallback to String. Having string as a fallback makes extending the database typesystem easier as you aren't required to also define a type map unless you want custom behavior.

Fixes #19054