### PR TITLE
(4.x) Mark E_COMPILE_ERROR as fatal error in ExceptionTrap::handleShutdown

### DIFF
--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -281,6 +281,7 @@ class ExceptionTrap
             E_USER_ERROR,
             E_ERROR,
             E_PARSE,
+            E_COMPILE_ERROR,
         ];
         if (!in_array($error['type'], $fatals, true)) {
             return;

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -401,6 +401,20 @@ class ExceptionTrapTest extends TestCase
         $this->assertStringContainsString(__FILE__, $out);
     }
 
+    public function testHandleFatalErrorWhenCompileError()
+    {
+        $trap = new ExceptionTrap([
+            'exceptionRenderer' => TextExceptionRenderer::class,
+        ]);
+        ob_start();
+        $trap->handleFatalError(E_COMPILE_ERROR, 'Compile error', __FILE__, __LINE__);
+        $out = ob_get_clean();
+
+        $this->assertStringContainsString('500 : Fatal Error', $out);
+        $this->assertStringContainsString('Compile error', $out);
+        $this->assertStringContainsString(__FILE__, $out);
+    }
+
     /**
      * Test integration with HTML rendering for fatal errors
      *


### PR DESCRIPTION
`E_COMPILE_ERROR` is an unrecoverable error and thus fatal. The error should be handled as such.
