### PR TITLE
Fix infinite loop when extending Collection class

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -1018,7 +1018,18 @@ trait CollectionTrait
     public function unwrap(): Iterator
     {
         $iterator = $this;
-        while ($iterator::class === Collection::class) {
+        // Unwrap Collection class and simple user subclasses.
+        // Internal CakePHP iterators/result sets have their own unwrap() implementations.
+        // We unwrap if the class is Collection itself, or a non-Cake subclass,
+        // or an anonymous class extending Collection.
+        while (
+            $iterator instanceof Collection &&
+            (
+                $iterator::class === Collection::class ||
+                !str_starts_with($iterator::class, 'Cake\\') ||
+                str_contains($iterator::class, '@anonymous')
+            )
+        ) {
             $iterator = $iterator->getInnerIterator();
         }
 

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -2794,4 +2794,32 @@ class CollectionTest extends TestCase
         $collection->filter($callable)->filter($callable);
         $this->assertTrue(true);
     }
+
+    /**
+     * Tests that extending Collection does not cause infinite loops
+     * when iterating and calling methods like every() inside the loop.
+     *
+     * @see https://github.com/cakephp/cakephp/issues/17483
+     */
+    public function testExtendedCollectionNoInfiniteLoop(): void
+    {
+        $items = [
+            ['id' => 1, 'name' => 'foo'],
+            ['id' => 2, 'name' => 'bar'],
+            ['id' => 3, 'name' => 'baz'],
+        ];
+
+        $collection = new class ($items) extends Collection {
+        };
+
+        $count = 0;
+        foreach ($collection as $item) {
+            $count++;
+            // Calling every() inside foreach should not cause infinite loop
+            $result = $collection->every(fn($i) => isset($i['id']));
+            $this->assertTrue($result);
+        }
+
+        $this->assertSame(3, $count);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #17483

When a class extends `Collection` and iterates while calling methods like `every()` inside the loop, it caused an infinite loop. This happened because `unwrap()` only unwrapped exact `Collection` instances, not user subclasses.

### The Problem

```php
class MyCollection extends Collection {}

$collection = new MyCollection([...]);
foreach ($collection as $item) {
    // This caused infinite loop
    $collection->every(fn($i) => isset($i['id']));
}
```

The `unwrap()` method checked `$iterator::class === Collection::class`, which failed for subclasses, causing the iterator to not be properly unwrapped.

### The Fix

Modified `unwrap()` to also unwrap user subclasses of `Collection`, while preserving the behavior for internal CakePHP classes (like `ResultSet`, `FilterIterator`, etc.) which have their own iteration logic.

The unwrap condition now handles:
- `Collection::class` itself (as before)
- Non-Cake namespace subclasses (user code like `App\MyCollection`)
- Anonymous classes extending Collection (commonly used in tests)

```php
while (
    $iterator instanceof Collection &&
    (
        $iterator::class === Collection::class ||
        !str_starts_with($iterator::class, 'Cake\\') ||
        str_contains($iterator::class, '@anonymous')
    )
) {
    $iterator = $iterator->getInnerIterator();
}
```

### Note

This is a 5.next PR. For 6.x, we may want to consider making `Collection` final and providing proper extension points instead.