### PR TITLE
6.x Re-add database type reflection tests.

### DIFF
--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -115,6 +115,262 @@ SQL;
     }
 
     /**
+     * Data provider for convert column testing
+     *
+     * @return array
+     */
+    public static function convertColumnProvider(): array
+    {
+        return [
+            [
+                'DATETIME',
+                ['type' => 'datetime', 'length' => null],
+            ],
+            [
+                'DATETIME(0)',
+                ['type' => 'datetime', 'length' => null],
+            ],
+            [
+                'DATETIME(6)',
+                ['type' => 'datetimefractional', 'length' => null, 'precision' => 6],
+            ],
+            [
+                'DATE',
+                ['type' => 'date', 'length' => null],
+            ],
+            [
+                'TIME',
+                ['type' => 'time', 'length' => null],
+            ],
+            [
+                'YEAR',
+                ['type' => 'year', 'length' => null],
+            ],
+            [
+                'TIMESTAMP',
+                ['type' => 'timestamp', 'length' => null],
+            ],
+            [
+                'TIMESTAMP(0)',
+                ['type' => 'timestamp', 'length' => null],
+            ],
+            [
+                'TIMESTAMP(6)',
+                ['type' => 'timestampfractional', 'length' => null, 'precision' => 6],
+            ],
+            [
+                'TINYINT(1)',
+                ['type' => 'boolean', 'length' => null],
+            ],
+            [
+                'TINYINT(1) UNSIGNED',
+                ['type' => 'tinyinteger', 'length' => null],
+            ],
+            [
+                'TINYINT(3)',
+                ['type' => 'tinyinteger', 'length' => null, 'unsigned' => false],
+            ],
+            [
+                'TINYINT(3) UNSIGNED',
+                ['type' => 'tinyinteger', 'length' => null, 'unsigned' => true],
+            ],
+            [
+                'SMALLINT(4)',
+                ['type' => 'smallinteger', 'length' => null, 'unsigned' => false],
+            ],
+            [
+                'SMALLINT(4) UNSIGNED',
+                ['type' => 'smallinteger', 'length' => null, 'unsigned' => true],
+            ],
+            [
+                'INTEGER(11)',
+                ['type' => 'integer', 'length' => null, 'unsigned' => false],
+            ],
+            [
+                'MEDIUMINT(11)',
+                ['type' => 'integer', 'length' => null, 'unsigned' => false],
+            ],
+            [
+                'INTEGER(11) UNSIGNED',
+                ['type' => 'integer', 'length' => null, 'unsigned' => true],
+            ],
+            [
+                'BIGINT',
+                ['type' => 'biginteger', 'length' => null, 'unsigned' => false],
+            ],
+            [
+                'BIGINT UNSIGNED',
+                ['type' => 'biginteger', 'length' => null, 'unsigned' => true],
+            ],
+            [
+                'VARCHAR(255)',
+                ['type' => 'string', 'length' => 255, 'collate' => 'utf8_general_ci'],
+            ],
+            [
+                'CHAR(25)',
+                ['type' => 'char', 'length' => 25],
+            ],
+            [
+                'CHAR(36)',
+                ['type' => 'uuid', 'length' => null],
+            ],
+            // This fails locally with mysql 8.0, so it might be mariadb dependent.
+            [
+                'UUID',
+                ['type' => 'nativeuuid', 'length' => null],
+            ],
+            [
+                'BINARY(16)',
+                ['type' => 'binaryuuid', 'length' => null],
+            ],
+            [
+                'BINARY(1)',
+                ['type' => 'binary', 'length' => 1],
+            ],
+            [
+                'TEXT',
+                ['type' => 'text', 'length' => null, 'collate' => 'utf8_general_ci'],
+            ],
+            [
+                'TINYTEXT',
+                ['type' => 'text', 'length' => TableSchema::LENGTH_TINY, 'collate' => 'utf8_general_ci'],
+            ],
+            [
+                'MEDIUMTEXT',
+                ['type' => 'text', 'length' => TableSchema::LENGTH_MEDIUM, 'collate' => 'utf8_general_ci'],
+            ],
+            [
+                'LONGTEXT',
+                ['type' => 'text', 'length' => TableSchema::LENGTH_LONG, 'collate' => 'utf8_general_ci'],
+            ],
+            [
+                'TINYBLOB',
+                ['type' => 'binary', 'length' => TableSchema::LENGTH_TINY],
+            ],
+            [
+                'BLOB',
+                ['type' => 'binary', 'length' => null],
+            ],
+            [
+                'MEDIUMBLOB',
+                ['type' => 'binary', 'length' => TableSchema::LENGTH_MEDIUM],
+            ],
+            [
+                'LONGBLOB',
+                ['type' => 'binary', 'length' => TableSchema::LENGTH_LONG],
+            ],
+            [
+                'FLOAT',
+                ['type' => 'float', 'length' => null, 'precision' => null, 'unsigned' => false],
+            ],
+            [
+                'FLOAT(24)',
+                ['type' => 'float', 'unsigned' => false],
+            ],
+            [
+                'DOUBLE',
+                ['type' => 'float', 'length' => null, 'precision' => null, 'unsigned' => false],
+            ],
+            [
+                'DOUBLE UNSIGNED',
+                ['type' => 'float', 'length' => null, 'precision' => null, 'unsigned' => true],
+            ],
+            [
+                'DECIMAL(11,2) UNSIGNED',
+                ['type' => 'decimal', 'length' => 11, 'precision' => 2, 'unsigned' => true],
+            ],
+            [
+                'DECIMAL(11,2)',
+                ['type' => 'decimal', 'length' => 11, 'precision' => 2, 'unsigned' => false],
+            ],
+            [
+                'DECIMAL(5,2)',
+                ['type' => 'decimal', 'length' => 5, 'precision' => 2, 'unsigned' => false],
+            ],
+            [
+                'FLOAT(11,2)',
+                ['type' => 'float', 'length' => 11, 'precision' => 2, 'unsigned' => false],
+            ],
+            [
+                'FLOAT(11,2) UNSIGNED',
+                ['type' => 'float', 'length' => 11, 'precision' => 2, 'unsigned' => true],
+            ],
+            [
+                'DOUBLE(10,4)',
+                ['type' => 'float', 'length' => 10, 'precision' => 4, 'unsigned' => false],
+            ],
+            [
+                'DOUBLE(10,4) UNSIGNED',
+                ['type' => 'float', 'length' => 10, 'precision' => 4, 'unsigned' => true],
+            ],
+            [
+                'JSON',
+                ['type' => 'json', 'length' => null],
+            ],
+            [
+                'GEOMETRY',
+                ['type' => 'geometry', 'length' => null],
+            ],
+            [
+                'POINT',
+                ['type' => 'point', 'length' => null],
+            ],
+            [
+                'LINESTRING',
+                ['type' => 'linestring', 'length' => null],
+            ],
+            [
+                'POLYGON',
+                ['type' => 'polygon', 'length' => null],
+            ],
+        ];
+    }
+
+    /**
+     * Test parsing MySQL column types from field description.
+     */
+    #[DataProvider('convertColumnProvider')]
+    public function testConvertColumn(string $type, array $expected): void
+    {
+        $this->_needsConnection();
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $sql = <<<SQL
+CREATE TABLE convert_columns (
+    reflection $type
+);
+SQL;
+        $connection->execute($sql);
+
+        $driver = $connection->getDriver();
+        $dialect = $driver->schemaDialect();
+        $table = $dialect->describe('convert_columns');
+        $connection->execute('DROP TABLE convert_columns');
+
+        $data = $table->column('reflection')->toArray();
+
+        // Collations are a mess in MySQL
+        if (isset($expected['collate'])) {
+            if ($driver->isMariaDb()) {
+                $expected['config']['collate'] = 'utf8mb4_bin';
+            }
+            // MariaDB 10.5+ and MySQL 8.0.30+ use utf8mb3 alias instead of utf8
+            if (
+                ($driver->isMariaDb() && version_compare($driver->version(), '10.5.0', '>=')) ||
+                (!$driver->isMariaDb() && version_compare($driver->version(), '8.0.30', '>='))
+            ) {
+                $expected['collate'] = 'utf8mb3_general_ci';
+            }
+        }
+
+        $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys(
+            $expected,
+            $data,
+            array_keys($expected),
+        );
+    }
+
+    /**
      * Integration test for SchemaCollection & MysqlSchemaDialect.
      */
     public function testListTables(): void

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -337,7 +337,7 @@ SQL;
         $connection = ConnectionManager::get('test');
         $sql = <<<SQL
 CREATE TABLE convert_columns (
-    reflection $type
+    reflection {$type}
 );
 SQL;
         $connection->execute($sql);

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -164,7 +164,7 @@ SQL;
             ],
             [
                 'TINYINT(1) UNSIGNED',
-                ['type' => 'tinyinteger', 'length' => null],
+                ['type' => 'boolean', 'length' => null],
             ],
             [
                 'TINYINT(3)',
@@ -351,16 +351,14 @@ SQL;
 
         // Collations are a mess in MySQL
         if (isset($expected['collate'])) {
-            if ($driver->isMariaDb()) {
-                $expected['config']['collate'] = 'utf8mb4_bin';
-            }
-            // MariaDB 10.5+ and MySQL 8.0.30+ use utf8mb3 alias instead of utf8
-            if (
-                ($driver->isMariaDb() && version_compare($driver->version(), '10.5.0', '>=')) ||
-                (!$driver->isMariaDb() && version_compare($driver->version(), '8.0.30', '>='))
-            ) {
-                $expected['collate'] = 'utf8mb3_general_ci';
-            }
+            $db = $driver->config()['database'];
+            $result = $connection->execute(
+                'SELECT default_collation_name FROM information_schema.schemata WHERE schema_name = ?',
+                [$db],
+            );
+            $row = $result->fetch('assoc');
+            $result->closeCursor();
+            $expected['collate'] = $row['DEFAULT_COLLATION_NAME'];
         }
 
         $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys(

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -163,10 +163,6 @@ SQL;
                 ['type' => 'boolean', 'length' => null],
             ],
             [
-                'TINYINT(1) UNSIGNED',
-                ['type' => 'boolean', 'length' => null],
-            ],
-            [
                 'TINYINT(3)',
                 ['type' => 'tinyinteger', 'length' => null, 'unsigned' => false],
             ],
@@ -213,11 +209,6 @@ SQL;
             [
                 'CHAR(36)',
                 ['type' => 'uuid', 'length' => null],
-            ],
-            // This fails locally with mysql 8.0, so it might be mariadb dependent.
-            [
-                'UUID',
-                ['type' => 'nativeuuid', 'length' => null],
             ],
             [
                 'BINARY(16)',
@@ -356,9 +347,9 @@ SQL;
                 'SELECT default_collation_name FROM information_schema.schemata WHERE schema_name = ?',
                 [$db],
             );
-            $row = $result->fetch('assoc');
+            $row = $result->fetch();
             $result->closeCursor();
-            $expected['collate'] = $row['DEFAULT_COLLATION_NAME'];
+            $expected['collate'] = $row[0];
         }
 
         $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys(
@@ -366,6 +357,34 @@ SQL;
             $data,
             array_keys($expected),
         );
