### PR TITLE
Move `@method` annotations to actual interface methods

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -29,7 +29,6 @@ use const SORT_NUMERIC;
  * @template TKey
  * @template-covariant TValue
  * @template-extends \Iterator<TKey, TValue>
- * @method bool any(callable $callback)
  */
 interface CollectionInterface extends Iterator, JsonSerializable, Countable
 {
@@ -139,6 +138,26 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      *   callback returns true, false otherwise.
      */
     public function every(callable $callback): bool;
+
+    /**
+     * Returns true if any the callback returns true for any element in the collection.
+     *
+     * The callback accepts the value and key of the element being tested.
+     *
+     * ### Example:
+     *
+     * ```
+     * $hasYoungPeople = (new Collection([24, 45, 15]))->any(function ($value, $key) {
+     *  return $value < 21;
+     * });
+     * ```
+     *
+     * @param callable $callback A callback receiving `($value, $key)` that returns
+     *   true if the test passed, false otherwise.
+     * @return bool True if the provided callback returns true for any element in this
+     *   collection, false otherwise.
+     */
+    public function any(callable $callback): bool;
 
     /**
      * Returns true if any of the values in this collection pass the truth test

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -21,11 +21,6 @@ use Closure;
 
 /**
  * The basis for every query object
- *
- * @method $this andWhere($conditions, array $types = []) Connects any previously defined set of conditions to the
- *   provided list using the AND operator. {@see \Cake\Database\Query::andWhere()}
- * @method \Cake\Datasource\EntityInterface|array firstOrFail() Get the first result from the executing query or raise an exception.
- *   {@see \Cake\Database\Query::firstOrFail()}
  */
 interface QueryInterface
 {
@@ -154,6 +149,14 @@ interface QueryInterface
      * @return mixed the first result from the ResultSet
      */
     public function first(): mixed;
+
+    /**
+     * Get the first result from the executing query or raise an exception.
+     *
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException When there is no first record.
+     * @return mixed The first result from the ResultSet.
+     */
+    public function firstOrFail(): mixed;
 
     /**
      * Returns the total amount of results for the query.
@@ -409,4 +412,18 @@ interface QueryInterface
         array $types = [],
         bool $overwrite = false,
     ): static;
+
+    /**
+     * Connects any previously defined set of conditions to the provided list
+     * using the AND operator.
+     *
+     * This method is identical to using `where()` with the third
+     * parameter set to `false` (the default).
+     *
+     * @param \Closure|array|string $conditions The conditions to add with AND.
+     * @param array<string, string> $types Associative array of type names used to bind values to query.
+     * @return $this
+     * @see \Cake\Datasource\QueryInterface::where()
+     */
+    public function andWhere(Closure|array|string $conditions, array $types = []): static;
 }


### PR DESCRIPTION
## Summary

- Add `any()` to `CollectionInterface` (was only `@method` annotation)
- Add `firstOrFail()` to `QueryInterface`
- Add `andWhere()` to `QueryInterface`

These methods were documented via `@method` annotations but had implementations in traits/classes. Moving them to the interface provides better type safety and IDE support.

### BC Impact

This is a BC-breaking change for any class that implements these interfaces directly without using the provided traits. Such classes will need to add these methods.


### Not Touched

There was a 4th method

  | Interface                  | Method                          | Current impl          |
  |----------------------------|---------------------------------|-----------------------|
  | Schema\CollectionInterface | listTablesWithoutViews(): array | Schema\Collection     |
  
  But this doesnt look like its worth to make a real interface method, right?