### PR TITLE
Color command names in help output

### DIFF
--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -271,7 +271,8 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
             $io->out('<info>Available Commands:</info>');
             foreach ($singleCommands as $prefix => $cmd) {
                 $description = $cmd['description'];
-                $linePrefix = '  ' . str_pad($prefix, $nameColumnWidth - 2);
+                $padding = str_repeat(' ', $nameColumnWidth - 2 - strlen($prefix));
+                $linePrefix = '  <info>' . $prefix . '</info>' . $padding;
 
                 if ($description !== '') {
                     $description = strtok($description, "\n");
@@ -294,7 +295,8 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
                 $fullName = $cmd['subcommand'] !== null ? $prefix . ' ' . $cmd['subcommand'] : $prefix;
                 $description = $cmd['description'];
 
-                $linePrefix = '  ' . str_pad($fullName, $nameColumnWidth - 2);
+                $padding = str_repeat(' ', $nameColumnWidth - 2 - strlen($fullName));
+                $linePrefix = '  <info>' . $fullName . '</info>' . $padding;
 
                 if ($description !== '') {
                     $description = strtok($description, "\n");
@@ -324,7 +326,8 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
         int $maxWidth,
         int $maxChars = 200,
     ): void {
-        $availableWidth = $maxWidth - strlen($prefix);
+        $prefixLength = strlen($this->stripMarkup($prefix));
+        $availableWidth = $maxWidth - $prefixLength;
 
         if ($availableWidth <= 10) {
             $io->out($prefix);
@@ -344,7 +347,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
         }
 
         // Wrap description across multiple lines
-        $indent = str_repeat(' ', strlen($prefix));
+        $indent = str_repeat(' ', $prefixLength);
         $remaining = $description;
         $firstLine = true;
 
@@ -442,6 +445,17 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
         });
 
         return array_shift($names);
+    }
+
+    /**
+     * Strip ConsoleOutput markup tags from a string.
+     *
+     * @param string $text Text that may contain markup tags
+     * @return string Text with markup tags removed
+     */
+    protected function stripMarkup(string $text): string
+    {
+        return preg_replace('/<\/?[a-z]+>/', '', $text) ?? $text;
     }
 
     /**


### PR DESCRIPTION
## Summary

* Add `<info>` markup to command names in the compact help output
* Improves visual distinction between command names and descriptions
* Makes it easier to scan the command list when running `bin/cake` or `bin/cake <prefix>`

Before:
```
illuminate:
  illuminate code PHP file modifier.
```

<img width="1222" height="358" alt="before" src="https://github.com/user-attachments/assets/271047bc-1f12-4538-9191-b4ee51469e65" />


After (command name in cyan/info color):

<img width="1140" height="294" alt="after" src="https://github.com/user-attachments/assets/fe67a6bd-c953-4961-9775-d3ee7772d726" />


The colored command name makes it immediately clear where the command ends and the description begins.