### PR TITLE
Use ExpressionInterface in Driver::schemaValue() and Association methods

### DIFF
--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -24,7 +24,6 @@ use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Exception\QueryException;
 use Cake\Database\Expression\ComparisonExpression;
 use Cake\Database\Expression\IdentifierExpression;
-use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Log\LoggedQuery;
 use Cake\Database\Log\QueryLogger;
 use Cake\Database\Query\DeleteQuery;
@@ -815,7 +814,7 @@ abstract class Driver implements LoggerAwareInterface
         ) {
             return (string)$value;
         }
-        if ($value instanceof QueryExpression) {
+        if ($value instanceof ExpressionInterface) {
             return $value->sql(new ValueBinder());
         }
 

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -874,13 +874,13 @@ abstract class Association
      * Proxies the update operation to the target `Table::updateAll()` method
      *
      * @param \Cake\Database\Expression\QueryExpression|\Closure|array|string $fields A hash of field => new value.
-     * @param \Cake\Database\Expression\QueryExpression|\Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
      * @return int Count Returns the affected rows.
      * @see \Cake\ORM\Table::updateAll()
      */
     public function updateAll(
         QueryExpression|Closure|array|string $fields,
-        QueryExpression|Closure|array|string|null $conditions,
+        ExpressionInterface|Closure|array|string|null $conditions,
     ): int {
         $expression = $this->find()
             ->where($conditions)
@@ -892,12 +892,12 @@ abstract class Association
     /**
      * Proxies the delete operation to the target `Table::deleteAll()` method
      *
-     * @param \Cake\Database\Expression\QueryExpression|\Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
      * can take.
      * @return int Returns the number of affected rows.
      * @see \Cake\ORM\Table::deleteAll()
      */
-    public function deleteAll(QueryExpression|Closure|array|string|null $conditions): int
+    public function deleteAll(ExpressionInterface|Closure|array|string|null $conditions): int
     {
         $expression = $this->find()
             ->where($conditions)


### PR DESCRIPTION
## Summary

Follow-up to #19104, addressing additional places where `QueryExpression` was used instead of `ExpressionInterface`:

- **Driver::schemaValue()** - Changed `instanceof QueryExpression` check to `instanceof ExpressionInterface`, allowing any expression implementation to work (same pattern as the FixtureHelper bug fix)
- **Association::updateAll()** - Changed `$conditions` parameter to accept `ExpressionInterface` instead of `QueryExpression`
- **Association::deleteAll()** - Changed `$conditions` parameter to accept `ExpressionInterface` instead of `QueryExpression`

These changes ensure consistency with the `Table` class methods and allow any `ExpressionInterface` implementation to be used, not just `QueryExpression`.