### PR TITLE
Deprecate loading plugins with plugin class named `Plugin`.

### DIFF
--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -274,11 +274,7 @@ class PluginCollection implements Iterator, Countable
         $namespace = str_replace('/', '\\', $name);
 
         $pos = strpos($name, '/');
-        if ($pos === false) {
-            $namePart = $name;
-        } else {
-            $namePart = substr($name, $pos + 1);
-        }
+        $namePart = $pos === false ? $name : substr($name, $pos + 1);
 
         // Check for [Vendor/]Foo/FooPlugin class
         $className = $namespace . '\\' . $namePart . 'Plugin';

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -273,20 +273,27 @@ class PluginCollection implements Iterator, Countable
         $config += ['name' => $name];
         $namespace = str_replace('/', '\\', $name);
 
-        $className = $namespace . '\\' . 'Plugin';
-        // Check for [Vendor/]Foo/Plugin class
+        $pos = strpos($name, '/');
+        if ($pos === false) {
+            $namePart = $name;
+        } else {
+            $namePart = substr($name, $pos + 1);
+        }
+
+        // Check for [Vendor/]Foo/FooPlugin class
+        $className = $namespace . '\\' . $namePart . 'Plugin';
+
         if (!class_exists($className)) {
-            $pos = strpos($name, '/');
-            if ($pos === false) {
-                $namePart = $name;
+            // Check for [Vendor/]Foo/Plugin class
+            $className = $namespace . '\\' . 'Plugin';
+
+            if (class_exists($className)) {
+                deprecationWarning(
+                    '5.3.0',
+                    'Loading plugins with a plugin class named `Plugin` is deprecated.'
+                    . " Rename the class to `{$namePart}Plugin` instead.",
+                );
             } else {
-                $namePart = substr($name, $pos + 1);
-            }
-
-            // Check for [Vendor/]Foo/FooPlugin
-            $className = $namespace . '\\' . $namePart . 'Plugin';
-
-            if (!class_exists($className)) {
                 $className = BasePlugin::class;
                 if (empty($config['path'])) {
                     $config['path'] = $this->findPath($name);

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -34,7 +34,7 @@ use Cake\TestSuite\TestCase;
 use Company\TestPluginThree\TestPluginThreePlugin;
 use Mockery;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
-use TestPlugin\Plugin as TestPlugin;
+use TestPlugin\TestPluginPlugin as TestPlugin;
 
 /**
  * BasePluginTest class

--- a/tests/TestCase/Core/PluginCollectionTest.php
+++ b/tests/TestCase/Core/PluginCollectionTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
 use Company\TestPluginThree\TestPluginThreePlugin;
 use InvalidArgumentException;
 use Named\NamedPlugin;
-use TestPlugin\Plugin as TestPlugin;
+use TestPlugin\TestPluginPlugin as TestPlugin;
 
 /**
  * PluginCollection Test

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -19,7 +19,7 @@ use Cake\Core\BasePlugin;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
-use TestPlugin\Plugin as TestPlugin;
+use TestPlugin\TestPluginPlugin as TestPlugin;
 
 /**
  * PluginTest class

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -34,7 +34,7 @@ use Cake\Routing\RouteCollection;
 use Cake\TestSuite\TestCase;
 use Mockery;
 use Psr\Http\Message\ResponseInterface;
-use TestPlugin\Plugin as TestPlugin;
+use TestPlugin\TestPluginPlugin as TestPlugin;
 
 /**
  * Base application test.

--- a/tests/test_app/Plugin/TestPlugin/src/TestPluginPlugin.php
+++ b/tests/test_app/Plugin/TestPlugin/src/TestPluginPlugin.php
@@ -19,7 +19,7 @@ use Cake\Core\BasePlugin;
 use Cake\Event\EventManagerInterface;
 use Cake\Http\MiddlewareQueue;
 
-class Plugin extends BasePlugin
+class TestPluginPlugin extends BasePlugin
 {
     public function events(EventManagerInterface $event): EventManagerInterface
     {


### PR DESCRIPTION
Such classes such be renamed to `{PluginName}Plugin` instead. Supporting only one form will avoid unnecessary lookups and checks in the future.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
