### PR TITLE
Fix completion command to exclude plugin-prefixed aliases

### DIFF
--- a/src/Command/CompletionCommand.php
+++ b/src/Command/CompletionCommand.php
@@ -124,14 +124,36 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
     {
         $options = [];
         $verbose = $io->level() >= ConsoleIo::VERBOSE;
+
+        // Build a map of command base names (without subcommands) to their classes
+        // to detect true duplicates (plugin-prefixed alias pointing to same command)
+        $commandClasses = [];
         foreach ($this->commands as $key => $value) {
             $parts = explode(' ', $key);
-            // Skip plugin-prefixed aliases (e.g., "migrations.migrations")
-            // to avoid duplicate completions unless verbose mode is enabled
-            if (!$verbose && str_contains($parts[0], '.')) {
-                continue;
+            $commandName = $parts[0];
+            // Only track base commands (no subcommands) and prefer first occurrence
+            if (count($parts) === 1 && !isset($commandClasses[$commandName])) {
+                $commandClasses[$commandName] = $value;
             }
-            $options[] = $parts[0];
+        }
+
+        foreach ($this->commands as $key => $value) {
+            $parts = explode(' ', $key);
+            $commandName = $parts[0];
+
+            // Skip plugin-prefixed aliases only if they are true duplicates
+            // (i.e., a short form exists that resolves to the same command class)
+            if (!$verbose && str_contains($commandName, '.')) {
+                $shortName = explode('.', $commandName)[1];
+                if (
+                    isset($commandClasses[$shortName]) &&
+                    isset($commandClasses[$commandName]) &&
+                    $commandClasses[$shortName] === $commandClasses[$commandName]
+                ) {
+                    continue;
+                }
+            }
+            $options[] = $commandName;
         }
         $options = array_unique($options);
         $io->out(implode(' ', $options));

--- a/src/Command/CompletionCommand.php
+++ b/src/Command/CompletionCommand.php
@@ -123,8 +123,14 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
     protected function getCommands(Arguments $args, ConsoleIo $io): int
     {
         $options = [];
+        $verbose = $io->level() >= ConsoleIo::VERBOSE;
         foreach ($this->commands as $key => $value) {
             $parts = explode(' ', $key);
+            // Skip plugin-prefixed aliases (e.g., "migrations.migrations")
+            // to avoid duplicate completions unless verbose mode is enabled
+            if (!$verbose && str_contains($parts[0], '.')) {
+                continue;
+            }
             $options[] = $parts[0];
         }
         $options = array_unique($options);

--- a/tests/TestCase/Command/CompletionCommandTest.php
+++ b/tests/TestCase/Command/CompletionCommandTest.php
@@ -70,9 +70,6 @@ class CompletionCommandTest extends TestCase
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $expected = [
-            'test_plugin.example',
-            'test_plugin.sample',
-            'test_plugin_two.example',
             'unique',
             'welcome',
             'cache',
@@ -92,6 +89,35 @@ class CompletionCommandTest extends TestCase
         foreach ($expected as $value) {
             $this->assertOutputContains($value);
         }
+    }
+
+    /**
+     * test commands excludes plugin-prefixed aliases to avoid duplicates
+     */
+    public function testCommandsExcludesPluginAliases(): void
+    {
+        $this->exec('completion commands');
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+
+        // Plugin-prefixed aliases should not be in the output
+        // as they are duplicates of the short form
+        $this->assertOutputNotContains('test_plugin.example');
+        $this->assertOutputNotContains('test_plugin.sample');
+        $this->assertOutputNotContains('test_plugin_two.example');
+    }
+
+    /**
+     * test commands includes plugin-prefixed aliases in verbose mode
+     */
+    public function testCommandsIncludesPluginAliasesInVerboseMode(): void
+    {
+        $this->exec('completion commands -v');
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+
+        // Plugin-prefixed aliases should be in the output in verbose mode
+        $this->assertOutputContains('test_plugin.example');
+        $this->assertOutputContains('test_plugin.sample');
+        $this->assertOutputContains('test_plugin_two.example');
     }
 
     /**

--- a/tests/TestCase/Command/CompletionCommandTest.php
+++ b/tests/TestCase/Command/CompletionCommandTest.php
@@ -70,6 +70,7 @@ class CompletionCommandTest extends TestCase
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
         $expected = [
+            'example',
             'unique',
             'welcome',
             'cache',
@@ -92,18 +93,26 @@ class CompletionCommandTest extends TestCase
     }
 
     /**
-     * test commands excludes plugin-prefixed aliases to avoid duplicates
+     * test commands excludes plugin-prefixed aliases only for true duplicates
      */
-    public function testCommandsExcludesPluginAliases(): void
+    public function testCommandsExcludesPluginAliasesForDuplicates(): void
     {
         $this->exec('completion commands');
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
-        // Plugin-prefixed aliases should not be in the output
-        // as they are duplicates of the short form
+        // Plugin-prefixed aliases should be excluded when they point to the
+        // same class as the short form (true duplicates)
         $this->assertOutputNotContains('test_plugin.example');
-        $this->assertOutputNotContains('test_plugin.sample');
-        $this->assertOutputNotContains('test_plugin_two.example');
+        $this->assertOutputNotContains('test_plugin_two.unique');
+        $this->assertOutputNotContains('test_plugin_two.welcome');
+
+        // Short forms should still be present
+        $this->assertOutputContains('example');
+
+        // Plugin-prefixed aliases should be included when multiple plugins
+        // have commands with the same name (different classes)
+        $this->assertOutputContains('test_plugin.sample');
+        $this->assertOutputContains('test_plugin_two.example');
     }
 
     /**


### PR DESCRIPTION
## Summary

The `completion commands` mode was outputting both short names and plugin-prefixed aliases (e.g., both `migrations` and `migrations.migrations`), causing duplicate suggestions in shell autocompletion.

This change filters out plugin-prefixed command names (those containing `.`) from the commands output, showing only the primary short form.

**Before:**
```
help version migrations migrations.migrations migrations.bake test_helper.linter linter ...
```

**After:**
```
help version migrations linter ...
```

The `subcommands` and `options` modes still support plugin-prefixed names for backward compatibility when explicitly used.

## Changes

- Modified `getCommands()` to skip command names containing `.`
- Updated test to not expect plugin-prefixed aliases in output
- Added new test `testCommandsExcludesPluginAliases()` to verify the fix

This is a critical fix needed to get CLI autocomplete to work properly:
```
hooks:
  post-start:
    - exec: |
        cat >> ~/.bashrc << 'EOF'
        alias c="composer"
        alias cake="bin/cake"
        _cake() {
          local cur prev
          COMPREPLY=()
          cur="${COMP_WORDS[COMP_CWORD]}"
          prev="${COMP_WORDS[COMP_CWORD-1]}"
          if [[ ${COMP_CWORD} == 1 ]]; then
            COMPREPLY=( $(compgen -W "$(bin/cake completion commands 2>/dev/null)" -- ${cur}) )
          elif [[ ${COMP_CWORD} == 2 ]]; then
            COMPREPLY=( $(compgen -W "$(bin/cake completion subcommands ${prev} 2>/dev/null)" -- ${cur}) )
          else
            COMPREPLY=( $(compgen -W "$(bin/cake completion options ${COMP_WORDS[1]} ${COMP_WORDS[2]} 2>/dev/null)" -- ${cur}) )
          fi
        }
        complete -F _cake bin/cake
        complete -F _cake cake
        EOF
```

//EDIT
I changed it so in verbose mode it retains current behavior if really needed (even though doubtful).