### PR TITLE
add missing ttl to cache events

### DIFF
--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -305,22 +305,27 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface, Even
     {
         $cachedValue = $this->get($key);
         $prefixedKey = $this->_key($key);
+        $duration = $this->getConfig('duration');
 
         $this->_eventClass = CacheBeforeAddEvent::class;
-        $this->dispatchEvent(CacheBeforeAddEvent::NAME, ['key' => $prefixedKey, 'value' => $value]);
+        $this->dispatchEvent(CacheBeforeAddEvent::NAME, [
+            'key' => $prefixedKey,
+            'value' => $value,
+            'ttl' => $duration,
+        ]);
 
         if ($cachedValue === null) {
             $success = $this->set($key, $value);
             $this->_eventClass = CacheAfterAddEvent::class;
             $this->dispatchEvent(CacheAfterAddEvent::NAME, [
-                'key' => $prefixedKey, 'value' => $value, 'success' => $success,
+                'key' => $prefixedKey, 'value' => $value, 'success' => $success, 'ttl' => $duration,
             ]);
 
             return $success;
         }
         $this->_eventClass = CacheAfterAddEvent::class;
         $this->dispatchEvent(CacheAfterAddEvent::NAME, [
-            'key' => $prefixedKey, 'value' => $value, 'success' => false,
+            'key' => $prefixedKey, 'value' => $value, 'success' => false, 'ttl' => $duration,
         ]);
 
         return false;

--- a/src/Cache/Engine/ApcuEngine.php
+++ b/src/Cache/Engine/ApcuEngine.php
@@ -82,13 +82,13 @@ class ApcuEngine extends CacheEngine
         $duration = $this->duration($ttl);
 
         $this->_eventClass = CacheBeforeSetEvent::class;
-        $this->dispatchEvent(CacheBeforeSetEvent::NAME, ['key' => $key, 'value' => $value, 'ttl' => $ttl]);
+        $this->dispatchEvent(CacheBeforeSetEvent::NAME, ['key' => $key, 'value' => $value, 'ttl' => $duration]);
 
         $success = apcu_store($key, $value, $duration);
 
         $this->_eventClass = CacheAfterSetEvent::class;
         $this->dispatchEvent(CacheAfterSetEvent::NAME, [
-            'key' => $key, 'value' => $value, 'success' => $success,
+            'key' => $key, 'value' => $value, 'success' => $success, 'ttl' => $duration,
         ]);
 
         return $success;
@@ -237,13 +237,15 @@ class ApcuEngine extends CacheEngine
         $key = $this->_key($key);
         $duration = $this->_config['duration'];
         $this->_eventClass = CacheBeforeAddEvent::class;
-        $this->dispatchEvent(CacheBeforeAddEvent::NAME, ['key' => $key, 'value' => $value]);
+        $this->dispatchEvent(CacheBeforeAddEvent::NAME, [
+            'key' => $key, 'value' => $value, 'ttl' => $duration,
+        ]);
 
         $result = apcu_add($key, $value, $duration);
 
         $this->_eventClass = CacheAfterAddEvent::class;
         $this->dispatchEvent(CacheAfterAddEvent::NAME, [
-            'key' => $key, 'value' => $value, 'success' => $result,
+            'key' => $key, 'value' => $value, 'success' => $result, 'ttl' => $duration,
         ]);
 
         return $result;

--- a/src/Cache/Engine/ArrayEngine.php
+++ b/src/Cache/Engine/ArrayEngine.php
@@ -68,12 +68,16 @@ class ArrayEngine extends CacheEngine
         $expires = time() + $this->duration($ttl);
 
         $this->_eventClass = CacheBeforeSetEvent::class;
-        $this->dispatchEvent(CacheBeforeSetEvent::NAME, ['key' => $key, 'value' => $value, 'ttl' => $ttl]);
+        $this->dispatchEvent(CacheBeforeSetEvent::NAME, [
+            'key' => $key, 'value' => $value, 'ttl' => $this->duration($ttl),
+        ]);
 
         $this->data[$key] = ['exp' => $expires, 'val' => $value];
 
         $this->_eventClass = CacheAfterSetEvent::class;
-        $this->dispatchEvent(CacheAfterSetEvent::NAME, ['key' => $key, 'value' => $value, 'success' => true]);
+        $this->dispatchEvent(CacheAfterSetEvent::NAME, [
+            'key' => $key, 'value' => $value, 'success' => true, 'ttl' => $this->duration($ttl),
+        ]);
 
         return true;
     }

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -124,14 +124,15 @@ class FileEngine extends CacheEngine
             return false;
         }
 
+        $duration = $this->duration($ttl);
         $key = $this->_key($key);
         $this->_eventClass = CacheBeforeSetEvent::class;