+    }
+
+    /**
+     * Test parsing UUID types in mariadb
+     */
+    public function testConvertColumnUuid(): void
+    {
+        $this->_needsConnection();
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $driver = $connection->getDriver();
+
+        $isMaria = $driver->isMariaDb();
+        $this->skipIf(!$isMaria, 'This test requires mariadb');
+
+        $sql = <<<SQL
+CREATE TABLE convert_columns (
+    reflection UUID
+);
+SQL;
+        $connection->execute($sql);
+
+        $dialect = $driver->schemaDialect();
+        $table = $dialect->describe('convert_columns');
+        $connection->execute('DROP TABLE convert_columns');
+
+        $column = $table->column('reflection');
+        $this->assertEquals('nativeuuid', $column->getType());
     }
 
     /**

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -295,10 +295,6 @@ SQL;
                 ['type' => 'float', 'length' => 10, 'precision' => 4, 'unsigned' => true],
             ],
             [
-                'JSON',
-                ['type' => 'json', 'length' => null],
-            ],
-            [
                 'GEOMETRY',
                 ['type' => 'geometry', 'length' => null],
             ],
@@ -357,6 +353,35 @@ SQL;
             $data,
             array_keys($expected),
         );
+    }
+
+    /**
+     * Test parsing JSON types in mysql
+     */
+    public function testConvertColumnJson(): void
+    {
+        $this->_needsConnection();
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $driver = $connection->getDriver();
+
+        $isMaria = $driver->isMariaDb();
+        $this->skipIf($isMaria, 'This test requires mysql');
+
+        $sql = <<<SQL
+CREATE TABLE convert_columns (
+    reflection JSON
+);
+SQL;
+        $connection->execute($sql);
+
+        $dialect = $driver->schemaDialect();
+        $table = $dialect->describe('convert_columns');
+        $connection->execute('DROP TABLE convert_columns');
+
+        $column = $table->column('reflection');
+        $this->assertEquals('json', $column->getType());
+        $this->assertNull($column->getLength());
     }
 
     /**

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -135,6 +135,202 @@ SQL;
     }
 
     /**
+     * Data provider for convert column testing
+     *
+     * @return array
+     */
+    public static function convertColumnProvider(): array
+    {
+        return [
+            // Timestamp
+            [
+                'TIMESTAMP(6)',
+                ['type' => 'timestampfractional', 'length' => null, 'precision' => 6],
+            ],
+            [
+                'TIMESTAMP(0)',
+                ['type' => 'timestamp', 'length' => null, 'precision' => 0],
+            ],
+            [
+                'TIMESTAMP(6) WITHOUT TIME ZONE',
+                ['type' => 'timestampfractional', 'length' => null, 'precision' => 6],
+            ],
+            [
+                'TIMESTAMP(6) WITH TIME ZONE',
+                ['type' => 'timestamptimezone', 'length' => null, 'precision' => 6],
+            ],
+            [
+                'TIMESTAMPTZ(6)',
+                ['type' => 'timestamptimezone', 'length' => null, 'precision' => 6],
+            ],
+            // Date & time
+            [
+                'DATE',
+                ['type' => 'date', 'length' => null],
+            ],
+            [
+                'TIME',
+                ['type' => 'time', 'length' => null],
+            ],
+            [
+                'TIME WITHOUT TIME ZONE',
+                ['type' => 'time', 'length' => null],
+            ],
+            [
+                'INTERVAL',
+                ['type' => 'interval', 'length' => null],
+            ],
+            // Integer
+            [
+                'SMALLINT',
+                ['type' => 'smallinteger', 'length' => 5],
+            ],
+            [
+                'INTEGER',
+                ['type' => 'integer', 'length' => 10],
+            ],
+            [
+                'SERIAL',
+                ['type' => 'integer', 'length' => 10],
+            ],
+            [
+                'BIGINT',
+                ['type' => 'biginteger', 'length' => 20],
+            ],
+            [
+                'BIGSERIAL',
+                ['type' => 'biginteger', 'length' => 20],
+            ],
+            // Decimal
+            [
+                'NUMERIC',
+                ['type' => 'decimal', 'length' => null, 'precision' => null],
+            ],
+            [
+                'NUMERIC DEFAULT NULL::numeric',
+                ['type' => 'decimal', 'length' => null, 'precision' => null, 'default' => null],
+            ],
+            [
+                'DECIMAL(10,2)',
+                ['type' => 'decimal', 'length' => 10, 'precision' => 2],
+            ],
+            // String
+            [
+                'VARCHAR',
+                ['type' => 'string', 'length' => null],
+            ],
+            [
+                'VARCHAR(10)',
+                ['type' => 'string', 'length' => 10],
+            ],
+            [
+                'CHARACTER VARYING',
+                ['type' => 'string', 'length' => null],
+            ],
+            [
+                'CHARACTER VARYING(10)',
+                ['type' => 'string', 'length' => 10],
+            ],
+            [
+                'CHARACTER VARYING(255) DEFAULT NULL::character varying',
+                ['type' => 'string', 'length' => 255, 'default' => null],
+            ],
+            [
+                'CHAR(10)',
+                ['type' => 'string', 'length' => 10],
+            ],
+            [
+                'CHAR(36)',
+                ['type' => 'string', 'length' => 36],
+            ],
+            [
+                'CHARACTER(10)',
+                ['type' => 'string', 'length' => 10],
+            ],
+            [
+                'MONEY',
+                ['type' => 'string', 'length' => null],
+            ],
+            // UUID
+            [
+                'UUID',
+                ['type' => 'uuid', 'length' => null],
+            ],
+            // Text
+            [
+                'TEXT',
+                ['type' => 'text', 'length' => null],
+            ],
+            // Blob
+            [
+                'BYTEA',
+                ['type' => 'binary', 'length' => null],
+            ],
+            // Float
+            [
+                'REAL',
+                ['type' => 'float', 'length' => null],
+            ],
+            [
+                'DOUBLE PRECISION',
+                ['type' => 'float', 'length' => null],
+            ],
+            // JSON
+            [
+                'JSON',
+                ['type' => 'json', 'length' => null],
+            ],
+            [
+                'JSONB',
+                ['type' => 'json', 'length' => null],
+            ],
+            // Geospatial - see testDescribeTableGeospatialTypes
+            // network addresses
+            [
+                'CIDR',
+                ['type' => 'cidr', 'length' => null],
+            ],
+            [
+                'inet',
+                ['type' => 'inet', 'length' => null],
+            ],
+            [
+                'macaddr',
+                ['type' => 'macaddr', 'length' => null],
+            ],
+        ];
+    }
+
+    /**
+     * Test parsing Postgres column types from field description.
+     */
+    #[DataProvider('convertColumnProvider')]
+    public function testConvertColumn(string $field, array $expected): void
+    {
+        $this->_needsConnection();
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $sql = <<<SQL
+CREATE TABLE convert_columns (
+    reflection $field
+);
+SQL;
+        $connection->execute($sql);
+
+        $driver = $connection->getDriver();
+        $dialect = $driver->schemaDialect();
+        $table = $dialect->describe('convert_columns');
+        $connection->execute('DROP TABLE convert_columns');
+
+        $data = $table->column('reflection')->toArray();
+        $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys(
+            $expected,
+            $data,
+            array_keys($expected),
+        );
+    }
+
+    /**
      * Test listing tables with Postgres
      */
     public function testListTables(): void

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -312,7 +312,7 @@ SQL;
         $connection = ConnectionManager::get('test');
         $sql = <<<SQL
 CREATE TABLE convert_columns (
-    reflection $field
+    reflection {$field}
 );
 SQL;
         $connection->execute($sql);

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -181,6 +181,170 @@ SQL;
     }
 
     /**
+     * Data provider for convert column testing
+     *
+     * @return array
+     */
+    public static function convertColumnProvider(): array
+    {
+        return [
+            [
+                'DATETIME',
+                ['type' => 'datetime', 'length' => null],
+            ],
+            [
+                'DATE',
+                ['type' => 'date', 'length' => null],
+            ],
+            [
+                'TIME',
+                ['type' => 'time', 'length' => null],
+            ],
+            [
+                'BOOLEAN DEFAULT 0',
+                ['type' => 'boolean', 'length' => null, 'default' => 0],
+            ],
+            [
+                'BIGINT',
+                ['type' => 'biginteger', 'length' => null, 'unsigned' => false],
+            ],
+            [
+                'UNSIGNED BIGINT',
+                ['type' => 'biginteger', 'length' => null, 'unsigned' => true],
+            ],
+            [
+                'VARCHAR(255)',
+                ['type' => 'string', 'length' => 255],
+            ],
+            [
+                'CHAR(25)',
+                ['type' => 'char', 'length' => 25],
+            ],
+            [
+                'CHAR(36)',
+                ['type' => 'uuid', 'length' => null],
+            ],
+            [
+                'BINARY(16)',
+                ['type' => 'binaryuuid', 'length' => null],
+            ],
+            [
+                'BINARY(1)',
+                ['type' => 'binary', 'length' => 1],
+            ],
+            [
+                'BLOB',
+                ['type' => 'binary', 'length' => null],
+            ],
+            [
+                'INTEGER(11)',
+                ['type' => 'integer', 'length' => 11, 'unsigned' => false],
+            ],
+            [
+                'UNSIGNED INTEGER(11)',
+                ['type' => 'integer', 'length' => 11, 'unsigned' => true],
+            ],
+            [
+                'TINYINT(3)',
+                ['type' => 'tinyinteger', 'length' => 3, 'unsigned' => false],
+            ],
+            [
+                'UNSIGNED TINYINT(3)',
+                ['type' => 'tinyinteger', 'length' => 3, 'unsigned' => true],
+            ],
+            [
+                'SMALLINT(5)',
+                ['type' => 'smallinteger', 'length' => 5, 'unsigned' => false],
+            ],
+            [
+                'UNSIGNED SMALLINT(5)',
+                ['type' => 'smallinteger', 'length' => 5, 'unsigned' => true],
+            ],
+            [
+                'MEDIUMINT(10)',
+                ['type' => 'integer', 'length' => 10, 'unsigned' => false],
+            ],
+            [
+                'FLOAT',
+                ['type' => 'float', 'length' => null, 'precision' => null, 'unsigned' => false],
+            ],
+            [
+                'DOUBLE',
+                ['type' => 'float', 'length' => null, 'precision' => null, 'unsigned' => false],
+            ],
+            [
+                'UNSIGNED DOUBLE',
+                ['type' => 'float', 'length' => null, 'precision' => null, 'unsigned' => true],
+            ],
+            [
+                'REAL',
+                ['type' => 'float', 'length' => null, 'precision' => null, 'unsigned' => false],
+            ],
+            [
+                'DECIMAL(11,2)',
+                ['type' => 'decimal', 'length' => 11, 'precision' => 2, 'unsigned' => false],
+            ],
+            [
+                'UNSIGNED DECIMAL(11,2)',
+                ['type' => 'decimal', 'length' => 11, 'precision' => 2, 'unsigned' => true],
+            ],
+            [
+                'UUID_TEXT',
+                ['type' => 'uuid', 'length' => null],
+            ],
+            [
+                'UUID_BLOB',
+                ['type' => 'binaryuuid', 'length' => null],
+            ],
+            [
+                'GEOMETRY_TEXT',
+                ['type' => 'geometry', 'length' => null],
+            ],
+            [
+                'POINT_TEXT',
+                ['type' => 'point', 'length' => null],
+            ],
+            [
+                'LINESTRING_TEXT',
+                ['type' => 'linestring', 'length' => null],
+            ],
+            [
+                'POLYGON_TEXT',
+                ['type' => 'polygon', 'length' => null],
+            ],
+        ];
+    }
+
+    /**
+     * Test parsing SQLite column types from field description.
+     */
+    #[DataProvider('convertColumnProvider')]
+    public function testConvertColumn(string $type, array $expected): void
+    {
+        $this->_needsConnection();
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $sql = <<<SQL
+CREATE TABLE convert_columns (
+    reflection $type
+);
+SQL;
+        $connection->execute($sql);
+
+        $driver = $connection->getDriver();
+        $dialect = $driver->schemaDialect();
+        $table = $dialect->describe('convert_columns');
+        $connection->execute('DROP TABLE convert_columns');
+
+        $data = $table->column('reflection')->toArray();
+        $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys(
+            $expected,
+            $data,
+            array_keys($expected),
+        );
+    }
+
+    /**
      * Test SchemaCollection listing tables with Sqlite
      */
     public function testListTables(): void

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -326,7 +326,7 @@ SQL;
         $connection = ConnectionManager::get('test');
         $sql = <<<SQL
 CREATE TABLE convert_columns (
-    reflection $type
+    reflection {$type}
 );
 SQL;
         $connection->execute($sql);

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -256,9 +256,7 @@ SQL;
         );
     }
 
