### PR TITLE
Add PSR-14 Event Dispatcher implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "psr/http-factory": "^1.1",
         "psr/http-message": "^1.1 || ^2.0",
         "psr/http-server-handler": "^1.0.2",
+        "psr/event-dispatcher": "^1.0",
         "psr/http-server-middleware": "^1.0.2",
         "psr/log": "^3.0",
         "psr/simple-cache": "^2.0 || ^3.0"
@@ -71,6 +72,7 @@
     },
     "provide": {
         "psr/container-implementation": "^2.0",
+        "psr/event-dispatcher-implementation": "^1.0",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",
         "psr/http-server-handler-implementation": "^1.0",

--- a/src/Event/Psr14/EventDispatcher.php
+++ b/src/Event/Psr14/EventDispatcher.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         6.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Event\Psr14;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
+use Psr\EventDispatcher\StoppableEventInterface;
+
+/**
+ * PSR-14 EventDispatcher implementation.
+ *
+ * Dispatches events to listeners provided by a ListenerProvider.
+ *
+ * ### Usage
+ *
+ * ```php
+ * $provider = new ListenerProvider();
+ * $provider->addListener(UserCreatedEvent::class, function (UserCreatedEvent $event) {
+ *     // Handle event
+ * });
+ *
+ * $dispatcher = new EventDispatcher($provider);
+ * $dispatcher->dispatch(new UserCreatedEvent($user));
+ * ```
+ */
+class EventDispatcher implements EventDispatcherInterface
+{
+    /**
+     * Constructor.
+     *
+     * @param \Psr\EventDispatcher\ListenerProviderInterface $listenerProvider The listener provider.
+     */
+    public function __construct(
+        private ListenerProviderInterface $listenerProvider,
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function dispatch(object $event): object
+    {
+        $stoppable = $event instanceof StoppableEventInterface;
+
+        foreach ($this->listenerProvider->getListenersForEvent($event) as $listener) {
+            if ($stoppable && $event->isPropagationStopped()) {
+                break;
+            }
+
+            $listener($event);
+        }
+
+        return $event;
+    }
+
+    /**
+     * Get the listener provider.
+     *
+     * @return \Psr\EventDispatcher\ListenerProviderInterface
+     */
+    public function getListenerProvider(): ListenerProviderInterface
+    {
+        return $this->listenerProvider;
+    }
+}

--- a/src/Event/Psr14/ListenerProvider.php
+++ b/src/Event/Psr14/ListenerProvider.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         6.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Event\Psr14;
+
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+/**
+ * PSR-14 ListenerProvider implementation.
+ *
+ * Stores and retrieves event listeners based on the event type.
+ * Listeners are matched using instanceof checks, so a listener
+ * for a parent class will receive events of child classes too.
+ *
+ * ### Usage
+ *
+ * ```php
+ * $provider = new ListenerProvider();
+ *
+ * // Add a listener for a specific event class
+ * $provider->addListener(UserCreatedEvent::class, function (UserCreatedEvent $event) {
+ *     sendWelcomeEmail($event->user);
+ * });
+ *
+ * // Listeners can be any callable
+ * $provider->addListener(OrderPlacedEvent::class, [$orderService, 'processOrder']);
+ * $provider->addListener(PaymentReceivedEvent::class, new PaymentHandler());
+ * ```
+ */
+class ListenerProvider implements ListenerProviderInterface
+{
+    /**
+     * Registered listeners indexed by event class name.
+     *
+     * @var array<class-string, array<array{callable, int}>>
+     */
+    private array $listeners = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function getListenersForEvent(object $event): iterable
+    {
+        $eventClass = $event::class;
+        $matchedListeners = [];
+
+        foreach ($this->listeners as $listenedClass => $listeners) {
+            if ($event instanceof $listenedClass) {
+                foreach ($listeners as [$listener, $priority]) {
+                    $matchedListeners[] = [$listener, $priority];
+                }
+            }
+        }
+
+        // Sort by priority (higher = earlier)
+        usort($matchedListeners, fn (array $a, array $b): int => $b[1] <=> $a[1]);
+
+        foreach ($matchedListeners as [$listener, $priority]) {
+            yield $listener;
+        }
+    }
+
+    /**
+     * Add a listener for an event type.
+     *
+     * @param class-string $eventClass The event class name to listen for.
+     * @param callable $listener The listener callable.
+     * @param int $priority The listener priority (higher = earlier). Default is 0.
+     * @return $this
+     */
+    public function addListener(string $eventClass, callable $listener, int $priority = 0): static
+    {
+        if (!isset($this->listeners[$eventClass])) {
+            $this->listeners[$eventClass] = [];
+        }
+
+        $this->listeners[$eventClass][] = [$listener, $priority];
+
+        return $this;
+    }
+
+    /**
+     * Remove a listener for an event type.
+     *
+     * @param class-string $eventClass The event class name.
+     * @param callable $listener The listener callable to remove.
+     * @return $this
+     */
+    public function removeListener(string $eventClass, callable $listener): static
+    {
+        if (!isset($this->listeners[$eventClass])) {
+            return $this;
+        }
+
+        $this->listeners[$eventClass] = array_values(array_filter(
+            $this->listeners[$eventClass],
+            fn (array $entry): bool => $entry[0] !== $listener
+        ));
+
+        if (empty($this->listeners[$eventClass])) {
+            unset($this->listeners[$eventClass]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Clear all listeners, optionally for a specific event type.
+     *
+     * @param class-string|null $eventClass The event class name, or null to clear all.
+     * @return $this
+     */
+    public function clearListeners(?string $eventClass = null): static
+    {
+        if ($eventClass === null) {
+            $this->listeners = [];
+        } else {
+            unset($this->listeners[$eventClass]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Check if there are listeners for an event type.
+     *
+     * @param class-string $eventClass The event class name.
+     * @return bool
+     */
+    public function hasListeners(string $eventClass): bool
+    {
+        return !empty($this->listeners[$eventClass]);
+    }
+}

--- a/src/Event/Psr14/ListenerProvider.php
+++ b/src/Event/Psr14/ListenerProvider.php
@@ -54,7 +54,6 @@ class ListenerProvider implements ListenerProviderInterface
      */
     public function getListenersForEvent(object $event): iterable
     {
-        $eventClass = $event::class;
         $matchedListeners = [];
 
         foreach ($this->listeners as $listenedClass => $listeners) {
@@ -66,7 +65,7 @@ class ListenerProvider implements ListenerProviderInterface
         }
 
         // Sort by priority (higher = earlier)
-        usort($matchedListeners, fn (array $a, array $b): int => $b[1] <=> $a[1]);
+        usort($matchedListeners, fn(array $a, array $b): int => $b[1] <=> $a[1]);
 
         foreach ($matchedListeners as [$listener, $priority]) {
             yield $listener;
@@ -107,7 +106,7 @@ class ListenerProvider implements ListenerProviderInterface
 
         $this->listeners[$eventClass] = array_values(array_filter(
             $this->listeners[$eventClass],
-            fn (array $entry): bool => $entry[0] !== $listener
+            fn(array $entry): bool => $entry[0] !== $listener,
         ));
 
         if (empty($this->listeners[$eventClass])) {

--- a/src/Event/Psr14/StoppableEventTrait.php
+++ b/src/Event/Psr14/StoppableEventTrait.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         6.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Event\Psr14;
+
+/**
+ * Trait for implementing PSR-14 StoppableEventInterface.
+ *
+ * Use this trait in your event classes to make them stoppable:
+ *
+ * ```php
+ * use Psr\EventDispatcher\StoppableEventInterface;
+ *
+ * class UserCreatedEvent implements StoppableEventInterface
+ * {
+ *     use StoppableEventTrait;
+ *
+ *     public function __construct(
+ *         public readonly User $user,
+ *     ) {}
+ * }
+ * ```
+ */
+trait StoppableEventTrait
+{
+    /**
+     * Whether propagation was stopped.
+     */
+    private bool $propagationStopped = false;
+
+    /**
+     * Stop event propagation.
+     *
+     * After calling this method, isPropagationStopped() will return true
+     * and the dispatcher will stop calling further listeners.
+     *
+     * @return void
+     */
+    public function stopPropagation(): void
+    {
+        $this->propagationStopped = true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isPropagationStopped(): bool
+    {
+        return $this->propagationStopped;
+    }
+}

--- a/tests/TestCase/Event/Psr14/EventDispatcherTest.php
+++ b/tests/TestCase/Event/Psr14/EventDispatcherTest.php
@@ -47,9 +47,12 @@ class EventDispatcherTest extends TestCase
     {
         $called = false;
         $provider = new ListenerProvider();
-        $provider->addListener(stdClass::class, function (stdClass $event) use (&$called) {
-            $called = true;
-        });
+        $provider->addListener(
+            stdClass::class,
+            function (stdClass $event) use (&$called) {
+                $called = true;
+            },
+        );
 
         $dispatcher = new EventDispatcher($provider);
         $event = new stdClass();
@@ -80,15 +83,27 @@ class EventDispatcherTest extends TestCase
     {
         $order = [];
         $provider = new ListenerProvider();
-        $provider->addListener(stdClass::class, function () use (&$order) {
-            $order[] = 'first';
-        }, 10);
-        $provider->addListener(stdClass::class, function () use (&$order) {
-            $order[] = 'second';
-        }, 5);
-        $provider->addListener(stdClass::class, function () use (&$order) {
-            $order[] = 'third';
-        }, 15);
+        $provider->addListener(
+            stdClass::class,
+            function () use (&$order) {
+                $order[] = 'first';
+            },
+            10,
+        );
+        $provider->addListener(
+            stdClass::class,
+            function () use (&$order) {
+                $order[] = 'second';
+            },
+            5,
+        );
+        $provider->addListener(
+            stdClass::class,
+            function () use (&$order) {
+                $order[] = 'third';
+            },
+            15,
+        );
 
         $dispatcher = new EventDispatcher($provider);
         $dispatcher->dispatch(new stdClass());
@@ -111,13 +126,21 @@ class EventDispatcherTest extends TestCase
         $eventClass = $event::class;
 
         $provider = new ListenerProvider();
-        $provider->addListener($eventClass, function (StoppableEventInterface $event) use (&$order) {
-            $order[] = 'first';
-            $event->stopPropagation();
-        }, 10);
-        $provider->addListener($eventClass, function () use (&$order) {
-            $order[] = 'second';
-        }, 5);
+        $provider->addListener(
+            $eventClass,
+            function (StoppableEventInterface $event) use (&$order) {
+                $order[] = 'first';
+                $event->stopPropagation();
+            },
+            10,
+        );
+        $provider->addListener(
+            $eventClass,
+            function () use (&$order) {
+                $order[] = 'second';
+            },
+            5,
+        );
 
         $dispatcher = new EventDispatcher($provider);
         $dispatcher->dispatch($event);

--- a/tests/TestCase/Event/Psr14/EventDispatcherTest.php
+++ b/tests/TestCase/Event/Psr14/EventDispatcherTest.php
@@ -104,17 +104,21 @@ class EventDispatcherTest extends TestCase
     {
         $order = [];
 
+        $event = new class implements StoppableEventInterface {
+            use StoppableEventTrait;
+        };
+        $eventClass = $event::class;
+
         $provider = new ListenerProvider();
-        $provider->addListener(TestStoppableEvent::class, function (TestStoppableEvent $event) use (&$order) {
+        $provider->addListener($eventClass, function (StoppableEventInterface $event) use (&$order) {
             $order[] = 'first';
             $event->stopPropagation();
         }, 10);
-        $provider->addListener(TestStoppableEvent::class, function () use (&$order) {
+        $provider->addListener($eventClass, function () use (&$order) {
             $order[] = 'second';
         }, 5);
 
         $dispatcher = new EventDispatcher($provider);
-        $event = new TestStoppableEvent();
         $dispatcher->dispatch($event);
 
         $this->assertSame(['first'], $order);
@@ -131,12 +135,4 @@ class EventDispatcherTest extends TestCase
 
         $this->assertSame($provider, $dispatcher->getListenerProvider());
     }
-}
-
-/**
- * Test event class that implements StoppableEventInterface.
- */
-class TestStoppableEvent implements StoppableEventInterface
-{
-    use StoppableEventTrait;
 }

--- a/tests/TestCase/Event/Psr14/EventDispatcherTest.php
+++ b/tests/TestCase/Event/Psr14/EventDispatcherTest.php
@@ -104,7 +104,8 @@ class EventDispatcherTest extends TestCase
     {
         $order = [];
 
-        $event = new class implements StoppableEventInterface {
+        $event = new class implements StoppableEventInterface
+        {
             use StoppableEventTrait;
         };
         $eventClass = $event::class;

--- a/tests/TestCase/Event/Psr14/EventDispatcherTest.php
+++ b/tests/TestCase/Event/Psr14/EventDispatcherTest.php
@@ -1,0 +1,142 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         6.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Event\Psr14;
+
+use Cake\Event\Psr14\EventDispatcher;
+use Cake\Event\Psr14\ListenerProvider;
+use Cake\Event\Psr14\StoppableEventTrait;
+use Cake\TestSuite\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\EventDispatcher\StoppableEventInterface;
+use stdClass;
+
+/**
+ * EventDispatcherTest class
+ */
+class EventDispatcherTest extends TestCase
+{
+    /**
+     * Test that dispatcher implements PSR-14 interface.
+     */
+    public function testImplementsInterface(): void
+    {
+        $provider = new ListenerProvider();
+        $dispatcher = new EventDispatcher($provider);
+
+        $this->assertInstanceOf(EventDispatcherInterface::class, $dispatcher);
+    }
+
+    /**
+     * Test dispatch calls listeners.
+     */
+    public function testDispatchCallsListeners(): void
+    {
+        $called = false;
+        $provider = new ListenerProvider();
+        $provider->addListener(stdClass::class, function (stdClass $event) use (&$called) {
+            $called = true;
+        });
+
+        $dispatcher = new EventDispatcher($provider);
+        $event = new stdClass();
+        $result = $dispatcher->dispatch($event);
+
+        $this->assertTrue($called);
+        $this->assertSame($event, $result);
+    }
+
+    /**
+     * Test dispatch returns the event.
+     */
+    public function testDispatchReturnsEvent(): void
+    {
+        $provider = new ListenerProvider();
+        $dispatcher = new EventDispatcher($provider);
+
+        $event = new stdClass();
+        $result = $dispatcher->dispatch($event);
+
+        $this->assertSame($event, $result);
+    }
+
+    /**
+     * Test dispatch with multiple listeners.
+     */
+    public function testDispatchMultipleListeners(): void
+    {
+        $order = [];
+        $provider = new ListenerProvider();
+        $provider->addListener(stdClass::class, function () use (&$order) {
+            $order[] = 'first';
+        }, 10);
+        $provider->addListener(stdClass::class, function () use (&$order) {
+            $order[] = 'second';
+        }, 5);
+        $provider->addListener(stdClass::class, function () use (&$order) {
+            $order[] = 'third';
+        }, 15);
+
+        $dispatcher = new EventDispatcher($provider);
+        $dispatcher->dispatch(new stdClass());
+
+        // Should be ordered by priority (highest first)
+        $this->assertSame(['third', 'first', 'second'], $order);
+    }
+
+    /**
+     * Test dispatch stops on stoppable event.
+     */
+    public function testDispatchStopsOnStoppableEvent(): void
+    {
+        $order = [];
+
+        $provider = new ListenerProvider();
+        $provider->addListener(TestStoppableEvent::class, function (TestStoppableEvent $event) use (&$order) {
+            $order[] = 'first';
+            $event->stopPropagation();
+        }, 10);
+        $provider->addListener(TestStoppableEvent::class, function () use (&$order) {
+            $order[] = 'second';
+        }, 5);
+
+        $dispatcher = new EventDispatcher($provider);
+        $event = new TestStoppableEvent();
+        $dispatcher->dispatch($event);
+
+        $this->assertSame(['first'], $order);
+        $this->assertTrue($event->isPropagationStopped());
+    }
+
+    /**
+     * Test getListenerProvider.
+     */
+    public function testGetListenerProvider(): void
+    {
+        $provider = new ListenerProvider();
+        $dispatcher = new EventDispatcher($provider);
+
+        $this->assertSame($provider, $dispatcher->getListenerProvider());
+    }
+}
+
+/**
+ * Test event class that implements StoppableEventInterface.
+ */
+class TestStoppableEvent implements StoppableEventInterface
+{
+    use StoppableEventTrait;
+}

--- a/tests/TestCase/Event/Psr14/EventDispatcherTest.php
+++ b/tests/TestCase/Event/Psr14/EventDispatcherTest.php
@@ -49,7 +49,7 @@ class EventDispatcherTest extends TestCase
         $provider = new ListenerProvider();
         $provider->addListener(
             stdClass::class,
-            function (stdClass $event) use (&$called) {
+            function (stdClass $event) use (&$called): void {
                 $called = true;
             },
         );
@@ -85,21 +85,21 @@ class EventDispatcherTest extends TestCase
         $provider = new ListenerProvider();
         $provider->addListener(
             stdClass::class,
-            function () use (&$order) {
+            function () use (&$order): void {
                 $order[] = 'first';
             },
             10,
         );
         $provider->addListener(
             stdClass::class,
-            function () use (&$order) {
+            function () use (&$order): void {
                 $order[] = 'second';
             },
             5,
         );
         $provider->addListener(
             stdClass::class,
-            function () use (&$order) {
+            function () use (&$order): void {
                 $order[] = 'third';
             },
             15,
@@ -128,7 +128,7 @@ class EventDispatcherTest extends TestCase
         $provider = new ListenerProvider();
         $provider->addListener(
             $eventClass,
-            function (StoppableEventInterface $event) use (&$order) {
+            function (StoppableEventInterface $event) use (&$order): void {
                 $order[] = 'first';
                 $event->stopPropagation();
             },
@@ -136,7 +136,7 @@ class EventDispatcherTest extends TestCase
         );
         $provider->addListener(
             $eventClass,
-            function () use (&$order) {
+            function () use (&$order): void {
                 $order[] = 'second';
             },
             5,

--- a/tests/TestCase/Event/Psr14/ListenerProviderTest.php
+++ b/tests/TestCase/Event/Psr14/ListenerProviderTest.php
@@ -73,7 +73,9 @@ class ListenerProviderTest extends TestCase
         $provider->addListener(stdClass::class, $listener);
 
         // ExtendedClass extends stdClass
-        $event = new class extends stdClass {};
+        $event = new class extends stdClass
+        {
+        };
 
         $listeners = iterator_to_array($provider->getListenersForEvent($event));
 
@@ -142,7 +144,9 @@ class ListenerProviderTest extends TestCase
      */
     public function testClearListenersForEvent(): void
     {
-        $testEvent = new class {};
+        $testEvent = new class
+        {
+        };
         $testEventClass = $testEvent::class;
 
         $provider = new ListenerProvider();
@@ -160,7 +164,9 @@ class ListenerProviderTest extends TestCase
      */
     public function testClearListenersAll(): void
     {
-        $testEvent = new class {};
+        $testEvent = new class
+        {
+        };
         $testEventClass = $testEvent::class;
 
         $provider = new ListenerProvider();

--- a/tests/TestCase/Event/Psr14/ListenerProviderTest.php
+++ b/tests/TestCase/Event/Psr14/ListenerProviderTest.php
@@ -51,7 +51,7 @@ class ListenerProviderTest extends TestCase
      */
     public function testAddListenerAndGetListeners(): void
     {
-        $listener = function (stdClass $event) {
+        $listener = function (stdClass $event): void {
         };
 
         $provider = new ListenerProvider();
@@ -68,7 +68,7 @@ class ListenerProviderTest extends TestCase
      */
     public function testListenersMatchParentClasses(): void
     {
-        $listener = function (object $event) {
+        $listener = function (object $event): void {
         };
 
         $provider = new ListenerProvider();
@@ -89,11 +89,11 @@ class ListenerProviderTest extends TestCase
      */
     public function testPriorityOrdering(): void
     {
-        $listener1 = function () {
+        $listener1 = function (): void {
         };
-        $listener2 = function () {
+        $listener2 = function (): void {
         };
-        $listener3 = function () {
+        $listener3 = function (): void {
         };
 
         $provider = new ListenerProvider();
@@ -113,9 +113,9 @@ class ListenerProviderTest extends TestCase
      */
     public function testRemoveListener(): void
     {
-        $listener1 = function () {
+        $listener1 = function (): void {
         };
-        $listener2 = function () {
+        $listener2 = function (): void {
         };
 
         $provider = new ListenerProvider();
@@ -134,9 +134,9 @@ class ListenerProviderTest extends TestCase
      */
     public function testRemoveListenerNotFound(): void
     {
-        $listener1 = function () {
+        $listener1 = function (): void {
         };
-        $listener2 = function () {
+        $listener2 = function (): void {
         };
 
         $provider = new ListenerProvider();
@@ -161,12 +161,12 @@ class ListenerProviderTest extends TestCase
         $provider = new ListenerProvider();
         $provider->addListener(
             stdClass::class,
-            function () {
+            function (): void {
             },
         );
         $provider->addListener(
             $testEventClass,
-            function () {
+            function (): void {
             },
         );
 
@@ -189,12 +189,12 @@ class ListenerProviderTest extends TestCase
         $provider = new ListenerProvider();
         $provider->addListener(
             stdClass::class,
-            function () {
+            function (): void {
             },
         );
         $provider->addListener(
             $testEventClass,
-            function () {
+            function (): void {
             },
         );
 
@@ -215,7 +215,7 @@ class ListenerProviderTest extends TestCase
 
         $provider->addListener(
             stdClass::class,
-            function () {
+            function (): void {
             },
         );
 
@@ -228,7 +228,7 @@ class ListenerProviderTest extends TestCase
     public function testFluentInterface(): void
     {
         $provider = new ListenerProvider();
-        $listener = function () {
+        $listener = function (): void {
         };
 
         $result = $provider

--- a/tests/TestCase/Event/Psr14/ListenerProviderTest.php
+++ b/tests/TestCase/Event/Psr14/ListenerProviderTest.php
@@ -51,7 +51,8 @@ class ListenerProviderTest extends TestCase
      */
     public function testAddListenerAndGetListeners(): void
     {
-        $listener = function (stdClass $event) {};
+        $listener = function (stdClass $event) {
+        };
 
         $provider = new ListenerProvider();
         $provider->addListener(stdClass::class, $listener);
@@ -67,7 +68,8 @@ class ListenerProviderTest extends TestCase
      */
     public function testListenersMatchParentClasses(): void
     {
-        $listener = function (object $event) {};
+        $listener = function (object $event) {
+        };
 
         $provider = new ListenerProvider();
         $provider->addListener(stdClass::class, $listener);
@@ -87,9 +89,12 @@ class ListenerProviderTest extends TestCase
      */
     public function testPriorityOrdering(): void
     {
-        $listener1 = function () {};
-        $listener2 = function () {};
-        $listener3 = function () {};
+        $listener1 = function () {
+        };
+        $listener2 = function () {
+        };
+        $listener3 = function () {
+        };
 
         $provider = new ListenerProvider();
         $provider->addListener(stdClass::class, $listener1, 5);
@@ -108,8 +113,10 @@ class ListenerProviderTest extends TestCase
      */
     public function testRemoveListener(): void
     {
-        $listener1 = function () {};
-        $listener2 = function () {};
+        $listener1 = function () {
+        };
+        $listener2 = function () {
+        };
 
         $provider = new ListenerProvider();
         $provider->addListener(stdClass::class, $listener1);
@@ -127,8 +134,10 @@ class ListenerProviderTest extends TestCase
      */
     public function testRemoveListenerNotFound(): void
     {
-        $listener1 = function () {};
-        $listener2 = function () {};
+        $listener1 = function () {
+        };
+        $listener2 = function () {
+        };
 
         $provider = new ListenerProvider();
         $provider->addListener(stdClass::class, $listener1);
@@ -219,7 +228,8 @@ class ListenerProviderTest extends TestCase
     public function testFluentInterface(): void
     {
         $provider = new ListenerProvider();
-        $listener = function () {};
+        $listener = function () {
+        };
 
         $result = $provider
             ->addListener(stdClass::class, $listener)

--- a/tests/TestCase/Event/Psr14/ListenerProviderTest.php
+++ b/tests/TestCase/Event/Psr14/ListenerProviderTest.php
@@ -150,8 +150,16 @@ class ListenerProviderTest extends TestCase
         $testEventClass = $testEvent::class;
 
         $provider = new ListenerProvider();
-        $provider->addListener(stdClass::class, function () {});
-        $provider->addListener($testEventClass, function () {});
+        $provider->addListener(
+            stdClass::class,
+            function () {
+            },
+        );
+        $provider->addListener(
+            $testEventClass,
+            function () {
+            },
+        );
 
         $provider->clearListeners(stdClass::class);
 
@@ -170,8 +178,16 @@ class ListenerProviderTest extends TestCase
         $testEventClass = $testEvent::class;
 
         $provider = new ListenerProvider();
-        $provider->addListener(stdClass::class, function () {});
-        $provider->addListener($testEventClass, function () {});
+        $provider->addListener(
+            stdClass::class,
+            function () {
+            },
+        );
+        $provider->addListener(
+            $testEventClass,
+            function () {
+            },
+        );
 
         $provider->clearListeners();
 
@@ -188,7 +204,11 @@ class ListenerProviderTest extends TestCase
 
         $this->assertFalse($provider->hasListeners(stdClass::class));
 
-        $provider->addListener(stdClass::class, function () {});
+        $provider->addListener(
+            stdClass::class,
+            function () {
+            },
+        );
 
         $this->assertTrue($provider->hasListeners(stdClass::class));
     }

--- a/tests/TestCase/Event/Psr14/ListenerProviderTest.php
+++ b/tests/TestCase/Event/Psr14/ListenerProviderTest.php
@@ -142,14 +142,17 @@ class ListenerProviderTest extends TestCase
      */
     public function testClearListenersForEvent(): void
     {
+        $testEvent = new class {};
+        $testEventClass = $testEvent::class;
+
         $provider = new ListenerProvider();
         $provider->addListener(stdClass::class, function () {});
-        $provider->addListener(TestEvent::class, function () {});
+        $provider->addListener($testEventClass, function () {});
 
         $provider->clearListeners(stdClass::class);
 
         $this->assertFalse($provider->hasListeners(stdClass::class));
-        $this->assertTrue($provider->hasListeners(TestEvent::class));
+        $this->assertTrue($provider->hasListeners($testEventClass));
     }
 
     /**
@@ -157,14 +160,17 @@ class ListenerProviderTest extends TestCase
      */
     public function testClearListenersAll(): void
     {
+        $testEvent = new class {};
+        $testEventClass = $testEvent::class;
+
         $provider = new ListenerProvider();
         $provider->addListener(stdClass::class, function () {});
-        $provider->addListener(TestEvent::class, function () {});
+        $provider->addListener($testEventClass, function () {});
 
         $provider->clearListeners();
 
         $this->assertFalse($provider->hasListeners(stdClass::class));
-        $this->assertFalse($provider->hasListeners(TestEvent::class));
+        $this->assertFalse($provider->hasListeners($testEventClass));
     }
 
     /**
@@ -196,11 +202,4 @@ class ListenerProviderTest extends TestCase
 
         $this->assertSame($provider, $result);
     }
-}
-
-/**
- * Test event class.
- */
-class TestEvent
-{
 }

--- a/tests/TestCase/Event/Psr14/ListenerProviderTest.php
+++ b/tests/TestCase/Event/Psr14/ListenerProviderTest.php
@@ -1,0 +1,206 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         6.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Event\Psr14;
+
+use Cake\Event\Psr14\ListenerProvider;
+use Cake\TestSuite\TestCase;
+use Psr\EventDispatcher\ListenerProviderInterface;
+use stdClass;
+
+/**
+ * ListenerProviderTest class
+ */
+class ListenerProviderTest extends TestCase
+{
+    /**
+     * Test that provider implements PSR-14 interface.
+     */
+    public function testImplementsInterface(): void
+    {
+        $provider = new ListenerProvider();
+        $this->assertInstanceOf(ListenerProviderInterface::class, $provider);
+    }
+
+    /**
+     * Test getListenersForEvent with no listeners.
+     */
+    public function testGetListenersForEventEmpty(): void
+    {
+        $provider = new ListenerProvider();
+        $listeners = iterator_to_array($provider->getListenersForEvent(new stdClass()));
+
+        $this->assertEmpty($listeners);
+    }
+
+    /**
+     * Test addListener and getListenersForEvent.
+     */
+    public function testAddListenerAndGetListeners(): void
+    {
+        $listener = function (stdClass $event) {};
+
+        $provider = new ListenerProvider();
+        $provider->addListener(stdClass::class, $listener);
+
+        $listeners = iterator_to_array($provider->getListenersForEvent(new stdClass()));
+
+        $this->assertCount(1, $listeners);
+        $this->assertSame($listener, $listeners[0]);
+    }
+
+    /**
+     * Test listeners are called for parent classes.
+     */
+    public function testListenersMatchParentClasses(): void
+    {
+        $listener = function (object $event) {};
+
+        $provider = new ListenerProvider();
+        $provider->addListener(stdClass::class, $listener);
+
+        // ExtendedClass extends stdClass
+        $event = new class extends stdClass {};
+
+        $listeners = iterator_to_array($provider->getListenersForEvent($event));
+
+        $this->assertCount(1, $listeners);
+    }
+
+    /**
+     * Test priority ordering.
+     */
+    public function testPriorityOrdering(): void
+    {
+        $listener1 = function () {};
+        $listener2 = function () {};
+        $listener3 = function () {};
+
+        $provider = new ListenerProvider();
+        $provider->addListener(stdClass::class, $listener1, 5);
+        $provider->addListener(stdClass::class, $listener2, 10);
+        $provider->addListener(stdClass::class, $listener3, 1);
+
+        $listeners = iterator_to_array($provider->getListenersForEvent(new stdClass()));
+
+        $this->assertSame($listener2, $listeners[0]); // priority 10
+        $this->assertSame($listener1, $listeners[1]); // priority 5
+        $this->assertSame($listener3, $listeners[2]); // priority 1
+    }
+
+    /**
+     * Test removeListener.
+     */
+    public function testRemoveListener(): void
+    {
+        $listener1 = function () {};
+        $listener2 = function () {};
+
+        $provider = new ListenerProvider();
+        $provider->addListener(stdClass::class, $listener1);
+        $provider->addListener(stdClass::class, $listener2);
+        $provider->removeListener(stdClass::class, $listener1);
+
+        $listeners = iterator_to_array($provider->getListenersForEvent(new stdClass()));
+
+        $this->assertCount(1, $listeners);
+        $this->assertSame($listener2, $listeners[0]);
+    }
+
+    /**
+     * Test removeListener with non-existent listener.
+     */
+    public function testRemoveListenerNotFound(): void
+    {
+        $listener1 = function () {};
+        $listener2 = function () {};
+
+        $provider = new ListenerProvider();
+        $provider->addListener(stdClass::class, $listener1);
+        $provider->removeListener(stdClass::class, $listener2);
+
+        $listeners = iterator_to_array($provider->getListenersForEvent(new stdClass()));
+
+        $this->assertCount(1, $listeners);
+    }
+
+    /**
+     * Test clearListeners for specific event.
+     */
+    public function testClearListenersForEvent(): void
+    {
+        $provider = new ListenerProvider();
+        $provider->addListener(stdClass::class, function () {});
+        $provider->addListener(TestEvent::class, function () {});
+
+        $provider->clearListeners(stdClass::class);
+
+        $this->assertFalse($provider->hasListeners(stdClass::class));
+        $this->assertTrue($provider->hasListeners(TestEvent::class));
+    }
+
+    /**
+     * Test clearListeners for all events.
+     */
+    public function testClearListenersAll(): void
+    {
+        $provider = new ListenerProvider();
+        $provider->addListener(stdClass::class, function () {});
+        $provider->addListener(TestEvent::class, function () {});
+
+        $provider->clearListeners();
+
+        $this->assertFalse($provider->hasListeners(stdClass::class));
+        $this->assertFalse($provider->hasListeners(TestEvent::class));
+    }
+
+    /**
+     * Test hasListeners.
+     */
+    public function testHasListeners(): void
+    {
+        $provider = new ListenerProvider();
+
+        $this->assertFalse($provider->hasListeners(stdClass::class));
+
+        $provider->addListener(stdClass::class, function () {});
+
+        $this->assertTrue($provider->hasListeners(stdClass::class));
+    }
+
+    /**
+     * Test fluent interface.
+     */
+    public function testFluentInterface(): void
+    {
+        $provider = new ListenerProvider();
+        $listener = function () {};
+
+        $result = $provider
+            ->addListener(stdClass::class, $listener)
+            ->removeListener(stdClass::class, $listener)
+            ->clearListeners();
+
+        $this->assertSame($provider, $result);
+    }
+}
+
+/**
+ * Test event class.
+ */
+class TestEvent
+{
+}


### PR DESCRIPTION
## Summary

Adds PSR-14 `EventDispatcherInterface` implementation alongside the existing CakePHP event system.

- `Cake\Event\Psr14\EventDispatcher` implements `EventDispatcherInterface`
- `Cake\Event\Psr14\ListenerProvider` implements `ListenerProviderInterface`
- `Cake\Event\Psr14\StoppableEventTrait` for `StoppableEventInterface`
- Priority-based listener ordering
- Full test coverage

### Usage

```php
use Cake\Event\Psr14\EventDispatcher;
use Cake\Event\Psr14\ListenerProvider;
use Cake\Event\Psr14\StoppableEventTrait;
use Psr\EventDispatcher\StoppableEventInterface;

// Define a typed event
class UserCreatedEvent implements StoppableEventInterface
{
    use StoppableEventTrait;

    public function __construct(
        public readonly User $user,
    ) {}
}

// Set up listener provider
$provider = new ListenerProvider();
$provider->addListener(UserCreatedEvent::class, function (UserCreatedEvent $event) {
    sendWelcomeEmail($event->user);
}, priority: 10);

// Create dispatcher
$dispatcher = new EventDispatcher($provider);

// Dispatch event
$event = new UserCreatedEvent($user);
$dispatcher->dispatch($event);
```

### Changes

- Added `psr/event-dispatcher` to composer.json requirements
- Added `psr/event-dispatcher-implementation` to composer.json provides
- New classes in `src/Event/Psr14/`
- Tests in `tests/TestCase/Event/Psr14/`

### Migration Path

This PR adds PSR-14 support alongside the existing event system:
- Existing code continues to work unchanged
- New code can use PSR-14 typed events
- Future: bridge between old EventManager and new PSR-14 dispatcher

Refs: PSR-14 https://www.php-fig.org/psr/psr-14/