### PR TITLE
Increase parallelism for phpcs execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
 
       - name: Run phpcs
         if: always()
-        run: vendor/bin/phpcs --parallel=4 --report=checkstyle | cs2pr
+        run: vendor/bin/phpcs --parallel=16 --report=checkstyle | cs2pr
 
       - name: Run phpstan for tests
         if: env.PHPSTAN_TESTS


### PR DESCRIPTION
Works for me so far on all repos - or is this a memory issue then for CI?

28s => <23s

We also have this in our composer scripts already:

        "cs-check": "phpcs --colors --parallel=16 -p",
        "cs-fix": "phpcbf --colors --parallel=16 -p",
