### PR TITLE
Only strip script tags if they are at the start and end of the block

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -648,7 +648,7 @@ class HtmlHelper extends Helper
     public function scriptEnd(): ?string
     {
         $buffer = (string)ob_get_clean();
-        preg_match('/\s*<script>(.*?)<\/script>\s*/s', $buffer, $matches);
+        preg_match('/^\s*<script>(.*?)<\/script>\s*$/s', $buffer, $matches);
         if ($matches) {
             $buffer = $matches[1];
         }


### PR DESCRIPTION
Constrain the pattern used for simple script tag stripping to prevent leading/trailing text from being removed.

Follows https://github.com/cakephp/cakephp/pull/18878