### PR TITLE
Add createIterator()/createRecursiveIterator() method to Filesystem utility

### DIFF
--- a/src/Utility/Filesystem.php
+++ b/src/Utility/Filesystem.php
@@ -125,7 +125,7 @@ class Filesystem
         string $path,
         ?int $flags = null,
         int $mode = RecursiveIteratorIterator::CHILD_FIRST,
-        bool $skipHiddenDirs = true,
+        bool $skipHiddenDirs = false,
         ?Closure $customFilter = null,
     ): RecursiveIteratorIterator {
         $flags ??= FilesystemIterator::KEY_AS_PATHNAME

--- a/src/Utility/Filesystem.php
+++ b/src/Utility/Filesystem.php
@@ -55,16 +55,56 @@ class Filesystem
      */
     public function find(string $path, Closure|string|null $filter = null, ?int $flags = null): Iterator
     {
+        return $this->createIterator($path, $flags, $filter);
+    }
+
+    /**
+     * Create a non-recursive directory iterator with optional filtering.
+     *
+     * This is a building block method for creating custom non-recursive file iteration.
+     * Consumers can wrap the returned iterator with additional filters or process it directly.
+     *
+     * Example:
+     * ```php
+     * $filesystem = new Filesystem();
+     * $iterator = $filesystem->createIterator(
+     *     '/path/to/dir',
+     *     customFilter: fn($file) => $file->getExtension() === 'php'
+     * );
+     *
+     * foreach ($iterator as $file) {
+     *     echo $file->getPathname() . PHP_EOL;
+     * }
+     * ```
+     *
+     * @param string $path Directory path.
+     * @param int|null $flags Flags for FilesystemIterator::__construct();
+     * @param \Closure|string|null $customFilter Optional filter. If string will be used as regex for
+     *   filtering using `RegexIterator`, if callable will be as callback for `CallbackFilterIterator`.
+     *   Receives SplFileInfo, returns bool.
+     * @return \Iterator
+     */
+    public function createIterator(
+        string $path,
+        ?int $flags = null,
+        Closure|string|null $customFilter = null,
+    ): Iterator {
         $flags ??= FilesystemIterator::KEY_AS_PATHNAME
             | FilesystemIterator::CURRENT_AS_FILEINFO
             | FilesystemIterator::SKIP_DOTS;
+
         $directory = new FilesystemIterator($path, $flags);
 
-        if ($filter === null) {
+        // Apply filter if provided
+        if ($customFilter === null) {
             return $directory;
         }
 
-        return $this->filterIterator($directory, $filter);
+        if (is_string($customFilter)) {
+            return new RegexIterator($directory, $customFilter);
+        }
+
+        return new CallbackFilterIterator($directory, $customFilter);
     }
 
     /**
@@ -79,18 +119,13 @@ class Filesystem
      */
     public function findRecursive(string $path, Closure|string|null $filter = null, ?int $flags = null): Iterator
     {
-        $iterator = $this->createRecursiveIterator(
+        return $this->createRecursiveIterator(
             $path,
             $flags,
             RecursiveIteratorIterator::CHILD_FIRST,
             includeHiddenDirs: false,
+            customFilter: $filter,
         );
-
-        if ($filter === null) {
-            return $iterator;
-        }
-
-        return $this->filterIterator($iterator, $filter);
     }
 
     /**
@@ -117,34 +152,40 @@ class Filesystem
      * @param int|null $flags Flags for FilesystemIterator::__construct();
      * @param int<0, 2> $mode RecursiveIteratorIterator mode (LEAVES_ONLY, SELF_FIRST, CHILD_FIRST).
      * @param bool $includeHiddenDirs Whether to include hidden directories (default: false).
-     * @param \Closure|null $customFilter Optional custom filter callback for RecursiveCallbackFilterIterator.
-     *   Receives SplFileInfo, returns bool. Combined with hidden directory filtering if enabled.
-     * @return \RecursiveIteratorIterator
+     * @param \Closure|string|null $customFilter Optional filter. If string will be used as regex for
+     *   filtering using `RegexIterator` (applied after iteration), if callable will be used with
+     *   `RecursiveCallbackFilterIterator` (applied during iteration). Combined with hidden directory
+     *   filtering if enabled.
+     * @return \RecursiveIteratorIterator|\Iterator
      */
     public function createRecursiveIterator(
         string $path,
         ?int $flags = null,
         int $mode = RecursiveIteratorIterator::CHILD_FIRST,
         bool $includeHiddenDirs = false,
-        ?Closure $customFilter = null,
-    ): RecursiveIteratorIterator {
+        Closure|string|null $customFilter = null,
+    ): Iterator {
         $flags ??= FilesystemIterator::KEY_AS_PATHNAME
             | FilesystemIterator::CURRENT_AS_FILEINFO
             | FilesystemIterator::SKIP_DOTS;
 
         $directory = new RecursiveDirectoryIterator($path, $flags);
 
-        // Apply filtering if needed
-        if (!$includeHiddenDirs || $customFilter !== null) {
-            $filterCallback = function (SplFileInfo $current) use ($includeHiddenDirs, $customFilter): bool {
+        // Separate callback filters from regex filters
+        $callbackFilter = $customFilter instanceof Closure ? $customFilter : null;
+        $regexFilter = is_string($customFilter) ? $customFilter : null;
+
+        // Apply callback filtering during iteration if needed
+        if (!$includeHiddenDirs || $callbackFilter !== null) {
+            $filterCallback = function (SplFileInfo $current) use ($includeHiddenDirs, $callbackFilter): bool {
                 // Skip hidden directories if not included
                 if (!$includeHiddenDirs && str_starts_with($current->getFilename(), '.') && $current->isDir()) {
                     return false;
                 }
 
-                // Apply custom filter if provided
-                if ($customFilter !== null) {
-                    return $customFilter($current);
+                // Apply custom callback filter if provided
+                if ($callbackFilter !== null) {
+                    return $callbackFilter($current);
                 }
 
                 return true;
@@ -153,23 +194,14 @@ class Filesystem
             $directory = new RecursiveCallbackFilterIterator($directory, $filterCallback);
         }
 
-        return new RecursiveIteratorIterator($directory, $mode);
-    }
+        $iterator = new RecursiveIteratorIterator($directory, $mode);
 
-    /**
-     * Wrap iterator in additional filtering iterator.
-     *
-     * @param \Iterator $iterator Iterator
-     * @param \Closure|string $filter Regex string or callback.
-     * @return \Iterator
-     */
-    protected function filterIterator(Iterator $iterator, Closure|string $filter): Iterator
-    {
-        if (is_string($filter)) {
-            return new RegexIterator($iterator, $filter);
+        // Apply regex filter after iteration if provided
+        if ($regexFilter !== null) {
+            return new RegexIterator($iterator, $regexFilter);
         }
 
-        return new CallbackFilterIterator($iterator, $filter);
+        return $iterator;
     }
 
     /**

--- a/src/Utility/Filesystem.php
+++ b/src/Utility/Filesystem.php
@@ -79,32 +79,81 @@ class Filesystem
      */
     public function findRecursive(string $path, Closure|string|null $filter = null, ?int $flags = null): Iterator
     {
-        $flags ??= FilesystemIterator::KEY_AS_PATHNAME
-            | FilesystemIterator::CURRENT_AS_FILEINFO
-            | FilesystemIterator::SKIP_DOTS;
-        $directory = new RecursiveDirectoryIterator($path, $flags);
-
-        $dirFilter = new RecursiveCallbackFilterIterator(
-            $directory,
-            function (SplFileInfo $current) {
-                if (str_starts_with($current->getFilename(), '.') && $current->isDir()) {
-                    return false;
-                }
-
-                return true;
-            },
-        );
-
-        $flatten = new RecursiveIteratorIterator(
-            $dirFilter,
+        $iterator = $this->createRecursiveIterator(
+            $path,
+            $flags,
             RecursiveIteratorIterator::CHILD_FIRST,
+            skipHiddenDirs: true,
         );
 
         if ($filter === null) {
-            return $flatten;
+            return $iterator;
         }
 
-        return $this->filterIterator($flatten, $filter);
+        return $this->filterIterator($iterator, $filter);
+    }
+
+    /**
+     * Create a recursive directory iterator with optional filtering.
+     *
+     * This is a building block method for creating custom recursive file iteration.
+     * Consumers can wrap the returned iterator with additional filters or process it directly.
+     *
+     * Example:
+     * ```php
+     * $filesystem = new Filesystem();
+     * $iterator = $filesystem->createRecursiveIterator(
+     *     '/path/to/dir',
+     *     mode: RecursiveIteratorIterator::LEAVES_ONLY,
+     *     customFilter: fn($file) => $file->getExtension() === 'php'
+     * );
+     *
+     * foreach ($iterator as $file) {
+     *     echo $file->getPathname() . PHP_EOL;
+     * }
+     * ```
+     *
+     * @param string $path Directory path.
+     * @param int|null $flags Flags for FilesystemIterator::__construct();
+     * @param int<0, 2> $mode RecursiveIteratorIterator mode (LEAVES_ONLY, SELF_FIRST, CHILD_FIRST).
+     * @param bool $skipHiddenDirs Whether to skip hidden directories (default: true).
+     * @param \Closure|null $customFilter Optional custom filter callback for RecursiveCallbackFilterIterator.
+     *   Receives SplFileInfo, returns bool. Combined with hidden directory filtering if enabled.
+     * @return \RecursiveIteratorIterator
+     */
+    public function createRecursiveIterator(
+        string $path,
+        ?int $flags = null,
+        int $mode = RecursiveIteratorIterator::CHILD_FIRST,
+        bool $skipHiddenDirs = true,
+        ?Closure $customFilter = null,
+    ): RecursiveIteratorIterator {
+        $flags ??= FilesystemIterator::KEY_AS_PATHNAME
+            | FilesystemIterator::CURRENT_AS_FILEINFO
+            | FilesystemIterator::SKIP_DOTS;
+
+        $directory = new RecursiveDirectoryIterator($path, $flags);
+
+        // Apply filtering if needed
+        if ($skipHiddenDirs || $customFilter !== null) {
+            $filterCallback = function (SplFileInfo $current) use ($skipHiddenDirs, $customFilter): bool {
+                // Skip hidden directories if enabled
+                if ($skipHiddenDirs && str_starts_with($current->getFilename(), '.') && $current->isDir()) {
+                    return false;
+                }
+
+                // Apply custom filter if provided
+                if ($customFilter !== null) {
+                    return $customFilter($current);
+                }
+
+                return true;
+            };
+
+            $directory = new RecursiveCallbackFilterIterator($directory, $filterCallback);
+        }
+
+        return new RecursiveIteratorIterator($directory, $mode);
     }
 
     /**

--- a/src/Utility/Filesystem.php
+++ b/src/Utility/Filesystem.php
@@ -83,7 +83,7 @@ class Filesystem
             $path,
             $flags,
             RecursiveIteratorIterator::CHILD_FIRST,
-            skipHiddenDirs: true,
+            includeHiddenDirs: false,
         );
 
         if ($filter === null) {
@@ -116,7 +116,7 @@ class Filesystem
      * @param string $path Directory path.
      * @param int|null $flags Flags for FilesystemIterator::__construct();
      * @param int<0, 2> $mode RecursiveIteratorIterator mode (LEAVES_ONLY, SELF_FIRST, CHILD_FIRST).
-     * @param bool $skipHiddenDirs Whether to skip hidden directories (default: true).
+     * @param bool $includeHiddenDirs Whether to include hidden directories (default: false).
      * @param \Closure|null $customFilter Optional custom filter callback for RecursiveCallbackFilterIterator.
      *   Receives SplFileInfo, returns bool. Combined with hidden directory filtering if enabled.
      * @return \RecursiveIteratorIterator
@@ -125,7 +125,7 @@ class Filesystem
         string $path,
         ?int $flags = null,
         int $mode = RecursiveIteratorIterator::CHILD_FIRST,
-        bool $skipHiddenDirs = false,
+        bool $includeHiddenDirs = false,
         ?Closure $customFilter = null,
     ): RecursiveIteratorIterator {
         $flags ??= FilesystemIterator::KEY_AS_PATHNAME
@@ -135,10 +135,10 @@ class Filesystem
         $directory = new RecursiveDirectoryIterator($path, $flags);
 
         // Apply filtering if needed
-        if ($skipHiddenDirs || $customFilter !== null) {
-            $filterCallback = function (SplFileInfo $current) use ($skipHiddenDirs, $customFilter): bool {
-                // Skip hidden directories if enabled
-                if ($skipHiddenDirs && str_starts_with($current->getFilename(), '.') && $current->isDir()) {
+        if (!$includeHiddenDirs || $customFilter !== null) {
+            $filterCallback = function (SplFileInfo $current) use ($includeHiddenDirs, $customFilter): bool {
+                // Skip hidden directories if not included
+                if (!$includeHiddenDirs && str_starts_with($current->getFilename(), '.') && $current->isDir()) {
                     return false;
                 }
 

--- a/tests/TestCase/Utility/FilesystemTest.php
+++ b/tests/TestCase/Utility/FilesystemTest.php
@@ -273,4 +273,53 @@ class FilesystemTest extends TestCase
         $this->assertContains('.hidden', $files);
         $this->assertContains('secret.php', $files);
     }
+
+    public function testCreateIterator(): void
+    {
+        $structure = [
+            'file1.php' => 'content',
+            'file2.txt' => 'content',
+            'subdir' => [
+                'file3.php' => 'should not see this (non-recursive)',
+            ],
+        ];
+        vfsStream::create($structure);
+
+        $iterator = $this->fs->createIterator($this->vfsPath);
+
+        $files = [];
+        foreach ($iterator as $file) {
+            $files[] = $file->getFilename();
+        }
+
+        // Should only see top-level files, not subdirectories' contents
+        $this->assertContains('file1.php', $files);
+        $this->assertContains('file2.txt', $files);
+        $this->assertContains('subdir', $files);
+        $this->assertNotContains('file3.php', $files);
+    }
+
+    public function testCreateIteratorWithCustomFilter(): void
+    {
+        $structure = [
+            'file1.php' => 'content',
+            'file2.txt' => 'content',
+            'file3.php' => 'content',
+            'subdir' => [],
+        ];
+        vfsStream::create($structure);
+
+        $filter = fn($file) => $file->isFile() && $file->getExtension() === 'php';
+        $iterator = $this->fs->createIterator($this->vfsPath, customFilter: $filter);
+
+        $files = [];
+        foreach ($iterator as $file) {
+            $files[] = $file->getFilename();
+        }
+
+        $this->assertContains('file1.php', $files);
+        $this->assertContains('file3.php', $files);
+        $this->assertNotContains('file2.txt', $files);
+        $this->assertNotContains('subdir', $files);
+    }
 }

--- a/tests/TestCase/Utility/FilesystemTest.php
+++ b/tests/TestCase/Utility/FilesystemTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Utility;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Filesystem;
 use org\bovigo\vfs\vfsStream;
+use RecursiveIteratorIterator;
 
 /**
  * Filesystem class
@@ -107,5 +108,169 @@ class FilesystemTest extends TestCase
 
         $this->assertTrue($this->fs->deleteDir($path));
         $this->assertFalse(file_exists($link));
+    }
+
+    public function testCreateRecursiveIteratorBasic(): void
+    {
+        $structure = [
+            'file1.php' => 'content',
+            'file2.txt' => 'content',
+            'subdir' => [
+                'file3.php' => 'content',
+                'file4.txt' => 'content',
+            ],
+        ];
+        vfsStream::create($structure);
+
+        $iterator = $this->fs->createRecursiveIterator($this->vfsPath);
+
+        $this->assertInstanceOf(RecursiveIteratorIterator::class, $iterator);
+
+        $files = [];
+        foreach ($iterator as $file) {
+            $files[] = $file->getFilename();
+        }
+
+        $this->assertContains('file1.php', $files);
+        $this->assertContains('file2.txt', $files);
+        $this->assertContains('file3.php', $files);
+        $this->assertContains('file4.txt', $files);
+    }
+
+    public function testCreateRecursiveIteratorSkipsHiddenDirs(): void
+    {
+        $structure = [
+            'visible.php' => 'content',
+            '.hidden' => [
+                'secret.php' => 'should not see this',
+            ],
+            'subdir' => [
+                'visible2.php' => 'content',
+            ],
+        ];
+        vfsStream::create($structure);
+
+        $iterator = $this->fs->createRecursiveIterator($this->vfsPath, skipHiddenDirs: true);
+
+        $files = [];
+        foreach ($iterator as $file) {
+            $files[] = $file->getFilename();
+        }
+
+        $this->assertContains('visible.php', $files);
+        $this->assertContains('visible2.php', $files);
+        $this->assertNotContains('secret.php', $files);
+        $this->assertNotContains('.hidden', $files);
+    }
+
+    public function testCreateRecursiveIteratorWithCustomFilter(): void
+    {
+        $structure = [
+            'file1.php' => 'content',
+            'file2.txt' => 'content',
+            'subdir' => [
+                'file3.php' => 'content',
+                'file4.txt' => 'content',
+            ],
+        ];
+        vfsStream::create($structure);
+
+        // Filter to only include .php files
+        // Note: Must allow directories to pass for recursion to work
+        $filter = fn($file) => $file->isDir() || $file->getExtension() === 'php';
+        $iterator = $this->fs->createRecursiveIterator(
+            $this->vfsPath,
+            customFilter: $filter,
+        );
+
+        $files = [];
+        foreach ($iterator as $file) {
+            if ($file->isFile()) {
+                $files[] = $file->getFilename();
+            }
+        }
+
+        $this->assertContains('file1.php', $files);
+        $this->assertContains('file3.php', $files);
+        $this->assertNotContains('file2.txt', $files);
+        $this->assertNotContains('file4.txt', $files);
+    }
+
+    public function testCreateRecursiveIteratorWithDifferentModes(): void
+    {
+        $structure = [
+            'file1.php' => 'content',
+            'subdir' => [
+                'file2.php' => 'content',
+            ],
+        ];
+        vfsStream::create($structure);
+
+        // Test LEAVES_ONLY mode
+        $iterator = $this->fs->createRecursiveIterator(
+            $this->vfsPath,
+            mode: RecursiveIteratorIterator::LEAVES_ONLY,
+        );
+
+        $files = [];
+        foreach ($iterator as $file) {
+            if ($file->isFile()) {
+                $files[] = $file->getFilename();
+            }
+        }
+
+        $this->assertContains('file1.php', $files);
+        $this->assertContains('file2.php', $files);
+    }
+
+    public function testFindRecursiveStillWorks(): void
+    {
+        $structure = [
+            'file1.php' => 'content',
+            'file2.txt' => 'content',
+            '.hidden' => [
+                'secret.php' => 'should not see this',
+            ],
+            'subdir' => [
+                'file3.php' => 'content',
+            ],
+        ];
+        vfsStream::create($structure);
+
+        $iterator = $this->fs->findRecursive($this->vfsPath);
+
+        $files = [];
+        foreach ($iterator as $file) {
+            $files[] = $file->getFilename();
+        }
+
+        $this->assertContains('file1.php', $files);
+        $this->assertContains('file2.txt', $files);
+        $this->assertContains('file3.php', $files);
+        // Hidden directories should be skipped
+        $this->assertNotContains('.hidden', $files);
+        $this->assertNotContains('secret.php', $files);
+    }
+
+    public function testCreateRecursiveIteratorAllowsHiddenDirs(): void
+    {
+        $structure = [
+            'visible.php' => 'content',
+            '.hidden' => [
+                'secret.php' => 'content in hidden dir',
+            ],
+        ];
+        vfsStream::create($structure);
+
+        $iterator = $this->fs->createRecursiveIterator($this->vfsPath, skipHiddenDirs: false);
+
+        $files = [];
+        foreach ($iterator as $file) {
+            $files[] = $file->getFilename();
+        }
+
+        $this->assertContains('visible.php', $files);
+        $this->assertContains('.hidden', $files);
+        $this->assertContains('secret.php', $files);
     }
 }

--- a/tests/TestCase/Utility/FilesystemTest.php
+++ b/tests/TestCase/Utility/FilesystemTest.php
@@ -150,7 +150,7 @@ class FilesystemTest extends TestCase
         ];
         vfsStream::create($structure);
 
-        $iterator = $this->fs->createRecursiveIterator($this->vfsPath, skipHiddenDirs: true);
+        $iterator = $this->fs->createRecursiveIterator($this->vfsPath, includeHiddenDirs: false);
 
         $files = [];
         foreach ($iterator as $file) {
@@ -262,7 +262,7 @@ class FilesystemTest extends TestCase
         ];
         vfsStream::create($structure);
 
-        $iterator = $this->fs->createRecursiveIterator($this->vfsPath, skipHiddenDirs: false);
+        $iterator = $this->fs->createRecursiveIterator($this->vfsPath, includeHiddenDirs: true);
 
         $files = [];
         foreach ($iterator as $file) {


### PR DESCRIPTION
Refs #19167

### Summary

Refactors the `Filesystem` class to expose flexible building block methods for creating both recursive and non-recursive directory iterators without immediately consuming them. This allows consumers to build custom iterators with fine-grained control over iteration behavior and filtering before processing.

### Motivation

Previously, `find()` and `findRecursive()` combined iterator creation, filtering, and consumption into single operations. This made it difficult to:
- Create custom iterators with specific `RecursiveIteratorIterator` modes (LEAVES_ONLY, SELF_FIRST, CHILD_FIRST)
- Apply custom filtering logic during recursion (not just post-flattening)
- Reuse iterator creation logic without immediately iterating
- Share filtering behavior between recursive and non-recursive modes

### Changes

#### New Building Block Methods

- **Added** `createIterator()` public method for non-recursive iteration:
  - Configurable `FilesystemIterator` flags
  - Optional filter support (regex string or callback)
  - Single source of truth for non-recursive iterator creation

- **Added** `createRecursiveIterator()` public method for recursive iteration:
  - Configurable `FilesystemIterator` flags
  - Choice of `RecursiveIteratorIterator` modes (defaults to CHILD_FIRST)
  - Optional hidden directory skipping (enabled by default)
  - Optional filter support (regex string or callback)
  - Callbacks applied during iteration, regex patterns applied after

#### Refactoring for DRY

- **Refactored** `find()` to delegate to `createIterator()`
  - Maintains full backward compatibility
  - Single line implementation

- **Refactored** `findRecursive()` to delegate to `createRecursiveIterator()`
  - Maintains full backward compatibility
  - Single line implementation

- **Consolidated** all filtering logic into building block methods
  - Both methods accept `Closure|string|null` for unified filtering
  - Regex strings use `RegexIterator`
  - Closures use `CallbackFilterIterator` (non-recursive) or `RecursiveCallbackFilterIterator` (recursive)
  - Removed redundant `filterIterator()` helper method

### Example Usage

```php
$filesystem = new Filesystem();

// Non-recursive with callback filter
$iterator = $filesystem->createIterator(
    '/path/to/dir',
    customFilter: fn($file) => $file->getExtension() === 'php'
);

// Non-recursive with regex filter
$iterator = $filesystem->createIterator(
    '/path/to/dir',
    customFilter: '/\.php$/'
);

// Recursive with custom mode
$iterator = $filesystem->createRecursiveIterator(
    '/path/to/dir',
    mode: RecursiveIteratorIterator::LEAVES_ONLY
);

// Recursive with callback filter (applied during iteration)
$iterator = $filesystem->createRecursiveIterator(
    '/path/to/dir',
    customFilter: fn($file) => $file->isDir() || $file->getExtension() === 'php'
);

// Recursive with regex filter (applied after iteration)
$iterator = $filesystem->createRecursiveIterator(
    '/path/to/dir',
    customFilter: '/\.php$/'
);

// Process later
foreach ($iterator as $file) {
    // Process files...
}