### PR TITLE
Fix flaky OpenSsl decryption test

### DIFF
--- a/tests/TestCase/Utility/Crypto/OpenSslTest.php
+++ b/tests/TestCase/Utility/Crypto/OpenSslTest.php
@@ -59,6 +59,9 @@ class OpenSslTest extends TestCase
         $result = $this->crypt->encrypt($txt, $key);
 
         $key = 'Not the same key.';
-        $this->assertNull($this->crypt->decrypt($result, $key), 'Modified key will fail.');
+        $decrypted = $this->crypt->decrypt($result, $key);
+        // With unauthenticated CBC mode, wrong key decryption may return null
+        // (padding failure) or garbage data (padding accidentally valid).
+        $this->assertNotSame($txt, $decrypted, 'Modified key should not decrypt to original text.');
     }
 }


### PR DESCRIPTION
With unauthenticated CBC mode, decryption with a wrong key may return `null` (padding validation fails) or garbage data (padding happens to be valid by chance). This is probabilistic behavior that can differ across PHP/OpenSSL versions.

Changed the assertion to verify that wrong-key decryption doesn't produce the original plaintext, which is the actual security property being tested.