### PR TITLE
Fix fixture table name derivation to respect custom Inflector rules

### DIFF
--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -58,8 +58,9 @@ class TestFixture implements FixtureInterface
      * If set, table must initially be empty.
      * $table will be read from the ORM table loaded via the alias.
      *
-     * If both table and tableAlias are empty, the alias,
-     * will be inflected from the class name with Inflector::pluralize()
+     * If both table and tableAlias are empty, the alias will be inflected
+     * from the class name using tableize() then camelize() to respect
+     * custom Inflector rules.
      *
      * @var string
      */
@@ -141,7 +142,10 @@ class TestFixture implements FixtureInterface
     }
 
     /**
-     * Returns the table name using the fixture class
+     * Returns the ORM table alias using the fixture class.
+     *
+     * Uses tableize() then camelize() to respect custom Inflector rules
+     * like uninflected words.
      *
      * @return string
      */
@@ -149,8 +153,9 @@ class TestFixture implements FixtureInterface
     {
         [, $class] = namespaceSplit(static::class);
         preg_match('/^(.*)Fixture$/', $class, $matches);
+        $name = $matches[1] ?? $class;
 
-        return Inflector::pluralize($matches[1] ?? $class);
+        return Inflector::camelize(Inflector::tableize($name));
     }
 
     /**

--- a/tests/Fixture/EquipmentFixture.php
+++ b/tests/Fixture/EquipmentFixture.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Fixture for testing uninflected word handling.
+ *
+ * "equipment" is in the default uninflected list, so the table
+ * should be "equipment" (not "equipments").
+ */
+class EquipmentFixture extends TestFixture
+{
+}

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -28,6 +28,7 @@ use Cake\Test\Fixture\ArticlesFixture;
 use Cake\Test\Fixture\PostsFixture;
 use Cake\Test\Fixture\SpecialPkFixture;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Inflector;
 use Mockery;
 use TestApp\Test\Fixture\FeaturedTagsFixture;
 use TestApp\Test\Fixture\LettersFixture;
@@ -60,6 +61,7 @@ class TestFixtureTest extends TestCase
     {
         parent::tearDown();
         Log::reset();
+        Inflector::reset();
         ConnectionManager::get('test')->execute('DROP TABLE IF EXISTS letters');
         ConnectionManager::get('test')->execute('DROP TABLE IF EXISTS special_pks');
     }
@@ -96,6 +98,33 @@ class TestFixtureTest extends TestCase
         $Fixture = new SpecialPkFixture();
         $this->assertSame('special_pks', $Fixture->table);
         $this->assertSame('SpecialPks', $Fixture->tableAlias);
+    }
+
+    /**
+     * Test that uninflected rules are respected when deriving table names.
+     *
+     * This ensures the fixture uses tableize() logic (underscore then pluralize)
+     * rather than pluralizing the CamelCase name directly.
+     */
+    public function testAliasRespectsUninflectedRules(): void
+    {
+        // 'equipment' is in the default uninflected list
+        $this->assertSame('equipment', Inflector::pluralize('equipment'));
+        $this->assertSame('equipment', Inflector::tableize('Equipment'));
+
+        // Verify tableize + camelize preserves uninflected words
+        $this->assertSame('Equipment', Inflector::camelize(Inflector::tableize('Equipment')));
+
+        // Add a custom uninflected rule
+        Inflector::rules('uninflected', ['invoice_tax_information']);
+        $this->assertSame('invoice_tax_information', Inflector::pluralize('invoice_tax_information'));
+        $this->assertSame('invoice_tax_information', Inflector::tableize('InvoiceTaxInformation'));
+
+        // The alias should be derived using tableize + camelize to respect uninflected rules
+        $this->assertSame(
+            'InvoiceTaxInformation',
+            Inflector::camelize(Inflector::tableize('InvoiceTaxInformation')),
+        );
     }
 
     /**

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -25,6 +25,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
 use Cake\Test\Fixture\AliasedArticlesFixture;
 use Cake\Test\Fixture\ArticlesFixture;
+use Cake\Test\Fixture\EquipmentFixture;
 use Cake\Test\Fixture\PostsFixture;
 use Cake\Test\Fixture\SpecialPkFixture;
 use Cake\TestSuite\TestCase;
@@ -64,6 +65,7 @@ class TestFixtureTest extends TestCase
         Inflector::reset();
         ConnectionManager::get('test')->execute('DROP TABLE IF EXISTS letters');
         ConnectionManager::get('test')->execute('DROP TABLE IF EXISTS special_pks');
+        ConnectionManager::get('test')->execute('DROP TABLE IF EXISTS equipment');
     }
 
     /**
@@ -103,28 +105,20 @@ class TestFixtureTest extends TestCase
     /**
      * Test that uninflected rules are respected when deriving table names.
      *
+     * "equipment" is in the default uninflected list, so EquipmentFixture
+     * should use table "equipment" (not "equipments").
+     *
      * This ensures the fixture uses tableize() logic (underscore then pluralize)
      * rather than pluralizing the CamelCase name directly.
      */
     public function testAliasRespectsUninflectedRules(): void
     {
-        // 'equipment' is in the default uninflected list
-        $this->assertSame('equipment', Inflector::pluralize('equipment'));
-        $this->assertSame('equipment', Inflector::tableize('Equipment'));
+        $connection = ConnectionManager::get('test');
+        $connection->execute('CREATE TABLE equipment (id INT PRIMARY KEY, name VARCHAR(50))');
 
-        // Verify tableize + camelize preserves uninflected words
-        $this->assertSame('Equipment', Inflector::camelize(Inflector::tableize('Equipment')));
-
-        // Add a custom uninflected rule
-        Inflector::rules('uninflected', ['invoice_tax_information']);
-        $this->assertSame('invoice_tax_information', Inflector::pluralize('invoice_tax_information'));
-        $this->assertSame('invoice_tax_information', Inflector::tableize('InvoiceTaxInformation'));
-
-        // The alias should be derived using tableize + camelize to respect uninflected rules
-        $this->assertSame(
-            'InvoiceTaxInformation',
-            Inflector::camelize(Inflector::tableize('InvoiceTaxInformation')),
-        );
+        $fixture = new EquipmentFixture();
+        $this->assertSame('equipment', $fixture->table);
+        $this->assertSame('Equipment', $fixture->tableAlias);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Fixes #19124 - Custom Inflector rules (like uninflected) are not respected when fixtures derive their table names

The change in #18959 and follow-up #18972 changed fixture table name derivation from using `tableize()` (underscore then pluralize) to pluralizing the CamelCase class name directly. This broke custom Inflector uninflected rules since those rules match against underscored strings.

**Example:** With `Inflector::rules('uninflected', ['invoice_tax_information'])`, the fixture `InvoiceTaxInformationFixture` would incorrectly use `invoice_tax_informations` instead of `invoice_tax_information`.

**Old behavior (5.2.x):**
- `InvoiceTaxInformation` → `underscore()` → `invoice_tax_information` → `pluralize()` → `invoice_tax_information` (uninflected rule matches!)

**Broken behavior (5.3.0rc2):**
- `InvoiceTaxInformation` → `pluralize()` → `InvoiceTaxInformations` → `underscore()` → `invoice_tax_informations`

**Fix:**
Changes `_aliasFromClass()` to use `tableize()` then `camelize()`, which respects custom Inflector rules by doing underscore-then-pluralize (matching how uninflected rules are defined).