### PR TITLE
Fix bugs, typos and loose comparisons

### DIFF
--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -697,7 +697,7 @@ class QueryExpression implements ExpressionInterface, Countable
             }
             $operator = array_pop($parts);
             $expression = implode(' ', $parts);
-        } elseif ($spaces == 1) {
+        } elseif ($spaces === 1) {
             $parts = explode(' ', $expression, 2);
             [$expression, $operator] = $parts;
         }

--- a/src/Database/Statement/Statement.php
+++ b/src/Database/Statement/Statement.php
@@ -96,7 +96,7 @@ class Statement implements StatementInterface
     }
 
     /**
-     * Converts a give value to a suitable database value based on type and
+     * Converts a given value to a suitable database value based on type and
      * return relevant internal statement type.
      *
      * @param mixed $value The value to cast.

--- a/src/Http/FlashMessage.php
+++ b/src/Http/FlashMessage.php
@@ -174,7 +174,7 @@ class FlashMessage
     }
 
     /**
-     * Set an success message.
+     * Set a success message.
      *
      * The `'element'` option will be set to  `'error'`.
      *

--- a/src/Http/Middleware/CspMiddleware.php
+++ b/src/Http/Middleware/CspMiddleware.php
@@ -86,7 +86,7 @@ class CspMiddleware implements MiddlewareInterface
         if ($this->getConfig('scriptNonce')) {
             $request = $request->withAttribute('cspScriptNonce', $this->csp->nonce('script-src'));
         }
-        if ($this->getconfig('styleNonce')) {
+        if ($this->getConfig('styleNonce')) {
             $request = $request->withAttribute('cspStyleNonce', $this->csp->nonce('style-src'));
         }
         $response = $handler->handle($request);

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -53,7 +53,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      * Config for the CSRF handling.
      *
      *  - `cookieName` The name of the cookie to send.
-     *  - `expiry` A strotime compatible value of how long the CSRF token should last.
+     *  - `expiry` A strtotime compatible value of how long the CSRF token should last.
      *    Defaults to browser session.
      *  - `secure` Whether the cookie will be set with the Secure flag. Defaults to false.
      *  - `httponly` Whether the cookie will be set with the HttpOnly flag. Defaults to false.

--- a/src/Http/Middleware/EncryptedCookieMiddleware.php
+++ b/src/Http/Middleware/EncryptedCookieMiddleware.php
@@ -33,7 +33,7 @@ use Psr\Http\Server\RequestHandlerInterface;
  *
  * Cookies in request data will be decrypted, while cookies in response headers will
  * be encrypted automatically. If the response is a {@link \Cake\Http\Response}, the cookie
- * data set with `withCookie()` and `cookie()`` will also be encrypted.
+ * data set with `withCookie()` and `cookie()` will also be encrypted.
  *
  * The encryption types and padding are compatible with those used by CookieComponent
  * for backwards compatibility.

--- a/src/Http/MimeType.php
+++ b/src/Http/MimeType.php
@@ -311,7 +311,7 @@ class MimeType
      */
     public static function getMimeType(string $ext, ?string $default = null): ?string
     {
-        return isset(static::$mimeTypes[$ext]) ? static::$mimeTypes[$ext][0] : null;
+        return isset(static::$mimeTypes[$ext]) ? static::$mimeTypes[$ext][0] : $default;
     }
 
     /**

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -40,7 +40,7 @@ use function Cake\I18n\__d;
  * There are external packages such as `fig/http-message-util` that provide HTTP
  * status code constants. These can be used with any method that accepts or
  * returns a status code integer. Keep in mind that these constants might
- * include status codes that are now allowed which will throw an
+ * include status codes that are not allowed which will throw an
  * `\InvalidArgumentException`.
  */
 class Response implements ResponseInterface, Stringable
@@ -363,7 +363,7 @@ class Response implements ResponseInterface, Stringable
      * There are external packages such as `fig/http-message-util` that provide HTTP
      * status code constants. These can be used with any method that accepts or
      * returns a status code integer. However, keep in mind that these constants
