### PR TITLE
Disable standalone true/false/null type hints check for BC

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,6 +6,13 @@
 
     <rule ref="CakePHP"/>
 
+    <!-- Disable standalone true/false/null type hints for BC -->
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+        <properties>
+            <property name="enableStandaloneNullTrueFalseTypeHints" value="false"/>
+        </properties>
+    </rule>
+
     <arg value="s"/>
     <!-- pretty sure this is a bug in slevomat -->
     <rule ref="Internal.Exception">


### PR DESCRIPTION
CI is currently red due to PHPCS

## Summary

- Disable `enableStandaloneNullTrueFalseTypeHints` in phpcs.xml for BC
- This slevomat rule enforces using `true`/`false`/`null` as standalone return types when `@return` annotations indicate these specific values
- Changing return types from `bool` to `true` would break BC for child classes overriding these methods

Affected methods that triggered this:
- `ConsoleInputOption::validChoice()`
- `ConsoleInputArgument::validChoice()`
- `Session::close()`
- `ServerRequest::allowMethod()`
- `Table::deleteOrFail()`