-        $this->dispatchEvent(CacheBeforeSetEvent::NAME, ['key' => $key, 'value' => $value, 'ttl' => $ttl]);
+        $this->dispatchEvent(CacheBeforeSetEvent::NAME, ['key' => $key, 'value' => $value, 'ttl' => $duration]);
 
         $this->_eventClass = CacheAfterSetEvent::class;
         if ($this->_setKey($key, true) === false) {
             $this->dispatchEvent(CacheAfterSetEvent::NAME, [
-                'key' => $key, 'value' => $value, 'success' => false,
+                'key' => $key, 'value' => $value, 'success' => false, 'ttl' => $duration,
             ]);
 
             return false;
@@ -142,7 +143,7 @@ class FileEngine extends CacheEngine
             $value = serialize($value);
         }
 
-        $expires = time() + $this->duration($ttl);
+        $expires = time() + $duration;
         $contents = implode('', [$expires, PHP_EOL, $value, PHP_EOL]);
 
         if ($this->_config['lock']) {
@@ -160,7 +161,7 @@ class FileEngine extends CacheEngine
         unset($this->_File);
 
         $this->dispatchEvent(CacheAfterSetEvent::NAME, [
-            'key' => $key, 'value' => $origValue, 'success' => $success,
+            'key' => $key, 'value' => $origValue, 'success' => $success, 'ttl' => $duration,
         ]);
 
         return $success;

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -322,12 +322,14 @@ class MemcachedEngine extends CacheEngine
         $key = $this->_key($key);
         $duration = $this->duration($ttl);
         $this->_eventClass = CacheBeforeSetEvent::class;
-        $this->dispatchEvent(CacheBeforeSetEvent::NAME, ['key' => $key, 'value' => $value, 'ttl' => $ttl]);
+        $this->dispatchEvent(CacheBeforeSetEvent::NAME, ['key' => $key, 'value' => $value, 'ttl' => $duration]);
 
         $success = $this->_Memcached->set($key, $value, $duration);
 
         $this->_eventClass = CacheAfterSetEvent::class;
-        $this->dispatchEvent(CacheAfterSetEvent::NAME, ['key' => $key, 'value' => $value, 'success' => $success]);
+        $this->dispatchEvent(CacheAfterSetEvent::NAME, [
+            'key' => $key, 'value' => $value, 'success' => $success, 'ttl' => $duration,
+        ]);
 
         return $success;
     }
@@ -535,13 +537,13 @@ class MemcachedEngine extends CacheEngine
         $key = $this->_key($key);
 
         $this->_eventClass = CacheBeforeAddEvent::class;
-        $this->dispatchEvent(CacheBeforeAddEvent::NAME, ['key' => $key, 'value' => $value]);
+        $this->dispatchEvent(CacheBeforeAddEvent::NAME, ['key' => $key, 'value' => $value, 'ttl' => $duration]);
 
         $success = $this->_Memcached->add($key, $value, $duration);
 
         $this->_eventClass = CacheAfterAddEvent::class;
         $this->dispatchEvent(CacheAfterAddEvent::NAME, [
-            'key' => $key, 'value' => $value, 'success' => $success,
+            'key' => $key, 'value' => $value, 'success' => $success, 'ttl' => $duration,
         ]);
 
         return $success;

--- a/src/Cache/Event/CacheAfterAddEvent.php
+++ b/src/Cache/Event/CacheAfterAddEvent.php
@@ -19,6 +19,7 @@ namespace Cake\Cache\Event;
 use Cake\Cache\CacheEngine;
 use Cake\Cache\Exception\InvalidArgumentException;
 use Cake\Event\Event;
+use DateInterval;
 
 /**
  * Class Cache AfterAdd Event
@@ -32,6 +33,8 @@ class CacheAfterAddEvent extends Event
     protected string $key;
 
     protected mixed $value = null;
+
+    protected DateInterval|int|null $ttl = null;
 
     /**
      * Constructor
@@ -53,6 +56,10 @@ class CacheAfterAddEvent extends Event
         if (isset($data['success'])) {
             $this->result = $data['success'];
             unset($data['success']);
+        }
+        if (isset($data['ttl'])) {
+            $this->ttl = $data['ttl'];
+            unset($data['ttl']);
         }
 
         parent::__construct($name, $subject, $data);
@@ -99,5 +106,13 @@ class CacheAfterAddEvent extends Event
     public function getValue(): mixed
     {
         return $this->value;
+    }
+
+    /**
+     * @return \DateInterval|int|null
+     */
+    public function getTtl(): DateInterval|int|null
+    {
+        return $this->ttl;
     }
 }

