### PR TITLE
Fix plugin template path duplication when templatePath equals name

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1373,8 +1373,10 @@ class View implements EventDispatcherInterface
         } elseif (str_contains($name, DIRECTORY_SEPARATOR)) {
             if (str_starts_with($name, DIRECTORY_SEPARATOR) || $name[1] === ':') {
                 $name = trim($name, DIRECTORY_SEPARATOR);
-            } else {
+            } elseif (!$plugin || $this->templatePath !== $this->name) {
                 $name = $templatePath . $subDir . $name;
+            } else {
+                $name = $subDir . $name;
             }
         }
 

--- a/tests/test_app/Plugin/TestPlugin/templates/Tests/nested/example.php
+++ b/tests/test_app/Plugin/TestPlugin/templates/Tests/nested/example.php
@@ -1,0 +1,1 @@
+Nested example in Tests folder


### PR DESCRIPTION
## Summary

- Fix template path duplication when rendering plugin templates where `templatePath` equals `name`
- Before: `templates/Controller/Controller/custom_file.php`
- After: `templates/Controller/custom_file.php`
- Restores conditional check from CakePHP 5.2

Fixes #19180