### PR TITLE
Use ExpressionInterface for conditions in updateAll, deleteAll, exists

### DIFF
--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource;
 
+use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ExpressionInterface;
 use Closure;
 use Psr\SimpleCache\CacheInterface;
 
@@ -129,12 +131,15 @@ interface RepositoryInterface
      * This method will *not* trigger beforeSave/afterSave events. If you need those,
      * first load a collection of records and update them.
      *
-     * @param \Closure|array|string $fields A hash of field => new value.
-     * @param \Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
+     * @param \Cake\Database\Expression\QueryExpression|\Closure|array|string $fields A hash of field => new value.
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
      * can take.
      * @return int Count Returns the affected rows.
      */
-    public function updateAll(Closure|array|string $fields, Closure|array|string|null $conditions): int;
+    public function updateAll(
+        QueryExpression|Closure|array|string $fields,
+        ExpressionInterface|Closure|array|string|null $conditions,
+    ): int;
 
     /**
      * Deletes all records matching the provided conditions.
@@ -146,21 +151,21 @@ interface RepositoryInterface
      * use database foreign keys + ON CASCADE rules if you need cascading deletes combined
      * with this method.
      *
-     * @param \Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
      * can take.
      * @return int Returns the number of affected rows.
      * @see \Cake\Datasource\RepositoryInterface::delete()
      */
-    public function deleteAll(Closure|array|string|null $conditions): int;
+    public function deleteAll(ExpressionInterface|Closure|array|string|null $conditions): int;
 
     /**
      * Returns true if there is any record in this repository matching the specified
      * conditions.
      *
-     * @param \Closure|array|string|null $conditions list of conditions to pass to the query
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions list of conditions to pass to the query
      * @return bool
      */
-    public function exists(Closure|array|string|null $conditions): bool;
+    public function exists(ExpressionInterface|Closure|array|string|null $conditions): bool;
 
     /**
      * Persists an entity based on the fields that are marked as dirty and

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -25,6 +25,7 @@ use Cake\Core\Exception\CakeException;
 use Cake\Database\Connection;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ExpressionInterface;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionManager;
@@ -1767,12 +1768,12 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * first load a collection of records and update them.
      *
      * @param \Cake\Database\Expression\QueryExpression|\Closure|array|string $fields A hash of field => new value.
-     * @param \Cake\Database\Expression\QueryExpression|\Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
      * @return int Count Returns the affected rows.
      */
     public function updateAll(
         QueryExpression|Closure|array|string $fields,
-        QueryExpression|Closure|array|string|null $conditions,
+        ExpressionInterface|Closure|array|string|null $conditions,
     ): int {
         $statement = $this->updateQuery()
             ->set($fields)
@@ -1792,11 +1793,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * use database foreign keys + ON CASCADE rules if you need cascading deletes combined
      * with this method.
      *
-     * @param \Cake\Database\Expression\QueryExpression|\Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
      * can take.
      * @return int Returns the number of affected rows.
      */
-    public function deleteAll(QueryExpression|Closure|array|string|null $conditions): int
+    public function deleteAll(ExpressionInterface|Closure|array|string|null $conditions): int
     {
         $statement = $this->deleteQuery()
             ->where($conditions)
@@ -1808,7 +1809,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * @inheritDoc
      */
-    public function exists(QueryExpression|Closure|array|string|null $conditions): bool
+    public function exists(ExpressionInterface|Closure|array|string|null $conditions): bool
     {
         return (bool)count(
             $this->find('all')


### PR DESCRIPTION
## Summary

Fixes inconsistent type hints in `RepositoryInterface` and `Table` where:
- `updateAll()` - both `$fields` and `$conditions` parameters
- `deleteAll()` - `$conditions` parameter  
- `exists()` - `$conditions` parameter

Were typed with `QueryExpression` but should accept `ExpressionInterface` to:
1. Match the broader interface contract
2. Allow passing any expression type that implements `ExpressionInterface`
3. Be consistent with how these values are used internally

This is a breaking change suitable for 6.x.

Resolves #19102