--- a/src/Cache/Event/CacheAfterSetEvent.php
+++ b/src/Cache/Event/CacheAfterSetEvent.php
@@ -19,6 +19,7 @@ namespace Cake\Cache\Event;
 use Cake\Cache\CacheEngine;
 use Cake\Cache\Exception\InvalidArgumentException;
 use Cake\Event\Event;
+use DateInterval;
 
 /**
  * Class Cache AfterSet Event
@@ -32,6 +33,8 @@ class CacheAfterSetEvent extends Event
     protected string $key;
 
     protected mixed $value = null;
+
+    protected DateInterval|int|null $ttl = null;
 
     /**
      * Constructor
@@ -53,6 +56,10 @@ class CacheAfterSetEvent extends Event
         if (isset($data['success'])) {
             $this->result = $data['success'];
             unset($data['success']);
+        }
+        if (isset($data['ttl'])) {
+            $this->ttl = $data['ttl'];
+            unset($data['ttl']);
         }
 
         parent::__construct($name, $subject, $data);
@@ -99,5 +106,13 @@ class CacheAfterSetEvent extends Event
     public function getValue(): mixed
     {
         return $this->value;
+    }
+
+    /**
+     * @return \DateInterval|int|null
+     */
+    public function getTtl(): DateInterval|int|null
+    {
+        return $this->ttl;
     }
 }

--- a/src/Cache/Event/CacheBeforeAddEvent.php
+++ b/src/Cache/Event/CacheBeforeAddEvent.php
@@ -18,6 +18,7 @@ namespace Cake\Cache\Event;
 
 use Cake\Cache\CacheEngine;
 use Cake\Event\Event;
+use DateInterval;
 
 /**
  * Class Cache BeforeAdd Event
@@ -31,6 +32,8 @@ class CacheBeforeAddEvent extends Event
     protected string $key;
 
     protected mixed $value = null;
+
+    protected DateInterval|int|null $ttl = null;
 
     /**
      * Constructor
@@ -48,6 +51,10 @@ class CacheBeforeAddEvent extends Event
         if (isset($data['value'])) {
             $this->value = $data['value'];
             unset($data['value']);
+        }
+        if (isset($data['ttl'])) {
+            $this->ttl = $data['ttl'];
+            unset($data['ttl']);
         }
 
         parent::__construct($name, $subject, $data);
@@ -67,5 +74,13 @@ class CacheBeforeAddEvent extends Event
     public function getValue(): mixed
     {
         return $this->value;
+    }
+
+    /**
+     * @return \DateInterval|int|null
+     */
+    public function getTtl(): DateInterval|int|null
+    {
+        return $this->ttl;
     }
 }

--- a/tests/TestCase/Cache/Engine/EngineEventsTrait.php
+++ b/tests/TestCase/Cache/Engine/EngineEventsTrait.php
@@ -70,13 +70,13 @@ trait EngineEventsTrait
         $manager->on(CacheBeforeSetEvent::NAME, function (CacheBeforeSetEvent $event) use (&$beforeEventIsCalled): void {
             $this->assertSame('cake_test', $event->getKey());
             $this->assertEquals(1234, $event->getValue());
-            $this->assertNull($event->getTtl());
+            $this->assertEquals(3600, $event->getTtl());
             $beforeEventIsCalled = true;
         });
         $manager->on(CacheAfterSetEvent::NAME, function (CacheAfterSetEvent $event) use (&$afterEventIsCalled): void {
             $this->assertSame('cake_test', $event->getKey());
             $this->assertEquals(1234, $event->getValue());
-            $this->assertTrue($event->getResult());
+            $this->assertEquals(3600, $event->getTtl());
             $afterEventIsCalled = true;
         });
 
@@ -94,11 +94,13 @@ trait EngineEventsTrait
         $manager->on(CacheBeforeAddEvent::NAME, function (CacheBeforeAddEvent $event) use (&$beforeEventIsCalled): void {
             $this->assertSame('cake_test', $event->getKey());
             $this->assertEquals(1234, $event->getValue());
+            $this->assertEquals(3600, $event->getTtl());
             $beforeEventIsCalled = true;
         });
         $manager->on(CacheAfterAddEvent::NAME, function (CacheAfterAddEvent $event) use (&$afterEventIsCalled): void {
             $this->assertSame('cake_test', $event->getKey());
             $this->assertEquals(1234, $event->getValue());
+            $this->assertEquals(3600, $event->getTtl());
             $this->assertTrue($event->getResult());
             $afterEventIsCalled = true;
         });


### PR DESCRIPTION
While trying to implement sentry cache instrumentation I realized, that I didn't pass down the configured `ttl` to all events where it can be usefull.

Extends the work from https://github.com/cakephp/cakephp/pull/18956