### PR TITLE
WIP: Fix phpunit notices

### DIFF
--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -200,8 +200,8 @@ class RedisClusterEngineTest extends TestCase
             }
         };
 
-        // Use a mocked RedisCluster to avoid triggering constructor logic
-        $redisMock = $this->createMock(RedisCluster::class);
+        // Use a stubbed RedisCluster to avoid triggering constructor logic
+        $redisMock = $this->createStub(RedisCluster::class);
 
         // Set $_Redis manually using Reflection
         $reflection = new ReflectionClass($mock);

--- a/tests/TestCase/Command/SchemaCacheCommandsTest.php
+++ b/tests/TestCase/Command/SchemaCacheCommandsTest.php
@@ -22,10 +22,12 @@ use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Database\Schema\CachedCollection;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * SchemaCacheCommands test.
  */
+#[AllowMockObjectsWithoutExpectations]
 class SchemaCacheCommandsTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -32,6 +32,7 @@ use Cake\Http\MiddlewareQueue;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Mockery;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use stdClass;
 use TestApp\Application;
 use TestApp\Command\AbortCommand;
@@ -42,6 +43,7 @@ use TestApp\Command\SampleCommand;
 /**
  * Test case for the CommandCollection
  */
+#[AllowMockObjectsWithoutExpectations]
 class CommandRunnerTest extends TestCase
 {
     /**

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -21,10 +21,12 @@ namespace Cake\Test\TestCase\Console;
 use Cake\Console\ConsoleOutput;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * ConsoleOutputTest
  */
+#[AllowMockObjectsWithoutExpectations]
 class ConsoleOutputTest extends TestCase
 {
     /**

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -24,10 +24,12 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Mockery;
 use PDO;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * Tests Postgres driver
  */
+#[AllowMockObjectsWithoutExpectations]
 class PostgresTest extends TestCase
 {
     /**

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -24,11 +24,13 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Mockery;
 use PDO;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Sqlite driver
  */
+#[AllowMockObjectsWithoutExpectations]
 class SqliteTest extends TestCase
 {
     protected function tearDown(): void

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -29,11 +29,13 @@ use InvalidArgumentException;
 use Mockery;
 use PDO;
 use PDOStatement;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Sqlserver driver
  */
+#[AllowMockObjectsWithoutExpectations]
 class SqlserverTest extends TestCase
 {
     /**

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -33,6 +33,7 @@ use Exception;
 use PDO;
 use PDOException;
 use PDOStatement;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Database\Driver\RetryDriver;
 use TestApp\Database\Driver\StubDriver;
@@ -40,10 +41,11 @@ use TestApp\Database\Driver\StubDriver;
 /**
  * Tests Driver class
  */
+#[AllowMockObjectsWithoutExpectations]
 class DriverTest extends TestCase
 {
     /**
-     * @var \Cake\Database\Driver|\PHPUnit\Framework\MockObject\MockObject
+     * @var \TestApp\Database\Driver\StubDriver|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $driver;
 

--- a/tests/TestCase/Database/Query/UpdateQueryTest.php
+++ b/tests/TestCase/Database/Query/UpdateQueryTest.php
@@ -33,10 +33,12 @@ use Cake\Test\TestCase\Database\QueryAssertsTrait;
 use Cake\TestSuite\TestCase;
 use DateTime;
 use PDOStatement;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * Tests UpdateQuery class
  */
+#[AllowMockObjectsWithoutExpectations]
 class UpdateQueryTest extends TestCase
 {
     use QueryAssertsTrait;

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -31,11 +31,13 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Exception;
 use PDO;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test case for MySQL Schema Dialect.
  */
+#[AllowMockObjectsWithoutExpectations]
 class MysqlSchemaDialectTest extends TestCase
 {
     protected PDO $pdo;
@@ -279,7 +281,7 @@ class MysqlSchemaDialectTest extends TestCase
             'default' => 'Default value',
             'comment' => 'Comment section',
         ];
-        $driver = $this->getMockBuilder(Mysql::class)->getMock();
+        $driver = $this->createStub(Mysql::class);
         $dialect = new MysqlSchemaDialect($driver);
 
         $table = new TableSchema('table');
@@ -301,7 +303,7 @@ class MysqlSchemaDialectTest extends TestCase
             'Collation' => 'utf8_general_ci',
             'Comment' => 'Comment section',
         ];
-        $driver = $this->getMockBuilder(Mysql::class)->getMock();
+        $driver = $this->createStub(Mysql::class);
         $dialect = new MysqlSchemaDialect($driver);
 
         $table = new TableSchema('table');

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -30,11 +30,13 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Exception;
 use PDO;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Postgres schema test case.
  */
+#[AllowMockObjectsWithoutExpectations]
 class PostgresSchemaDialectTest extends TestCase
 {
     /**
@@ -329,7 +331,7 @@ SQL;
             'comment' => 'Comment section',
         ];
 
-        $driver = $this->getMockBuilder(Postgres::class)->getMock();
+        $driver = $this->createStub(Postgres::class);
         $dialect = new PostgresSchemaDialect($driver);
 
         $table = new TableSchema('table');
@@ -1949,7 +1951,7 @@ SQL;
 
     public function testDescribeIndexSql(): void
     {
-        $driver = $this->getMockBuilder(Postgres::class)->getMock();
+        $driver = $this->createStub(Postgres::class);
         $dialect = new PostgresSchemaDialect($driver);
 
         $result = $dialect->describeIndexSql('schema_name.table_name', []);
@@ -1992,7 +1994,7 @@ SQL;
 
     public function testDescribeForeignKeySql(): void
     {
-        $driver = $this->getMockBuilder(Postgres::class)->getMock();
+        $driver = $this->createStub(Postgres::class);
         $dialect = new PostgresSchemaDialect($driver);
 
         $result = $dialect->describeForeignKeySql('schema_name.table_name', []);

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -29,11 +29,13 @@ use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use PDO;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test case for Sqlite Schema Dialect.
  */
+#[AllowMockObjectsWithoutExpectations]
 class SqliteSchemaDialectTest extends TestCase
 {
     protected PDO $pdo;
@@ -218,7 +220,7 @@ class SqliteSchemaDialectTest extends TestCase
             'comment' => null,
         ];
 
-        $driver = $this->getMockBuilder(Sqlite::class)->getMock();
+        $driver = $this->createStub(Sqlite::class);
         $dialect = new SqliteSchemaDialect($driver);
 
         $table = new TableSchema('table');
@@ -236,7 +238,7 @@ class SqliteSchemaDialectTest extends TestCase
      */
     public function testConvertCompositePrimaryKey(): void
     {
-        $driver = $this->getMockBuilder(Sqlite::class)->getMock();
+        $driver = $this->createStub(Sqlite::class);
         $dialect = new SqliteSchemaDialect($driver);
 
         $field1 = [

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -27,11 +27,13 @@ use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use PDO;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * SQL Server schema test case.
  */
+#[AllowMockObjectsWithoutExpectations]
 class SqlserverSchemaDialectTest extends TestCase
 {
     /**
@@ -350,7 +352,7 @@ SQL;
             'default' => 'Default value',
         ];
 
-        $driver = $this->getMockBuilder(Sqlserver::class)->getMock();
+        $driver = $this->createStub(Sqlserver::class);
         $dialect = new SqlserverSchemaDialect($driver);
 
         $table = new TableSchema('table');

--- a/tests/TestCase/Database/Type/BinaryTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryTypeTest.php
@@ -44,7 +44,7 @@ class BinaryTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = TypeFactory::build('binary');
-        $this->driver = $this->getMockBuilder(Driver::class)->getMock();
+        $this->driver = $this->createStub(Driver::class);
     }
 
     /**

--- a/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
@@ -45,7 +45,7 @@ class BinaryUuidTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = new BinaryUuidType();
-        $this->driver = $this->getMockBuilder(Driver::class)->getMock();
+        $this->driver = $this->createStub(Driver::class);
     }
 
     /**

--- a/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -44,7 +44,7 @@ class BoolTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = TypeFactory::build('boolean');
-        $this->driver = $this->getMockBuilder(Driver::class)->getMock();
+        $this->driver = $this->createStub(Driver::class);
     }
 
     /**

--- a/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
@@ -45,7 +45,7 @@ class DateTimeFractionalTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = new DateTimeFractionalType();
-        $this->driver = $this->getMockBuilder(Driver::class)->getMock();
+        $this->driver = $this->createStub(Driver::class);
     }
 
     /**

--- a/tests/TestCase/Database/Type/DateTimeTimezoneTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTimezoneTypeTest.php
@@ -45,7 +45,7 @@ class DateTimeTimezoneTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = new DateTimeTimezoneType();
-        $this->driver = $this->getMockBuilder(Driver::class)->getMock();
+        $this->driver = $this->createStub(Driver::class);
     }
 
     /**

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -61,7 +61,7 @@ class DateTimeTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = new DateTimeType();
-        $this->driver = $this->getMockBuilder(Driver::class)->getMock();
+        $this->driver = $this->createStub(Driver::class);
 
         $this->originalTimeZone = date_default_timezone_get();
     }

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -53,7 +53,7 @@ class DateTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = new DateType();
-        $this->driver = $this->getMockBuilder(Driver::class)->getMock();
+        $this->driver = $this->createStub(Driver::class);
 
         $this->originalTimeZone = date_default_timezone_get();
     }

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -50,7 +50,7 @@ class FloatTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = new FloatType();
-        $this->driver = $this->getMockBuilder(Driver::class)->getMock();
+        $this->driver = $this->createStub(Driver::class);
         $this->numberClass = FloatType::$numberClass;
     }
 

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -45,7 +45,7 @@ class IntegerTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = TypeFactory::build('integer');
-        $this->driver = $this->getMockBuilder(Driver::class)->getMock();
+        $this->driver = $this->createStub(Driver::class);
     }
 
     /**

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -46,7 +46,7 @@ class JsonTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = TypeFactory::build('json');
-        $this->driver = $this->getMockBuilder(Driver::class)->getMock();
+        $this->driver = $this->createStub(Driver::class);
     }
 
     /**

--- a/tests/TestCase/Database/Type/StringTypeTest.php
+++ b/tests/TestCase/Database/Type/StringTypeTest.php
@@ -45,7 +45,7 @@ class StringTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = TypeFactory::build('string');
-        $this->driver = $this->getMockBuilder(Driver::class)->getMock();
+        $this->driver = $this->createStub(Driver::class);
     }
 
     /**

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -50,7 +50,7 @@ class TimeTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = new TimeType();
-        $this->driver = $this->getMockBuilder(Driver::class)->getMock();
+        $this->driver = $this->createStub(Driver::class);
     }
 
     /**

--- a/tests/TestCase/Database/Type/UuidTypeTest.php
+++ b/tests/TestCase/Database/Type/UuidTypeTest.php
@@ -43,7 +43,7 @@ class UuidTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = TypeFactory::build('uuid');
-        $this->driver = $this->getMockBuilder(Driver::class)->getMock();
+        $this->driver = $this->createStub(Driver::class);
     }
 
     /**

--- a/tests/TestCase/Database/TypeFactoryTest.php
+++ b/tests/TestCase/Database/TypeFactoryTest.php
@@ -236,7 +236,7 @@ class TypeFactoryTest extends TestCase
         );
         $type = TypeFactory::build('biginteger');
         $integer = time() * time();
-        $driver = $this->getMockBuilder(Driver::class)->getMock();
+        $driver = $this->createStub(Driver::class);
         $this->assertSame($integer, $type->toPHP($integer, $driver));
         $this->assertSame($integer, $type->toPHP('' . $integer, $driver));
         $this->assertSame(3, $type->toPHP(3.57, $driver));
@@ -249,7 +249,7 @@ class TypeFactoryTest extends TestCase
     {
         $type = TypeFactory::build('biginteger');
         $integer = time() * time();
-        $driver = $this->getMockBuilder(Driver::class)->getMock();
+        $driver = $this->createStub(Driver::class);
         $this->assertSame(PDO::PARAM_INT, $type->toStatement($integer, $driver));
     }
 
@@ -259,7 +259,7 @@ class TypeFactoryTest extends TestCase
     public function testDecimalToPHP(): void
     {
         $type = TypeFactory::build('decimal');
-        $driver = $this->getMockBuilder(Driver::class)->getMock();
+        $driver = $this->createStub(Driver::class);
 
         $this->assertSame('3.14159', $type->toPHP('3.14159', $driver));
         $this->assertSame('3.14159', $type->toPHP(3.14159, $driver));
@@ -273,7 +273,7 @@ class TypeFactoryTest extends TestCase
     {
         $type = TypeFactory::build('decimal');
         $string = '12.55';
-        $driver = $this->getMockBuilder(Driver::class)->getMock();
+        $driver = $this->createStub(Driver::class);
         $this->assertSame(PDO::PARAM_STR, $type->toStatement($string, $driver));
     }
 
@@ -282,7 +282,7 @@ class TypeFactoryTest extends TestCase
      */
     public function testSet(): void
     {
-        $instance = $this->getMockBuilder(TypeInterface::class)->getMock();
+        $instance = $this->createStub(TypeInterface::class);
         TypeFactory::set('random', $instance);
         $this->assertSame($instance, TypeFactory::build('random'));
     }

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -32,6 +32,7 @@ use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use MyClass;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use RuntimeException;
 use SplFixedArray;
 use stdClass;
@@ -46,6 +47,7 @@ use TestApp\Utility\ThrowsDebugInfo;
  * !!! Be careful with changing code below as it may
  * !!! change line numbers which are used in the tests
  */
+#[AllowMockObjectsWithoutExpectations]
 class DebuggerTest extends TestCase
 {
     /**

--- a/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
+++ b/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
@@ -983,7 +983,7 @@ class WebExceptionRendererTest extends TestCase
         $loggedQuery = new LoggedQuery();
         $loggedQuery->setContext([
             'query' => 'SELECT * from poo_query < 5 and :seven',
-            'driver' => $this->getMockBuilder(Driver::class)->getMock(),
+            'driver' => $this->createStub(Driver::class),
             'params' => ['seven' => 7],
         ]);
         $exception = new QueryException($loggedQuery, new PDOException());

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -22,11 +22,13 @@ use Cake\Http\Client\Request;
 use Cake\Http\Client\Response;
 use Cake\TestSuite\TestCase;
 use Exception;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use TestApp\Http\Client\Adapter\CakeStreamWrapper;
 
 /**
  * HTTP stream adapter test.
  */
+#[AllowMockObjectsWithoutExpectations]
 class StreamTest extends TestCase
 {
     /**

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -28,11 +28,13 @@ use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Laminas\Diactoros\Request as LaminasRequest;
 use Mockery;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * HTTP client test.
  */
+#[AllowMockObjectsWithoutExpectations]
 class ClientTest extends TestCase
 {
     protected function tearDown(): void

--- a/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
@@ -22,12 +22,14 @@ use Cake\Http\Middleware\RateLimitMiddleware;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Psr\Http\Server\RequestHandlerInterface;
 use stdClass;
 
 /**
  * RateLimitMiddleware test case
  */
+#[AllowMockObjectsWithoutExpectations]
 class RateLimitMiddlewareTest extends TestCase
 {
     /**

--- a/tests/TestCase/Http/ResponseEmitterTest.php
+++ b/tests/TestCase/Http/ResponseEmitterTest.php
@@ -21,12 +21,14 @@ use Cake\Http\Cookie\Cookie;
 use Cake\Http\Response;
 use Cake\Http\ResponseEmitter;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 require_once __DIR__ . '/server_mocks.php';
 
 /**
  * Response emitter test.
  */
+#[AllowMockObjectsWithoutExpectations]
 class ResponseEmitterTest extends TestCase
 {
     /**

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -31,10 +31,12 @@ use Laminas\Diactoros\Uri;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * ServerRequest Test
  */
+#[AllowMockObjectsWithoutExpectations]
 class ServerRequestTest extends TestCase
 {
     /**

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -28,10 +28,10 @@ use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use Laminas\Diactoros\Uri;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * ServerRequest Test

--- a/tests/TestCase/I18n/TranslatorRegistryTest.php
+++ b/tests/TestCase/I18n/TranslatorRegistryTest.php
@@ -24,8 +24,10 @@ use Cake\I18n\PackageLocator;
 use Cake\I18n\Translator;
 use Cake\I18n\TranslatorRegistry;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use TestApp\Cache\Engine\TestAppCacheEngine;
 
+#[AllowMockObjectsWithoutExpectations]
 class TranslatorRegistryTest extends TestCase
 {
     /**

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -22,10 +22,12 @@ use Cake\Core\Exception\CakeException;
 use Cake\Mailer\Message;
 use Cake\Mailer\Transport\MailTransport;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * Test case
  */
+#[AllowMockObjectsWithoutExpectations]
 class MailTransportTest extends TestCase
 {
     /**

--- a/tests/TestCase/ORM/Association/BelongsToManySaveAssociatedOnlyEntitiesAppendTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManySaveAssociatedOnlyEntitiesAppendTest.php
@@ -21,10 +21,12 @@ use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * Tests BelongsToManySaveAssociatedOnlyEntitiesAppendTest class
  */
+#[AllowMockObjectsWithoutExpectations]
 class BelongsToManySaveAssociatedOnlyEntitiesAppendTest extends TestCase
 {
     /**

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -38,6 +38,7 @@ use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Entity\ArticlesTag;
 use function Cake\Collection\collection;
@@ -45,6 +46,7 @@ use function Cake\Collection\collection;
 /**
  * Tests BelongsToMany class
  */
+#[AllowMockObjectsWithoutExpectations]
 class BelongsToManyTest extends TestCase
 {
     /**

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -29,10 +29,12 @@ use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Mockery;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * Tests BelongsTo class
  */
+#[AllowMockObjectsWithoutExpectations]
 class BelongsToTest extends TestCase
 {
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -35,12 +35,14 @@ use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Mockery;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function Cake\I18n\__;
 
 /**
  * Tests HasMany class
  */
+#[AllowMockObjectsWithoutExpectations]
 class HasManyTest extends TestCase
 {
     /**

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -28,10 +28,12 @@ use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Mockery;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * Tests HasOne class
  */
+#[AllowMockObjectsWithoutExpectations]
 class HasOneTest extends TestCase
 {
     /**

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -27,11 +27,13 @@ use Cake\ORM\Locator\LocatorInterface;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * AssociationCollection test case.
  */
+#[AllowMockObjectsWithoutExpectations]
 class AssociationCollectionTest extends TestCase
 {
     /**

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -23,6 +23,7 @@ use Cake\ORM\Locator\LocatorInterface;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use TestApp\Model\Table\AuthorsTable;
 use TestApp\Model\Table\TestTable;
 use TestPlugin\Model\Table\CommentsTable;
@@ -30,6 +31,7 @@ use TestPlugin\Model\Table\CommentsTable;
 /**
  * Tests Association class
  */
+#[AllowMockObjectsWithoutExpectations]
 class AssociationTest extends TestCase
 {
     /**

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -33,7 +33,7 @@ class BehaviorTest extends TestCase
      */
     public function testConstructor(): void
     {
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
         $config = ['key' => 'value'];
         $behavior = new TestBehavior($table, $config);
         $this->assertEquals($config, $behavior->getConfig());
@@ -44,7 +44,7 @@ class BehaviorTest extends TestCase
      */
     public function testGetTable(): void
     {
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
 
         $behavior = new TestBehavior($table);
         $this->assertSame($table, $behavior->table());
@@ -52,7 +52,7 @@ class BehaviorTest extends TestCase
 
     public function testReflectionCache(): void
     {
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
         $behavior = new Test3Behavior($table);
         $expected = [
             'finders' => [
@@ -71,7 +71,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedEvents(): void
     {
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
         $behavior = new TestBehavior($table);
         $expected = [
             'Model.beforeFind' => 'beforeFind',
@@ -89,7 +89,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedEventsWithPriority(): void
     {
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
         $behavior = new TestBehavior($table, ['priority' => 10]);
         $expected = [
             'Model.beforeFind' => [
@@ -125,7 +125,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedMethods(): void
     {
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
         $behavior = new Test2Behavior($table);
         $expected = [
             'doSomething' => 'doSomething',
@@ -138,7 +138,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedMethodsAliased(): void
     {
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
         $behavior = new Test2Behavior($table, [
             'implementedMethods' => [
                 'aliased' => 'doSomething',
@@ -155,7 +155,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedMethodsDisabled(): void
     {
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
         $behavior = new Test2Behavior($table, [
             'implementedMethods' => [],
         ]);
@@ -168,7 +168,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedFinders(): void
     {
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
         $behavior = new Test2Behavior($table);
         $expected = [
             'foo' => 'findFoo',
@@ -181,7 +181,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedFindersAliased(): void
     {
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
         $behavior = new Test2Behavior($table, [
             'implementedFinders' => [
                 'aliased' => 'findFoo',
@@ -198,7 +198,7 @@ class BehaviorTest extends TestCase
      */
     public function testImplementedFindersDisabled(): void
     {
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
         $behavior = new Test2Behavior($table, [
             'implementedFinders' => [],
         ]);
@@ -212,7 +212,7 @@ class BehaviorTest extends TestCase
      */
     public function testVerifyConfig(): void
     {
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
         $behavior = new Test2Behavior($table);
         $behavior->verifyConfig();
         $this->assertTrue(true, 'No exception thrown');
@@ -225,7 +225,7 @@ class BehaviorTest extends TestCase
      */
     public function testVerifyConfigImplementedFindersOverridden(): void
     {
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
         $behavior = new Test2Behavior($table, [
             'implementedFinders' => [
                 'aliased' => 'findFoo',
@@ -242,7 +242,7 @@ class BehaviorTest extends TestCase
     {
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('The method `findNotDefined` is not callable on class `' . Test2Behavior::class . '`');
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
         $behavior = new Test2Behavior($table, [
             'implementedFinders' => [
                 'aliased' => 'findNotDefined',
@@ -258,7 +258,7 @@ class BehaviorTest extends TestCase
      */
     public function testVerifyConfigImplementedMethodsOverridden(): void
     {
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
         $behavior = new Test2Behavior($table);
         $behavior = new Test2Behavior($table, [
             'implementedMethods' => [
@@ -276,7 +276,7 @@ class BehaviorTest extends TestCase
     {
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('The method `iDoNotExist` is not callable on class `' . Test2Behavior::class . '`');
-        $table = $this->getMockBuilder(Table::class)->getMock();
+        $table = $this->createStub(Table::class);
         $behavior = new Test2Behavior($table, [
             'implementedMethods' => [
                 'aliased' => 'iDoNotExist',

--- a/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
+++ b/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
@@ -60,7 +60,7 @@ class LocatorAwareTraitTest extends TestCase
      */
     public function testSetTableLocator(): void
     {
-        $newLocator = $this->getMockBuilder(LocatorInterface::class)->getMock();
+        $newLocator = $this->createStub(LocatorInterface::class);
         $this->subject->setTableLocator($newLocator);
         $subjectLocator = $this->subject->getTableLocator();
         $this->assertSame($newLocator, $subjectLocator);

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -36,10 +36,12 @@ use TestPlugin\Model\Entity\Comment;
 use TestPlugin\Model\Table\CommentsTable;
 use TestPlugin\Model\Table\TestPluginCommentsTable;
 use TestPluginTwo\Model\Table\CommentsTable as PluginTwoCommentsTable;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * Test case for TableLocator
  */
+#[AllowMockObjectsWithoutExpectations]
 class TableLocatorTest extends TestCase
 {
     /**
@@ -488,7 +490,7 @@ class TableLocatorTest extends TestCase
      */
     public function testSet(): void
     {
-        $mock = $this->getMockBuilder(Table::class)->getMock();
+        $mock = $this->createStub(Table::class);
         $this->assertSame($mock, $this->_locator->set('Articles', $mock));
         $this->assertSame($mock, $this->_locator->get('Articles'));
     }
@@ -500,7 +502,7 @@ class TableLocatorTest extends TestCase
     {
         $this->loadPlugins(['TestPlugin']);
 
-        $mock = $this->getMockBuilder(CommentsTable::class)->getMock();
+        $mock = $this->createStub(CommentsTable::class);
 
         $this->assertSame($mock, $this->_locator->set('TestPlugin.Comments', $mock));
         $this->assertSame($mock, $this->_locator->get('TestPlugin.Comments'));

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -25,6 +25,7 @@ use Cake\ORM\Query\QueryFactory;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use ReflectionProperty;
 use TestApp\Infrastructure\Table\AddressesTable;
 use TestApp\Model\Entity\Article;
@@ -36,7 +37,6 @@ use TestPlugin\Model\Entity\Comment;
 use TestPlugin\Model\Table\CommentsTable;
 use TestPlugin\Model\Table\TestPluginCommentsTable;
 use TestPluginTwo\Model\Table\CommentsTable as PluginTwoCommentsTable;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * Test case for TableLocator

--- a/tests/TestCase/ORM/Query/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/Query/CompositeKeysTest.php
@@ -26,12 +26,14 @@ use Cake\ORM\Marshaller;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Entity\OpenArticleEntity;
 
 /**
  * Integration tests for table operations involving composite keys
  */
+#[AllowMockObjectsWithoutExpectations]
 class CompositeKeysTest extends TestCase
 {
     /**

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -48,10 +48,12 @@ use ReflectionProperty;
 use TestApp\Model\Table\ArticlesTable;
 use TestApp\Model\Table\AuthorsTable;
 use TestApp\Model\Table\TagsTable;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * Tests SelectQuery class
  */
+#[AllowMockObjectsWithoutExpectations]
 class SelectQueryTest extends TestCase
 {
     /**

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -43,12 +43,12 @@ use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\ResultSet;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 use TestApp\Model\Table\ArticlesTable;
 use TestApp\Model\Table\AuthorsTable;
 use TestApp\Model\Table\TagsTable;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * Tests SelectQuery class

--- a/tests/TestCase/ORM/ResultSetFactoryTest.php
+++ b/tests/TestCase/ORM/ResultSetFactoryTest.php
@@ -32,10 +32,12 @@ use TestApp\Dto\AuthorArrayDto;
 use TestApp\Dto\AuthorDto;
 use TestApp\Dto\CommentDto;
 use TestApp\Dto\SimpleArticleDto;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * ResultSetFactory test case.
  */
+#[AllowMockObjectsWithoutExpectations]
 class ResultSetFactoryTest extends TestCase
 {
     /**

--- a/tests/TestCase/ORM/ResultSetFactoryTest.php
+++ b/tests/TestCase/ORM/ResultSetFactoryTest.php
@@ -26,13 +26,13 @@ use Cake\ORM\ResultSetFactory;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Mockery;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use TestApp\Dto\ArticleArrayDto;
 use TestApp\Dto\ArticleDto;
 use TestApp\Dto\AuthorArrayDto;
 use TestApp\Dto\AuthorDto;
 use TestApp\Dto\CommentDto;
 use TestApp\Dto\SimpleArticleDto;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * ResultSetFactory test case.

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -59,7 +59,7 @@ class TableRegistryTest extends TestCase
      */
     protected function _setMockLocator()
     {
-        $locator = $this->getMockBuilder(LocatorInterface::class)->getMock();
+        $locator = $this->createStub(LocatorInterface::class);
         TableRegistry::setTableLocator($locator);
 
         return $locator;

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -63,6 +63,7 @@ use Exception;
 use InvalidArgumentException;
 use Mockery;
 use PDOException;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use TestApp\Model\Entity\Article;
@@ -78,6 +79,7 @@ use TestPlugin\Model\Table\CommentsTable;
 /**
  * Tests Table class
  */
+#[AllowMockObjectsWithoutExpectations]
 class TableTest extends TestCase
 {
     /**

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -30,6 +30,7 @@ use Cake\Test\Fixture\FixturizedTestCase;
 use Cake\TestSuite\TestCase;
 use Exception;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestStatus\Skipped;
 use PHPUnit\Framework\TestStatus\Success;
@@ -40,7 +41,6 @@ use TestApp\Model\Table\SecondaryPostsTable;
 use TestPlugin\Model\Entity\Author;
 use TestPlugin\Model\Table\AuthorsTable;
 use TestPlugin\Model\Table\TestPluginCommentsTable;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use function Cake\Core\deprecationWarning;
 
 /**

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -40,11 +40,13 @@ use TestApp\Model\Table\SecondaryPostsTable;
 use TestPlugin\Model\Entity\Author;
 use TestPlugin\Model\Table\AuthorsTable;
 use TestPlugin\Model\Table\TestPluginCommentsTable;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use function Cake\Core\deprecationWarning;
 
 /**
  * TestCaseTest
  */
+#[AllowMockObjectsWithoutExpectations]
 class TestCaseTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -31,12 +31,14 @@ use Cake\Test\Fixture\SpecialPkFixture;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Inflector;
 use Mockery;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use TestApp\Test\Fixture\FeaturedTagsFixture;
 use TestApp\Test\Fixture\LettersFixture;
 
 /**
  * Test case for TestFixture
  */
+#[AllowMockObjectsWithoutExpectations]
 class TestFixtureTest extends TestCase
 {
     /**

--- a/tests/phpstan-baseline.neon
+++ b/tests/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Attribute class PHPUnit\\Framework\\Attributes\\AllowMockObjectsWithoutExpectations does not exist\.$#'
+			identifier: attribute.notFound
+			reportUnmatched: false
+
+		-
 			message: '#^Access to constant ATTR_INIT_COMMAND on an unknown class Pdo\\Mysql\.$#'
 			identifier: class.notFound
 			count: 1


### PR DESCRIPTION
This PR fixes the various PHPunit notices that started to pop up in 12.5 when using `createMock` with no expectations.

I focussed on quick wins where `createMock` could relatively easily be swapped with `createStub`. The more complex situations are handled with the `AllowMockObjectsWithoutExpectations` attribute.

- [x] Phase 1: Paginator Tests (124 notices)
  - [x] PaginatorTestTrait  (62) 
- [x] Phase 2: ORM Behavior Tests (16 notices)
  - [x] BehaviorTest.php (16) 
- [x] Phase 3: Database Type Tests (226 notices)
  - [x] DateTimeTimezoneTypeTest.php (52) 
  - [x] DateTimeFractionalTypeTest.php (49) 
  - [x] DateTimeTypeTest.php (42) 
  - [x] TimeTypeTest.php (29) 
  - [x] DateTypeTest.php (28) 
  - [x] DriverTest.php (25) 
- [x] Phase 4: ORM Association Tests (160 notices)
  - [x] BelongsToManyTest.php (73)
  - [x] HasManyTest.php (60)
  - [x] AssociationTest.php (27)
- [x] Phase 5: Database Schema Tests (268 notices)
  - [x] SqliteSchemaDialectTest.php (96)
  - [x] MysqlSchemaDialectTest.php (51)
  - [x] PostgresSchemaDialectTest.php (40)
  - [x] SqlserverSchemaDialectTest.php (30)
- [x] Phase 6: HTTP & Remaining Tests (31+ notices)
  - [x] StreamTest.php (12)
  - [x] ResponseEmitterTest.php (10)
  - [x] RateLimitMiddlewareTest.php (9)
- [x] Phase 7: TableTest.php (14 notices)
- [x] Phase 8: Remaining Type & Driver Tests (120 notices)
  - [x] Database Type Tests:
    - [x] IntegerTypeTest.php (9 notices)
    - [x] JsonTypeTest.php (8 notices)
    - [x] FloatTypeTest.php (7 notices)
    - [x] BoolTypeTest.php (7 notices)
    - [x] UuidTypeTest.php (5 notices)
    - [x] StringTypeTest.php (5 notices)
    - [x] BinaryUuidTypeTest.php (5 notices)
    - [x] BinaryTypeTest.php (4 notices)
  - [x] Database Driver/Factory Tests:
    - [x] SqliteTest.php (9 notices)
    - [x] TypeFactoryTest.php (5 notices)
    - [x] SqlserverTest.php (5 notices)
    - [x] PostgresTest.php (3 notices)
  - [x] Console Tests:
    - [x] CommandRunnerTest.php (9 notices)
    - [x] ConsoleOutputTest.php (4 notices)
    - [x] SchemaCacheCommandsTest.php (4 notices)
  - [x] ORM Tests:
    - [x] AssociationCollectionTest.php (7 notices)
    - [x] TableLocatorTest.php (3 notices)
    - [x] TableRegistryTest.php (1 notice)
    - [x] Other ORM tests (6 notices total)
  - [x] Other Tests (9 notices)


