### PR TITLE
Cleanup EnumType.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -73,18 +73,6 @@ parameters:
 			path: src/Database/Type/DateTimeType.php
 
 		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/Database/Type/EnumType.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between \*NEVER\* and '''' will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: src/Database/Type/EnumType.php
-
-		-
 			message: '#^Unsafe usage of new static\(\)\.$#'
 			identifier: new.static
 			count: 2

--- a/src/Database/Type/EnumType.php
+++ b/src/Database/Type/EnumType.php
@@ -87,7 +87,7 @@ class EnumType extends BaseType
      * @param mixed $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return string|int|null
-     * @throws \InvalidArgumentException When the given value is not a valid value for the associaed enum
+     * @throws \InvalidArgumentException When the given value is not a valid value for the associated enum
      */
     public function toDatabase(mixed $value, Driver $driver): string|int|null
     {

--- a/src/Database/Type/EnumType.php
+++ b/src/Database/Type/EnumType.php
@@ -25,6 +25,8 @@ use InvalidArgumentException;
 use PDO;
 use ReflectionEnum;
 use ReflectionException;
+use TypeError;
+use ValueError;
 
 /**
  * Enum type converter.
@@ -85,6 +87,7 @@ class EnumType extends BaseType
      * @param mixed $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
      * @return string|int|null
+     * @throws \InvalidArgumentException When the given value is not a valid value for the associaed enum
      */
     public function toDatabase(mixed $value, Driver $driver): string|int|null
     {
@@ -92,36 +95,36 @@ class EnumType extends BaseType
             return null;
         }
 
-        if ($value instanceof BackedEnum) {
-            if (!$value instanceof $this->enumClassName) {
+        if ($value instanceof $this->enumClassName) {
+            return $value->value;
+        }
+
+        if ($this->backingType === 'int' && is_string($value)) {
+            $intVal = filter_var($value, FILTER_VALIDATE_INT);
+            if ($intVal !== false) {
+                $value = $intVal;
+            }
+        }
+
+        try {
+            return $this->enumClassName::from($value)->value;
+        } catch (ValueError | TypeError $exception) {
+            if ($exception instanceof TypeError) {
                 throw new InvalidArgumentException(sprintf(
-                    'Given value type `%s` does not match associated `%s` backed enum in `%s`',
+                    'Given value `%s` of type `%s` does not match associated `%s` backed enum in `%s`',
+                    print_r($value, true),
                     get_debug_type($value),
                     $this->backingType,
                     $this->enumClassName,
                 ));
             }
 
-            return $value->value;
-        }
-
-        if (!is_string($value) && !is_int($value)) {
-            throw new InvalidArgumentException(sprintf(
-                'Cannot convert value `%s` of type `%s` to string or int',
-                print_r($value, true),
-                get_debug_type($value),
-            ));
-        }
-
-        if ($this->enumClassName::tryFrom($value) === null) {
             throw new InvalidArgumentException(sprintf(
                 '`%s` is not a valid value for `%s`',
                 $value,
                 $this->enumClassName,
             ));
         }
-
-        return $value;
     }
 
     /**
@@ -175,15 +178,6 @@ class EnumType extends BaseType
             return $value;
         }
 
-        if (!is_string($value) && !is_int($value)) {
-            throw new InvalidArgumentException(sprintf(
-                'Unable to marshal value `%s` of type `%s` to `%s`',
-                print_r($value, true),
-                get_debug_type($value),
-                $this->enumClassName,
-            ));
-        }
-
         if ($this->backingType === 'int') {
             if ($value === '') {
                 return null;
@@ -194,30 +188,11 @@ class EnumType extends BaseType
             }
         }
 
-        if (get_debug_type($value) !== $this->backingType) {
-            throw new InvalidArgumentException(sprintf(
-                'Given value type `%s` does not match associated `%s` backed enum in `%s`',
-                get_debug_type($value),
-                $this->backingType,
-                $this->enumClassName,
-            ));
+        try {
+            return $this->enumClassName::from($value);
+        } catch (ValueError | TypeError) {
+            return null;
         }
-
-        $enumInstance = $this->enumClassName::tryFrom($value);
-        if ($enumInstance === null) {
-            if ($value === '' && $this->backingType === 'string') {
-                return null;
-            }
-
-            throw new InvalidArgumentException(sprintf(
-                'Unable to marshal value `%s` of type `%s` to `%s`',
-                print_r($value, true),
-                get_debug_type($value),
-                $this->enumClassName,
-            ));
-        }
-
-        return $enumInstance;
     }
 
     /**


### PR DESCRIPTION
Trying to marshal an invalid value now results in null. This is inline with how other types classes handle invalid values.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
