### PR TITLE
Fix loose comparisons and docblock typos

### DIFF
--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -101,7 +101,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
                 if (
                     $parameter->getName() === 'components' &&
                     $paramType instanceof ReflectionNamedType &&
-                    $paramType->getName() == ComponentRegistry::class
+                    $paramType->getName() === ComponentRegistry::class
                 ) {
                     $hasComponents = true;
                     break;

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -265,7 +265,7 @@ class Socket
     }
 
     /**
-     * socket_stream_client() does not populate errNum, or $errStr when there are
+     * stream_socket_client() does not populate errNum, or $errStr when there are
      * connection errors, as in the case of SSL verification failure.
      *
      * Instead, we need to handle those errors manually.
@@ -450,7 +450,7 @@ class Socket
     }
 
     /**
-     * Resets the state of this Socket instance to it's initial state (before Object::__construct got executed)
+     * Resets the state of this Socket instance to its initial state (before __construct() got executed)
      *
      * @param array|null $state Array with key and values to reset
      * @return void

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -1629,13 +1629,13 @@ trait IntegrationTestTrait
     {
         $exceptions = [$exception];
         $previous = $exception->getPrevious();
-        while ($previous != null) {
+        while ($previous !== null) {
             $exceptions[] = $previous;
             $previous = $previous->getPrevious();
         }
         $message = PHP_EOL;
         foreach ($exceptions as $i => $error) {
-            if ($i == 0) {
+            if ($i === 0) {
                 $message .= sprintf('Possibly related to `%s`: "%s"', $error::class, $error->getMessage());
                 $message .= PHP_EOL;
             } else {

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -191,7 +191,7 @@ abstract class TestCase extends BaseTestCase
                 &$deprecation,
                 $type,
             ): bool {
-                if ($code == $type) {
+                if ($code === $type) {
                     $deprecation = true;
 
                     return true;


### PR DESCRIPTION
## Summary

- Fix 4 loose comparisons (`==` to `===`) in TestCase, IntegrationTestTrait, and ControllerFactory
- Fix wrong function name in Socket.php docblock (`socket_stream_client` → `stream_socket_client`)
- Fix typos in Socket.php docblock (`it's` → `its`, `Object::__construct` → `__construct()`)

## Test plan

- [ ] Run phpcs to ensure code style is correct
- [ ] Run phpstan to ensure no type errors
- [ ] Run tests to verify no regressions