### PR TITLE
Add assert on conflicting association joins

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -713,3 +713,9 @@ parameters:
 			identifier: class.notFound
 			count: 1
 			path: src/Database/Driver/Mysql.php
+
+		-
+			message: '#^Call to function assert\(\) with false and string will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: src/ORM/EagerLoader.php


### PR DESCRIPTION
refs https://github.com/cakephp/cakephp/issues/17679
resolves https://github.com/cakephp/cakephp/issues/18929

We assert because re-writing the alias is not possible in cake 5. We'd have to enforce all joins us their full path name to be consistent enough for user application.