### PR TITLE
Revert postgres column regex after removing unused parsing

### DIFF
--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -123,7 +123,7 @@ class PostgresSchemaDialect extends SchemaDialect
      */
     protected function _convertColumn(string $column): array
     {
-        preg_match('/([a-z\s]+)(?:\(([a-z0-9,]+)(?:,\s*([0-9]+))?\))?/i', $column, $matches);
+        preg_match('/([a-z\s]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
         if (!$matches) {
             throw new DatabaseException(sprintf('Unable to parse column type from `%s`', $column));
         }


### PR DESCRIPTION
refs https://github.com/cakephp/cakephp/pull/19113

After fixing postgresql tests to type strings actually returned by query, we can revert the regex to the simple form from before http://github.com/cakephp/cakephp/pull/17733.