### PR TITLE
5.next: add flag to enable ErrorController for MissingRouteException

### DIFF
--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -16,12 +16,14 @@ declare(strict_types=1);
  */
 namespace Cake\Routing\Middleware;
 
+use Cake\Core\Configure;
 use Cake\Core\ContainerApplicationInterface;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Http\Exception\RedirectException;
 use Cake\Http\MiddlewareQueue;
 use Cake\Http\Runner;
 use Cake\Http\ServerRequest;
+use Cake\Routing\Exception\MissingRouteException;
 use Cake\Routing\Router;
 use Cake\Routing\RoutingApplicationInterface;
 use Laminas\Diactoros\Response\RedirectResponse;
@@ -112,6 +114,19 @@ class RoutingMiddleware implements MiddlewareInterface
                 $e->getCode(),
                 $e->getHeaders(),
             );
+        } catch (MissingRouteException $e) {
+            if (Configure::read('debug', false) || !Configure::read('Error.enableErrorControllerFor404')) {
+                throw $e;
+            }
+            $request = $request->withAttribute('exception', $e);
+            $params = [
+                'controller' => 'Error',
+                'action' => 'missingRoute',
+            ];
+            $request = $request->withAttribute('params', $params);
+            Router::setRequest($request);
+
+            return $handler->handle($request);
         }
         $matching = Router::getRouteCollection()->getMiddleware($middleware);
         if (!$matching) {

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -248,6 +248,37 @@ class RoutingMiddlewareTest extends TestCase
     }
 
     /**
+     * Test missing routes being passed to error controller.
+     */
+    public function testMissingRoutePassedDownToErrorController(): void
+    {
+        Configure::write('debug', false);
+        Configure::write('Error.enableErrorControllerFor404', true);
+        $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/missing']);
+        $handler = new TestRequestHandler(function ($req) {
+            $this->assertEquals('Error', $req->getAttribute('params')['controller']);
+            $this->assertEquals('missingRoute', $req->getAttribute('params')['action']);
+            $this->assertInstanceOf(MissingRouteException::class, $req->getAttribute('exception'));
+
+            return new Response();
+        });
+        $middleware = new RoutingMiddleware($this->app());
+        $middleware->process($request, $handler);
+    }
+
+    /**
+     * Test missing routes not being caught in debug mode.
+     */
+    public function testMissingRouteNotCaughtInDebugMode(): void
+    {
+        $this->expectException(MissingRouteException::class);
+        Configure::write('debug', true);
+        $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/missing']);
+        $middleware = new RoutingMiddleware($this->app());
+        $middleware->process($request, new TestRequestHandler());
+    }
+
+    /**
      * Test route with _method being parsed correctly.
      */
     public function testFakedRequestMethodParsed(): void


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/issues/19165

This doesn't need to go into 5.3 as I'd say its fine if it goes into 5.4 with maybe some other exceptions which follow the same logic here.

---

Currently there is 1 separate flag for this 404 specific logic but this can be unified later with maybe some other exceptions manually being caught and passed down to the respective ErrorController method.

With this setup these exceptions are "properly" passed down to the ErrorController and therefore the user has much more control on how they want to render these kind of exceptions.

When debug mode is enabled the exception is re-thrown as normal to use the proper debug template.