-     * might include status codes that are now allowed which will throw an
+     * might include status codes that are not allowed which will throw an
      * `\InvalidArgumentException`.
      *
      * @link https://tools.ietf.org/html/rfc7231#section-6
@@ -1091,7 +1091,7 @@ class Response implements ResponseInterface, Stringable
      * Get a CorsBuilder instance for defining CORS headers.
      *
      * @param \Cake\Http\ServerRequest $request Request object
-     * @return \Cake\Http\CorsBuilder A builder object the provides a fluent interface for defining
+     * @return \Cake\Http\CorsBuilder A builder object that provides a fluent interface for defining
      *   additional CORS headers.
      */
     public function cors(ServerRequest $request): CorsBuilder

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -623,7 +623,7 @@ class ServerRequest implements ServerRequestInterface
         if (isset($detect['value'])) {
             $value = $detect['value'];
 
-            return isset($this->params[$key]) && $this->params[$key] == $value;
+            return isset($this->params[$key]) && $this->params[$key] === $value;
         }
         if (isset($detect['options'])) {
             return isset($this->params[$key]) && in_array($this->params[$key], $detect['options']);
@@ -642,7 +642,7 @@ class ServerRequest implements ServerRequestInterface
     {
         if (isset($detect['env'])) {
             if (isset($detect['value'])) {
-                return $this->getEnv($detect['env']) == $detect['value'];
+                return $this->getEnv($detect['env']) === $detect['value'];
             }
             if (isset($detect['pattern'])) {
                 return (bool)preg_match($detect['pattern'], (string)$this->getEnv($detect['env']));

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -40,7 +40,7 @@ class TimestampBehavior extends Behavior
      * the field value always, only when a new record or only when an existing record.
      *
      * refreshTimestamp - if true (the default) the timestamp used will be the current time when
-     * the code is executed, to set to an explicit date time value - set refreshTimetamp to false
+     * the code is executed, to set to an explicit date time value - set refreshTimestamp to false
      * and call setTimestamp() on the behavior class before use.
      *
      * @var array<string, mixed>

--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -24,7 +24,7 @@ use InvalidArgumentException;
 use SplFixedArray;
 
 /**
- * Factory class for generating ResulSet instances.
+ * Factory class for generating ResultSet instances.
  *
  * It is responsible for correctly nesting result keys reported from the query
  * and hydrating entities.
@@ -68,7 +68,7 @@ class ResultSetFactory
     }
 
     /**
-     * Get repository and it's associations data for nesting results key and
+     * Get repository and its associations data for nesting results key and
      * entity hydration.
      *
      * @param \Cake\ORM\Query\SelectQuery $query The query from where to derive the data.

--- a/src/ORM/TableEventsTrait.php
+++ b/src/ORM/TableEventsTrait.php
@@ -155,7 +155,7 @@ trait TableEventsTrait
 
     /**
      * The Model.afterDeleteCommit event is fired after the transaction in which the delete operation is wrapped has
-     * been is committed. It’s also triggered for non atomic deletes where database operations are implicitly committed.
+     * been committed. It's also triggered for non atomic deletes where database operations are implicitly committed.
      * The event is triggered only for the primary table on which delete() is directly called. The event is not
      * triggered if a transaction is started before calling delete.
      *

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -71,7 +71,7 @@ class BreadcrumbsHelper extends Helper
      *
      * @param array|string|null $url URL of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link.
-     * @param array<string, mixed> $options Array of options. These options will be used as attributes HTML attribute the crumb will
+     * @param array<string, mixed> $options Array of options. These options will be used as HTML attributes the crumb will
      * be rendered in (a <li> tag by default). It accepts two special keys:
      *
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
@@ -133,7 +133,7 @@ class BreadcrumbsHelper extends Helper
      *
      * @param array|string|null $url URL of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link.
-     * @param array<string, mixed> $options Array of options. These options will be used as attributes HTML attribute the crumb will
+     * @param array<string, mixed> $options Array of options. These options will be used as HTML attributes the crumb will
      * be rendered in (a <li> tag by default). It accepts two special keys:
      *
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
@@ -198,7 +198,7 @@ class BreadcrumbsHelper extends Helper
      * @param string $title Title of the crumb.
      * @param array|string|null $url URL of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link.
-     * @param array<string, mixed> $options Array of options. These options will be used as attributes HTML attribute the crumb will
+     * @param array<string, mixed> $options Array of options. These options will be used as HTML attributes the crumb will
      * be rendered in (a <li> tag by default). It accepts two special keys:
      *
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
@@ -228,7 +228,7 @@ class BreadcrumbsHelper extends Helper
      * @param string $title Title of the crumb.
      * @param array|string|null $url URL of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link.
-     * @param array<string, mixed> $options Array of options. These options will be used as attributes HTML attribute the crumb will
+     * @param array<string, mixed> $options Array of options. These options will be used as HTML attributes the crumb will
      * be rendered in (a <li> tag by default). It accepts two special keys:
      *
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
@@ -262,7 +262,7 @@ class BreadcrumbsHelper extends Helper
      * @param string $title Title of the crumb.
      * @param array|string|null $url URL of the crumb. Either a string, an array of route params to pass to
      * Url::build() or null / empty if the crumb does not have a link.
-     * @param array<string, mixed> $options Array of options. These options will be used as attributes HTML attribute the crumb will
+     * @param array<string, mixed> $options Array of options. These options will be used as HTML attributes the crumb will
      * be rendered in (a <li> tag by default). It accepts two special keys:
      *
      * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -76,7 +76,7 @@ class FormHelper extends Helper
      */
     protected array $_defaultConfig = [
         'idPrefix' => null,
-        // Deprecated option, use templates.errorClass intead.
+        // Deprecated option, use templates.errorClass instead.
         'errorClass' => null,
         'defaultPostLinkBlock' => null,
         'typeMap' => [
@@ -1258,7 +1258,7 @@ class FormHelper extends Helper
             case 'radio':
             case 'multicheckbox':
                 $opts = $options['options'];
-                if ($opts == null) {
+                if ($opts === null) {
                     $opts = [];
                 }
                 unset($options['options']);


### PR DESCRIPTION
## Summary

- Fix two bugs: `getconfig()` → `getConfig()` in CspMiddleware, and unused `$default` parameter in MimeType::getMimeType()
- Fix typos in 11 files across Response, FlashMessage, FormHelper, TimestampBehavior, CsrfProtectionMiddleware, Statement, ResultSetFactory, TableEventsTrait, BreadcrumbsHelper, and EncryptedCookieMiddleware
- Fix loose comparisons in FormHelper, QueryExpression, and ServerRequest

## Details

### Bugs
| File | Issue |
|------|-------|
| CspMiddleware.php | `getconfig()` → `getConfig()` (wrong method case) |
| MimeType.php | `$default` parameter was ignored, always returned `null` |

### Typos
| File | Fix |
|------|-----|
| Response.php | "now allowed" → "not allowed" (×2), "the provides" → "that provides" |
| FlashMessage.php | "an success" → "a success" |
| FormHelper.php | "intead" → "instead" |
| TimestampBehavior.php | "refreshTimetamp" → "refreshTimestamp" |
| CsrfProtectionMiddleware.php | "strotime" → "strtotime" |
| Statement.php | "give" → "given" |
| ResultSetFactory.php | "ResulSet" → "ResultSet", "it's" → "its" |
| TableEventsTrait.php | "been is committed" → "been committed" |
| BreadcrumbsHelper.php | "attributes HTML attribute" → "HTML attributes" (×5) |
| EncryptedCookieMiddleware.php | Extra backtick removed |

### Loose Comparisons
| File | Line | Fix |
|------|------|-----|
| FormHelper.php | 1261 | `== null` → `=== null` |
| QueryExpression.php | 700 | `== 1` → `=== 1` |
| ServerRequest.php | 626, 645 | `== $value` → `=== $value` |