### PR TITLE
Fix CI failures: rector and phpstan issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,7 +130,7 @@
         "stan-setup": "phive install",
         "lowest": "validate-prefer-lowest",
         "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json",
-        "rector-setup": "cp composer.json composer.backup && composer require --dev rector/rector:\"~2.2\" && mv composer.backup composer.json",
+        "rector-setup": "cp composer.json composer.backup && composer require --dev rector/rector:\"~2.3.1\" && mv composer.backup composer.json",
         "rector-check": "vendor/bin/rector process --dry-run",
         "rector-fix": "vendor/bin/rector process",
         "test": "phpunit",

--- a/src/Command/PluginAssetsTrait.php
+++ b/src/Command/PluginAssetsTrait.php
@@ -125,10 +125,8 @@ trait PluginAssetsTrait
 
             $dest = $config['destDir'] . $config['link'];
             if ($copy) {
-                if (is_link($dest) || $overwrite) {
-                    if (!$this->_remove($config)) {
-                        continue;
-                    }
+                if ((is_link($dest) || $overwrite) && !$this->_remove($config)) {
+                    continue;
                 }
 
                 if (file_exists($dest)) {
@@ -139,15 +137,13 @@ trait PluginAssetsTrait
                 continue;
             }
 
-            if (!$copy) {
-                $result = $this->_createSymlink(
-                    $config['srcPath'],
-                    $dest,
-                    $relative,
-                );
-                if ($result) {
-                    continue;
-                }
+            $result = $this->_createSymlink(
+                $config['srcPath'],
+                $dest,
+                $relative,
+            );
+            if ($result) {
+                continue;
             }
 
             if ($this->_isSymlinkValid($config['srcPath'], $dest)) {

--- a/src/Console/ConsoleInput.php
+++ b/src/Console/ConsoleInput.php
@@ -60,8 +60,6 @@ class ConsoleInput
 
     /**
      * Destruct and free resources
-     *
-     * @return void
      */
     public function __destruct()
     {

--- a/src/Database/Expression/AggregateExpression.php
+++ b/src/Database/Expression/AggregateExpression.php
@@ -249,8 +249,6 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
 
     /**
      * Clone this object and its subtree of expressions.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -130,8 +130,6 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
 
     /**
      * Do a deep clone of this expression.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -570,8 +570,6 @@ class CaseStatementExpression implements ExpressionInterface, TypedResultInterfa
 
     /**
      * Clones the inner expression objects.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/src/Database/Expression/CommonTableExpression.php
+++ b/src/Database/Expression/CommonTableExpression.php
@@ -223,8 +223,6 @@ class CommonTableExpression implements ExpressionInterface
 
     /**
      * Clones the inner expression objects.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -190,8 +190,6 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
      * Create a deep clone.
      *
      * Clones the field and value if they are expression objects.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/src/Database/Expression/OrderClauseExpression.php
+++ b/src/Database/Expression/OrderClauseExpression.php
@@ -78,8 +78,6 @@ class OrderClauseExpression implements ExpressionInterface, FieldInterface
 
     /**
      * Create a deep clone of the order clause.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -774,8 +774,6 @@ class QueryExpression implements ExpressionInterface, Countable
 
     /**
      * Clone this object and its subtree of expressions.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/src/Database/Expression/UnaryExpression.php
+++ b/src/Database/Expression/UnaryExpression.php
@@ -106,8 +106,6 @@ class UnaryExpression implements ExpressionInterface
 
     /**
      * Perform a deep clone of the inner expression.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -304,8 +304,6 @@ class WhenThenExpression implements ExpressionInterface
 
     /**
      * Clones the inner expression objects.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/src/Database/Expression/WindowExpression.php
+++ b/src/Database/Expression/WindowExpression.php
@@ -334,8 +334,6 @@ class WindowExpression implements ExpressionInterface, WindowInterface
 
     /**
      * Clone this object and its subtree of expressions.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1817,8 +1817,6 @@ abstract class Query implements ExpressionInterface, Stringable
 
     /**
      * Handles clearing iterator and cloning all expressions and value binders.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -772,8 +772,6 @@ class SelectQuery extends Query implements IteratorAggregate
 
     /**
      * Handles clearing iterator and cloning all expressions and value binders.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/src/Mailer/Renderer.php
+++ b/src/Mailer/Renderer.php
@@ -109,8 +109,6 @@ class Renderer
 
     /**
      * Clone ViewBuilder instance when renderer is cloned.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/src/ORM/EagerLoadable.php
+++ b/src/ORM/EagerLoadable.php
@@ -316,8 +316,6 @@ class EagerLoadable
 
     /**
      * Handles cloning eager loadables.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -877,8 +877,6 @@ class EagerLoader
 
     /**
      * Handles cloning eager loaders and eager loadables.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/src/TestSuite/Constraint/Email/MailConstraintBase.php
+++ b/src/TestSuite/Constraint/Email/MailConstraintBase.php
@@ -35,7 +35,6 @@ abstract class MailConstraintBase extends Constraint
      * Constructor
      *
      * @param int|null $at At
-     * @return void
      */
     public function __construct(?int $at = null)
     {

--- a/src/TestSuite/Constraint/Email/MailSentWith.php
+++ b/src/TestSuite/Constraint/Email/MailSentWith.php
@@ -33,7 +33,6 @@ class MailSentWith extends MailConstraintBase
      *
      * @param int|null $at At
      * @param string|null $method Method
-     * @return void
      */
     public function __construct(?int $at = null, ?string $method = null)
     {

--- a/src/TestSuite/Stub/TestExceptionRenderer.php
+++ b/src/TestSuite/Stub/TestExceptionRenderer.php
@@ -37,7 +37,6 @@ class TestExceptionRenderer implements ExceptionRendererInterface
      * Simply rethrow the given exception
      *
      * @param \Throwable $exception Exception.
-     * @return void
      * @throws \Throwable $exception Rethrows the passed exception.
      */
     public function __construct(Throwable $exception)


### PR DESCRIPTION
## Summary

- Apply rector fixes to remove `@return void` from magic methods (`__clone`, `__construct`, `__destruct`)
- Combine nested if statements in PluginAssetsTrait (rector CombineIfRector)
- Fix PHPStan issue: remove redundant `if (!$copy)` check that was always true

I also fixed up the broken constraint.

