### PR TITLE
Fix PHP 8+ notice in EntityTrait::isModified() for object-scalar comparison

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -365,6 +365,7 @@ trait EntityTrait
 
         if (
             is_object($value)
+            && is_object($existing)
             && !($value instanceof EntityInterface)
             && $existing == $value
         ) {


### PR DESCRIPTION
## Summary

- Fix PHP 8+ notice when `isModified()` compares an object value against a scalar existing value
- Add `is_object($existing)` check to ensure loose equality comparison only occurs between two objects

## Problem

In `EntityTrait::isModified()`, the code compared an object value with an existing field value using loose equality:

```php
if (
    is_object($value)
    && !($value instanceof EntityInterface)
    && $existing == $value
) {
```

When `$existing` is a scalar (float/int) and `$value` is an object, PHP 8+ raises a notice:

```
Object of class Brick\Math\BigDecimal could not be converted to float
```

This occurs in real-world usage when a behavior or custom type converts a scalar field value to an object representation (e.g., converting `10.50` float to `BigDecimal('10.50')` for precision).

## Solution

Add a check to ensure `$existing` is also an object before performing the loose equality comparison:

```php
if (
    is_object($value)
    && is_object($existing)
    && !($value instanceof EntityInterface)
    && $existing == $value
) {
```

This ensures the `==` comparison only occurs between two objects, avoiding the problematic object-to-scalar coercion. If types differ (one scalar, one object), the method correctly returns `true` (field is modified).

## Test plan

- [x] Added `testDirtyObjectReplacingScalar` - verifies no PHP notice when setting object on scalar field
- [x] Added `testDirtyObjectReplacingEquivalentObject` - verifies object-to-object comparison still works
- [x] All existing EntityTest tests pass (93 tests, 304 assertions)
- [x] MarshallerTest passes (103 tests)
- [x] TableTest passes (263 tests)