### PR TITLE
Fix undefined array key 'origin' on older SQLite versions

### DIFF
--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -403,7 +403,7 @@ class SqliteSchemaDialect extends SchemaDialect
     public function convertIndexDescription(TableSchema $schema, array $row): void
     {
         // Skip auto-indexes created for non-ROWID primary keys.
-        if ($row['origin'] === 'pk') {
+        if (($row['origin'] ?? null) === 'pk') {
             return;
         }
 
@@ -417,7 +417,7 @@ class SqliteSchemaDialect extends SchemaDialect
             $columns[] = $column['name'];
         }
         if ($row['unique']) {
-            if ($row['origin'] === 'u') {
+            if (($row['origin'] ?? null) === 'u') {
                 $createTableSql = $this->getCreateTableSql($schema->name());
                 $name = $this->extractIndexName($createTableSql, 'UNIQUE', $columns);
                 if ($name !== null) {
@@ -553,7 +553,7 @@ class SqliteSchemaDialect extends SchemaDialect
             if ($row['unique']) {
                 $indexType = TableSchema::CONSTRAINT_UNIQUE;
             }
-            if ($row['origin'] === 'pk') {
+            if (($row['origin'] ?? null) === 'pk') {
                 $indexType = TableSchema::CONSTRAINT_PRIMARY;
                 $foundPrimary = true;
             }


### PR DESCRIPTION
## Summary

- Fix undefined array key "origin" warning on SQLite versions < 3.8.9
- The `origin` column in `PRAGMA index_list` was added in SQLite 3.8.9 (April 2015)
- Users on older SQLite versions (e.g., shared hosting environments) get warnings

The fix uses null coalescing (`$row['origin'] ?? null`) to handle the missing key gracefully. The existing fallback logic in `describeIndexes()` already handles primary key detection when the `origin` column is not available.

Fixes #19216