### PR TITLE
Fix singularize cache bug and various typos

### DIFF
--- a/src/I18n/PluralRules.php
+++ b/src/I18n/PluralRules.php
@@ -22,7 +22,7 @@ use Locale;
 
 /**
  * Utility class used to determine the plural number to be used for a variable
- * base on the locale.
+ * based on the locale.
  *
  * @internal
  */

--- a/src/I18n/RelativeTimeFormatter.php
+++ b/src/I18n/RelativeTimeFormatter.php
@@ -99,7 +99,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
     }
 
     /**
-     * Format a into a relative timestring.
+     * Format a time into a relative timestring.
      *
      * @param \Cake\I18n\DateTime|\Cake\I18n\Date $time The time instance to format.
      * @param array<string, mixed> $options Array of options.
@@ -329,7 +329,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
     }
 
     /**
-     * Format a into a relative date string.
+     * Format a date into a relative date string.
      *
      * @param \Cake\I18n\DateTime|\Cake\I18n\Date $date The date to format.
      * @param array<string, mixed> $options Array of options.

--- a/src/Routing/Exception/DuplicateNamedRouteException.php
+++ b/src/Routing/Exception/DuplicateNamedRouteException.php
@@ -18,7 +18,7 @@ use Cake\Core\Exception\CakeException;
 use Throwable;
 
 /**
- * Exception raised when a route names used twice.
+ * Exception raised when a route name is used twice.
  */
 class DuplicateNamedRouteException extends CakeException
 {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -186,7 +186,7 @@ class Router
     }
 
     /**
-     * Get the routing parameters for the request is possible.
+     * Get the routing parameters for the request if possible.
      *
      * @param \Cake\Http\ServerRequest $request The request to parse request data from.
      * @return array Parsed elements from URL.

--- a/src/Utility/Filesystem.php
+++ b/src/Utility/Filesystem.php
@@ -182,7 +182,7 @@ class Filesystem
     }
 
     /**
-     * Delete directory along with all it's contents.
+     * Delete directory along with all its contents.
      *
      * @param string $path Directory path.
      * @return bool
@@ -229,7 +229,7 @@ class Filesystem
     }
 
     /**
-     * Copies directory with all it's contents.
+     * Copies directory with all its contents.
      *
      * @param string $source Source path.
      * @param string $destination Destination path.

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -1273,7 +1273,7 @@ class Hash
         foreach ($return as $i => $result) {
             $id = static::get($result, $idKeys);
             $parentId = static::get($result, $parentKeys);
-            if ($id !== $root && $parentId != $root) {
+            if ($id !== $root && $parentId !== $root) {
                 unset($return[$i]);
             }
         }

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -349,7 +349,7 @@ class Inflector
         }
 
         if (preg_match(static::$_cache['uninflected'], $word, $regs)) {
-            static::$_cache['pluralize'][$word] = $word;
+            static::$_cache['singularize'][$word] = $word;
 
             return $word;
         }

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -867,7 +867,7 @@ class Text
      *
      * @param string $text String to search the phrase in
      * @param string $phrase Phrase that will be searched for
-     * @param int $radius The amount of characters that will be returned on each side of the founded phrase
+     * @param int $radius The amount of characters that will be returned on each side of the found phrase
      * @param string $ellipsis Ending that will be appended
      * @return string Modified string
      * @link https://book.cakephp.org/5/en/core-libraries/text.html#extracting-an-excerpt


### PR DESCRIPTION
## Summary

### Bug Fix
**`src/Utility/Inflector.php:352`** - The `singularize()` method was caching uninflected words to the wrong cache key (`pluralize` instead of `singularize`). This could cause incorrect cache hits when singularizing words that were previously pluralized.

### Typos Fixed (8)
| File | Line | Typo | Fixed |
|------|------|------|-------|
| `src/I18n/RelativeTimeFormatter.php` | 102 | `Format a into` | `Format a time into` |
| `src/I18n/RelativeTimeFormatter.php` | 332 | `Format a into` | `Format a date into` |
| `src/I18n/PluralRules.php` | 25 | `base on` | `based on` |
| `src/Utility/Filesystem.php` | 185 | `it's contents` | `its contents` |
| `src/Utility/Filesystem.php` | 232 | `it's contents` | `its contents` |
| `src/Utility/Text.php` | 870 | `founded phrase` | `found phrase` |
| `src/Routing/Router.php` | 189 | `is possible` | `if possible` |
| `src/Routing/Exception/DuplicateNamedRouteException.php` | 21 | `route names used` | `route name is used` |

### Code Quality
**`src/Utility/Hash.php:1276`** - Fixed inconsistent comparison operators in `nest()` method. Changed `$parentId != $root` to `$parentId !== $root` for consistency with `$id !== $root` on the same line.

## Test plan

- [x] PHPStan passes on all changed files
- [x] Inflector tests pass (176 tests)
- [x] Hash nest tests pass