### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,9 @@ jobs:
         if ${{ matrix.php-version == '8.5' }}; then
           composer update --ignore-platform-req=php
         elif ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then
-          composer update --prefer-lowest --prefer-stable
+          composer update --prefer-lowest --prefer-stable --no-security-blocking
         else
-          composer update
+          composer update --no-security-blocking
         fi
 
     - name: Setup problem matchers for PHPUnit
@@ -259,7 +259,7 @@ jobs:
         key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}
 
     - name: Composer install
-      run: composer update
+      run: composer update --no-security-blocking
 
     - name: Install PHP tools with phive.
       run: phive install --trust-gpg-keys 'CF1A108D0E7AE720,51C67305FFC2E5C0,12CE0F1D262429A5'


### PR DESCRIPTION
[Composer 2.9+](https://blog.packagist.com/composer-2-9/) blocks packages which have security advisories attached to them.

This causes the 7.4 install to break:
```
    - Root composer.json requires laminas/laminas-diactoros ^2.2.2 -> satisfiable by laminas/laminas-diactoros[2.18.1, ..., 2.26.0].
    - laminas/laminas-diactoros[2.18.1, ..., 2.25.2] require php ~8.0.0 || ~8.1.0 || ~8.2.0 -> your php version (7.4.33) does not satisfy that requirement.
    - laminas/laminas-diactoros 2.26.0 requires php ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 -> your php version (7.4.33) does not satisfy that requirement.
```

Since laminas-diactoros had a [security issue](https://github.com/laminas/laminas-diactoros/security/advisories/GHSA-xv3h-4844-9h36) which is only fixed in newer versions, but all of those require at least 8.0+ as you can see above.

This option now tells composer to ignore that security advisory and install the older version which can still be installed.