### PR TITLE
Fix typos and code quality issues

### DIFF
--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -182,7 +182,7 @@ class ConsoleInputOption
     }
 
     /**
-     * Generate the help for this this option.
+     * Generate the help for this option.
      *
      * @param int $width The width to make the name of the option.
      * @return string

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -265,7 +265,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     /**
      * Add a component to the controller's registry.
      *
-     * After loading a component it will be be accessible as a property through Controller::__get().
+     * After loading a component it will be accessible as a property through Controller::__get().
      * For example:
      *
      * ```

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -248,7 +248,7 @@ class Postgres extends Driver
     }
 
     /**
-     * Changes identifer expression into postgresql format.
+     * Changes identifier expression into postgresql format.
      *
      * @param \Cake\Database\Expression\IdentifierExpression $expression The expression to transform.
      * @return void

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -383,7 +383,7 @@ class MysqlSchemaDialect extends SchemaDialect
         }
 
         $unsigned = (isset($matches[3]) && strtolower($matches[3]) === 'unsigned');
-        if (str_contains($col, 'bigint') || $col === 'bigint') {
+        if (str_contains($col, 'bigint')) {
             return ['type' => TableSchemaInterface::TYPE_BIGINTEGER, 'length' => null, 'unsigned' => $unsigned];
         }
         if ($col === 'tinyint') {

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -726,7 +726,7 @@ abstract class SchemaDialect
      * Check if a table has a foreign key with a given name.
      *
      * @param string $tableName The name of the table
-     * @param array<string> $columns The columns in the foriegn key. Specific
+     * @param array<string> $columns The columns in the foreign key. Specific
      *   ordering matters.
      * @param string $name The name of the foreign key to match on. Can be used alone,
      *   or with $columns to match keys more precisely.

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -207,7 +207,7 @@ class SqlserverSchemaDialect extends SchemaDialect
 
         if ($col === 'image' || str_contains($col, 'binary')) {
             // -1 is the value for MAX which we treat as a 'long' binary
-            if ($length == -1) {
+            if ($length === -1) {
                 $length = TableSchema::LENGTH_LONG;
             }
 

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -40,7 +40,7 @@ class ExceptionTrap
      * Configuration options. Generally these will be defined in your config/app.php
      *
      * - `exceptionRenderer` - string - The class responsible for rendering uncaught exceptions.
-     *   The chosen class will be used for for both CLI and web environments. If  you want different
+     *   The chosen class will be used for both CLI and web environments. If you want different
      *   classes used in CLI and web environments you'll need to write that conditional logic as well.
      *   The conventional location for custom renderers is in `src/Error`. Your exception renderer needs to
      *   implement the `render()` method and return either a string or Http\Response.

--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -196,9 +196,9 @@ class FormData implements Countable, Stringable
      */
     public function addRecursive(string $name, mixed $value): void
     {
-        foreach ($value as $key => $value) {
+        foreach ($value as $key => $item) {
             $key = $name . '[' . $key . ']';
-            $this->add($key, $value);
+            $this->add($key, $item);
         }
     }
 

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -599,7 +599,7 @@ class Response implements ResponseInterface, Stringable
     }
 
     /**
-     * Create a new instace with the public/private Cache-Control directive set.
+     * Create a new instance with the public/private Cache-Control directive set.
      *
      * @param bool $public If set to true, the Cache-Control header will be set as public
      *   if set to false, the response will be set to private.

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -673,7 +673,7 @@ class HtmlHelper extends Helper
      * @param array<string, string> $data Style data array, keys will be used as property names, values as property values.
      * @param bool $oneLine Whether the style block should be displayed on one line.
      * @return string CSS styling data
-     * @link https://book.cakephp.org/5/en/views/helpers/html.html#creating-css-programatically
+     * @link https://book.cakephp.org/5/en/views/helpers/html.html#creating-css-programmatically
      */
     public function style(array $data, bool $oneLine = true): string
     {


### PR DESCRIPTION
## Summary

### Typos fixed (7)
| File | Typo | Fixed |
|------|------|-------|
| `src/Http/Response.php:602` | `instace` | `instance` |
| `src/View/Helper/HtmlHelper.php:676` | `programatically` | `programmatically` |
| `src/Error/ExceptionTrap.php:43` | `for for` | `for` |
| `src/Controller/Controller.php:268` | `will be be` | `will be` |
| `src/Console/ConsoleInputOption.php:185` | `this this` | `this` |
| `src/Database/Driver/Postgres.php:251` | `identifer` | `identifier` |
| `src/Database/Schema/SchemaDialect.php:729` | `foriegn` | `foreign` |

### Code quality fixes (3)
| File | Issue | Fix |
|------|-------|-----|
| `src/Database/Schema/MysqlSchemaDialect.php:386` | Redundant condition | `str_contains($col, 'bigint') \|\| $col === 'bigint'` → `str_contains($col, 'bigint')` |
| `src/Http/Client/FormData.php:199` | Variable shadowing | `foreach ($value as $key => $value)` → `foreach ($value as $key => $item)` |
| `src/Database/Schema/SqlserverSchemaDialect.php:210` | Loose comparison | `$length == -1` → `$length === -1` |

## Test plan

- [x] PHPStan passes on all changed files
- [x] FormData tests pass
- [x] MySQL schema dialect tests pass