### PR TITLE
Fix isset bug in debug formatters, typos and loose comparisons

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -58,7 +58,7 @@ class Collection extends IteratorIterator implements CollectionInterface
     }
 
     /**
-     * Returns an array for serializing this of this object.
+     * Returns an array for serializing this object.
      *
      * @return array
      */

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -122,7 +122,7 @@ trait CollectionTrait
     }
 
     /**
-     * Returns true if any the callback returns true for any element in the collection.
+     * Returns true if the callback returns true for any element in the collection.
      *
      * The callback accepts the value and key of the element being tested.
      *

--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -162,7 +162,7 @@ class MapReduce implements IteratorAggregate
      * for this record.
      *
      * @param mixed $val The value to be appended to the final list of results
-     * @param mixed $key and optional key to assign to the value
+     * @param mixed $key An optional key to assign to the value
      * @return void
      */
     public function emit(mixed $val, mixed $key = null): void
@@ -172,8 +172,8 @@ class MapReduce implements IteratorAggregate
     }
 
     /**
-     * Runs the actual Map-Reduce algorithm. This is iterate the original data
-     * and call the mapper function for each , then for each intermediate
+     * Runs the actual Map-Reduce algorithm. This iterates the original data
+     * and calls the mapper function for each record, then for each intermediate
      * bucket created during the Map phase call the reduce function.
      *
      * @return void

--- a/src/Collection/Iterator/UnfoldIterator.php
+++ b/src/Collection/Iterator/UnfoldIterator.php
@@ -22,7 +22,7 @@ use Traversable;
 
 /**
  * An iterator that can be used to generate nested iterators out of a collection
- * of items by applying an function to each of the elements in this iterator.
+ * of items by applying a function to each of the elements in this iterator.
  *
  * @internal
  * @see \Cake\Collection\Collection::unfold()

--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -235,7 +235,7 @@ class PluginLoadCommand extends Command
             ])
             ->addOption('no-middleware', [
                 'boolean' => true,
-                'help' => 'Do not run the `middleware()` hook..',
+                'help' => 'Do not run the `middleware()` hook.',
             ])
             ->addOption('no-routes', [
                 'boolean' => true,

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -291,7 +291,7 @@ class CommandRunner implements EventDispatcherInterface
             }
 
             $firstChar = $name[0] ?? '';
-            if ($firstChar == strtoupper($firstChar) && str_contains($name, '.')) {
+            if ($firstChar === strtoupper($firstChar) && str_contains($name, '.')) {
                 $underName = Inflector::underscore($name);
                 if ($commands->has($underName)) {
                     return [$underName, array_slice($argv, $i)];

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -293,7 +293,7 @@ class ConsoleIo
     }
 
     /**
-     * Halts the the current process with a StopException.
+     * Halts the current process with a StopException.
      *
      * @param string $message Error message.
      * @param int $code Error code.

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -41,7 +41,7 @@ use LogicException;
  * only be one letter long. Using more than one letter for a short option will raise an exception.
  *
  * Calling options can be done using syntax similar to most *nix command line tools. Long options
- * cane either include an `=` or leave it out.
+ * can either include an `=` or leave it out.
  *
  * `cake my_command --connection default --name=something`
  *

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -327,7 +327,7 @@ class ConsoleOutput
      * ```
      *
      * @param string $style The style to set.
-     * @param array $definition The array definition of the style to change or create..
+     * @param array $definition The array definition of the style to change or create.
      * @return void
      */
     public function setStyle(string $style, array $definition): void

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -211,7 +211,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * Check whether a given object is loaded.
      *
      * @param string $name The object name to check for.
-     * @return bool True is object is loaded else false.
+     * @return bool True if object is loaded else false.
      */
     public function has(string $name): bool
     {

--- a/src/Error/Debug/ConsoleFormatter.php
+++ b/src/Error/Debug/ConsoleFormatter.php
@@ -84,7 +84,7 @@ class ConsoleFormatter implements FormatterInterface
     public function formatWrapper(string $contents, array $location): string
     {
         $lineInfo = '';
-        if (isset($location['file'], $location['file'])) {
+        if (isset($location['file'], $location['line'])) {
             $lineInfo = sprintf('%s (line %s)', $location['file'], $location['line']);
         }
         $parts = [

--- a/src/Error/Debug/HtmlFormatter.php
+++ b/src/Error/Debug/HtmlFormatter.php
@@ -66,7 +66,7 @@ class HtmlFormatter implements FormatterInterface
     public function formatWrapper(string $contents, array $location): string
     {
         $lineInfo = '';
-        if (isset($location['file'], $location['file'])) {
+        if (isset($location['file'], $location['line'])) {
             $lineInfo = sprintf(
                 '<span><strong>%s</strong> (line <strong>%s</strong>)</span>',
                 $location['file'],

--- a/src/Error/Debug/TextFormatter.php
+++ b/src/Error/Debug/TextFormatter.php
@@ -41,7 +41,7 @@ class TextFormatter implements FormatterInterface
 
 TEXT;
         $lineInfo = '';
-        if (isset($location['file'], $location['file'])) {
+        if (isset($location['file'], $location['line'])) {
             $lineInfo = sprintf('%s (line %s)', $location['file'], $location['line']);
         }
 

--- a/src/Form/Schema.php
+++ b/src/Form/Schema.php
@@ -75,7 +75,7 @@ class Schema
     }
 
     /**
-     * Removes a field to the schema.
+     * Removes a field from the schema.
      *
      * @param string $name The field to remove.
      * @return $this

--- a/src/Mailer/TransportFactory.php
+++ b/src/Mailer/TransportFactory.php
@@ -73,7 +73,7 @@ class TransportFactory
      *
      * @param string $name Name of the config array that needs a transport instance built
      * @return void
-     * @throws \InvalidArgumentException When a tranport cannot be created.
+     * @throws \InvalidArgumentException When a transport cannot be created.
      */
     protected static function _buildTransport(string $name): void
     {


### PR DESCRIPTION
## Summary

- Fix isset() bug in debug formatters (HtmlFormatter, TextFormatter, ConsoleFormatter) where `$location['file']` was checked twice instead of checking both `$location['file']` and `$location['line']` - this could cause undefined array key errors
- Fix 12 typos in docblocks and comments across Collection, Console, Core, Event, Form, Command, and Mailer directories
- Fix 1 loose comparison (`==` to `===`) in CommandRunner

## Test plan

- [ ] Verify debug output still works correctly with the isset fix
- [ ] Run phpcs to ensure code style is correct
- [ ] Run phpstan to ensure no type errors