### PR TITLE
5.x: Fix TypeError in FixtureHelper::getForeignReferences()

### DIFF
--- a/src/TestSuite/Fixture/FixtureHelper.php
+++ b/src/TestSuite/Fixture/FixtureHelper.php
@@ -280,7 +280,7 @@ class FixtureHelper
 
         $references = [];
         foreach ($schema->constraints() as $constraintName) {
-            $constraint = $schema->getConstraint($constraintName);
+            $constraint = $schema->getConstraint((string)$constraintName);
 
             if ($constraint && $constraint['type'] === TableSchema::CONSTRAINT_FOREIGN) {
                 $references[] = $constraint['references'][0];


### PR DESCRIPTION
## Summary
- Backport of #19090 to 5.x branch
- Cast constraint names to string when calling `TableSchema::getConstraint()` to fix TypeError

## Details
PHP's `array_keys()` returns integers for numeric string keys. When a constraint name is a numeric string like `"1"`, it gets converted to integer `1` in the internal array. Calling `array_keys()` (via `constraints()`) then returns `1` instead of `"1"`, which causes a TypeError when passed to `getConstraint(string $name)`.
