### PR TITLE
Make EventInterface template covariant

### DIFF
--- a/src/Event/EventInterface.php
+++ b/src/Event/EventInterface.php
@@ -21,7 +21,7 @@ namespace Cake\Event;
  * payload. The name can be any string that uniquely identifies the event across the application, while the subject
  * represents the object that the event applies to.
  *
- * @template TSubject of object
+ * @template-covariant TSubject of object
  */
 interface EventInterface
 {


### PR DESCRIPTION
## Summary
The `TSubject` template parameter on `EventInterface` is only used in output (return) position via `getSubject(): TSubject`, so it should be marked as covariant with `@template-covariant`.

This allows `EventInterface<View>` to correctly be a subtype of `EventInterface<object>`, fixing PHPStan errors when overriding `dispatchEvent()` in child classes that extend View.

## Current behavior
When a class extends `View` and overrides `dispatchEvent()`, PHPStan reports:
```
Return type (Cake\Event\EventInterface<Cake\View\View>) of method ... should be compatible 
with return type (Cake\Event\EventInterface<object>) of method 
Cake\Event\EventDispatcherInterface<object>::dispatchEvent()
```

## After this fix
The covariant template allows proper subtype relationship, eliminating the false positive.

## References
- https://phpstan.org/blog/whats-up-with-template-covariant

Note: It currently forces me to ignoreError this in plugins ( https://github.com/dereuromark/cakephp-dto/pull/89 )

 Why EventInterface is the only issue:                                                                                                                                                                                             
  - It's the only interface where the template parameter is exclusively used in a return/output position                                                                                                                            
  - getSubject(): TSubject - only output, never input                                                                                                                                                                               
  - All other interfaces with templates either use them in both positions (invariant required) or are already correctly marked covariant                                                                                            
                        