### PR TITLE
Fix up PHPStan issue on behaviors.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -847,7 +847,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @return \Cake\ORM\Behavior
      * @template TName of string
      * @phpstan-param TName $name The behavior alias to get from the registry.
-     * @phpstan-return (TName is key-of<TBehaviors> ? TBehaviors[TName] : Behavior)
+     * @phpstan-return (TName is key-of<TBehaviors> ? TBehaviors[TName] : \Cake\ORM\Behavior)
      * @throws \InvalidArgumentException If the behavior does not exist.
      */
     public function getBehavior(string $name): Behavior

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -845,9 +845,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @param string $name The behavior alias to get from the registry.
      * @return \Cake\ORM\Behavior
-     * @template TName of key-of<TBehaviors>
+     * @template TName of string
      * @phpstan-param TName $name The behavior alias to get from the registry.
-     * @phpstan-return TBehaviors[TName]
+     * @phpstan-return (TName is key-of<TBehaviors> ? TBehaviors[TName] : Behavior)
      * @throws \InvalidArgumentException If the behavior does not exist.
      */
     public function getBehavior(string $name): Behavior


### PR DESCRIPTION
Now you can do this without suppressions:
```php
  $table->addBehavior('Bouncer.Bouncer', [...]);
  /** @var \Bouncer\Model\Behavior\BouncerBehavior $bouncerBehavior */
  $bouncerBehavior = $table->getBehavior('Bouncer');
```

@rochamarcelo
is that the right approach?

Resolves https://github.com/cakephp/cakephp/issues/19069