### PR TITLE
add warning if a given view var gets overwritten when using an element

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -37,6 +37,7 @@ use InvalidArgumentException;
 use LogicException;
 use Throwable;
 use function Cake\Core\pluginSplit;
+use function Cake\Core\triggerWarning;
 
 /**
  * View, the V in the MVC triad. View interacts with Helpers and view variables passed
@@ -1697,6 +1698,14 @@ class View implements EventDispatcherInterface
 
         if ($options['callbacks']) {
             $this->dispatchEvent('View.beforeRender', [$file]);
+        }
+
+        $overlappingKeys = array_intersect(array_keys($this->viewVars), array_keys($data));
+        if ($overlappingKeys !== []) {
+            triggerWarning(
+                'The following keys in $data will overwrite existing view variables: ' .
+                implode(', ', $overlappingKeys),
+            );
         }
 
         $element = $this->_render($file, array_merge($this->viewVars, $data));

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -648,6 +648,18 @@ class ViewTest extends TestCase
     }
 
     /**
+     * Test that element triggers a warning when data would overwrite existing view variables.
+     */
+    public function testElementTriggersWarningWhenDataIsOverwritten(): void
+    {
+        $someViewVar = 'original value';
+        $this->View->set(compact('someViewVar'));
+        $this->expectWarningMessageMatches('/The following keys in \$data will overwrite existing view variables: someViewVar/', function (): void {
+            $this->View->element('test_element', ['someViewVar' => 'new value']);
+        });
+    }
+
+    /**
      * Test element method with a prefix
      */
     public function testPrefixElement(): void


### PR DESCRIPTION
while cleaning up my templates, I noticed I had a lot of element calls which looked like this:

```
<?= $this->element( 'Maintenances/table', [ 'maintenances' => $maintenances ] ) ?>
```

which of course doesn't need to happen, as the element shares the context of the current PHP template and therefore all variables. So this gets me the same result:

```
<?= $this->element( 'Maintenances/table' ) ?>
```

The quesiton is if there is a scenario, when this overwrite is actually wanted/needed or if this should never happen anyways.