### PR TITLE
Apply $options to all crumbs when using array format in BreadcrumbsHelper

### DIFF
--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -71,7 +71,8 @@ class BreadcrumbsHelper extends Helper
      * @param array|string|null $url URL of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link.
      * @param array<string, mixed> $options Array of options. These options will be used as attributes HTML attribute the crumb will
-     * be rendered in (a <li> tag by default). It accepts two special keys:
+     * be rendered in (a <li> tag by default). When $title is an array, these options will be used as defaults
+     * for each crumb, with individual crumb options taking precedence. It accepts two special keys:
      *
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
      *   the link)
@@ -82,7 +83,9 @@ class BreadcrumbsHelper extends Helper
     {
         if (is_array($title)) {
             foreach ($title as $crumb) {
-                $this->crumbs[] = $crumb + ['title' => '', 'url' => null, 'options' => []];
+                $crumb += ['title' => '', 'url' => null, 'options' => []];
+                $crumb['options'] += $options;
+                $this->crumbs[] = $crumb;
             }
 
             return $this;
@@ -107,7 +110,8 @@ class BreadcrumbsHelper extends Helper
      * @param array|string|null $url URL of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link.
      * @param array<string, mixed> $options Array of options. These options will be used as attributes HTML attribute the crumb will
-     * be rendered in (a <li> tag by default). It accepts two special keys:
+     * be rendered in (a <li> tag by default). When $title is an array, these options will be used as defaults
+     * for each crumb, with individual crumb options taking precedence. It accepts two special keys:
      *
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
      *   the link)
@@ -119,7 +123,9 @@ class BreadcrumbsHelper extends Helper
         if (is_array($title)) {
             $crumbs = [];
             foreach ($title as $crumb) {
-                $crumbs[] = $crumb + ['title' => '', 'url' => null, 'options' => []];
+                $crumb += ['title' => '', 'url' => null, 'options' => []];
+                $crumb['options'] += $options;
+                $crumbs[] = $crumb;
             }
 
             array_splice($this->crumbs, 0, 0, $crumbs);

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -122,6 +122,72 @@ class BreadcrumbsHelperTest extends TestCase
     }
 
     /**
+     * Test adding multiple crumbs with shared options
+     */
+    public function testAddMultipleWithSharedOptions(): void
+    {
+        $this->breadcrumbs
+            ->add([
+                ['title' => 'Home', 'url' => '/'],
+                ['title' => 'Products', 'url' => '/products'],
+                ['title' => 'Widget'],
+            ], null, ['class' => 'breadcrumb-item']);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Home',
+                'url' => '/',
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+            [
+                'title' => 'Products',
+                'url' => '/products',
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+            [
+                'title' => 'Widget',
+                'url' => null,
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test adding multiple crumbs with shared options and individual override
+     */
+    public function testAddMultipleWithSharedOptionsAndOverride(): void
+    {
+        $this->breadcrumbs
+            ->add([
+                ['title' => 'Home', 'url' => '/', 'options' => ['class' => 'home-crumb']],
+                ['title' => 'Products', 'url' => '/products'],
+                ['title' => 'Widget', 'options' => ['data-active' => 'true']],
+            ], null, ['class' => 'breadcrumb-item', 'data-type' => 'crumb']);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Home',
+                'url' => '/',
+                'options' => ['class' => 'home-crumb', 'data-type' => 'crumb'],
+            ],
+            [
+                'title' => 'Products',
+                'url' => '/products',
+                'options' => ['class' => 'breadcrumb-item', 'data-type' => 'crumb'],
+            ],
+            [
+                'title' => 'Widget',
+                'url' => null,
+                'options' => ['data-active' => 'true', 'class' => 'breadcrumb-item', 'data-type' => 'crumb'],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * Test adding crumbs to the trail using prepend()
      */
     public function testPrepend(): void
@@ -183,6 +249,82 @@ class BreadcrumbsHelperTest extends TestCase
                 'title' => 'The root',
                 'url' => '/root',
                 'options' => ['data-name' => 'some-name'],
+            ],
+            [
+                'title' => 'Home',
+                'url' => '/',
+                'options' => [
+                    'class' => 'first',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test prepending multiple crumbs with shared options
+     */
+    public function testPrependMultipleWithSharedOptions(): void
+    {
+        $this->breadcrumbs
+            ->add('Home', '/', ['class' => 'first'])
+            ->prepend([
+                ['title' => 'Some text', 'url' => ['controller' => 'Some', 'action' => 'text']],
+                ['title' => 'The root', 'url' => '/root'],
+            ], null, ['class' => 'breadcrumb-item']);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Some text',
+                'url' => [
+                    'controller' => 'Some',
+                    'action' => 'text',
+                ],
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+            [
+                'title' => 'The root',
+                'url' => '/root',
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+            [
+                'title' => 'Home',
+                'url' => '/',
+                'options' => [
+                    'class' => 'first',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test prepending multiple crumbs with shared options and individual override
+     */
+    public function testPrependMultipleWithSharedOptionsAndOverride(): void
+    {
+        $this->breadcrumbs
+            ->add('Home', '/', ['class' => 'first'])
+            ->prepend([
+                ['title' => 'Some text', 'url' => ['controller' => 'Some', 'action' => 'text'], 'options' => ['data-special' => 'yes']],
+                ['title' => 'The root', 'url' => '/root'],
+            ], null, ['class' => 'breadcrumb-item', 'data-type' => 'nav']);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Some text',
+                'url' => [
+                    'controller' => 'Some',
+                    'action' => 'text',
+                ],
+                'options' => ['data-special' => 'yes', 'class' => 'breadcrumb-item', 'data-type' => 'nav'],
+            ],
+            [
+                'title' => 'The root',
+                'url' => '/root',
+                'options' => ['class' => 'breadcrumb-item', 'data-type' => 'nav'],
             ],
             [
                 'title' => 'Home',


### PR DESCRIPTION
## Summary

- When calling `add()` or `prepend()` with an array of crumbs, the `$options` parameter is now applied as defaults to all crumbs
- Individual crumb options take precedence over shared options
- Updated docblocks to document the new behavior

This follows the DRY principle and allows shared styling across multiple breadcrumbs without repeating options in each array element.

Related discussion: https://discourse.cakephp.org/t/re-breadcrumb-options-lost-when-title-is-an-array/12750

Resolves https://github.com/cakephp/cakephp/issues/19127

### Example usage

```php
// Shared class applied to all three breadcrumbs
$this->Breadcrumbs->add([
    ['title' => 'Home', 'url' => '/'],
    ['title' => 'Products', 'url' => '/products'],
    ['title' => 'Widget'],
], null, ['class' => 'breadcrumb-item']);

// Individual override still works - Home gets 'special', Products gets 'breadcrumb-item'
$this->Breadcrumbs->add([
    ['title' => 'Home', 'url' => '/', 'options' => ['class' => 'special']],
    ['title' => 'Products', 'url' => '/products'],
], null, ['class' => 'breadcrumb-item']);
```