### PR TITLE
Prioritize event manager setup in CommandRunner

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -136,6 +136,13 @@ class CommandRunner implements EventDispatcherInterface
 
         $this->bootstrap();
 
+        $eventManager = $this->getEventManager();
+        if ($this->app instanceof EventAwareApplicationInterface) {
+            $eventManager = $this->app->events($eventManager);
+            $eventManager = $this->app->pluginEvents($eventManager);
+        }
+        $this->setEventManager($eventManager);
+
         $commands = new CommandCollection([
             'help' => HelpCommand::class,
         ]);
@@ -325,12 +332,6 @@ class CommandRunner implements EventDispatcherInterface
     protected function runCommand(CommandInterface $command, array $argv, ConsoleIo $io): ?int
     {
         try {
-            $eventManager = $this->getEventManager();
-            if ($this->app instanceof EventAwareApplicationInterface) {
-                $eventManager = $this->app->events($eventManager);
-                $eventManager = $this->app->pluginEvents($eventManager);
-            }
-            $this->setEventManager($eventManager);
             if ($command instanceof EventDispatcherInterface) {
                 $command->setEventManager($this->getEventManager());
             }

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -136,12 +136,12 @@ class CommandRunner implements EventDispatcherInterface
 
         $this->bootstrap();
 
-        $eventManager = $this->getEventManager();
         if ($this->app instanceof EventAwareApplicationInterface) {
+            $eventManager = $this->getEventManager();
             $eventManager = $this->app->events($eventManager);
             $eventManager = $this->app->pluginEvents($eventManager);
+            $this->setEventManager($eventManager);
         }
-        $this->setEventManager($eventManager);
 
         $commands = new CommandCollection([
             'help' => HelpCommand::class,

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -26,12 +26,14 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Core\Configure;
 use Cake\Event\EventManager;
+use Cake\Event\EventManagerInterface;
 use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Mockery;
 use stdClass;
+use TestApp\Application;
 use TestApp\Command\AbortCommand;
 use TestApp\Command\DemoCommand;
 use TestApp\Command\DependencyCommand;
@@ -480,6 +482,49 @@ class CommandRunnerTest extends TestCase
         $runner = $this->getRunner();
         $runner->run(['cake', '--version'], $this->getMockIo($output));
         $this->assertGreaterThan(2, count(Router::getRouteCollection()->routes()));
+    }
+
+    /**
+     * Test that events registered in EventAwareApplicationInterface methods
+     * are available early during command runner execution.
+     */
+    public function testRunRegistersEventsEarly(): void
+    {
+        $output = new StubConsoleOutput();
+        $app = new class ($this->config) extends Application {
+            public bool $customEventFired = false;
+            public bool $pluginEventFired = false;
+
+            public function events(EventManagerInterface $eventManager): EventManagerInterface
+            {
+                $eventManager->on('Test.customEvent', function (): void {
+                    $this->customEventFired = true;
+                });
+
+                return $eventManager;
+            }
+
+            public function pluginEvents(EventManagerInterface $eventManager): EventManagerInterface
+            {
+                $eventManager->on('Test.pluginEvent', function (): void {
+                    $this->pluginEventFired = true;
+                });
+
+                return $eventManager;
+            }
+        };
+
+        $runner = new CommandRunner($app);
+        $runner->getEventManager()->on('Console.buildCommands', function () use ($runner): void {
+            // Trigger the events that should have been registered by events() and pluginEvents()
+            $runner->getEventManager()->dispatch('Test.customEvent');
+            $runner->getEventManager()->dispatch('Test.pluginEvent');
+        });
+
+        $runner->run(['cake', '--version'], $this->getMockIo($output));
+
+        $this->assertTrue($app->customEventFired, 'Custom event should have been fired');
+        $this->assertTrue($app->pluginEventFired, 'Plugin event should have been fired');
     }
 
     protected function makeAppWithCommands(array $commands): BaseApplication


### PR DESCRIPTION
- Moved `events()` and `pluginEvents()` calls from `runCommand()` to `run()` method
- Event manager is now set up immediately after bootstrap, before command collection building

This ensures that events such as `Console.buildCommands` are properly fired when listeners are registered. Previously, they could only be subscribed to in bootstrap rather than via `events()` hooks.