### PR TITLE
5.next: limitControl() improvements

### DIFF
--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -98,6 +98,7 @@ class NumericPaginator implements PaginatorInterface
      */
     protected array $pagingParams = [
         'limit' => null,
+        'maxLimit' => null,
         'count' => null,
         'totalCount' => null,
         'perPage' => null,
@@ -389,6 +390,9 @@ class NumericPaginator implements PaginatorInterface
         $this->pagingParams['limit'] = $data['defaults']['limit'] != $data['options']['limit']
             ? $data['options']['limit']
             : null;
+        if (isset($data['options']['maxLimit'])) {
+            $this->pagingParams['maxLimit'] = $data['options']['maxLimit'];
+        }
 
         // Add sortableFields configuration for view helpers
         if (isset($data['options']['sortableFields'])) {

--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -380,6 +380,7 @@ class NumericPaginator implements PaginatorInterface
             'requestedPage' => $data['options']['page'],
             'alias' => $data['alias'],
             'scope' => $data['options']['scope'],
+            'maxLimit' => $data['options']['maxLimit'],
         ] + $this->pagingParams;
 
         $this->addPageCountParams($data);
@@ -390,9 +391,6 @@ class NumericPaginator implements PaginatorInterface
         $this->pagingParams['limit'] = $data['defaults']['limit'] != $data['options']['limit']
             ? $data['options']['limit']
             : null;
-        if (isset($data['options']['maxLimit'])) {
-            $this->pagingParams['maxLimit'] = $data['options']['maxLimit'];
-        }
 
         // Add sortableFields configuration for view helpers
         if (isset($data['options']['sortableFields'])) {

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1179,6 +1179,18 @@ class PaginatorHelper extends Helper
             '50' => '50',
             '100' => '100',
         ];
+
+        // Filter out limits that exceed maxLimit
+        $maxLimit = $this->param('maxLimit');
+        if ($maxLimit !== null) {
+            $limits = array_filter($limits, function ($limit) use ($maxLimit) {
+                return (int)$limit <= $maxLimit;
+            });
+            if (!$limits) {
+                $limits[$maxLimit] = (string)$maxLimit;
+            }
+        }
+
         $default ??= $this->paginated()->perPage();
         $scope = $this->param('scope');
         assert($scope === null || is_string($scope));

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -26,6 +26,7 @@ use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper\PaginatorHelper;
 use Cake\View\View;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
@@ -3464,6 +3465,93 @@ class PaginatorHelperTest extends TestCase
             '/form',
         ];
         $this->assertHtml($expected, $out);
