### PR TITLE
Add PSR-6 Cache adapter

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpstan" version="2.1.32" installed="2.1.32" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="2.1.34" installed="2.1.34" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "psr/http-message": "^1.1 || ^2.0",
         "psr/http-server-handler": "^1.0.2",
         "psr/http-server-middleware": "^1.0.2",
+        "psr/cache": "^3.0",
         "psr/log": "^3.0",
         "psr/simple-cache": "^2.0 || ^3.0"
     },
@@ -70,6 +71,7 @@
         "paragonie/csp-builder": "CSP builder, to use the CSP Middleware"
     },
     "provide": {
+        "psr/cache-implementation": "^3.0",
         "psr/container-implementation": "^2.0",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",

--- a/src/Cache/Psr6/CacheItem.php
+++ b/src/Cache/Psr6/CacheItem.php
@@ -1,0 +1,145 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Cache\Psr6;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Psr\Cache\CacheItemInterface;
+
+/**
+ * PSR-6 CacheItem implementation.
+ *
+ * Wraps cache data with metadata for PSR-6 compatibility.
+ */
+class CacheItem implements CacheItemInterface
+{
+    /**
+     * Whether the item was found in the cache.
+     */
+    private bool $isHit;
+
+    /**
+     * The cached value.
+     */
+    private mixed $value = null;
+
+    /**
+     * Expiration time for this item.
+     */
+    private ?DateTimeInterface $expiration = null;
+
+    /**
+     * Constructor.
+     *
+     * @param string $key The cache key.
+     * @param bool $isHit Whether the item was found in cache.
+     */
+    public function __construct(
+        private string $key,
+        bool $isHit = false,
+    ) {
+        $this->isHit = $isHit;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get(): mixed
+    {
+        return $this->value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isHit(): bool
+    {
+        return $this->isHit;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set(mixed $value): static
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function expiresAt(?DateTimeInterface $expiration): static
+    {
+        $this->expiration = $expiration;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function expiresAfter(int|DateInterval|null $time): static
+    {
+        if ($time === null) {
+            $this->expiration = null;
+        } elseif ($time instanceof DateInterval) {
+            $this->expiration = (new DateTimeImmutable())->add($time);
+        } else {
+            $this->expiration = (new DateTimeImmutable())->modify("+{$time} seconds");
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the expiration time.
+     *
+     * @return \DateTimeInterface|null The expiration time or null for no expiration.
+     */
+    public function getExpiration(): ?DateTimeInterface
+    {
+        return $this->expiration;
+    }
+
+    /**
+     * Get the TTL in seconds.
+     *
+     * @return int|null The TTL in seconds, or null for default/no expiration.
+     */
+    public function getTtl(): ?int
+    {
+        if ($this->expiration === null) {
+            return null;
+        }
+
+        $now = new DateTimeImmutable();
+        $diff = $this->expiration->getTimestamp() - $now->getTimestamp();
+
+        return max(0, $diff);
+    }
+}

--- a/src/Cache/Psr6/CacheItem.php
+++ b/src/Cache/Psr6/CacheItem.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         5.2.0
+ * @since         5.4.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Cache\Psr6;

--- a/src/Cache/Psr6/CacheItemPool.php
+++ b/src/Cache/Psr6/CacheItemPool.php
@@ -61,9 +61,9 @@ class CacheItemPool implements CacheItemPoolInterface
     /**
      * Constructor.
      *
-     * @param \Cake\Cache\CacheEngineInterface&\Psr\SimpleCache\CacheInterface|string $cache Cache config name or engine instance.
+     * @param (\Cake\Cache\CacheEngineInterface&\Psr\SimpleCache\CacheInterface)|string $cache Cache config name or engine instance.
      */
-    public function __construct(CacheEngineInterface&CacheInterface|string $cache = 'default')
+    public function __construct((CacheEngineInterface&CacheInterface)|string $cache = 'default')
     {
         if (is_string($cache)) {
             $this->engine = Cache::pool($cache);

--- a/src/Cache/Psr6/CacheItemPool.php
+++ b/src/Cache/Psr6/CacheItemPool.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         5.2.0
+ * @since         5.4.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Cache\Psr6;

--- a/src/Cache/Psr6/CacheItemPool.php
+++ b/src/Cache/Psr6/CacheItemPool.php
@@ -17,9 +17,10 @@ declare(strict_types=1);
 namespace Cake\Cache\Psr6;
 
 use Cake\Cache\Cache;
-use Cake\Cache\CacheEngine;
+use Cake\Cache\CacheEngineInterface;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\SimpleCache\CacheInterface;
 
 /**
  * PSR-6 CacheItemPool implementation.
@@ -45,8 +46,10 @@ class CacheItemPool implements CacheItemPoolInterface
 {
     /**
      * The underlying cache engine.
+     *
+     * @var \Cake\Cache\CacheEngineInterface&\Psr\SimpleCache\CacheInterface
      */
-    private CacheEngine $engine;
+    private CacheEngineInterface&CacheInterface $engine;
 
     /**
      * Deferred cache items waiting to be committed.
@@ -58,9 +61,9 @@ class CacheItemPool implements CacheItemPoolInterface
     /**
      * Constructor.
      *
-     * @param string|\Cake\Cache\CacheEngine $cache Cache config name or engine instance.
+     * @param \Cake\Cache\CacheEngineInterface&\Psr\SimpleCache\CacheInterface|string $cache Cache config name or engine instance.
      */
-    public function __construct(string|CacheEngine $cache = 'default')
+    public function __construct(CacheEngineInterface&CacheInterface|string $cache = 'default')
     {
         if (is_string($cache)) {
             $this->engine = Cache::pool($cache);

--- a/src/Cache/Psr6/CacheItemPool.php
+++ b/src/Cache/Psr6/CacheItemPool.php
@@ -221,7 +221,7 @@ class CacheItemPool implements CacheItemPoolInterface
         // PSR-6 reserved characters
         if (preg_match('/[{}()\/\\\\@:]/', $key)) {
             throw new InvalidArgumentException(
-                'Cache key contains reserved characters: {}()/\\@:'
+                'Cache key contains reserved characters: {}()/\\@:',
             );
         }
     }

--- a/src/Cache/Psr6/CacheItemPool.php
+++ b/src/Cache/Psr6/CacheItemPool.php
@@ -1,0 +1,233 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Cache\Psr6;
+
+use Cake\Cache\Cache;
+use Cake\Cache\CacheEngine;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * PSR-6 CacheItemPool implementation.
+ *
+ * Wraps a CakePHP cache engine to provide PSR-6 compatibility.
+ *
+ * ### Usage
+ *
+ * ```php
+ * // Using a configured cache pool
+ * $pool = new CacheItemPool('default');
+ *
+ * // Get an item
+ * $item = $pool->getItem('my_key');
+ * if (!$item->isHit()) {
+ *     $item->set('computed value');
+ *     $pool->save($item);
+ * }
+ * $value = $item->get();
+ * ```
+ */
+class CacheItemPool implements CacheItemPoolInterface
+{
+    /**
+     * The underlying cache engine.
+     */
+    private CacheEngine $engine;
+
+    /**
+     * Deferred cache items waiting to be committed.
+     *
+     * @var array<string, \Cake\Cache\Psr6\CacheItem>
+     */
+    private array $deferred = [];
+
+    /**
+     * Constructor.
+     *
+     * @param string|\Cake\Cache\CacheEngine $cache Cache config name or engine instance.
+     */
+    public function __construct(string|CacheEngine $cache = 'default')
+    {
+        if (is_string($cache)) {
+            $this->engine = Cache::pool($cache);
+        } else {
+            $this->engine = $cache;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getItem(string $key): CacheItemInterface
+    {
+        $this->validateKey($key);
+
+        // Check deferred items first
+        if (isset($this->deferred[$key])) {
+            return clone $this->deferred[$key];
+        }
+
+        $value = $this->engine->get($key);
+
+        if ($value === null) {
+            return new CacheItem($key, false);
+        }
+
+        $item = new CacheItem($key, true);
+        $item->set($value);
+
+        return $item;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getItems(array $keys = []): iterable
+    {
+        $items = [];
+        foreach ($keys as $key) {
+            $items[$key] = $this->getItem($key);
+        }
+
+        return $items;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasItem(string $key): bool
+    {
+        $this->validateKey($key);
+
+        if (isset($this->deferred[$key])) {
+            return true;
+        }
+
+        return $this->engine->get($key) !== null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(): bool
+    {
+        $this->deferred = [];
+
+        return $this->engine->clear();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteItem(string $key): bool
+    {
+        $this->validateKey($key);
+
+        unset($this->deferred[$key]);
+
+        return $this->engine->delete($key);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteItems(array $keys): bool
+    {
+        $success = true;
+        foreach ($keys as $key) {
+            if (!$this->deleteItem($key)) {
+                $success = false;
+            }
+        }
+
+        return $success;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function save(CacheItemInterface $item): bool
+    {
+        if (!$item instanceof CacheItem) {
+            return false;
+        }
+
+        $ttl = $item->getTtl();
+
+        return $this->engine->set($item->getKey(), $item->get(), $ttl);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        if (!$item instanceof CacheItem) {
+            return false;
+        }
+
+        $this->deferred[$item->getKey()] = $item;
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function commit(): bool
+    {
+        $success = true;
+
+        foreach ($this->deferred as $key => $item) {
+            if (!$this->save($item)) {
+                $success = false;
+            }
+            unset($this->deferred[$key]);
+        }
+
+        return $success;
+    }
+
+    /**
+     * Validate a cache key.
+     *
+     * @param string $key The key to validate.
+     * @return void
+     * @throws \Cake\Cache\Psr6\InvalidArgumentException If the key is invalid.
+     */
+    private function validateKey(string $key): void
+    {
+        if ($key === '') {
+            throw new InvalidArgumentException('Cache key cannot be empty.');
+        }
+
+        // PSR-6 reserved characters
+        if (preg_match('/[{}()\/\\\\@:]/', $key)) {
+            throw new InvalidArgumentException(
+                'Cache key contains reserved characters: {}()/\\@:'
+            );
+        }
+    }
+
+    /**
+     * Commits any deferred items on destruction.
+     */
+    public function __destruct()
+    {
+        $this->commit();
+    }
+}

--- a/src/Cache/Psr6/InvalidArgumentException.php
+++ b/src/Cache/Psr6/InvalidArgumentException.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Cache\Psr6;
 
+use InvalidArgumentException as BaseInvalidArgumentException;
 use Psr\Cache\InvalidArgumentException as Psr6InvalidArgumentException;
 
 /**
@@ -23,6 +24,6 @@ use Psr\Cache\InvalidArgumentException as Psr6InvalidArgumentException;
  *
  * Thrown when an invalid cache key is provided.
  */
-class InvalidArgumentException extends \InvalidArgumentException implements Psr6InvalidArgumentException
+class InvalidArgumentException extends BaseInvalidArgumentException implements Psr6InvalidArgumentException
 {
 }

--- a/src/Cache/Psr6/InvalidArgumentException.php
+++ b/src/Cache/Psr6/InvalidArgumentException.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         5.2.0
+ * @since         5.4.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Cache\Psr6;

--- a/src/Cache/Psr6/InvalidArgumentException.php
+++ b/src/Cache/Psr6/InvalidArgumentException.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Cache\Psr6;
+
+use Psr\Cache\InvalidArgumentException as Psr6InvalidArgumentException;
+
+/**
+ * PSR-6 InvalidArgumentException.
+ *
+ * Thrown when an invalid cache key is provided.
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements Psr6InvalidArgumentException
+{
+}

--- a/src/Cache/composer.json
+++ b/src/Cache/composer.json
@@ -1,11 +1,13 @@
 {
     "name": "cakephp/cache",
-    "description": "Easy to use Caching library with support for multiple caching backends",
+    "description": "Easy to use Caching library with support for multiple caching backends, PSR-6 and PSR-16 compliant",
     "type": "library",
     "keywords": [
         "cakephp",
         "caching",
-        "cache"
+        "cache",
+        "PSR-6",
+        "PSR-16"
     ],
     "homepage": "https://cakephp.org",
     "license": "MIT",
@@ -25,9 +27,11 @@
         "php": ">=8.2",
         "cakephp/core": "^5.3.0",
         "cakephp/event": "^5.3.0",
+        "psr/cache": "^3.0",
         "psr/simple-cache": "^2.0 || ^3.0"
     },
     "provide": {
+        "psr/cache-implementation": "^3.0",
         "psr/simple-cache-implementation": "^3.0"
     },
     "autoload": {

--- a/tests/TestCase/Cache/Psr6/CacheItemPoolTest.php
+++ b/tests/TestCase/Cache/Psr6/CacheItemPoolTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         5.2.0
+ * @since         5.4.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\TestCase\Cache\Psr6;

--- a/tests/TestCase/Cache/Psr6/CacheItemPoolTest.php
+++ b/tests/TestCase/Cache/Psr6/CacheItemPoolTest.php
@@ -1,0 +1,223 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Cache\Psr6;
+
+use Cake\Cache\Cache;
+use Cake\Cache\Psr6\CacheItem;
+use Cake\Cache\Psr6\CacheItemPool;
+use Cake\Cache\Psr6\InvalidArgumentException;
+use Cake\TestSuite\TestCase;
+use DateInterval;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * CacheItemPoolTest class
+ */
+class CacheItemPoolTest extends TestCase
+{
+    /**
+     * setUp method
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::setConfig('psr6_test', [
+            'engine' => 'Array',
+        ]);
+    }
+
+    /**
+     * tearDown method
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Cache::drop('psr6_test');
+    }
+
+    /**
+     * Test that pool implements PSR-6 interface.
+     */
+    public function testImplementsInterface(): void
+    {
+        $pool = new CacheItemPool('psr6_test');
+        $this->assertInstanceOf(CacheItemPoolInterface::class, $pool);
+    }
+
+    /**
+     * Test getItem returns CacheItem.
+     */
+    public function testGetItem(): void
+    {
+        $pool = new CacheItemPool('psr6_test');
+        $item = $pool->getItem('test_key');
+
+        $this->assertInstanceOf(CacheItemInterface::class, $item);
+        $this->assertSame('test_key', $item->getKey());
+        $this->assertFalse($item->isHit());
+    }
+
+    /**
+     * Test getItem returns hit after save.
+     */
+    public function testGetItemAfterSave(): void
+    {
+        $pool = new CacheItemPool('psr6_test');
+        $item = $pool->getItem('test_key');
+        $item->set('test_value');
+        $pool->save($item);
+
+        $retrieved = $pool->getItem('test_key');
+        $this->assertTrue($retrieved->isHit());
+        $this->assertSame('test_value', $retrieved->get());
+    }
+
+    /**
+     * Test getItems returns multiple items.
+     */
+    public function testGetItems(): void
+    {
+        $pool = new CacheItemPool('psr6_test');
+        $items = $pool->getItems(['key1', 'key2', 'key3']);
+
+        $this->assertCount(3, $items);
+        foreach ($items as $key => $item) {
+            $this->assertInstanceOf(CacheItemInterface::class, $item);
+            $this->assertFalse($item->isHit());
+        }
+    }
+
+    /**
+     * Test hasItem.
+     */
+    public function testHasItem(): void
+    {
+        $pool = new CacheItemPool('psr6_test');
+        $this->assertFalse($pool->hasItem('test_key'));
+
+        $item = $pool->getItem('test_key');
+        $item->set('value');
+        $pool->save($item);
+
+        $this->assertTrue($pool->hasItem('test_key'));
+    }
+
+    /**
+     * Test deleteItem.
+     */
+    public function testDeleteItem(): void
+    {
+        $pool = new CacheItemPool('psr6_test');
+
+        $item = $pool->getItem('test_key');
+        $item->set('value');
+        $pool->save($item);
+        $this->assertTrue($pool->hasItem('test_key'));
+
+        $pool->deleteItem('test_key');
+        $this->assertFalse($pool->hasItem('test_key'));
+    }
+
+    /**
+     * Test deleteItems.
+     */
+    public function testDeleteItems(): void
+    {
+        $pool = new CacheItemPool('psr6_test');
+
+        foreach (['key1', 'key2', 'key3'] as $key) {
+            $item = $pool->getItem($key);
+            $item->set('value');
+            $pool->save($item);
+        }
+
+        $pool->deleteItems(['key1', 'key2']);
+
+        $this->assertFalse($pool->hasItem('key1'));
+        $this->assertFalse($pool->hasItem('key2'));
+        $this->assertTrue($pool->hasItem('key3'));
+    }
+
+    /**
+     * Test clear.
+     */
+    public function testClear(): void
+    {
+        $pool = new CacheItemPool('psr6_test');
+
+        $item = $pool->getItem('test_key');
+        $item->set('value');
+        $pool->save($item);
+
+        $pool->clear();
+        $this->assertFalse($pool->hasItem('test_key'));
+    }
+
+    /**
+     * Test saveDeferred and commit.
+     */
+    public function testSaveDeferredAndCommit(): void
+    {
+        $pool = new CacheItemPool('psr6_test');
+
+        $item1 = $pool->getItem('key1');
+        $item1->set('value1');
+        $pool->saveDeferred($item1);
+
+        $item2 = $pool->getItem('key2');
+        $item2->set('value2');
+        $pool->saveDeferred($item2);
+
+        // Before commit, deferred items should be accessible
+        $this->assertTrue($pool->hasItem('key1'));
+        $this->assertTrue($pool->hasItem('key2'));
+
+        $pool->commit();
+
+        // After commit, items should be persisted
+        $retrieved1 = $pool->getItem('key1');
+        $retrieved2 = $pool->getItem('key2');
+
+        $this->assertTrue($retrieved1->isHit());
+        $this->assertTrue($retrieved2->isHit());
+        $this->assertSame('value1', $retrieved1->get());
+        $this->assertSame('value2', $retrieved2->get());
+    }
+
+    /**
+     * Test invalid key throws exception.
+     */
+    public function testInvalidKeyThrowsException(): void
+    {
+        $pool = new CacheItemPool('psr6_test');
+
+        $this->expectException(InvalidArgumentException::class);
+        $pool->getItem('invalid{key');
+    }
+
+    /**
+     * Test empty key throws exception.
+     */
+    public function testEmptyKeyThrowsException(): void
+    {
+        $pool = new CacheItemPool('psr6_test');
+
+        $this->expectException(InvalidArgumentException::class);
+        $pool->getItem('');
+    }
+}

--- a/tests/TestCase/Cache/Psr6/CacheItemPoolTest.php
+++ b/tests/TestCase/Cache/Psr6/CacheItemPoolTest.php
@@ -17,11 +17,9 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Cache\Psr6;
 
 use Cake\Cache\Cache;
-use Cake\Cache\Psr6\CacheItem;
 use Cake\Cache\Psr6\CacheItemPool;
 use Cake\Cache\Psr6\InvalidArgumentException;
 use Cake\TestSuite\TestCase;
-use DateInterval;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
@@ -96,7 +94,7 @@ class CacheItemPoolTest extends TestCase
         $items = $pool->getItems(['key1', 'key2', 'key3']);
 
         $this->assertCount(3, $items);
-        foreach ($items as $key => $item) {
+        foreach ($items as $item) {
             $this->assertInstanceOf(CacheItemInterface::class, $item);
             $this->assertFalse($item->isHit());
         }

--- a/tests/TestCase/Cache/Psr6/CacheItemTest.php
+++ b/tests/TestCase/Cache/Psr6/CacheItemTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         5.2.0
+ * @since         5.4.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\TestCase\Cache\Psr6;

--- a/tests/TestCase/Cache/Psr6/CacheItemTest.php
+++ b/tests/TestCase/Cache/Psr6/CacheItemTest.php
@@ -1,0 +1,172 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Cache\Psr6;
+
+use Cake\Cache\Psr6\CacheItem;
+use Cake\TestSuite\TestCase;
+use DateInterval;
+use DateTimeImmutable;
+use Psr\Cache\CacheItemInterface;
+
+/**
+ * CacheItemTest class
+ */
+class CacheItemTest extends TestCase
+{
+    /**
+     * Test that item implements PSR-6 interface.
+     */
+    public function testImplementsInterface(): void
+    {
+        $item = new CacheItem('test_key');
+        $this->assertInstanceOf(CacheItemInterface::class, $item);
+    }
+
+    /**
+     * Test getKey.
+     */
+    public function testGetKey(): void
+    {
+        $item = new CacheItem('my_cache_key');
+        $this->assertSame('my_cache_key', $item->getKey());
+    }
+
+    /**
+     * Test isHit for miss.
+     */
+    public function testIsHitMiss(): void
+    {
+        $item = new CacheItem('key', false);
+        $this->assertFalse($item->isHit());
+    }
+
+    /**
+     * Test isHit for hit.
+     */
+    public function testIsHitSuccess(): void
+    {
+        $item = new CacheItem('key', true);
+        $this->assertTrue($item->isHit());
+    }
+
+    /**
+     * Test get and set.
+     */
+    public function testGetSet(): void
+    {
+        $item = new CacheItem('key');
+        $this->assertNull($item->get());
+
+        $result = $item->set('my value');
+        $this->assertSame($item, $result);
+        $this->assertSame('my value', $item->get());
+    }
+
+    /**
+     * Test set with various types.
+     */
+    public function testSetVariousTypes(): void
+    {
+        $item = new CacheItem('key');
+
+        $item->set(['array', 'value']);
+        $this->assertSame(['array', 'value'], $item->get());
+
+        $item->set(123);
+        $this->assertSame(123, $item->get());
+
+        $item->set(null);
+        $this->assertNull($item->get());
+
+        $obj = new \stdClass();
+        $item->set($obj);
+        $this->assertSame($obj, $item->get());
+    }
+
+    /**
+     * Test expiresAt with DateTime.
+     */
+    public function testExpiresAt(): void
+    {
+        $item = new CacheItem('key');
+        $expiration = new DateTimeImmutable('+1 hour');
+
+        $result = $item->expiresAt($expiration);
+        $this->assertSame($item, $result);
+        $this->assertSame($expiration, $item->getExpiration());
+    }
+
+    /**
+     * Test expiresAt with null.
+     */
+    public function testExpiresAtNull(): void
+    {
+        $item = new CacheItem('key');
+        $item->expiresAt(null);
+        $this->assertNull($item->getExpiration());
+    }
+
+    /**
+     * Test expiresAfter with int.
+     */
+    public function testExpiresAfterInt(): void
+    {
+        $item = new CacheItem('key');
+        $before = time();
+
+        $result = $item->expiresAfter(3600);
+        $this->assertSame($item, $result);
+
+        $ttl = $item->getTtl();
+        $this->assertGreaterThanOrEqual(3599, $ttl);
+        $this->assertLessThanOrEqual(3600, $ttl);
+    }
+
+    /**
+     * Test expiresAfter with DateInterval.
+     */
+    public function testExpiresAfterDateInterval(): void
+    {
+        $item = new CacheItem('key');
+        $interval = new DateInterval('PT1H');
+
+        $item->expiresAfter($interval);
+
+        $ttl = $item->getTtl();
+        $this->assertGreaterThanOrEqual(3599, $ttl);
+        $this->assertLessThanOrEqual(3600, $ttl);
+    }
+
+    /**
+     * Test expiresAfter with null.
+     */
+    public function testExpiresAfterNull(): void
+    {
+        $item = new CacheItem('key');
+        $item->expiresAfter(null);
+        $this->assertNull($item->getTtl());
+    }
+
+    /**
+     * Test getTtl returns null when no expiration set.
+     */
+    public function testGetTtlNoExpiration(): void
+    {
+        $item = new CacheItem('key');
+        $this->assertNull($item->getTtl());
+    }
+}

--- a/tests/TestCase/Cache/Psr6/CacheItemTest.php
+++ b/tests/TestCase/Cache/Psr6/CacheItemTest.php
@@ -21,6 +21,7 @@ use Cake\TestSuite\TestCase;
 use DateInterval;
 use DateTimeImmutable;
 use Psr\Cache\CacheItemInterface;
+use stdClass;
 
 /**
  * CacheItemTest class
@@ -92,7 +93,7 @@ class CacheItemTest extends TestCase
         $item->set(null);
         $this->assertNull($item->get());
 
-        $obj = new \stdClass();
+        $obj = new stdClass();
         $item->set($obj);
         $this->assertSame($obj, $item->get());
     }
@@ -126,7 +127,6 @@ class CacheItemTest extends TestCase
     public function testExpiresAfterInt(): void
     {
         $item = new CacheItem('key');
-        $before = time();
 
         $result = $item->expiresAfter(3600);
         $this->assertSame($item, $result);


### PR DESCRIPTION
## Summary

Adds PSR-6 `CacheItemPoolInterface` implementation that wraps existing CakePHP cache engines.

- `Cake\Cache\Psr6\CacheItem` implements `CacheItemInterface`
- `Cake\Cache\Psr6\CacheItemPool` implements `CacheItemPoolInterface`
- Supports deferred saves and commit
- Full test coverage

### Usage

```php
use Cake\Cache\Psr6\CacheItemPool;

$pool = new CacheItemPool('default');

$item = $pool->getItem('my_key');
if (!$item->isHit()) {
    $item->set('computed value');
    $item->expiresAfter(3600);
    $pool->save($item);
}

$value = $item->get();
```

### Changes

- Added `psr/cache` to composer.json requirements
- Added `psr/cache-implementation` to composer.json provides
- New classes in `src/Cache/Psr6/`
- Tests in `tests/TestCase/Cache/Psr6/`

Refs: PSR-6 https://www.php-fig.org/psr/psr-6/