### PR TITLE
Fix return type annotation for Validator::validate()

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -221,9 +221,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param array<string, mixed> $data The data to be checked for errors.
      *   Keys are field names, values are the field values to validate.
      * @param bool $newRecord Whether the data to be validated is new or to be updated.
-     * @return array<string, array<string, string>> Array of validation errors.
+     * @return array<string, array<string, string|array>> Array of validation errors.
      *   Outer keys are field names, inner keys are validation rule names,
-     *   values are error messages. Special rule names: '_required', '_empty'.
+     *   values are error messages. When using `addNested()` or `addNestedMany()`,
+     *   values may be nested error arrays. Special rule names: '_required', '_empty'.
      */
     public function validate(array $data, bool $newRecord = true): array
     {


### PR DESCRIPTION
## Summary
- Fixes #19112 - Return type annotation for `Validator::validate()` is too restrictive

The return type `array<string, array<string, string>>` didn't account for nested validators. When using `addNested()` or `addNestedMany()`, the error values can be nested arrays, not just strings.

**Example with nested validator:**
```php
$validator->addNested('address', $addressValidator);
```

**Error structure when nested validation fails:**
```php
[
    'address' => [
        'street' => ['_required' => 'This field is required'],
        'city' => ['_required' => 'This field is required'],
    ]
]
```

The inner values are `array<string, string>`, not `string`.

**Fix:** Updated return type to `array<string, array<string, string|array>>` which accurately reflects the actual return structure when nested validators are used.