### PR TITLE
Cast limit query param to int in limitControl()

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1184,11 +1184,13 @@ class PaginatorHelper extends Helper
         $out = $this->Form->create(null, ['type' => 'get', 'url' => []]);
 
         $out .= $this->generateHiddenFields($hiddenFields);
+
+        $limit = $this->_View->getRequest()->getQuery('limit');
         $out .= $this->Form->control($scope . 'limit', $options + [
             'type' => 'select',
             'label' => __('View'),
             'default' => $default,
-            'value' => $this->_View->getRequest()->getQuery('limit'),
+            'value' => $limit !== null ? (int)$limit : null,
             'options' => $limits,
             'onChange' => 'this.form.submit()',
         ]);


### PR DESCRIPTION
## Summary

- Cast the `limit` query parameter value to int in `PaginatorHelper::limitControl()` to sanitize potentially malicious input
- Preserves `null` handling so the default value is used when no limit is specified

Closes #19172

Note: There is no XSS issue, this is purely to have easier handling of such input downstream, incl logging etc.