### PR TITLE
Add addMany() and prependMany() methods to BreadcrumbsHelper

### DIFF
--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -19,6 +19,7 @@ namespace Cake\View\Helper;
 use Cake\View\Helper;
 use Cake\View\StringTemplateTrait;
 use LogicException;
+use function Cake\Core\deprecationWarning;
 
 /**
  * BreadcrumbsHelper to register and display a breadcrumb trail for your views
@@ -81,14 +82,40 @@ class BreadcrumbsHelper extends Helper
     public function add(array|string $title, array|string|null $url = null, array $options = [])
     {
         if (is_array($title)) {
-            foreach ($title as $crumb) {
-                $this->crumbs[] = $crumb + ['title' => '', 'url' => null, 'options' => []];
-            }
+            deprecationWarning(
+                '5.3.0',
+                'Passing an array as the first argument to BreadcrumbsHelper::add() is deprecated. ' .
+                'Use addMany() instead.',
+            );
 
-            return $this;
+            return $this->addMany($title, $options);
         }
 
         $this->crumbs[] = compact('title', 'url', 'options');
+
+        return $this;
+    }
+
+    /**
+     * Add multiple crumbs to the end of the trail.
+     *
+     * @param array<array{title?: string, url?: array|string|null, options?: array<string, mixed>}> $crumbs Array of crumbs to add.
+     * @param array<string, mixed> $options Shared options for all crumbs. These options will be used as defaults
+     * for each crumb, with individual crumb options taking precedence. These options will be used as attributes
+     * HTML attribute the crumb will be rendered in (a <li> tag by default). It accepts two special keys:
+     *
+     * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
+     *   the link)
+     * - *templateVars*: Specific template vars in case you override the templates provided.
+     * @return $this
+     */
+    public function addMany(array $crumbs, array $options = [])
+    {
+        foreach ($crumbs as $crumb) {
+            $crumb += ['title' => '', 'url' => null, 'options' => []];
+            $crumb['options'] += $options;
+            $this->crumbs[] = $crumb;
+        }
 
         return $this;
     }
