### PR TITLE
Add fixed option for binary column type in MySQL

### DIFF
--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -47,6 +47,7 @@ class Column
      * @param string|null $collate Collation for the column
      * @param int|null $srid SRID for geometry fields
      * @param string|null $baseType The basic schema type if the column type is a complex/custom type.
+     * @param bool|null $fixed Whether the column is fixed-length (BINARY vs VARBINARY)
      */
     public function __construct(
         protected string $name,
@@ -65,6 +66,7 @@ class Column
         protected ?string $collate = null,
         protected ?int $srid = null,
         protected ?string $baseType = null,
+        protected ?bool $fixed = null,
     ) {
     }
 
@@ -504,6 +506,41 @@ class Column
     }
 
     /**
+     * Sets whether the column is fixed-length.
+     *
+     * Used for binary columns to distinguish between BINARY and VARBINARY.
+     *
+     * @param bool $fixed Fixed
+     * @return $this
+     */
+    public function setFixed(bool $fixed)
+    {
+        $this->fixed = $fixed;
+
+        return $this;
+    }
+
+    /**
+     * Gets whether the column is fixed-length.
+     *
+     * @return bool|null
+     */
+    public function getFixed(): ?bool
+    {
+        return $this->fixed;
+    }
+
+    /**
+     * Is the column fixed-length?
+     *
+     * @return bool
+     */
+    public function isFixed(): bool
+    {
+        return $this->getFixed() === true;
+    }
+
+    /**
      * Gets all allowed options. Each option must have a corresponding `setFoo` method.
      *
      * @return array
@@ -527,6 +564,7 @@ class Column
             'srid',
             'increment',
             'generated',
+            'fixed',
         ];
     }
 
@@ -590,6 +628,7 @@ class Column
             'comment' => $this->getComment(),
             'autoIncrement' => $this->getIdentity(),
             'identity' => $this->getIdentity(),
+            'fixed' => $this->getFixed(),
         ];
     }
 }

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -420,7 +420,12 @@ class MysqlSchemaDialect extends SchemaDialect
             $lengthName = substr($col, 0, -4);
             $length = TableSchema::$columnLengths[$lengthName] ?? $length;
 
-            return ['type' => TableSchemaInterface::TYPE_BINARY, 'length' => $length];
+            $result = ['type' => TableSchemaInterface::TYPE_BINARY, 'length' => $length];
+            if ($col === 'binary') {
+                $result['fixed'] = true;
+            }
+
+            return $result;
         }
         if (str_contains($col, 'float') || str_contains($col, 'double')) {
             return [
@@ -759,10 +764,10 @@ SQL;
                         break;
                     }
 
-                    if ($column['length'] > 2) {
-                        $out .= ' VARBINARY';
-                    } else {
+                    if (!empty($column['fixed'])) {
                         $out .= ' BINARY';
+                    } else {
+                        $out .= ' VARBINARY';
                     }
                     break;
             }

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -195,6 +195,9 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         'timestamptimezone' => [
             'onUpdate' => null,
         ],
+        'binary' => [
+            'fixed' => null,
+        ],
     ];
 
     /**

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -161,7 +161,15 @@ class MysqlSchemaDialectTest extends TestCase
             ],
             [
                 'BINARY(1)',
-                ['type' => 'binary', 'length' => 1],
+                ['type' => 'binary', 'length' => 1, 'fixed' => true],
+            ],
+            [
+                'BINARY(20)',
+                ['type' => 'binary', 'length' => 20, 'fixed' => true],
+            ],
+            [
+                'VARBINARY(20)',
+                ['type' => 'binary', 'length' => 20],
             ],
             [
                 'TEXT',
@@ -1248,7 +1256,13 @@ SQL;
             [
                 'bit',
                 ['type' => 'binary', 'length' => 1],
-                '`bit` BINARY(1)',
+                '`bit` VARBINARY(1)',
+            ],
+            // Fixed binary (BINARY vs VARBINARY)
+            [
+                'hash',
+                ['type' => 'binary', 'length' => 20, 'fixed' => true],
+                '`hash` BINARY(20)',
             ],
             // Integers
             [


### PR DESCRIPTION
## Summary

- Adds a `fixed` attribute for binary columns to distinguish between fixed-length `BINARY` and variable-length `VARBINARY` types
- When reflecting a `BINARY(n)` column from the database, `fixed => true` is now set
- When generating SQL with `fixed => true`, `BINARY(n)` is produced instead of `VARBINARY(n)`

## Motivation

Previously, the decision between `BINARY` and `VARBINARY` was based on an arbitrary length threshold (`> 2`), which didn't allow explicit control over the SQL type. This caused issues in migrations where:

1. A column originally defined as `BINARY(20)` would become `VARBINARY(20)` after migration
2. There was no way to explicitly request fixed-length binary storage

The `fixed` option mirrors how `CHAR` vs `VARCHAR` is handled for string types.

## Usage

```php
// Creates VARBINARY(20) - variable length (default)
$table->addColumn('data', 'binary', ['length' => 20]);

// Creates BINARY(20) - fixed length  
$table->addColumn('hash', 'binary', ['length' => 20, 'fixed' => true]);
```

Refs cakephp/migrations#999