### PR TITLE
Fix bugs, typos and loose comparisons

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -56,10 +56,9 @@ use RuntimeException;
  * - `FileEngine` - Uses simple files to store content. Poor performance, but good for
  *    storing large objects, or things that are not IO sensitive. Well suited to development
  *    as it is an easy cache to inspect and manually flush.
- * - `MemcacheEngine` - Uses the PECL::Memcache extension and Memcached for storage.
- *    Fast reads/writes, and benefits from memcache being distributed.
+ * - `MemcachedEngine` - Uses the PECL::Memcached extension and Memcached for storage.
+ *    Fast reads/writes, and benefits from memcached being distributed.
  * - `RedisEngine` - Uses redis and php-redis extension to store cache data.
- * - `XcacheEngine` - Uses the Xcache extension, an alternative to APCu.
  *
  * See Cache engine documentation for expected configuration keys.
  *

--- a/src/Cache/Engine/ApcuEngine.php
+++ b/src/Cache/Engine/ApcuEngine.php
@@ -192,7 +192,7 @@ class ApcuEngine extends CacheEngine
     }
 
     /**
-     * Delete all keys from the cache. This will clear every cache config using APC.
+     * Delete all keys from the cache. This will clear every cache config using APCu.
      *
      * @return bool True Returns true.
      * @link https://secure.php.net/manual/en/function.apcu-cache-info.php

--- a/src/Cache/Engine/ApcuEngine.php
+++ b/src/Cache/Engine/ApcuEngine.php
@@ -194,7 +194,7 @@ class ApcuEngine extends CacheEngine
     /**
      * Delete all keys from the cache. This will clear every cache config using APCu.
      *
-     * @return bool True Returns true.
+     * @return bool True on success.
      * @link https://secure.php.net/manual/en/function.apcu-cache-info.php
      * @link https://secure.php.net/manual/en/function.apcu-delete.php
      */

