### PR TITLE
Add test db compose config

### DIFF
--- a/tests/docker-compose-db.yml
+++ b/tests/docker-compose-db.yml
@@ -1,0 +1,16 @@
+services:
+  postgres:
+    image: postgis/postgis:17-3.5
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: cakephp
+  mysql:
+    image: mysql:latest
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: cakephp


### PR DESCRIPTION
For easier test iteration with postgis support. Can add sqlserver as well, but have to manually create db.
