### PR TITLE
Fix sprintf bug, typos, docblocks and loose comparisons

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -27,7 +27,7 @@ use RuntimeException;
 /**
  * Cache provides a consistent interface to Caching in your application. It allows you
  * to use several different Cache engines, without coupling your application to a specific
- * implementation. It also allows you to change out cache storage or configuration without effecting
+ * implementation. It also allows you to change out cache storage or configuration without affecting
  * the rest of your application.
  *
  * ### Configuring Cache engines
@@ -561,7 +561,7 @@ class Cache
      * @param string $config The cache configuration to use for this operation.
      *   Defaults to default.
      * @return mixed If the key is found: the cached data.
-     *   If the key is not found the value returned by the the default callback.
+     *   If the key is not found the value returned by the default callback.
      */
     public static function remember(string $key, Closure $default, string $config = 'default'): mixed
     {

--- a/src/Cache/Engine/ArrayEngine.php
+++ b/src/Cache/Engine/ArrayEngine.php
@@ -192,7 +192,7 @@ class ArrayEngine extends CacheEngine
     }
 
     /**
-     * Delete all keys from the cache. This will clear every cache config using APC.
+     * Delete all keys from the cache.
      *
      * @return bool True Returns true.
      */

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -435,8 +435,8 @@ class FileEngine extends CacheEngine
             if (!$exists && !chmod($this->_File->getPathname(), (int)$this->_config['mask'])) {
                 trigger_error(sprintf(
                     'Could not apply permission mask `%s` on cache file `%s`',
-                    $this->_File->getPathname(),
                     $this->_config['mask'],
+                    $this->_File->getPathname(),
                 ), E_USER_WARNING);
             }
         }

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -216,7 +216,7 @@ class MemcachedEngine extends CacheEngine
     }
 
     /**
-     * Settings the memcached instance
+     * Set the memcached instance options
      *
      * @return void
      * @throws \Cake\Cache\Exception\InvalidArgumentException When the Memcached extension is not built
@@ -372,7 +372,7 @@ class MemcachedEngine extends CacheEngine
         $value = $this->_Memcached->get($key);
 
         $this->_eventClass = CacheAfterGetEvent::class;
-        if ($this->_Memcached->getResultCode() == Memcached::RES_NOTFOUND) {
+        if ($this->_Memcached->getResultCode() === Memcached::RES_NOTFOUND) {
             $this->dispatchEvent(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
 
             return $default;

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -109,7 +109,7 @@ trait EntityTrait
     /**
      * Map of fields in this entity that can be safely mass assigned, each
      * field name points to a boolean indicating its status. An empty array
-     * means no fields are accessible for mass assigment.
+     * means no fields are accessible for mass assignment.
      *
      * The special field '\*' can also be mapped, meaning that any other field
      * not defined in the map will take its value. For example, `'*' => true`

--- a/src/Datasource/Locator/LocatorInterface.php
+++ b/src/Datasource/Locator/LocatorInterface.php
@@ -54,7 +54,7 @@ interface LocatorInterface
     public function exists(string $alias): bool;
 
     /**
-     * Removes an repository instance from the registry.
+     * Removes a repository instance from the registry.
      *
      * @param string $alias The alias to remove.
      * @return void

--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -388,7 +388,7 @@ class NumericPaginator implements PaginatorInterface
         $this->addPrevNextParams($data);
         $this->addSortingParams($data);
 
-        $this->pagingParams['limit'] = $data['defaults']['limit'] != $data['options']['limit']
+        $this->pagingParams['limit'] = $data['defaults']['limit'] !== $data['options']['limit']
             ? $data['options']['limit']
             : null;
 

--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -388,7 +388,7 @@ class NumericPaginator implements PaginatorInterface
         $this->addPrevNextParams($data);
         $this->addSortingParams($data);
 
-        $this->pagingParams['limit'] = $data['defaults']['limit'] !== $data['options']['limit']
+        $this->pagingParams['limit'] = (int)$data['defaults']['limit'] !== (int)$data['options']['limit']
             ? $data['options']['limit']
             : null;
 

--- a/src/Datasource/Paging/SimplePaginator.php
+++ b/src/Datasource/Paging/SimplePaginator.php
@@ -31,7 +31,7 @@ class SimplePaginator extends NumericPaginator
     /**
      * Get paginated items.
      *
-     * Get one additional record than the limit. This helps deduce if next page exits.
+     * Get one additional record than the limit. This helps deduce if next page exists.
      *
      * @param \Cake\Datasource\QueryInterface $query Query to fetch items.
      * @param array $data Paging data.

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -174,7 +174,7 @@ class Validation
     }
 
     /**
-     * Checks that a doesn't contain any alpha numeric characters
+     * Checks that a value doesn't contain any alpha numeric characters
      *
      * This method's definition of letters and integers includes unicode characters.
      * Use `notAsciiAlphaNumeric()` if you want to exclude ascii only.
@@ -203,7 +203,7 @@ class Validation
     }
 
     /**
-     * Checks that a doesn't contain any non-ascii alpha numeric characters
+     * Checks that a value doesn't contain any non-ascii alpha numeric characters
      *
      * @param mixed $check Value to check
      * @return bool Success
@@ -1729,7 +1729,7 @@ class Validation
     /**
      * Convenience method for longitude validation.
      *
-     * @param mixed $value Latitude as string
+     * @param mixed $value Longitude as string
      * @param array<string, mixed> $options Options for the validation logic.
      * @return bool
      * @link https://en.wikipedia.org/wiki/Longitude

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -203,7 +203,7 @@ class TimeHelper extends Helper
      *
      * @param \Cake\Chronos\ChronosDate|\DateTimeInterface|string|int $dateString UNIX timestamp, strtotime() valid string or DateTime object
      * @param \DateTimeZone|string|null $timezone User's timezone string or DateTimeZone object
-     * @return bool True if datetime string was yesterday
+     * @return bool True if datetime string is tomorrow
      */
     public function isTomorrow(
         ChronosDate|DateTimeInterface|string|int $dateString,
@@ -387,7 +387,7 @@ class TimeHelper extends Helper
      * @param \Cake\Chronos\ChronosDate|\DateTimeInterface|string|int $dateString UNIX timestamp, strtotime() valid string or DateTime object
      * @param \DateTimeZone|string|null $timezone User's timezone string or DateTimeZone object
      * @return bool
-     * @see \Cake\I18n\Time::wasWithinLast()
+     * @see \Cake\I18n\Time::isWithinNext()
      */
     public function isWithinNext(
         string $timeInterval,

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -99,7 +99,7 @@ class XmlView extends SerializedView
     /**
      * Mime-type this view class renders as.
      *
-     * @return string The JSON content type.
+     * @return string The XML content type.
      */
     public static function contentType(): string
     {


### PR DESCRIPTION
## Summary

### Bug Fix
**`src/Cache/Engine/FileEngine.php:436-439`** - The sprintf arguments were in the wrong order for the permission mask error message. The mask value and file path were swapped.

### Typos Fixed (10)
| File | Line | Typo | Fixed |
|------|------|------|-------|
| `src/Cache/Cache.php` | 30 | `without effecting` | `without affecting` |
| `src/Cache/Cache.php` | 564 | `the the default` | `the default` |
| `src/Cache/Engine/ArrayEngine.php` | 195 | `using APC` | removed APC reference |
| `src/Cache/Engine/MemcachedEngine.php` | 218 | `Settings the` | `Set the` |
| `src/Datasource/EntityTrait.php` | 112 | `assigment` | `assignment` |
| `src/Datasource/Paging/SimplePaginator.php` | 34 | `page exits` | `page exists` |
| `src/Datasource/Locator/LocatorInterface.php` | 57 | `an repository` | `a repository` |
| `src/Validation/Validation.php` | 177,206 | `Checks that a doesn't` | `Checks that a value doesn't` |
| `src/Validation/Validation.php` | 1732 | `Latitude` | `Longitude` |

### Wrong Docblocks Fixed (3)
| File | Line | Issue |
|------|------|-------|
| `src/View/XmlView.php` | 102 | Said "JSON content type" but returns XML |
| `src/View/Helper/TimeHelper.php` | 206 | `isTomorrow()` docblock said "was yesterday" |
| `src/View/Helper/TimeHelper.php` | 390 | `isWithinNext()` referenced `wasWithinLast()` |

### Code Quality (2)
| File | Line | Issue |
|------|------|-------|
| `src/Cache/Engine/MemcachedEngine.php` | 375 | `==` → `===` for Memcached result code |
| `src/Datasource/Paging/NumericPaginator.php` | 391 | `!=` → `!==` for limit comparison |

## Test plan

- [x] PHPStan passes on all 11 changed files
- [x] FileEngine tests pass