### PR TITLE
Remove argument overloading in EventMangerInterface::on()

### DIFF
--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Event;
 
+use Closure;
 use InvalidArgumentException;
 
 /**
@@ -99,8 +100,8 @@ class EventManager implements EventManagerInterface
      */
     public function on(
         EventListenerInterface|string $eventKey,
-        callable|array $options = [],
         ?callable $callable = null,
+        array $options = [],
     ): static {
         if ($eventKey instanceof EventListenerInterface) {
             $this->attachSubscriber($eventKey);
@@ -108,22 +109,12 @@ class EventManager implements EventManagerInterface
             return $this;
         }
 
-        if ($callable === null && !is_callable($options)) {
+        if ($callable === null) {
             throw new InvalidArgumentException(
-                'Second argument of `EventManager::on()` must be a callable if `$callable` is null.',
+                'Second argument of `EventManager::on()` must be a callable when the 1st argument is a string.',
             );
         }
 
-        if ($callable === null) {
-            /** @var callable $options */
-            $this->listeners[$eventKey][static::$defaultPriority][] = [
-                'callable' => $options(...),
-            ];
-
-            return $this;
-        }
-
-        /** @var array $options */
         $priority = $options['priority'] ?? static::$defaultPriority;
         $this->listeners[$eventKey][$priority][] = [
             'callable' => $callable(...),
@@ -143,7 +134,7 @@ class EventManager implements EventManagerInterface
     {
         foreach ($subscriber->implementedEvents() as $eventKey => $handlers) {
             foreach ($this->normalizeHandlers($subscriber, $handlers) as $handler) {
-                $this->on($eventKey, $handler['settings'], $handler['callable']);
+                $this->on($eventKey, $handler['callable'], $handler['settings']);
             }
         }
     }
@@ -231,7 +222,7 @@ class EventManager implements EventManagerInterface
      *
      * @param \Cake\Event\EventListenerInterface $subscriber Event subscriber
      * @param callable|array|string $handlers Event handlers
-     * @return array
+     * @return array<array{callable: \Closure, settings: array}>
      */
     protected function normalizeHandlers(
         EventListenerInterface $subscriber,
@@ -259,7 +250,7 @@ class EventManager implements EventManagerInterface
      *
      * @param \Cake\Event\EventListenerInterface $subscriber Event subscriber
      * @param callable|array|string $handler Event handler
-     * @return array
+     * @return array{callable: \Closure, settings: array}
      */
     protected function normalizeHandler(
         EventListenerInterface $subscriber,
@@ -319,11 +310,11 @@ class EventManager implements EventManagerInterface
      * Calls a listener.
      *
      * @template TSubject of object
-     * @param callable $listener The listener to trigger.
+     * @param \Closure $listener The listener to trigger.
      * @param \Cake\Event\EventInterface<TSubject> $event Event instance.
      * @return void
      */
-    protected function callListener(callable $listener, EventInterface $event): void
+    protected function callListener(Closure $listener, EventInterface $event): void
     {
         $listener($event, ...array_values($event->getData()));
 

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -111,7 +111,7 @@ class EventManager implements EventManagerInterface
 
         if ($callable === null) {
             throw new InvalidArgumentException(
-                'Second argument of `EventManager::on()` must be a callable when the 1st argument is a string.',
+                '`EventManager::on()` requires `callable` to be set when `eventKey` is a string.',
             );
         }
 

--- a/src/Event/EventManagerInterface.php
+++ b/src/Event/EventManagerInterface.php
@@ -23,8 +23,6 @@ interface EventManagerInterface
     /**
      * Adds a new listener to an event.
      *
-     * A variadic interface to add listeners that emulates jQuery.on().
-     *
      * Binding an EventListenerInterface:
      *
      * ```
@@ -40,27 +38,24 @@ interface EventManagerInterface
      * Binding with options:
      *
      * ```
-     * $eventManager->on('Model.beforeSave', ['priority' => 90], $callable);
+     * $eventManager->on('Model.beforeSave', $callable, ['priority' => 90]);
      * ```
      *
      * @param \Cake\Event\EventListenerInterface|string $eventKey The event unique identifier name
      * with which the callback will be associated. If $eventKey is an instance of
      * Cake\Event\EventListenerInterface its events will be bound using the `implementedEvents()` methods.
-     *
-     * @param callable|array $options Either an array of options or the callable you wish to
-     * bind to $eventKey. If an array of options, the `priority` key can be used to define the order.
+     * @param callable|null $callable The callable function you want invoked.
+     * @param array $options An array of options, the `priority` key can be used to define the order.
      * Priorities are treated as queues. Lower values are called before higher ones, and multiple attachments
      * added to the same priority queue will be treated in the order of insertion.
-     *
-     * @param callable|null $callable The callable function you want invoked.
      * @return $this
      * @throws \InvalidArgumentException When event key is missing or callable is not an
      *   instance of Cake\Event\EventListenerInterface.
      */
     public function on(
         EventListenerInterface|string $eventKey,
-        callable|array $options = [],
         ?callable $callable = null,
+        array $options = [],
     ): static;
 
     /**

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -614,8 +614,8 @@ trait IntegrationTestTrait
                 $controller->getRequest()->getSession()->read('Flash'),
             );
         };
-        $events->on('Controller.beforeRedirect', ['priority' => -100], $flashCapture);
-        $events->on('Controller.beforeRender', ['priority' => -100], $flashCapture);
+        $events->on('Controller.beforeRedirect', $flashCapture, ['priority' => -100]);
+        $events->on('Controller.beforeRender', $flashCapture, ['priority' => -100]);
         $events->on('View.beforeRender', function ($event, $viewFile): void {
             if (!$this->_viewName) {
                 $this->_viewName = $viewFile;

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -130,7 +130,7 @@ class EventManagerTest extends TestCase
         ];
         $this->assertEquals($expected, $manager->listeners('my.event'));
 
-        $manager->on('my.event', ['priority' => 1], 'strpos');
+        $manager->on('my.event', 'strpos', ['priority' => 1]);
         $expected = [
             ['callable' => strpos(...)],
             ['callable' => substr(...)],
@@ -161,7 +161,7 @@ class EventManagerTest extends TestCase
         $manager = new EventManager();
         $manager->on('fake.event', 'strlen');
         $manager->on('another.event', strlen(...));
-        $manager->on('another.event', ['priority' => 1], 'substr');
+        $manager->on('another.event', 'substr', ['priority' => 1]);
 
         $manager->off('fake.event', strlen(...));
         $this->assertEquals([], $manager->listeners('fake.event'));
@@ -186,7 +186,7 @@ class EventManagerTest extends TestCase
         };
         $manager->on('fake.event', $callable);
         $manager->on('another.event', $callable);
-        $manager->on('another.event', ['priority' => 1], 'substr');
+        $manager->on('another.event', 'substr', ['priority' => 1]);
 
         $manager->off($callable);
         $expected = [
@@ -204,7 +204,7 @@ class EventManagerTest extends TestCase
         $manager = new EventManager();
         $manager->on('fake.event', 'strlen');
 
-        $manager->on('another.event', ['priority' => 1], 'substr');
+        $manager->on('another.event', 'substr', ['priority' => 1]);
 
         $manager->off('fake.event');
 
@@ -375,7 +375,7 @@ class EventManagerTest extends TestCase
         $manager = new EventManager();
         $listener = new EventTestListener();
         $manager->on('fake.event', $listener->listenerFunction(...));
-        $manager->on('fake.event', ['priority' => 5], $listener->secondListenerFunction(...));
+        $manager->on('fake.event', $listener->secondListenerFunction(...), ['priority' => 5]);
         $event = new Event('fake.event');
         $manager->dispatch($event);
 
@@ -547,8 +547,8 @@ class EventManagerTest extends TestCase
 
         EventManager::instance($generalManager);
         $manager->on('fake.event', $listener->listenerFunction(...));
-        $manager->on('fake.event', ['priority' => 8], $listener->stopListener(...));
-        $manager->on('fake.event', ['priority' => 5], $listener->secondListenerFunction(...));
+        $manager->on('fake.event', $listener->stopListener(...), ['priority' => 8]);
+        $manager->on('fake.event', $listener->secondListenerFunction(...), ['priority' => 5]);
         $event = new Event('fake.event');
         $manager->dispatch($event);
 
@@ -583,7 +583,7 @@ class EventManagerTest extends TestCase
 
         EventManager::instance($generalManager);
         $manager->on('fake.event', $listener->listenerFunction(...));
-        $manager->on('fake.event', ['priority' => 15], $listener->thirdListenerFunction(...));
+        $manager->on('fake.event', $listener->thirdListenerFunction(...), ['priority' => 15]);
 
         $manager->dispatch($event);
 
@@ -885,7 +885,7 @@ class EventManagerTest extends TestCase
         $returnValue = $eventManager->on('foo', $callable);
         $this->assertSame($eventManager, $returnValue);
 
-        $returnValue = $eventManager->on('foo', [], $callable);
+        $returnValue = $eventManager->on('foo', $callable);
         $this->assertSame($eventManager, $returnValue);
 
         $returnValue = $eventManager->off($listener);

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -99,7 +99,7 @@ class HelperTest extends TestCase
     {
         $eventsManager = new class extends EventManager
         {
-            public function on(string|EventListenerInterface $eventKey, callable|array $options = [], ?callable $callable = null): never
+            public function on(string|EventListenerInterface $eventKey, ?callable $callable = null, array $options = []): never
             {
                 throw new Exception('Should not be called');
             }


### PR DESCRIPTION
Refs #18002

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
