### PR TITLE
Remove obsolete phpstan-ignore directive

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -226,7 +226,7 @@ abstract class TestCase extends BaseTestCase
         parent::assertPostConditions();
 
         if (class_exists(Mockery::class)) {
-            // @phpstan-ignore method.internal, argument.type
+            // @phpstan-ignore method.internal
             $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
         }
     }


### PR DESCRIPTION
## Summary

Remove obsolete `argument.type` from `@phpstan-ignore` directive in TestCase.php.

PHPStan no longer reports an `argument.type` error on this line, so the ignore directive causes a "No error with identifier argument.type is reported" error.