### PR TITLE
Add missing deprecation warnings to MiddlewareDispatcher

### DIFF
--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -18,6 +18,8 @@ namespace Cake\TestSuite;
 use Cake\Core\HttpApplicationInterface;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Http\FlashMessage;
+
+use function Cake\Core\deprecationWarning;
 use Cake\Http\Server;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
@@ -59,6 +61,11 @@ class MiddlewareDispatcher
      */
     public function resolveUrl(array|string $url): string
     {
+        deprecationWarning(
+            '5.1.0',
+            'MiddlewareDispatcher::resolveUrl() is deprecated. Use IntegrationTestTrait::resolveUrl() instead.',
+        );
+
         // If we need to resolve a Route URL but there are no routes, load routes.
         if (is_array($url) && Router::getRouteCollection()->routes() === []) {
             return $this->resolveRoute($url);
@@ -76,6 +83,11 @@ class MiddlewareDispatcher
      */
     protected function resolveRoute(array $url): string
     {
+        deprecationWarning(
+            '5.1.0',
+            'MiddlewareDispatcher::resolveRoute() is deprecated. Use IntegrationTestTrait::resolveRoute() instead.',
+        );
+
         // Simulate application bootstrap and route loading.
         // We need both to ensure plugins are loaded.
         $this->app->bootstrap();

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -18,14 +18,13 @@ namespace Cake\TestSuite;
 use Cake\Core\HttpApplicationInterface;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Http\FlashMessage;
-
-use function Cake\Core\deprecationWarning;
 use Cake\Http\Server;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\Routing\Router;
 use Cake\Routing\RoutingApplicationInterface;
 use Psr\Http\Message\ResponseInterface;
+use function Cake\Core\deprecationWarning;
 
 /**
  * Dispatches a request capturing the response for integration


### PR DESCRIPTION
## Summary

- Add runtime `deprecationWarning()` calls to `MiddlewareDispatcher::resolveUrl()` and `resolveRoute()`
- These methods were marked as `@deprecated 5.1.0` in docblocks but were missing the actual runtime warnings

## Problem

The `MiddlewareDispatcher::resolveUrl()` and `resolveRoute()` methods have been deprecated since 5.1.0 (per docblock annotations) but users were not receiving runtime deprecation notices when calling these methods.

## Solution

Added `deprecationWarning()` calls to both methods to match the existing docblock annotations and ensure users are notified of the deprecation.

## Test plan

- [x] Syntax check passes
- [ ] CI tests pass