### PR TITLE
Fix typos, documentation, and mock adapter bugs

### DIFF
--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -144,12 +144,11 @@ class MysqlSchemaDialect extends SchemaDialect
                 'comment' => $row['Comment'],
                 'length' => null,
             ];
-            if (isset($row['Extra']) && $row['Extra'] === 'auto_increment') {
+            $extra = $row['Extra'] ?? '';
+            if ($extra === 'auto_increment') {
                 $field['autoIncrement'] = true;
             }
-            if ($row['Extra'] === 'on update CURRENT_TIMESTAMP') {
-                $field['onUpdate'] = 'CURRENT_TIMESTAMP';
-            } elseif ($row['Extra'] === 'on update current_timestamp()') {
+            if ($extra === 'on update CURRENT_TIMESTAMP' || $extra === 'on update current_timestamp()') {
                 $field['onUpdate'] = 'CURRENT_TIMESTAMP';
             }
 
@@ -165,8 +164,9 @@ class MysqlSchemaDialect extends SchemaDialect
     }
 
     /**
-     * Describes geoemetry-specific column information.
+     * Describes geometry-specific column information.
      *
+     * @param string $table The table name.
      * @return array<string, array{name: string, srid: int}> The column information.
      */
     private function describeGeometryColumns(string $table): array

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -903,7 +903,7 @@ SQL;
         $data = $schema->getColumn($name);
         assert($data !== null);
 
-        // TODO deprecrate Type defined schema mappings?
+        // TODO deprecate Type defined schema mappings?
         $sql = $this->_getTypeSpecificColumnSql($data['type'], $schema, $name);
         if ($sql !== null) {
             return $sql;

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -554,7 +554,17 @@ class Client implements EventDispatcherInterface, ClientInterface
      *
      * ### Matching Requests
      *
-     * TODO finish this.
+     * Request matching is done on the HTTP method and URL. If the URL is
+     * an exact match, the response will be returned. You can use `*` as
+     * a wildcard to match any suffix:
+     *
+     * ```
+     * // Match any URL starting with /api/
+     * Client::addMockResponse('GET', '/api/*', $response);
+     * ```
+     *
+     * For more complex matching, use the `match` option with a closure
+     * that receives the request and returns a boolean.
      *
      * ### Options
      *

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -559,8 +559,8 @@ class Client implements EventDispatcherInterface, ClientInterface
      * a wildcard to match any suffix:
      *
      * ```
-     * // Match any URL starting with /api/
-     * Client::addMockResponse('GET', '/api/*', $response);
+     * // Match any URL starting with https://example.com/api/
+     * Client::addMockResponse('GET', 'https://example.com/api/*', $response);
      * ```
      *
      * For more complex matching, use the `match` option with a closure

--- a/src/Http/Client/Adapter/Mock.php
+++ b/src/Http/Client/Adapter/Mock.php
@@ -71,8 +71,9 @@ class Mock implements AdapterInterface
      * Find a response if one exists.
      *
      * @param \Psr\Http\Message\RequestInterface $request The request to match
-     * @param array<string, mixed> $options Unused.
-     * @return array<\Cake\Http\Client\Response> The matched response or an empty array for no matches.
+     * @param array<string, mixed> $options The options are passed to match callbacks.
+     * @return array<\Cake\Http\Client\Response> The matched response.
+     * @throws \Cake\Http\Client\Exception\MissingResponseException When no mock response matches.
      */
     public function send(RequestInterface $request, array $options): array
     {

--- a/src/Http/Client/Adapter/Mock.php
+++ b/src/Http/Client/Adapter/Mock.php
@@ -81,12 +81,12 @@ class Mock implements AdapterInterface
         $requestUri = (string)$request->getUri();
 
         foreach ($this->responses as $index => $mock) {
-            /** @var \Psr\Http\Message\RequestInterface $request */
-            $request = $mock['request'];
-            if ($method !== $request->getMethod()) {
+            /** @var \Psr\Http\Message\RequestInterface $mockRequest */
+            $mockRequest = $mock['request'];
+            if ($method !== $mockRequest->getMethod()) {
                 continue;
             }
-            if (!$this->urlMatches($requestUri, $mock['request'])) {
+            if (!$this->urlMatches($requestUri, $mockRequest)) {
                 continue;
             }
             if (isset($mock['options']['match'])) {


### PR DESCRIPTION
## Summary

### MysqlSchemaDialect.php
- Fix typo: "deprecrate" → "deprecate"
- Fix typo in docblock: "geoemetry" → "geometry"
- Add missing `@param` for `describeGeometryColumns()`
- Fix inconsistent `isset()` check for `$row['Extra']` in `describeColumns()` using null coalescing

### Http\Client.php
- Complete `addMockResponse` documentation with URL matching examples
- Fix documentation example to use full URL (partial URLs don't work with URL matching)

### Http\Client\Adapter\Mock.php
- Fix bug where `match` closure received the mock request instead of the actual request (variable shadowing)
- Fix `send()` docblock: was incorrectly stating it returns empty array when no match (it throws `MissingResponseException`)
- Fix `$options` parameter doc: was marked as "Unused" but is actually passed to match callbacks

## Test plan

- [x] All existing mock-related tests pass
- [x] PHPStan passes with no errors on all changed files
- [x] MySQL schema dialect tests pass