### PR TITLE
Throw exception on short option collision

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -20,7 +20,6 @@ use Cake\Console\Exception\ConsoleException;
 use Cake\Console\Exception\MissingOptionException;
 use Cake\Utility\Inflector;
 use LogicException;
-use function Cake\Core\deprecationWarning;
 
 /**
  * Handles parsing the ARGV in the command line and provides support
@@ -411,7 +410,11 @@ class ConsoleOptionParser
         asort($this->_options);
         if ($option->short()) {
             if (isset($this->_shortOptions[$option->short()])) {
-                deprecationWarning('5.2.0', 'You cannot redefine short options. This will throw an error in 5.3.0+.');
+                throw new LogicException(sprintf(
+                    'Short option `%s` is already defined for option `%s`. You cannot redefine short options.',
+                    $option->short(),
+                    $this->_shortOptions[$option->short()],
+                ));
             }
 
             $this->_shortOptions[$option->short()] = $name;

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -217,7 +217,7 @@ class ConsoleOptionParserTest extends TestCase
     }
 
     /**
-     * test adding an option and using the short value for parsing throws deprecation if conflicting.
+     * test adding an option with a conflicting short value throws an exception.
      */
     public function testAddOptionShortConflict(): void
     {
@@ -226,11 +226,12 @@ class ConsoleOptionParserTest extends TestCase
             'short' => 't',
         ]);
 
-        $this->deprecated(function () use ($parser): void {
-            $parser->addOption('other', [
-                'short' => 't',
-            ]);
-        });
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Short option `t` is already defined for option `test`.');
+
+        $parser->addOption('other', [
+            'short' => 't',
+        ]);
     }
 
     /**


### PR DESCRIPTION
Converts the deprecation warning for short option redefinition (added in #18336) to a `LogicException`.

This is consistent with similar validation errors in `ConsoleOptionParser`, such as "A required argument cannot follow an optional one" which also throws a `LogicException`.

Resolves the 5.3+ upgrade path noted in #18336.