### PR TITLE
Fix setTimezone call on Date in RelativeTimeFormatter

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -319,12 +319,6 @@ parameters:
 			path: src/I18n/DateTime.php
 
 		-
-			message: '#^Call to an undefined method Cake\\I18n\\Date\|Cake\\I18n\\DateTime\:\:setTimezone\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/I18n/RelativeTimeFormatter.php
-
-		-
 			message: '#^@readonly property cannot have a default value\.$#'
 			identifier: property.readOnlyByPhpDocDefaultValue
 			count: 4

--- a/src/I18n/RelativeTimeFormatter.php
+++ b/src/I18n/RelativeTimeFormatter.php
@@ -109,7 +109,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
     public function timeAgoInWords(DateTime|Date $time, array $options = []): string
     {
         $options = $this->_options($options, DateTime::class);
-        if ($options['timezone']) {
+        if ($time instanceof DateTime && $options['timezone']) {
             $time = $time->setTimezone($options['timezone']);
         }
 


### PR DESCRIPTION
## Summary

`Date` does not have `setTimezone()` method, only `DateTime` does. This adds an `instanceof` check to prevent calling `setTimezone` on `Date` objects.

This matches the pattern already used in `dateAgoInWords()` method in the same class.

## Fix

```php
// Before
if ($options['timezone']) {
    $time = $time->setTimezone($options['timezone']);
}

// After
if ($time instanceof DateTime && $options['timezone']) {
    $time = $time->setTimezone($options['timezone']);
}
```