### PR TITLE
Show more version output on verbose mode.

### DIFF
--- a/src/Command/VersionCommand.php
+++ b/src/Command/VersionCommand.php
@@ -42,8 +42,35 @@ class VersionCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
-        $io->out(Configure::version());
+        $version = Configure::version();
+        $io->out($version);
+
+        if ($args->getOption('verbose')) {
+            $this->outputVerbose($io, $version);
+        }
 
         return static::CODE_SUCCESS;
+    }
+
+    /**
+     * Output verbose version information.
+     *
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @param string $version The CakePHP version
+     * @return void
+     */
+    protected function outputVerbose(ConsoleIo $io, string $version): void
+    {
+        $io->out();
+
+        // Show release link for stable and RC versions, but not dev
+        if (!str_contains($version, '-dev')) {
+            $io->out(sprintf(
+                '<info>Release:</info> https://github.com/cakephp/cakephp/releases/tag/%s',
+                $version,
+            ));
+        }
+
+        $io->out(sprintf('<info>PHP:</info> %s (%s)', PHP_VERSION, PHP_SAPI));
     }
 }

--- a/tests/TestCase/Command/VersionCommandTest.php
+++ b/tests/TestCase/Command/VersionCommandTest.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP :  Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP Project
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Command;
+
+use Cake\Console\CommandInterface;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+
+/**
+ * VersionCommandTest class.
+ */
+class VersionCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setAppNamespace();
+    }
+
+    /**
+     * Test basic version output
+     */
+    public function testVersion(): void
+    {
+        $this->exec('version');
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+        $this->assertOutputContains(Configure::version());
+    }
+
+    /**
+     * Test verbose output with stable version
+     */
+    public function testVerboseWithStableVersion(): void
+    {
+        $originalVersion = Configure::read('Cake.version');
+        Configure::write('Cake.version', '5.2.9');
+
+        $this->exec('version --verbose');
+
+        Configure::write('Cake.version', $originalVersion);
+
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+        $this->assertOutputContains('5.2.9');
+        $this->assertOutputContains('https://github.com/cakephp/cakephp/releases/tag/5.2.9');
+        $this->assertOutputContains('PHP:');
+        $this->assertOutputContains(PHP_VERSION);
+        $this->assertOutputContains(PHP_SAPI);
+    }
+
+    /**
+     * Test verbose output with RC version (shows release link)
+     */
+    public function testVerboseWithRcVersion(): void
+    {
+        $originalVersion = Configure::read('Cake.version');
+        Configure::write('Cake.version', '5.3.0-RC1');
+
+        $this->exec('version --verbose');
+
+        Configure::write('Cake.version', $originalVersion);
+
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+        $this->assertOutputContains('5.3.0-RC1');
+        $this->assertOutputContains('https://github.com/cakephp/cakephp/releases/tag/5.3.0-RC1');
+        $this->assertOutputContains('PHP:');
+    }
+
+    /**
+     * Test verbose output with dev version (no release link)
+     */
+    public function testVerboseWithDevVersion(): void
+    {
+        $originalVersion = Configure::read('Cake.version');
+        Configure::write('Cake.version', '5.3.0-dev');
+
+        $this->exec('version --verbose');
+
+        Configure::write('Cake.version', $originalVersion);
+
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+        $this->assertOutputContains('5.3.0-dev');
+        $this->assertOutputNotContains('https://github.com/cakephp/cakephp/releases/tag/');
+        $this->assertOutputContains('PHP:');
+    }
+}


### PR DESCRIPTION
Would it make sense to add a quick link in verbose mode and PHP info?

 Example output:
```
  $ bin/cake version
  5.2.9
```
this needs to stay in case people are using this somehow to get the version string exactly like this.

But we can use verbose mode for more useful stuff:
```
  $ bin/cake version -v
  5.2.9

  Release: https://github.com/cakephp/cakephp/releases/tag/5.2.9
  PHP: 8.4.15 (cli)
```
to have a quicklink to the release notes, making this release a bit more useful.

I wasnt sure if we also wanted to add
- Debug status - immediately know if debug is on/off
- other phpruntime infos

probably not
Thats what healthcheck is then for.