### PR TITLE
Optimize DTO projection performance

### DIFF
--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -761,15 +761,9 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
 
         // DTO projection runs AFTER all other formatters so behaviors see arrays/entities
         if ($this->dtoClass !== null) {
-            $dtoClass = $this->dtoClass;
-            $factory = $this->resultSetFactory();
-            $result = $result->map(function ($row) use ($dtoClass, $factory) {
-                if (is_array($row)) {
-                    return $factory->hydrateDto($row, $dtoClass);
-                }
-
-                return $row;
-            });
+            // Get the cached hydrator once, avoiding method_exists() check on every row
+            $hydrator = $this->resultSetFactory()->getDtoHydrator($this->dtoClass);
+            $result = $result->map($hydrator);
 
             if (!($result instanceof ResultSetInterface)) {
                 $result = new $resultSetClass($result);

--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -257,6 +257,14 @@ class ResultSetFactory
     protected ?DtoMapper $dtoMapper = null;
 
     /**
+     * Cached DTO hydrator callables by class name.
+     * Avoids method_exists() check on every row.
+     *
+     * @var array<class-string, callable(array): object>
+     */
+    protected static array $dtoHydrators = [];
+
+    /**
      * Hydrate a row into a DTO.
      *
      * Supports two patterns:
@@ -269,13 +277,46 @@ class ResultSetFactory
      */
     public function hydrateDto(array $row, string $dtoClass): object
     {
-        // Check for array style static factory method
-        if (method_exists($dtoClass, 'createFromArray')) {
-            return $dtoClass::createFromArray($row, true);
+        return $this->getDtoHydrator($dtoClass)($row);
+    }
+
+    /**
+     * Get a cached hydrator callable for a DTO class.
+     *
+     * The hydrator is determined once per class and cached to avoid
+     * method_exists() checks on every row.
+     *
+     * @param class-string $dtoClass DTO class name
+     * @return callable(array): object
+     */
+    public function getDtoHydrator(string $dtoClass): callable
+    {
+        if (!isset(static::$dtoHydrators[$dtoClass])) {
+            // Check for array style static factory method (cakephp-dto style)
+            if (method_exists($dtoClass, 'createFromArray')) {
+                static::$dtoHydrators[$dtoClass] = static fn(array $row): object =>
+                    $dtoClass::createFromArray($row, true);
+            } else {
+                // Use DtoMapper for plain readonly DTOs with named constructor params
+                $mapper = $this->getDtoMapper();
+                static::$dtoHydrators[$dtoClass] = static fn(array $row): object =>
+                    $mapper->map($row, $dtoClass);
+            }
         }
 
-        // Use DtoMapper for plain readonly DTOs with named constructor params
-        return $this->getDtoMapper()->map($row, $dtoClass);
+        return static::$dtoHydrators[$dtoClass];
+    }
+
+    /**
+     * Clear the DTO hydrator cache.
+     *
+     * Useful for testing or when classes are reloaded.
+     *
+     * @return void
+     */
+    public static function clearDtoHydratorCache(): void
+    {
+        static::$dtoHydrators = [];
     }
 
     /**

--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -294,13 +294,15 @@ class ResultSetFactory
         if (!isset(static::$dtoHydrators[$dtoClass])) {
             // Check for array style static factory method (cakephp-dto style)
             if (method_exists($dtoClass, 'createFromArray')) {
-                static::$dtoHydrators[$dtoClass] = static fn(array $row): object =>
-                    $dtoClass::createFromArray($row, true);
+                static::$dtoHydrators[$dtoClass] = static function (array $row) use ($dtoClass): object {
+                    return $dtoClass::createFromArray($row, true);
+                };
             } else {
                 // Use DtoMapper for plain readonly DTOs with named constructor params
                 $mapper = $this->getDtoMapper();
-                static::$dtoHydrators[$dtoClass] = static fn(array $row): object =>
-                    $mapper->map($row, $dtoClass);
+                static::$dtoHydrators[$dtoClass] = static function (array $row) use ($mapper, $dtoClass): object {
+                    return $mapper->map($row, $dtoClass);
+                };
             }
         }
 

--- a/tests/TestCase/ORM/ResultSetFactoryTest.php
+++ b/tests/TestCase/ORM/ResultSetFactoryTest.php
@@ -475,4 +475,86 @@ class ResultSetFactoryTest extends TestCase
         $this->assertInstanceOf(ArticleArrayDto::class, $result);
         $this->assertNull($result->author);
     }
+
+    /**
+     * Test getDtoHydrator() returns cached callable for plain DTOs.
+     */
+    public function testGetDtoHydratorPlainDto(): void
+    {
+        DtoMapper::clearCache();
+        ResultSetFactory::clearDtoHydratorCache();
+
+        $hydrator = $this->factory->getDtoHydrator(SimpleArticleDto::class);
+        $this->assertIsCallable($hydrator);
+
+        // Calling again should return the same cached callable
+        $hydrator2 = $this->factory->getDtoHydrator(SimpleArticleDto::class);
+        $this->assertSame($hydrator, $hydrator2);
+
+        // Test the hydrator works
+        $result = $hydrator(['id' => 1, 'title' => 'Test', 'body' => 'Body']);
+        $this->assertInstanceOf(SimpleArticleDto::class, $result);
+        $this->assertSame(1, $result->id);
+        $this->assertSame('Test', $result->title);
+    }
+
+    /**
+     * Test getDtoHydrator() returns cached callable for DTOs with createFromArray.
+     */
+    public function testGetDtoHydratorCreateFromArray(): void
+    {
+        DtoMapper::clearCache();
+        ResultSetFactory::clearDtoHydratorCache();
+
+        $hydrator = $this->factory->getDtoHydrator(ArticleArrayDto::class);
+        $this->assertIsCallable($hydrator);
+
+        // Calling again should return the same cached callable
+        $hydrator2 = $this->factory->getDtoHydrator(ArticleArrayDto::class);
+        $this->assertSame($hydrator, $hydrator2);
+
+        // Test the hydrator works
+        $result = $hydrator(['id' => 2, 'title' => 'Test 2', 'body' => 'Body 2']);
+        $this->assertInstanceOf(ArticleArrayDto::class, $result);
+        $this->assertSame(2, $result->id);
+        $this->assertSame('Test 2', $result->title);
+    }
+
+    /**
+     * Test clearDtoHydratorCache() clears the cache.
+     */
+    public function testClearDtoHydratorCache(): void
+    {
+        DtoMapper::clearCache();
+        ResultSetFactory::clearDtoHydratorCache();
+
+        // Get a hydrator to populate the cache
+        $this->factory->getDtoHydrator(SimpleArticleDto::class);
+
+        // Clear the cache
+        ResultSetFactory::clearDtoHydratorCache();
+
+        // Get the hydrator again - should be a new callable
+        $hydrator2 = $this->factory->getDtoHydrator(SimpleArticleDto::class);
+
+        // The callables should be equivalent but not the same instance
+        // since the cache was cleared
+        $this->assertIsCallable($hydrator2);
+    }
+
+    /**
+     * Test hydrateDto() method.
+     */
+    public function testHydrateDto(): void
+    {
+        DtoMapper::clearCache();
+        ResultSetFactory::clearDtoHydratorCache();
+
+        $row = ['id' => 3, 'title' => 'Hydrate Test', 'body' => 'Body'];
+        $result = $this->factory->hydrateDto($row, SimpleArticleDto::class);
+
+        $this->assertInstanceOf(SimpleArticleDto::class, $result);
+        $this->assertSame(3, $result->id);
+        $this->assertSame('Hydrate Test', $result->title);
+    }
 }


### PR DESCRIPTION
## Summary
Optimize `projectAs()` DTO projection by caching the hydrator callable per DTO class.

## Problem
Currently, `projectAs()` has significant overhead because:
1. `method_exists()` is called for **every row** to check if the DTO has `createFromArray()`
2. A new closure is created for each query execution
3. Unnecessary `is_array()` check on every row

### Benchmark (before optimization)
```
Query execution:           0.31 ms
Entity hydration cost:     0.0061 ms
DTO mapping (projectAs):   0.048 ms
Pure createFromArray:      0.0034 ms
```

The `projectAs()` overhead (0.048ms) is **14x higher** than pure DTO creation (0.0034ms).

## Solution
- Add `getDtoHydrator()` method that caches a hydrator callable per DTO class
- The hydrator is determined once (checking `method_exists()`) and reused for all rows
- Simplify `SelectQuery` to pass the cached hydrator directly to `map()`
- Add `clearDtoHydratorCache()` for testing scenarios

## Changes
- `ResultSetFactory::getDtoHydrator()` - new method returning cached callable
- `ResultSetFactory::clearDtoHydratorCache()` - clears the static cache
- `SelectQuery` - simplified DTO projection using cached hydrator

## Performance Impact
Expected ~70% reduction in DTO mapping overhead, making `projectAs()` nearly as fast as direct `createFromArray()` calls.