### PR TITLE
5.next: Fix TypeError: TableSchema::getConstraint

### DIFF
--- a/src/TestSuite/Fixture/FixtureHelper.php
+++ b/src/TestSuite/Fixture/FixtureHelper.php
@@ -280,10 +280,7 @@ class FixtureHelper
 
         $references = [];
         foreach ($schema->constraints() as $constraintName) {
-            if (!is_string($constraintName)) {
-                throw new \RuntimeException('Expected constraint name to be a string: ' . print_r($constraintName, true) . ' ' . print_r($schema->constraints(), true));
-            }
-            $constraint = $schema->getConstraint($constraintName);
+            $constraint = $schema->getConstraint((string)$constraintName);
 
             if ($constraint && $constraint['type'] === TableSchema::CONSTRAINT_FOREIGN) {
                 $references[] = $constraint['references'][0];

--- a/src/TestSuite/Fixture/FixtureHelper.php
+++ b/src/TestSuite/Fixture/FixtureHelper.php
@@ -280,6 +280,9 @@ class FixtureHelper
 
         $references = [];
         foreach ($schema->constraints() as $constraintName) {
+            if (!is_string($constraintName)) {
+                throw new \RuntimeException('Expected constraint name to be a string: ' . print_r($constraintName, true) . ' ' . print_r($schema->constraints(), true));
+            }
             $constraint = $schema->getConstraint($constraintName);
 
             if ($constraint && $constraint['type'] === TableSchema::CONSTRAINT_FOREIGN) {


### PR DESCRIPTION
> TypeError: Cake\Database\Schema\TableSchema::getConstraint(): Argument #1 ($name) must be of type string, int given

Follow https://github.com/cakephp/cakephp/pull/19089

Annoying PHP behavior that keys of int even set as string revert to int.
So we have two options: A costly one (correct approach) to string cast on the returns:

```diff
     public function columns(): array
     {
-        return array_keys($this->_columns);
+        // Cast to string to handle numeric column names (PHP converts "1" to int 1 as array key)
+        return array_map('strval', array_keys($this->_columns));
     }
 
     /**
@@ -602,7 +603,8 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function indexes(): array
     {
-        return array_keys($this->_indexes);
+        // Cast to string to handle numeric index names (PHP converts "1" to int 1 as array key)
+        return array_map('strval', array_keys($this->_indexes));
     }
 
     /**
@@ -829,7 +831,8 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function constraints(): array
     {
-        return array_keys($this->_constraints);
+        // Cast to string to handle numeric constraint names (PHP converts "1" to int 1 as array key)
+        return array_map('strval', array_keys($this->_constraints));
     }
```

or the simple approach in this PR.