-
-
-    /**
+/**
      * Test listing tables with Sqlserver
      */
     public function testListTables(): void

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -108,6 +108,157 @@ SQL;
     }
 
     /**
+     * Data provider for convert column testing
+     *
+     * @return array
+     */
+    public static function convertColumnProvider(): array
+    {
+        return [
+            [
+                'DATETIME',
+                ['type' => 'datetime', 'length' => null],
+            ],
+            [
+                'DATETIME2',
+                ['type' => 'datetimefractional', 'length' => null, 'precision' => 7],
+            ],
+            [
+                'DATETIME2(0)',
+                ['type' => 'datetime', 'length' => null, 'precision' => 0],
+            ],
+            [
+                'DATE',
+                ['type' => 'date', 'length' => null],
+            ],
+            [
+                'TIME',
+                ['type' => 'time', 'length' => null],
+            ],
+            [
+                'TINYINT',
+                ['type' => 'tinyinteger', 'length' => 3],
+            ],
+            [
+                'SMALLINT',
+                ['type' => 'smallinteger', 'length' => 5],
+            ],
+            [
+                'INTEGER',
+                ['type' => 'integer', 'length' => 10],
+            ],
+            [
+                'BIGINT',
+                ['type' => 'biginteger', 'length' => 19],
+            ],
+            [
+                'NUMERIC',
+                ['type' => 'decimal', 'length' => 18],
+            ],
+            [
+                'DECIMAL(11,3)',
+                ['type' => 'decimal', 'length' => 11, 'precision' => 3],
+            ],
+            [
+                'MONEY',
+                ['type' => 'decimal', 'length' => 19, 'precision' => 4],
+            ],
+            [
+                'VARCHAR(255)',
+                ['type' => 'string', 'length' => 255, 'collate' => 'SQL_Latin1_General_CP1_CI_AS'],
+            ],
+            [
+                'VARCHAR(10)',
+                ['type' => 'string', 'length' => 10, 'collate' => 'SQL_Latin1_General_CP1_CI_AS'],
+            ],
+            [
+                'NVARCHAR(25)',
+                ['type' => 'string', 'length' => 25, 'collate' => 'SQL_Latin1_General_CP1_CI_AS'],
+            ],
+            [
+                'VARCHAR(MAX)',
+                ['type' => 'text', 'length' => null, 'collate' => 'SQL_Latin1_General_CP1_CI_AS'],
+            ],
+            [
+                'CHAR(10)',
+                ['type' => 'char', 'length' => 10, 'collate' => 'SQL_Latin1_General_CP1_CI_AS'],
+            ],
+            [
+                'NCHAR(5)',
+                ['type' => 'char', 'length' => 5, 'collate' => 'SQL_Latin1_General_CP1_CI_AS'],
+            ],
+            [
+                'UNIQUEIDENTIFIER',
+                ['type' => 'uuid'],
+            ],
+            [
+                'TEXT',
+                ['type' => 'text', 'length' => null, 'collate' => 'SQL_Latin1_General_CP1_CI_AS'],
+            ],
+            [
+                'REAL',
+                ['type' => 'float', 'length' => null],
+            ],
+            [
+                'IMAGE',
+                ['type' => 'binary', 'length' => 16],
+            ],
+            [
+                'BINARY(20)',
+                ['type' => 'binary', 'length' => 20],
+            ],
+            [
+                'VARBINARY(30)',
+                ['type' => 'binary', 'length' => 30],
+            ],
+            [
+                'VARBINARY(MAX)',
+                ['type' => 'binary', 'length' => TableSchema::LENGTH_LONG],
+            ],
+            // Geospatial types
+            [
+                'GEOMETRY',
+                ['type' => 'geometry', 'null' => true],
+            ],
+            [
+                'GEOGRAPHY',
+                ['type' => 'point', 'null' => true],
+            ],
+        ];
+    }
+
+    /**
+     * Test parsing sqlserver column types from field description.
+     */
+    #[DataProvider('convertColumnProvider')]
+    public function testConvertColumn(string $type, array $expected): void
+    {
+        $this->_needsConnection();
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('test');
+        $sql = <<<SQL
+CREATE TABLE convert_columns (
+    reflection {$type}
+);
+SQL;
+        $connection->execute($sql);
+
+        $driver = $connection->getDriver();
+        $dialect = $driver->schemaDialect();
+        $table = $dialect->describe('convert_columns');
+        $connection->execute('DROP TABLE convert_columns');
+
+        $data = $table->column('reflection')->toArray();
+        $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys(
+            $expected,
+            $data,
+            array_keys($expected),
+        );
+    }
+
+
+
+    /**
      * Test listing tables with Sqlserver
      */
     public function testListTables(): void

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -256,7 +256,7 @@ SQL;
         );
     }
 
-/**
+    /**
      * Test listing tables with Sqlserver
      */
     public function testListTables(): void


### PR DESCRIPTION
Re-add tests for column type reflection for sqlite, postgres, and mysql. I'll do sqlserver separately as my local environment is broken right now.

Refs #19161