@@ -117,17 +144,43 @@ class BreadcrumbsHelper extends Helper
     public function prepend(array|string $title, array|string|null $url = null, array $options = [])
     {
         if (is_array($title)) {
-            $crumbs = [];
-            foreach ($title as $crumb) {
-                $crumbs[] = $crumb + ['title' => '', 'url' => null, 'options' => []];
-            }
+            deprecationWarning(
+                '5.3.0',
+                'Passing an array as the first argument to BreadcrumbsHelper::prepend() is deprecated. ' .
+                'Use prependMany() instead.',
+            );
 
-            array_splice($this->crumbs, 0, 0, $crumbs);
-
-            return $this;
+            return $this->prependMany($title, $options);
         }
 
         array_unshift($this->crumbs, compact('title', 'url', 'options'));
+
+        return $this;
+    }
+
+    /**
+     * Prepend multiple crumbs to the start of the queue.
+     *
+     * @param array<array{title?: string, url?: array|string|null, options?: array<string, mixed>}> $crumbs Array of crumbs to prepend.
+     * @param array<string, mixed> $options Shared options for all crumbs. These options will be used as defaults
+     * for each crumb, with individual crumb options taking precedence. These options will be used as attributes
+     * HTML attribute the crumb will be rendered in (a <li> tag by default). It accepts two special keys:
+     *
+     * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
+     *   the link)
+     * - *templateVars*: Specific template vars in case you override the templates provided.
+     * @return $this
+     */
+    public function prependMany(array $crumbs, array $options = [])
+    {
+        $prepend = [];
+        foreach ($crumbs as $crumb) {
+            $crumb += ['title' => '', 'url' => null, 'options' => []];
+            $crumb['options'] += $options;
+            $prepend[] = $crumb;
+        }
+
+        array_splice($this->crumbs, 0, 0, $prepend);
 
         return $this;
     }

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -79,46 +79,48 @@ class BreadcrumbsHelperTest extends TestCase
      */
     public function testAddMultiple(): void
     {
-        $this->breadcrumbs
-            ->add([
+        $this->deprecated(function (): void {
+            $this->breadcrumbs
+                ->add([
+                    [
+                        'title' => 'Home',
+                        'url' => '/',
+                        'options' => ['class' => 'first'],
+                    ],
+                    [
+                        'title' => 'Some text',
+                        'url' => ['controller' => 'Some', 'action' => 'text'],
+                    ],
+                    [
+                        'title' => 'Final',
+                    ],
+                ]);
+
+            $result = $this->breadcrumbs->getCrumbs();
+            $expected = [
                 [
                     'title' => 'Home',
                     'url' => '/',
-                    'options' => ['class' => 'first'],
+                    'options' => [
+                        'class' => 'first',
+                    ],
                 ],
                 [
                     'title' => 'Some text',
-                    'url' => ['controller' => 'Some', 'action' => 'text'],
+                    'url' => [
+                        'controller' => 'Some',
+                        'action' => 'text',
+                    ],
+                    'options' => [],
                 ],
                 [
                     'title' => 'Final',
+                    'url' => null,
+                    'options' => [],
                 ],
-            ]);
-
-        $result = $this->breadcrumbs->getCrumbs();
-        $expected = [
-            [
-                'title' => 'Home',
-                'url' => '/',
-                'options' => [
-                    'class' => 'first',
-                ],
-            ],
-            [
-                'title' => 'Some text',
-                'url' => [
-                    'controller' => 'Some',
-                    'action' => 'text',
-                ],
-                'options' => [],
-            ],
-            [
-                'title' => 'Final',
-                'url' => null,
-                'options' => [],
-            ],
-        ];
-        $this->assertEquals($expected, $result);
+            ];
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
@@ -162,37 +164,39 @@ class BreadcrumbsHelperTest extends TestCase
      */
     public function testPrependMultiple(): void
     {
-        $this->breadcrumbs
-            ->add('Home', '/', ['class' => 'first'])
-            ->prepend([
-                ['title' => 'Some text', 'url' => ['controller' => 'Some', 'action' => 'text']],
-                ['title' => 'The root', 'url' => '/root', 'options' => ['data-name' => 'some-name']],
-            ]);
+        $this->deprecated(function (): void {
+            $this->breadcrumbs
+                ->add('Home', '/', ['class' => 'first'])
+                ->prepend([
+                    ['title' => 'Some text', 'url' => ['controller' => 'Some', 'action' => 'text']],
+                    ['title' => 'The root', 'url' => '/root', 'options' => ['data-name' => 'some-name']],
+                ]);
 
-        $result = $this->breadcrumbs->getCrumbs();
-        $expected = [
-            [
-                'title' => 'Some text',
-                'url' => [
-                    'controller' => 'Some',
-                    'action' => 'text',
+            $result = $this->breadcrumbs->getCrumbs();
+            $expected = [
+                [
+                    'title' => 'Some text',
+                    'url' => [
+                        'controller' => 'Some',
+                        'action' => 'text',
+                    ],
+                    'options' => [],
                 ],
-                'options' => [],
-            ],
-            [
-                'title' => 'The root',
-                'url' => '/root',
-                'options' => ['data-name' => 'some-name'],
-            ],
-            [
-                'title' => 'Home',
-                'url' => '/',
-                'options' => [
-                    'class' => 'first',
+                [
+                    'title' => 'The root',
+                    'url' => '/root',
+                    'options' => ['data-name' => 'some-name'],
                 ],
-            ],
-        ];
-        $this->assertEquals($expected, $result);
+                [
+                    'title' => 'Home',
+                    'url' => '/',
+                    'options' => [
+                        'class' => 'first',
+                    ],
+                ],
+            ];
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
@@ -510,5 +514,222 @@ class BreadcrumbsHelperTest extends TestCase
             '/ol',
         ];
         $this->assertHtml($expected, $result, true);
+    }
+
+    /**
+     * Test adding multiple crumbs at once using addMany()
+     */
+    public function testAddMany(): void
+    {
+        $this->breadcrumbs
+            ->addMany([
+                [
+                    'title' => 'Home',
+                    'url' => '/',
+                    'options' => ['class' => 'first'],
+                ],
+                [
+                    'title' => 'Some text',
+                    'url' => ['controller' => 'Some', 'action' => 'text'],
+                ],
+                [
+                    'title' => 'Final',
+                ],
+            ]);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Home',
+                'url' => '/',
+                'options' => [
+                    'class' => 'first',
+                ],
+            ],
+            [
+                'title' => 'Some text',
+                'url' => [
+                    'controller' => 'Some',
+                    'action' => 'text',
+                ],
+                'options' => [],
+            ],
+            [
+                'title' => 'Final',
+                'url' => null,
+                'options' => [],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test adding multiple crumbs with shared options using addMany()
+     */
+    public function testAddManyWithSharedOptions(): void
+    {
+        $this->breadcrumbs
+            ->addMany([
+                ['title' => 'Home', 'url' => '/'],
+                ['title' => 'Products', 'url' => '/products'],
+                ['title' => 'Category'],
+            ], ['class' => 'breadcrumb-item']);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Home',
+                'url' => '/',
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+            [
+                'title' => 'Products',
+                'url' => '/products',
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+            [
+                'title' => 'Category',
+                'url' => null,
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test that individual crumb options override shared options in addMany()
+     */
+    public function testAddManyWithSharedOptionsAndOverride(): void
+    {
+        $this->breadcrumbs
+            ->addMany([
+                ['title' => 'Home', 'url' => '/', 'options' => ['class' => 'special']],
+                ['title' => 'Products', 'url' => '/products'],
+                ['title' => 'Category'],
+            ], ['class' => 'breadcrumb-item']);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Home',
+                'url' => '/',
+                'options' => ['class' => 'special'],
+            ],
+            [
+                'title' => 'Products',
+                'url' => '/products',
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+            [
+                'title' => 'Category',
+                'url' => null,
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test prepending multiple crumbs using prependMany()
+     */
+    public function testPrependMany(): void
+    {
+        $this->breadcrumbs
+            ->add('Home', '/', ['class' => 'first'])
+            ->prependMany([
+                ['title' => 'Some text', 'url' => ['controller' => 'Some', 'action' => 'text']],
+                ['title' => 'The root', 'url' => '/root', 'options' => ['data-name' => 'some-name']],
+            ]);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Some text',
+                'url' => [
+                    'controller' => 'Some',
+                    'action' => 'text',
+                ],
+                'options' => [],
+            ],
+            [
+                'title' => 'The root',
+                'url' => '/root',
+                'options' => ['data-name' => 'some-name'],
+            ],
+            [
+                'title' => 'Home',
+                'url' => '/',
+                'options' => [
+                    'class' => 'first',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test prepending multiple crumbs with shared options using prependMany()
+     */
+    public function testPrependManyWithSharedOptions(): void
+    {
+        $this->breadcrumbs
+            ->add('Current', '/current')
+            ->prependMany([
+                ['title' => 'Home', 'url' => '/'],
+                ['title' => 'Products', 'url' => '/products'],
+            ], ['class' => 'breadcrumb-item']);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Home',
+                'url' => '/',
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+            [
+                'title' => 'Products',
+                'url' => '/products',
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+            [
+                'title' => 'Current',
+                'url' => '/current',
+                'options' => [],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test that individual crumb options override shared options in prependMany()
+     */
+    public function testPrependManyWithSharedOptionsAndOverride(): void
+    {
+        $this->breadcrumbs
+            ->add('Current', '/current')
+            ->prependMany([
+                ['title' => 'Home', 'url' => '/', 'options' => ['class' => 'special']],
+                ['title' => 'Products', 'url' => '/products'],
+            ], ['class' => 'breadcrumb-item']);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Home',
+                'url' => '/',
+                'options' => ['class' => 'special'],
+            ],
+            [
+                'title' => 'Products',
+                'url' => '/products',
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+            [
+                'title' => 'Current',
+                'url' => '/current',
+                'options' => [],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
## Summary

Alternative approach to #19129 as suggested by @ADmad - adds dedicated `addMany()` and `prependMany()` methods instead of modifying the existing method signatures.

- Add `addMany(array $crumbs, array $options = [])` method for adding multiple breadcrumbs with optional shared options
- Add `prependMany(array $crumbs, array $options = [])` method for prepending multiple breadcrumbs with optional shared options  
- Deprecate passing arrays as the first argument to `add()` and `prepend()`
- Individual crumb options take precedence over shared options

### Example usage

```php
// Add multiple crumbs with shared options
$this->Breadcrumbs->addMany([
    ['title' => 'Home', 'url' => '/'],
    ['title' => 'Products', 'url' => '/products'],
    ['title' => 'Category'],
], ['class' => 'breadcrumb-item']);

// Individual options override shared options
$this->Breadcrumbs->addMany([
    ['title' => 'Home', 'url' => '/', 'options' => ['class' => 'special']], // uses 'special'
    ['title' => 'Products', 'url' => '/products'], // uses 'breadcrumb-item'
], ['class' => 'breadcrumb-item']);
```

Refs #19129