### PR TITLE
Add preserveQuery option to PaginatorHelper::limitControl

### DIFF
--- a/src/Command/PluginAssetsTrait.php
+++ b/src/Command/PluginAssetsTrait.php
@@ -125,10 +125,8 @@ trait PluginAssetsTrait
 
             $dest = $config['destDir'] . $config['link'];
             if ($copy) {
-                if (is_link($dest) || $overwrite) {
-                    if (!$this->_remove($config)) {
-                        continue;
-                    }
+                if ((is_link($dest) || $overwrite) && !$this->_remove($config)) {
+                    continue;
                 }
 
                 if (file_exists($dest)) {
@@ -139,15 +137,13 @@ trait PluginAssetsTrait
                 continue;
             }
 
-            if (!$copy) {
-                $result = $this->_createSymlink(
-                    $config['srcPath'],
-                    $dest,
-                    $relative,
-                );
-                if ($result) {
-                    continue;
-                }
+            $result = $this->_createSymlink(
+                $config['srcPath'],
+                $dest,
+                $relative,
+            );
+            if ($result) {
+                continue;
             }
 
             if ($this->_isSymlinkValid($config['srcPath'], $dest)) {

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1170,6 +1170,9 @@ class PaginatorHelper extends Helper
      * Options:
      *  - `steps`: If provided as an integer, will generate limit options in multiples of this value
      *     up to maxLimit (e.g., steps of 10 with maxLimit 50 generates [10, 20, 30, 40, 50]).
+     *  - `preserveQuery`: Controls which query params are included as hidden fields.
+     *     Use `true` to keep all (default), `false` to keep none, or an array of
+     *     keys to keep (top-level keys, including scoped ones).
      *
      * @param array<string, string> $limits The options array.
      * @param int|null $default Default option for pagination limit. Defaults to `$this->param('perPage')`.
@@ -1180,6 +1183,9 @@ class PaginatorHelper extends Helper
     {
         $steps = $options['steps'] ?? null;
         unset($options['steps']);
+
+        $preserveQuery = $options['preserveQuery'] ?? true;
+        unset($options['preserveQuery']);
 
         $limits = $this->prepareLimitOptions($limits, $steps);
 
@@ -1192,6 +1198,11 @@ class PaginatorHelper extends Helper
 
         // Prepare query params to preserve as hidden fields
         $hiddenFields = $query;
+        if ($preserveQuery === false) {
+            $hiddenFields = [];
+        } elseif (is_array($preserveQuery)) {
+            $hiddenFields = array_intersect_key($hiddenFields, array_flip($preserveQuery));
+        }
         if ($scope) {
             // Remove limit and page from scoped params
             unset($hiddenFields[$scope]['limit'], $hiddenFields[$scope]['page']);

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -3260,6 +3260,82 @@ class PaginatorHelperTest extends TestCase
     }
 
     /**
+     * test the limitControl() method can skip query strings
+     */
+    public function testLimitControlPreserveQueryFalse(): void
+    {
+        $request = new ServerRequest([
+            'url' => '/batches?owner=billy&expected=1&page=2',
+            'params' => [
+                'plugin' => null, 'controller' => 'Batches', 'action' => 'index', 'pass' => [],
+            ],
+            'query' => ['owner' => 'billy', 'expected' => 1],
+            'base' => '',
+            'webroot' => '/',
+        ]);
+        Router::setRequest($request);
+        $this->View->setRequest($request);
+        $this->setPaginatedResult(['perPage' => 10, 'currentPage' => 2]);
+
+        $out = $this->Paginator->limitControl([1 => 1], null, ['preserveQuery' => false]);
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/Batches/index']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.requestSubmit()']],
+            ['option' => ['value' => '1']],
+            '1',
+            '/option',
+            '/select',
+            '/div',
+            '/form',
+        ];
+        $this->assertHtml($expected, $out);
+    }
+
+    /**
+     * test the limitControl() method can limit preserved query strings
+     */
+    public function testLimitControlPreserveQueryWhitelist(): void
+    {
+        $request = new ServerRequest([
+            'url' => '/users?status=active&role=admin',
+            'params' => [
+                'plugin' => null, 'controller' => 'Users', 'action' => 'index', 'pass' => [],
+            ],
+            'query' => ['status' => 'active', 'role' => 'admin'],
+            'base' => '',
+            'webroot' => '/',
+        ]);
+        Router::setRequest($request);
+        $this->View->setRequest($request);
+        $this->setPaginatedResult(['perPage' => 20, 'currentPage' => 1]);
+
+        $out = $this->Paginator->limitControl([20 => 20, 50 => 50], null, ['preserveQuery' => ['status']]);
+        $expected = [
+            ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/Users/index']],
+            ['input' => ['type' => 'hidden', 'name' => 'status', 'value' => 'active']],
+            ['div' => ['class' => 'input select']],
+            ['label' => ['for' => 'limit']],
+            'View',
+            '/label',
+            ['select' => ['name' => 'limit', 'id' => 'limit', 'onChange' => 'this.form.requestSubmit()']],
+            ['option' => ['value' => '20', 'selected' => 'selected']],
+            '20',
+            '/option',
+            ['option' => ['value' => '50']],
+            '50',
+            '/option',
+            '/select',
+            '/div',
+            '/form',
+        ];
+        $this->assertHtml($expected, $out);
+    }
+
+    /**
      * test the limitControl() method excludes pagination params but preserves other query strings
      */
     public function testLimitControlExcludesPaginationParams(): void

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -3280,6 +3280,7 @@ class PaginatorHelperTest extends TestCase
         $out = $this->Paginator->limitControl([1 => 1], null, ['preserveQuery' => false]);
         $expected = [
             ['form' => ['method' => 'get', 'accept-charset' => 'utf-8', 'action' => '/Batches/index']],
+            ['input' => ['type' => 'hidden', 'name' => 'page', 'value' => '1']],
             ['div' => ['class' => 'input select']],
             ['label' => ['for' => 'limit']],
             'View',


### PR DESCRIPTION
## Summary
- add preserveQuery option for limitControl to control preserved query params
- add tests for preserveQuery false/whitelist
- simplify plugin assets copy/symlink flow to satisfy phpstan/rector on 5.x

## Behavior
- `preserveQuery: true` (default) keeps all query parameters as hidden fields
- `preserveQuery: false` keeps none
- `preserveQuery: ["key", ...]` only keeps the listed top-level keys

## Docs
- docs update in cakephp/docs PR https://github.com/cakephp/docs/pull/8153