### PR TITLE
Add preserveQuery option to PaginatorHelper::limitControl

### DIFF
--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -71,7 +71,8 @@ class BreadcrumbsHelper extends Helper
      * @param array|string|null $url URL of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link.
      * @param array<string, mixed> $options Array of options. These options will be used as attributes HTML attribute the crumb will
-     * be rendered in (a <li> tag by default). It accepts two special keys:
+     * be rendered in (a <li> tag by default). When $title is an array, these options will be used as defaults
+     * for each crumb, with individual crumb options taking precedence. It accepts two special keys:
      *
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
      *   the link)
@@ -82,7 +83,9 @@ class BreadcrumbsHelper extends Helper
     {
         if (is_array($title)) {
             foreach ($title as $crumb) {
-                $this->crumbs[] = $crumb + ['title' => '', 'url' => null, 'options' => []];
+                $crumb += ['title' => '', 'url' => null, 'options' => []];
+                $crumb['options'] += $options;
+                $this->crumbs[] = $crumb;
             }
 
             return $this;
@@ -107,7 +110,8 @@ class BreadcrumbsHelper extends Helper
      * @param array|string|null $url URL of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link.
      * @param array<string, mixed> $options Array of options. These options will be used as attributes HTML attribute the crumb will
-     * be rendered in (a <li> tag by default). It accepts two special keys:
+     * be rendered in (a <li> tag by default). When $title is an array, these options will be used as defaults
+     * for each crumb, with individual crumb options taking precedence. It accepts two special keys:
      *
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
      *   the link)
@@ -119,7 +123,9 @@ class BreadcrumbsHelper extends Helper
         if (is_array($title)) {
             $crumbs = [];
             foreach ($title as $crumb) {
-                $crumbs[] = $crumb + ['title' => '', 'url' => null, 'options' => []];
+                $crumb += ['title' => '', 'url' => null, 'options' => []];
+                $crumb['options'] += $options;
+                $crumbs[] = $crumb;
             }
 
             array_splice($this->crumbs, 0, 0, $crumbs);

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1170,6 +1170,9 @@ class PaginatorHelper extends Helper
      * Options:
      *  - `steps`: If provided as an integer, will generate limit options in multiples of this value
      *     up to maxLimit (e.g., steps of 10 with maxLimit 50 generates [10, 20, 30, 40, 50]).
+     *  - `preserveQuery`: Controls which query params are included as hidden fields.
+     *     Use `true` to keep all (default), `false` to keep none, or an array of
+     *     keys to keep (top-level keys, including scoped ones).
      *
      * @param array<string, string> $limits The options array.
      * @param int|null $default Default option for pagination limit. Defaults to `$this->param('perPage')`.
@@ -1180,6 +1183,9 @@ class PaginatorHelper extends Helper
     {
         $steps = $options['steps'] ?? null;
         unset($options['steps']);
+
+        $preserveQuery = $options['preserveQuery'] ?? true;
+        unset($options['preserveQuery']);
 
         $limits = $this->prepareLimitOptions($limits, $steps);
 
@@ -1192,6 +1198,11 @@ class PaginatorHelper extends Helper
 
         // Prepare query params to preserve as hidden fields
         $hiddenFields = $query;
+        if ($preserveQuery === false) {
+            $hiddenFields = [];
+        } elseif (is_array($preserveQuery)) {
+            $hiddenFields = array_intersect_key($hiddenFields, array_flip($preserveQuery));
+        }
         if ($scope) {
             // Remove limit and page from scoped params
             unset($hiddenFields[$scope]['limit'], $hiddenFields[$scope]['page']);

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -122,6 +122,72 @@ class BreadcrumbsHelperTest extends TestCase
     }
 
     /**
+     * Test adding multiple crumbs with shared options
+     */
+    public function testAddMultipleWithSharedOptions(): void
+    {
+        $this->breadcrumbs
+            ->add([
+                ['title' => 'Home', 'url' => '/'],
+                ['title' => 'Products', 'url' => '/products'],
+                ['title' => 'Widget'],
+            ], null, ['class' => 'breadcrumb-item']);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Home',
+                'url' => '/',
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+            [
+                'title' => 'Products',
+                'url' => '/products',
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+            [
+                'title' => 'Widget',
+                'url' => null,
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test adding multiple crumbs with shared options and individual override
+     */
+    public function testAddMultipleWithSharedOptionsAndOverride(): void
+    {
+        $this->breadcrumbs
+            ->add([
+                ['title' => 'Home', 'url' => '/', 'options' => ['class' => 'home-crumb']],
+                ['title' => 'Products', 'url' => '/products'],
+                ['title' => 'Widget', 'options' => ['data-active' => 'true']],
+            ], null, ['class' => 'breadcrumb-item', 'data-type' => 'crumb']);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Home',
+                'url' => '/',
+                'options' => ['class' => 'home-crumb', 'data-type' => 'crumb'],
+            ],
+            [
+                'title' => 'Products',
+                'url' => '/products',
+                'options' => ['class' => 'breadcrumb-item', 'data-type' => 'crumb'],
+            ],
+            [
+                'title' => 'Widget',
+                'url' => null,
+                'options' => ['data-active' => 'true', 'class' => 'breadcrumb-item', 'data-type' => 'crumb'],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * Test adding crumbs to the trail using prepend()
      */
     public function testPrepend(): void
@@ -183,6 +249,82 @@ class BreadcrumbsHelperTest extends TestCase
                 'title' => 'The root',
                 'url' => '/root',
                 'options' => ['data-name' => 'some-name'],
+            ],
+            [
+                'title' => 'Home',
+                'url' => '/',
+                'options' => [
+                    'class' => 'first',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test prepending multiple crumbs with shared options
+     */
+    public function testPrependMultipleWithSharedOptions(): void
+    {
+        $this->breadcrumbs
+            ->add('Home', '/', ['class' => 'first'])
+            ->prepend([
+                ['title' => 'Some text', 'url' => ['controller' => 'Some', 'action' => 'text']],
+                ['title' => 'The root', 'url' => '/root'],
+            ], null, ['class' => 'breadcrumb-item']);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Some text',
+                'url' => [
+                    'controller' => 'Some',
+                    'action' => 'text',
+                ],
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+            [
+                'title' => 'The root',
+                'url' => '/root',
+                'options' => ['class' => 'breadcrumb-item'],
+            ],
+            [
+                'title' => 'Home',
+                'url' => '/',
+                'options' => [
+                    'class' => 'first',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test prepending multiple crumbs with shared options and individual override
+     */
+    public function testPrependMultipleWithSharedOptionsAndOverride(): void
+    {
+        $this->breadcrumbs
+            ->add('Home', '/', ['class' => 'first'])
+            ->prepend([
+                ['title' => 'Some text', 'url' => ['controller' => 'Some', 'action' => 'text'], 'options' => ['data-special' => 'yes']],
+                ['title' => 'The root', 'url' => '/root'],
+            ], null, ['class' => 'breadcrumb-item', 'data-type' => 'nav']);
+
+        $result = $this->breadcrumbs->getCrumbs();
+        $expected = [
+            [
+                'title' => 'Some text',
+                'url' => [
+                    'controller' => 'Some',
+                    'action' => 'text',
+                ],
+                'options' => ['data-special' => 'yes', 'class' => 'breadcrumb-item', 'data-type' => 'nav'],
+            ],
+            [
+                'title' => 'The root',
+                'url' => '/root',
+                'options' => ['class' => 'breadcrumb-item', 'data-type' => 'nav'],
             ],
             [
                 'title' => 'Home',

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -3260,6 +3260,82 @@ class PaginatorHelperTest extends TestCase
     }
 
     /**
+     * test the limitControl() method can skip query strings
+     */
+    public function testLimitControlPreserveQueryFalse(): void
+    {
+        $request = new ServerRequest([
+            'url' => '/batches?owner=billy&expected=1&page=2',
+            'params' => [
+                'plugin' => null, 'controller' => 'Batches', 'action' => 'index', 'pass' => [],
+            ],
+            'query' => ['owner' => 'billy', 'expected' => 1],
+            'base' => '',
+            'webroot' => '/',
+        ]);
+        Router::setRequest($request);
+        $this->View->setRequest($request);
+        $this->setPaginatedResult(['perPage' => 10, 'currentPage' => 2]);
+
+        $out = $this->Paginator->limitControl([1 => 1], null, ['preserveQuery' => false]);
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/Batches/index']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.requestSubmit()']],
+            ['option' => ['value' => '1']],
+            '1',
+            '/option',
+            '/select',
+            '/div',
+            '/form',
+        ];
+        $this->assertHtml($expected, $out);
+    }
+
+    /**
+     * test the limitControl() method can limit preserved query strings
+     */
+    public function testLimitControlPreserveQueryWhitelist(): void
+    {
+        $request = new ServerRequest([
+            'url' => '/users?status=active&role=admin',
+            'params' => [
+                'plugin' => null, 'controller' => 'Users', 'action' => 'index', 'pass' => [],
+            ],
+            'query' => ['status' => 'active', 'role' => 'admin'],
+            'base' => '',
+            'webroot' => '/',
+        ]);
+        Router::setRequest($request);
+        $this->View->setRequest($request);
+        $this->setPaginatedResult(['perPage' => 20, 'currentPage' => 1]);
+
+        $out = $this->Paginator->limitControl([20 => 20, 50 => 50], null, ['preserveQuery' => ['status']]);
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/Users/index']],
+            ['input' => ['type' => 'hidden', 'name' => 'status', 'value' => 'active']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.requestSubmit()']],
+            ['option' => ['value' => '20', 'selected' => 'selected']],
+            '20',
+            '/option',
+            ['option' => ['value' => '50']],
+            '50',
+            '/option',
+            '/select',
+            '/div',
+            '/form',
+        ];
+        $this->assertHtml($expected, $out);
+    }
+
+    /**
      * test the limitControl() method excludes pagination params but preserves other query strings
      */
     public function testLimitControlExcludesPaginationParams(): void


### PR DESCRIPTION
## Summary
- add preserveQuery option for limitControl to control preserved query params
- add tests for preserveQuery false/whitelist

## Docs
- docs update prepared in dereuromark/cakephp-docs branch docs-limitcontrol-preserve-query