### PR TITLE
Fix TypeError in TableSchema::__unserialize() with integer keys

### DIFF
--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -1004,6 +1004,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
 
         $columns = $data["\0*\0_columns"] ?? [];
         foreach ($columns as $name => $column) {
+            $name = (string)$name;
             if (is_array($column)) {
                 $this->addColumn($name, $column);
             } else {
@@ -1012,6 +1013,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         }
         $indexes = $data["\0*\0_indexes"] ?? [];
         foreach ($indexes as $name => $index) {
+            $name = (string)$name;
             if (is_array($index)) {
                 $this->addIndex($name, $index);
             } else {
@@ -1020,6 +1022,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         }
         $constraints = $data["\0*\0_constraints"] ?? [];
         foreach ($constraints as $name => $constraint) {
+            $name = (string)$name;
             if (is_array($constraint)) {
                 $this->addConstraint($name, $constraint);
             } else {


### PR DESCRIPTION
## Summary

When deserializing `TableSchema`, the `__unserialize()` method iterates over columns, indexes, and constraints using `foreach ($array as $name => $value)`. If the serialized data contains integer keys (which can happen with corrupted cache data or cross-version compatibility issues), the `$name` variable will be an integer.

This causes issues because:
1. The `constraints()` method returns `array_keys($this->_constraints)` which would return integers
2. When `FixtureHelper::getForeignReferences()` iterates and calls `getConstraint($constraintName)`, it passes an integer to a method expecting a string

### Error
```
TypeError: Cake\Database\Schema\TableSchema::getConstraint(): Argument #1 ($name) must be of type string, int given, called in vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureHelper.php on line 283
```

### Fix
Cast the `$name` to string in `__unserialize()` for columns, indexes, and constraints to ensure type safety.

## Test plan
- [x] Existing tests pass
- [x] Manual testing with serialized schema data containing integer keys