--- a/src/Cache/Engine/ArrayEngine.php
+++ b/src/Cache/Engine/ArrayEngine.php
@@ -196,7 +196,7 @@ class ArrayEngine extends CacheEngine
     /**
      * Delete all keys from the cache.
      *
-     * @return bool True Returns true.
+     * @return bool True on success.
      */
     public function clear(): bool
     {

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -72,7 +72,7 @@ class MemcachedEngine extends CacheEngine
      * - `serialize` The serializer engine used to serialize data. Available engines are 'php',
      *    'igbinary' and 'json'. Besides 'php', the memcached extension must be compiled with the
      *    appropriate serializer support.
-     * - `servers` String or array of memcached servers. If an array MemcacheEngine will use
+     * - `servers` String or array of memcached servers. If an array MemcachedEngine will use
      *    them as a pool.
      * - `options` - Additional options for the memcached client. Should be an array of option => value.
      *    Use the \Memcached::OPT_* constants as keys.

--- a/src/Console/HelperRegistry.php
+++ b/src/Console/HelperRegistry.php
@@ -36,7 +36,7 @@ class HelperRegistry extends ObjectRegistry
     protected ConsoleIo $_io;
 
     /**
-     * Sets The IO instance that should be passed to the shell helpers
+     * Sets the IO instance that should be passed to the shell helpers
      *
      * @param \Cake\Console\ConsoleIo $io An io instance.
      * @return void

--- a/src/Core/Configure/FileConfigTrait.php
+++ b/src/Core/Configure/FileConfigTrait.php
@@ -45,7 +45,7 @@ trait FileConfigTrait
     protected function _getFilePath(string $key, bool $checkExists = false): string
     {
         if (str_contains($key, '..')) {
-            throw new CakeException('Cannot load/dump configuration files with ../ in them.');
+            throw new CakeException('Cannot load/dump configuration files with .. in them.');
         }
 
         [$plugin, $key] = pluginSplit($key);

--- a/src/Core/PluginConfig.php
+++ b/src/Core/PluginConfig.php
@@ -176,7 +176,7 @@ class PluginConfig
         $json = json_decode($jsonString, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new CakeException(sprintf(
-                'Error parsing %ss: %s',
+                'Error parsing %s: %s',
                 $jsonPath,
                 json_last_error_msg(),
             ));

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -187,7 +187,7 @@ class ExceptionTrap
      */
     public function unregister(): void
     {
-        if (static::$registeredTrap == $this) {
+        if (static::$registeredTrap === $this) {
             $this->disabled = true;
             static::$registeredTrap = null;
             restore_exception_handler();

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -53,7 +53,7 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
     /**
      * Default configuration values.
      *
-     * Ignored if contructor is passed an ExceptionTrap instance.
+     * Ignored if constructor is passed an ExceptionTrap instance.
      *
      * Configuration keys and values are shared with `ExceptionTrap`.
      * This class will pass its configuration onto the ExceptionTrap

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -52,7 +52,7 @@ class I18n
 
     /**
      * Returns the translators collection instance. It can be used
-     * for getting specific translators based of their name and locale
+     * for getting specific translators based on their name and locale
      * or to configure some aspect of future translations that are not yet constructed.
      *
      * @return \Cake\I18n\TranslatorRegistry The translator collection.
@@ -180,7 +180,7 @@ class I18n
      *
      * Registering loaders is useful when you need to lazily use translations in multiple
      * different locales for the same domain, and don't want to use the built-in
-     * translation service based of `gettext` files.
+     * translation service based on `gettext` files.
      *
      * Loader objects will receive two arguments: The domain name that needs to be
      * built, and the locale that is requested. These objects can assemble the messages
@@ -237,7 +237,7 @@ class I18n
     }
 
     /**
-     * Will return the currently configure locale as stored in the
+     * Will return the currently configured locale as stored in the
      * `intl.default_locale` PHP setting.
      *
      * @return string The name of the default locale.

--- a/src/Log/Engine/ArrayLog.php
+++ b/src/Log/Engine/ArrayLog.php
@@ -55,7 +55,7 @@ class ArrayLog extends BaseLog
      * @param mixed $level The severity level of log you are making.
      * @param \Stringable|string $message The message you want to log.
      * @param array $context Additional information about the logged message
-     * @return void success of write.
+     * @return void
      * @see \Cake\Log\Log::$_levels
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -87,7 +87,7 @@ class ConsoleLog extends BaseLog
      * @param mixed $level The severity level of log you are making.
      * @param \Stringable|string $message The message you want to log.
      * @param array $context Additional information about the logged message
-     * @return void success of write.
+     * @return void
      * @see \Cake\Log\Log::$_levels
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -24,7 +24,7 @@ use Stringable;
 
 /**
  * Logs messages to configured Log adapters. One or more adapters
- * can be configured using Cake Logs's methods. If you don't
+ * can be configured using Cake Log's methods. If you don't
  * configure any adapters, and write to Log, the messages will be
  * ignored.
  *

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -236,7 +236,7 @@ class Mailer implements EventListenerInterface
     /**
      * Set email renderer.
      *
-     * @param \Cake\Mailer\Renderer $renderer Render instance.
+     * @param \Cake\Mailer\Renderer $renderer Renderer instance.
      * @return $this
      */
     public function setRenderer(Renderer $renderer)

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -38,14 +38,14 @@ use function Cake\Core\env;
 class Message implements JsonSerializable
 {
     /**
-     * Line length - no should more - RFC 2822 - 2.1.1
+     * Line length - should not exceed - RFC 2822 - 2.1.1
      *
      * @var int
      */
     public const LINE_LENGTH_SHOULD = 78;
 
     /**
-     * Line length - no must more - RFC 2822 - 2.1.1
+     * Line length - must not exceed - RFC 2822 - 2.1.1
      *
      * @var int
      */

--- a/src/Mailer/TransportRegistry.php
+++ b/src/Mailer/TransportRegistry.php
@@ -42,12 +42,12 @@ class TransportRegistry extends ObjectRegistry
     }
 
     /**
-     * Throws an exception when a cache engine is missing.
+     * Throws an exception when a transport is missing.
      *
      * Part of the template method for Cake\Core\ObjectRegistry::load()
      *
      * @param string $class The classname that is missing.
-     * @param string|null $plugin The plugin the cache is missing in.
+     * @param string|null $plugin The plugin the transport is missing in.
      * @return void
      * @throws \BadMethodCallException
      */
@@ -63,7 +63,7 @@ class TransportRegistry extends ObjectRegistry
      *
      * @param \Cake\Mailer\AbstractTransport|class-string<\Cake\Mailer\AbstractTransport> $class The classname or object to make.
      * @param string $alias The alias of the object.
-     * @param array<string, mixed> $config An array of settings to use for the cache engine.
+     * @param array<string, mixed> $config An array of settings to use for the transport.
      * @return \Cake\Mailer\AbstractTransport The constructed transport class.
      */
     protected function _create(object|string $class, string $alias, array $config): AbstractTransport

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -710,7 +710,7 @@ class Route
             if (($key === 'plugin' || $key === 'prefix') && $val === null && !isset($url[$key])) {
                 continue;
             }
-            if (isset($url[$key]) && $url[$key] != $val) {
+            if (isset($url[$key]) && $url[$key] !== $val) {
                 return null;
             }
             if (!isset($url[$key]) && $val !== null) {

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -710,7 +710,7 @@ class Route
             if (($key === 'plugin' || $key === 'prefix') && $val === null && !isset($url[$key])) {
                 continue;
             }
-            if (isset($url[$key]) && $url[$key] !== $val) {
+            if (isset($url[$key]) && $url[$key] != $val) {
                 return null;
             }
             if (!isset($url[$key]) && $val !== null) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -342,7 +342,7 @@ class Router
      * ### Usage
      *
      * - `Router::url('/posts/edit/1');` Returns the string with the base dir prepended.
-     *   This usage does not use reverser routing.
+     *   This usage does not use reverse routing.
      * - `Router::url(['controller' => 'Posts', 'action' => 'edit']);` Returns a URL
      *   generated through reverse routing.
      * - `Router::url(['_name' => 'custom-name', ...]);` Returns a URL generated
@@ -364,7 +364,7 @@ class Router
      *
      * @param \Psr\Http\Message\UriInterface|array|string|null $url An array specifying any of the following:
      *   'controller', 'action', 'plugin' additionally, you can provide routed
-     *   elements or query string parameters. If string it can be name any valid url
+     *   elements or query string parameters. If string it can be any valid url
      *   string or it can be an UriInterface instance.
      * @param bool $full If true, the full base URL will be prepended to the result.
      *   Default is false.
@@ -512,7 +512,7 @@ class Router
      * @see Router::url()
      * @param array|string|null $url An array specifying any of the following:
      *   'controller', 'action', 'plugin' additionally, you can provide routed
-     *   elements or query string parameters. If string it can be name any valid url
+     *   elements or query string parameters. If string it can be any valid url
      *   string.
      * @param bool $full If true, the full base URL will be prepended to the result.
      *   Default is false.

--- a/src/Routing/functions.php
+++ b/src/Routing/functions.php
@@ -44,7 +44,7 @@ function urlArray(string $path, array $params = []): array
  *
  * @param \Psr\Http\Message\UriInterface|array|string|null $url An array specifying any of the following:
  *   'controller', 'action', 'plugin' additionally, you can provide routed
- *   elements or query string parameters. If string it can be name any valid url
+ *   elements or query string parameters. If string it can be any valid url
  *   string or it can be an UriInterface instance.
  * @param bool $full If true, the full base URL will be prepended to the result.
  *   Default is false.

--- a/src/Routing/functions_global.php
+++ b/src/Routing/functions_global.php
@@ -26,7 +26,7 @@ if (!function_exists('url')) {
      *
      * @param \Psr\Http\Message\UriInterface|array|string|null $url An array specifying any of the following:
      *   'controller', 'action', 'plugin' additionally, you can provide routed
-     *   elements or query string parameters. If string it can be name any valid url
+     *   elements or query string parameters. If string it can be any valid url
      *   string or it can be an UriInterface instance.
      * @param bool $full If true, the full base URL will be prepended to the result.
      *   Default is false.

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -149,7 +149,7 @@ trait CookieCryptTrait
     }
 
     /**
-     * Implode method to keep keys are multidimensional arrays
+     * Implode method to keep keys in multidimensional arrays
      *
      * @param array $array Map of key and values
      * @return string A JSON encoded string.

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -594,7 +594,7 @@ class Hash
      * Determines if one array contains the exact keys and values of another.
      *
      * @param array $data The data to search through.
-     * @param array $needle The values to file in $data
+     * @param array $needle The values to find in $data
      * @return bool true If $data contains $needle, false otherwise
      * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::contains
      */

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -999,7 +999,7 @@ class Validation
     /**
      * Checks that value has a valid file extension.
      *
-     * Supports checking `\Psr\Http\Message\UploadedFileInterface` instances and
+     * Supports checking `\Psr\Http\Message\UploadedFileInterface` instances
      * and arrays with a `name` key.
      *
      * @param mixed $check Value to check
@@ -1492,8 +1492,8 @@ class Validation
     /**
      * Checking for upload errors
      *
-     * Supports checking `\Psr\Http\Message\UploadedFileInterface` instances and
-     * and arrays with a `error` key.
+     * Supports checking `\Psr\Http\Message\UploadedFileInterface` instances
+     * and arrays with an `error` key.
      *
      * @param mixed $check Value to check.
      * @param bool $allowNoFile Set to true to allow UPLOAD_ERR_NO_FILE as a pass.

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -113,7 +113,7 @@ trait ValidatorAwareTrait
     {
         $method = 'validation' . ucfirst($name);
         if (!$this->validationMethodExists($method)) {
-            $message = sprintf('The `%s::%s()` validation method does not exists.', static::class, $method);
+            $message = sprintf('The `%s::%s()` validation method does not exist.', static::class, $method);
             throw new InvalidArgumentException($message);
         }
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3647,7 +3647,7 @@ class TableTest extends TestCase
     public function testValidatorWithMissingMethod(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The `Cake\ORM\Table::validationMissing()` validation method does not exists.');
+        $this->expectExceptionMessage('The `Cake\ORM\Table::validationMissing()` validation method does not exist.');
         $table = new Table();
         $table->getValidator('missing');
     }


### PR DESCRIPTION
## Summary

- Fix sprintf bug in PluginConfig, loose comparison in ExceptionTrap
- Fix typos and documentation errors across 24 files
- Remove reference to non-existent XcacheEngine
- Fix inconsistent @return docblocks

## Details

### Bugs
| File | Issue |
|------|-------|
| PluginConfig.php | sprintf format `%ss` → `%s` (extra 's' caused incorrect error message) |
| ExceptionTrap.php | Loose comparison `==` → `===` for object identity check |

### Cache Documentation
| File | Fix |
|------|-----|
| Cache.php | Remove non-existent XcacheEngine, fix "MemcacheEngine" → "MemcachedEngine" |
| MemcachedEngine.php | Fix "MemcacheEngine" → "MemcachedEngine" |
| ApcuEngine.php | Fix "APC" → "APCu" |
| ArrayEngine.php, ApcuEngine.php | Fix redundant "@return bool True Returns true" → "@return bool True on success" |

### Typos
| File | Fix |
|------|-----|
| Router.php | "reverser routing" → "reverse routing" |
| Router.php, functions.php, functions_global.php | "can be name any" → "can be any" (4×) |
| ValidatorAwareTrait.php | "does not exists" → "does not exist" |
| Validation.php | "and and arrays" → "and arrays" (2×) |
| Message.php | "no should more" → "should not exceed", "no must more" → "must not exceed" |
| Mailer.php | "Render instance" → "Renderer instance" |
| TransportRegistry.php | "cache engine" → "transport" (3×) |
| I18n.php | "based of" → "based on" (2×), "configure" → "configured" |
| ErrorHandlerMiddleware.php | "contructor" → "constructor" |
| Log.php | "Cake Logs's" → "Cake Log's" |
| HelperRegistry.php | "Sets The IO" → "Sets the IO" |
| FileConfigTrait.php | "with ../" → "with .." (matches actual check for "..") |
| Hash.php | "file in" → "find in" |
| CookieCryptTrait.php | "keep keys are" → "keep keys in" |
| ArrayLog.php, ConsoleLog.php | Remove contradictory "success of write" from @return void |