### PR TITLE
Handle optional config in addPlugin()

### DIFF
--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -138,12 +138,20 @@ abstract class BaseApplication implements
      */
     public function addPlugin($name, array $config = [])
     {
-        if (is_string($name)) {
-            $plugin = $this->plugins->create($name, $config);
-        } else {
-            $plugin = $name;
+        $optional = $config['optional'] ?? false;
+
+        try {
+            if (is_string($name)) {
+                $plugin = $this->plugins->create($name, $config);
+            } else {
+                $plugin = $name;
+            }
+            $this->plugins->add($plugin);
+        } catch (MissingPluginException $e) {
+            if (!$optional) {
+                throw $e;
+            }
         }
-        $this->plugins->add($plugin);
 
         return $this;
     }

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -19,6 +19,7 @@ namespace Cake\Http;
 
 use Cake\Console\CommandCollection;
 use Cake\Controller\ControllerFactory;
+use Cake\Core\Configure;
 use Cake\Core\ConsoleApplicationInterface;
 use Cake\Core\Container;
 use Cake\Core\ContainerApplicationInterface;
@@ -139,6 +140,15 @@ abstract class BaseApplication implements
     public function addPlugin($name, array $config = [])
     {
         $optional = $config['optional'] ?? false;
+        $onlyDebug = $config['onlyDebug'] ?? false;
+        $onlyCli = $config['onlyCli'] ?? false;
+
+        if (
+            ($onlyDebug && !Configure::read('debug'))
+            || ($onlyCli && PHP_SAPI !== 'cli')
+        ) {
+            return $this;
+        }
 
         try {
             if (is_string($name)) {

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -23,6 +23,7 @@ use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
 use Cake\Core\Container;
 use Cake\Core\ContainerInterface;
+use Cake\Core\Exception\MissingPluginException;
 use Cake\Event\EventInterface;
 use Cake\Event\EventManagerInterface;
 use Cake\Http\BaseApplication;
@@ -248,6 +249,28 @@ class BaseApplicationTest extends TestCase
 
         $this->assertCount(1, $app->getPlugins());
         $this->assertTrue($app->getPlugins()->has('TestPlugin'));
+    }
+
+    /**
+     * Tests that addPlugin() with optional config does not throw exception for missing plugin
+     */
+    public function testAddPluginOptionalConfigMissingPlugin(): void
+    {
+        $app = $this->app;
+        $pluginCountBefore = count($app->getPlugins());
+        $app->addPlugin('NonExistentPlugin', ['optional' => true]);
+        $pluginCountAfter = count($app->getPlugins());
+        $this->assertSame($pluginCountBefore, $pluginCountAfter);
+    }
+
+    /**
+     * Tests that addPlugin() without optional config throws exception for missing plugin
+     */
+    public function testAddPluginMissingPluginThrows(): void
+    {
+        $this->expectException(MissingPluginException::class);
+        $app = $this->app;
+        $app->addPlugin('NonExistentPlugin');
     }
 
     public function testGetContainer(): void

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -273,6 +273,46 @@ class BaseApplicationTest extends TestCase
         $app->addPlugin('NonExistentPlugin');
     }
 
+    /**
+     * Tests that addPlugin() with onlyDebug config only loads plugin in debug mode
+     */
+    public function testAddPluginOnlyDebugWhenDebugEnabled(): void
+    {
+        Configure::write('debug', true);
+        $app = $this->app;
+        $app->addPlugin(TestPlugin::class, ['onlyDebug' => true]);
+
+        $this->assertCount(1, $app->getPlugins());
+        $this->assertTrue($app->getPlugins()->has('TestPlugin'));
+    }
+
+    /**
+     * Tests that addPlugin() with onlyDebug config skips plugin when debug is disabled
+     */
+    public function testAddPluginOnlyDebugWhenDebugDisabled(): void
+    {
+        Configure::write('debug', false);
+        $app = $this->app;
+        $pluginCountBefore = count($app->getPlugins());
+        $app->addPlugin(TestPlugin::class, ['onlyDebug' => true]);
+        $pluginCountAfter = count($app->getPlugins());
+
+        $this->assertSame($pluginCountBefore, $pluginCountAfter);
+    }
+
+    /**
+     * Tests that addPlugin() with onlyCli config loads plugin in CLI mode
+     */
+    public function testAddPluginOnlyCliWhenInCli(): void
+    {
+        // PHP_SAPI is 'cli' in test environment
+        $app = $this->app;
+        $app->addPlugin(TestPlugin::class, ['onlyCli' => true]);
+
+        $this->assertCount(1, $app->getPlugins());
+        $this->assertTrue($app->getPlugins()->has('TestPlugin'));
+    }
+
     public function testGetContainer(): void
     {
         $app = $this->app;


### PR DESCRIPTION
## Summary

- Fix `addPlugin()` to respect the `optional` config key
- When `['optional' => true]` is passed and the plugin is missing, silently continue instead of throwing `MissingPluginException`
- This aligns the behavior of `addPlugin()` with `addFromConfig()` which already supports this option

Fixes #19096
