### PR TITLE
Remove internal annotation from ConnectionHelper

### DIFF
--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -23,8 +23,6 @@ use Closure;
 
 /**
  * Helper for managing test connections
- *
- * @internal
  */
 class ConnectionHelper
 {


### PR DESCRIPTION
Removed internal annotation from ConnectionHelper class.

https://github.com/cakephp/app/blob/cd65af35ad977d06371c652d372e4a27d47c319a/tests/bootstrap.php#L47
This is an important method we directly advertise to use in the app test code.
So I am sure we should not mark this as internal (anymore), it doesnt have a good look. In my IDE it is shown as "strike through".

<img width="396" height="157" alt="tests" src="https://github.com/user-attachments/assets/863ebeaf-0179-47b0-b3de-71779d29c02b" />