+    }
+
+    /**
+     * Test that limitControl() generates options based on steps
+     */
+    public function testLimitControlWithSteps(): void
+    {
+        $this->setPaginatedResult(['perPage' => 20, 'maxLimit' => 50]);
+
+        // Generate limits in steps of 10 up to maxLimit (50)
+        $out = $this->Paginator->limitControl([], null, ['steps' => 10]);
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.requestSubmit()']],
+            ['option' => ['value' => '10']],
+            '10',
+            '/option',
+            ['option' => ['value' => '20', 'selected' => 'selected']],
+            '20',
+            '/option',
+            ['option' => ['value' => '30']],
+            '30',
+            '/option',
+            ['option' => ['value' => '40']],
+            '40',
+            '/option',
+            ['option' => ['value' => '50']],
+            '50',
+            '/option',
+            '/select',
+            '/div',
+            '/form',
+        ];
+        $this->assertHtml($expected, $out);
+    }
+
+    /**
+     * Test that limitControl() with steps uses 100 as default upper limit when no maxLimit
+     */
+    public function testLimitControlWithStepsNoMaxLimit(): void
+    {
+        $this->setPaginatedResult(['perPage' => 25]);
+
+        // Generate limits in steps of 25 up to default 100
+        $out = $this->Paginator->limitControl([], null, ['steps' => 25]);
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.requestSubmit()']],
+            ['option' => ['value' => '25', 'selected' => 'selected']],
+            '25',
+            '/option',
+            ['option' => ['value' => '50']],
+            '50',
+            '/option',
+            ['option' => ['value' => '75']],
+            '75',
+            '/option',
+            ['option' => ['value' => '100']],
+            '100',
+            '/option',
+            '/select',
+            '/div',
+            '/form',
+        ];
+        $this->assertHtml($expected, $out);
+    }
+
+    /**
+     * Test that limitControl() throws exception when both steps and explicit limits are provided
+     */
+    public function testLimitControlWithStepsAndExplicitLimits(): void
+    {
+        $this->setPaginatedResult(['perPage' => 20]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot use both `steps` option and explicit `$limits` array');
+
+        // Should throw exception when using both steps and explicit limits
+        $this->Paginator->limitControl([20 => 20, 50 => 50], null, ['steps' => 10]);
     }
 
     /**

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -3351,6 +3351,122 @@ class PaginatorHelperTest extends TestCase
     }
 
     /**
+     * Test that limitControl() filters out limits exceeding maxLimit
+     */
+    public function testLimitControlWithMaxLimit(): void
+    {
+        $this->setPaginatedResult(['perPage' => 20, 'maxLimit' => 50]);
+
+        $out = $this->Paginator->limitControl([20 => 20, 50 => 50, 100 => 100, 200 => 200]);
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.requestSubmit()']],
+            ['option' => ['value' => '20', 'selected' => 'selected']],
+            '20',
+            '/option',
+            ['option' => ['value' => '50']],
+            '50',
+            '/option',
+            '/select',
+            '/div',
+            '/form',
+        ];
+        $this->assertHtml($expected, $out);
+    }
+
+    /**
+     * Test that limitControl() uses default limits when maxLimit filters them all out
+     */
+    public function testLimitControlWithLowMaxLimit(): void
+    {
+        $this->setPaginatedResult(['perPage' => 10, 'maxLimit' => 25]);
+
+        // Default limits are 20, 50, 100 - with maxLimit 25, only 20 should remain
+        $out = $this->Paginator->limitControl();
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.requestSubmit()']],
+            ['option' => ['value' => '20']],
+            '20',
+            '/option',
+            '/select',
+            '/div',
+            '/form',
+        ];
+        $this->assertHtml($expected, $out);
+    }
+
+    /**
+     * Test that limitControl() works normally when no maxLimit is set
+     */
+    public function testLimitControlWithoutMaxLimit(): void
+    {
+        $this->setPaginatedResult(['perPage' => 20]);
+
+        // Without maxLimit, all provided limits should be available
+        $out = $this->Paginator->limitControl([20 => 20, 50 => 50, 100 => 100, 200 => 200]);
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.requestSubmit()']],
+            ['option' => ['value' => '20', 'selected' => 'selected']],
+            '20',
+            '/option',
+            ['option' => ['value' => '50']],
+            '50',
+            '/option',
+            ['option' => ['value' => '100']],
+            '100',
+            '/option',
+            ['option' => ['value' => '200']],
+            '200',
+            '/option',
+            '/select',
+            '/div',
+            '/form',
+        ];
+        $this->assertHtml($expected, $out);
+    }
+
+    /**
+     * Test that limitControl() adds maxLimit as option when all limits are filtered out
+     */
+    public function testLimitControlWithMaxLimitBelowAllDefaults(): void
+    {
+        $this->setPaginatedResult(['perPage' => 10, 'maxLimit' => 10]);
+
+        // Default limits are 20, 50, 100 - all exceed maxLimit of 10
+        // Should fallback to showing maxLimit (10) as the only option
+        $out = $this->Paginator->limitControl();
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.requestSubmit()']],
+            ['option' => ['value' => '10', 'selected' => 'selected']],
+            '10',
+            '/option',
+            '/select',
+            '/div',
+            '/form',
+        ];
+        $this->assertHtml($expected, $out);
+    }
+
+    /**
      * Test using paging params set by SimplePaginator which doesn't do count query.
      */
     public function testMethodsWhenThereIsNoPageCount(): void


### PR DESCRIPTION
### Fix up maxLimit restriction 
Currently, since limitControl() can be used across the application, it can in some cases have invalid output, e.g. too high.
This solves it by re-using the declared maxLimit from the component for building the dropdown.

### Steps
Also added steps config to allow up until maxLimit to set the desired limit steps as dropdown.

### Outcome
Moved into own protected method this makes the actual limitControl() method 1 line smaller and has the logic for this fully inside the submethod.