### PR TITLE
Update documentation anchors for VitePress compatibility

### DIFF
--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -92,7 +92,7 @@ class ServerCommand extends Command
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return void
-     * @link https://book.cakephp.org/5/en/console-and-shells.html#hook-methods
+     * @link https://book.cakephp.org/5/en/console-commands/commands.html#lifecycle-callbacks
      */
     protected function startup(Arguments $args, ConsoleIo $io): void
     {

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -214,7 +214,7 @@ class ConsoleIo
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout
      *   or null if provided $level is greater than current level.
-     * @link https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::out
+     * @link https://book.cakephp.org/5/en/console-commands/input-output.html#creating-output
      */
     public function info(array|string $message, int $newlines = 1, int $level = self::NORMAL): ?int
     {
@@ -232,7 +232,7 @@ class ConsoleIo
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout
      *   or null if provided $level is greater than current level.
-     * @link https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::out
+     * @link https://book.cakephp.org/5/en/console-commands/input-output.html#creating-output
      */
     public function comment(array|string $message, int $newlines = 1, int $level = self::NORMAL): ?int
     {
@@ -248,7 +248,7 @@ class ConsoleIo
      * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to stderr.
-     * @link https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::err
+     * @link https://book.cakephp.org/5/en/console-commands/input-output.html#creating-output
      */
     public function warning(array|string $message, int $newlines = 1): int
     {
@@ -264,7 +264,7 @@ class ConsoleIo
      * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to stderr.
-     * @link https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::err
+     * @link https://book.cakephp.org/5/en/console-commands/input-output.html#creating-output
      */
     public function error(array|string $message, int $newlines = 1): int
     {
@@ -282,7 +282,7 @@ class ConsoleIo
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout
      *   or null if provided $level is greater than current level.
-     * @link https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::out
+     * @link https://book.cakephp.org/5/en/console-commands/input-output.html#creating-output
      */
     public function success(array|string $message, int $newlines = 1, int $level = self::NORMAL): ?int
     {

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -194,6 +194,7 @@ class ConsoleIo
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout
      *   or null if provided $level is greater than current level.
+     * @link https://book.cakephp.org/5/en/console-commands/input-output.html#creating-output
      */
     public function out(array|string $message = '', int $newlines = 1, int $level = self::NORMAL): ?int
     {
@@ -374,6 +375,7 @@ class ConsoleIo
      * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to stderr.
+     * @link https://book.cakephp.org/5/en/console-commands/input-output.html#creating-output
      */
     public function err(array|string $message = '', int $newlines = 1): int
     {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -278,6 +278,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * @param array<string, mixed> $config The config for the component.
      * @return \Cake\Controller\Component
      * @throws \Exception
+     * @link https://book.cakephp.org/5/en/controllers.html#configuring-components-to-load
      */
     public function loadComponent(string $name, array $config = []): Component
     {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -636,7 +636,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * @param \Psr\Http\Message\UriInterface|array|string $url A string, array-based URL or UriInterface instance.
      * @param int $status HTTP status code. Defaults to `302`.
      * @return \Cake\Http\Response|null
-     * @link https://book.cakephp.org/5/en/controllers.html#Controller::redirect
+     * @link https://book.cakephp.org/5/en/controllers.html#redirecting-to-other-pages
      */
     public function redirect(UriInterface|array|string $url, int $status = 302): ?Response
     {

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -321,7 +321,7 @@ class Configure
      * @param bool $merge if config files should be merged instead of simply overridden
      * @return bool True if load successful.
      * @throws \Cake\Core\Exception\CakeException if the $config engine is not found
-     * @link https://book.cakephp.org/5/en/development/configuration.html#reading-and-writing-configuration-files
+     * @link https://book.cakephp.org/5/en/development/configuration.html#reading-writing-configuration-files
      */
     public static function load(string $key, string $config = 'default', bool $merge = true): bool
     {

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -146,7 +146,7 @@ if (!function_exists('Cake\Core\pluginSplit')) {
      * @param bool $dotAppend Set to true if you want the plugin to have a '.' appended to it.
      * @param string|null $plugin Optional default plugin to use if no plugin is found. Defaults to null.
      * @return array Array with 2 indexes. 0 => plugin name, 1 => class name.
-     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#pluginSplit
+     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#pluginsplit
      * @phpstan-return array{string|null, string}
      */
     function pluginSplit(string $name, bool $dotAppend = false, ?string $plugin = null): array

--- a/src/Core/functions_global.php
+++ b/src/Core/functions_global.php
@@ -83,7 +83,7 @@ if (!function_exists('pluginSplit')) {
      * @param bool $dotAppend Set to true if you want the plugin to have a '.' appended to it.
      * @param string|null $plugin Optional default plugin to use if no plugin is found. Defaults to null.
      * @return array Array with 2 indexes. 0 => plugin name, 1 => class name.
-     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#pluginSplit
+     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#pluginsplit
      * @phpstan-return array{string|null, string}
      */
     function pluginSplit(string $name, bool $dotAppend = false, ?string $plugin = null): array

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -50,7 +50,7 @@ use function Cake\Core\pr;
  * Debugger extends PHP's default error handling and gives
  * simpler to use more powerful interfaces.
  *
- * @link https://book.cakephp.org/5/en/development/debugging.html#namespace-Cake\Error
+ * @link https://book.cakephp.org/5/en/development/debugging.html#using-the-debugger-class
  */
 class Debugger
 {

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -25,7 +25,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 /**
  * Handles common security headers in a convenient way
  *
- * @link https://book.cakephp.org/5/en/controllers/middleware.html#security-header-middleware
+ * @link https://book.cakephp.org/5/en/security/security-headers.html
  */
 class SecurityHeadersMiddleware implements MiddlewareInterface
 {

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -280,7 +280,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
      * globally configured locale.
      * @return $this
      * @see \Cake\ORM\Behavior\TranslateBehavior::getLocale()
-     * @link https://book.cakephp.org/5/en/orm/behaviors/translate.html#retrieving-one-language-without-using-i18n-locale
+     * @link https://book.cakephp.org/5/en/orm/behaviors/translate.html#retrieving-one-language-without-using-i18n-setlocale
      * @link https://book.cakephp.org/5/en/orm/behaviors/translate.html#saving-in-another-language
      */
     public function setLocale(?string $locale)

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -22,8 +22,6 @@ use InvalidArgumentException;
  * Cookie Crypt Trait.
  *
  * Provides the encrypt/decrypt logic for the CookieComponent.
- *
- * @link https://book.cakephp.org/5/en/controllers/components/cookie.html
  */
 trait CookieCryptTrait
 {

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -52,7 +52,7 @@ class Hash
      * @throws \InvalidArgumentException
      * @return mixed The value fetched from the array, or $default if path doesn't exist, is null,
      *   or $data is empty.
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::get
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-get
      */
     public static function get(ArrayAccess|array $data, array|string|int|null $path, mixed $default = null): mixed
     {
@@ -115,7 +115,7 @@ class Hash
      * @param string $path The path to extract.
      * @return \ArrayAccess|array An array of the extracted values. Returns an empty array
      *   if there are no matches.
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::extract
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-extract
      * @phpstan-return ($path is non-empty-string ? array : \ArrayAccess|array)
      */
     public static function extract(ArrayAccess|array $data, string $path): ArrayAccess|array
@@ -296,7 +296,7 @@ class Hash
      * @param mixed $values The values to insert.
      * @return \ArrayAccess|array The data with $values inserted.
      * @phpstan-return (T is array ? array : \ArrayAccess)
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::insert
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-insert
      */
     public static function insert(ArrayAccess|array $data, string $path, mixed $values = null): ArrayAccess|array
     {
@@ -400,7 +400,7 @@ class Hash
      * @param string $path A path expression to use to remove.
      * @return \ArrayAccess|array The modified array.
      * @phpstan-return (T is array ? array : \ArrayAccess)
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::remove
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-remove
      */
     public static function remove(ArrayAccess|array $data, string $path): ArrayAccess|array
     {
@@ -465,7 +465,7 @@ class Hash
      * @param array<string>|string|null $valuePath A dot-separated string.
      * @param string|null $groupPath A dot-separated string.
      * @return array Combined array
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::combine
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-combine
      * @throws \InvalidArgumentException When keys and values count is unequal.
      */
     public static function combine(
@@ -554,7 +554,7 @@ class Hash
      * @param string $format Format string into which values will be inserted, see sprintf()
      * @return array<string>|null An array of strings extracted from `$path` and formatted with `$format`,
      *   or null if $paths is empty.
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::format
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-format
      * @see sprintf()
      * @see \Cake\Utility\Hash::extract()
      * @phpstan-return ($paths is non-empty-array ? array : null)
@@ -596,7 +596,7 @@ class Hash
      * @param array $data The data to search through.
      * @param array $needle The values to find in $data
      * @return bool true If $data contains $needle, false otherwise
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::contains
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-contains
      */
     public static function contains(array $data, array $needle): bool
     {
@@ -640,7 +640,7 @@ class Hash
      * @param string $path The path to check for.
      * @return bool Existence of path.
      * @see \Cake\Utility\Hash::extract()
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::check
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-check
      */
     public static function check(array $data, string $path): bool
     {
@@ -659,7 +659,7 @@ class Hash
      * @param callable|null $callback A function to filter the data with. Defaults to
      *   all non-empty or zero values.
      * @return array Filtered array
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::filter
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-filter
      */
     public static function filter(array $data, ?callable $callback = null): array
     {
@@ -690,7 +690,7 @@ class Hash
      * @param array $data Array to flatten
      * @param string $separator String used to separate array key elements in a path, defaults to '.'
      * @return array
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::flatten
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-flatten
      */
     public static function flatten(array $data, string $separator = '.'): array
     {
@@ -734,7 +734,7 @@ class Hash
      * @param array $data Flattened array
      * @param string $separator The delimiter used
      * @return array
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::expand
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-expand
      */
     public static function expand(array $data, string $separator = '.'): array
     {
@@ -774,7 +774,7 @@ class Hash
      * @param array $data Array to be merged
      * @param mixed $merge Array to merge with. The argument and all trailing arguments will be array cast when merged
      * @return array Merged array
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::merge
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-merge
      */
     public static function merge(array $data, mixed $merge): array
     {
@@ -831,7 +831,7 @@ class Hash
      *
      * @param array $data The array to check.
      * @return bool true if values are numeric, false otherwise
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::numeric
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-numeric
      */
     public static function numeric(array $data): bool
     {
@@ -851,7 +851,7 @@ class Hash
      *
      * @param array $data Array to count dimensions on
      * @return int The number of dimensions in $data
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::dimensions
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-dimensions
      */
     public static function dimensions(array $data): int
     {
@@ -878,7 +878,7 @@ class Hash
      *
      * @param array $data Array to count dimensions on
      * @return int The maximum number of dimensions in $data
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::maxDimensions
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-maxdimensions
      */
     public static function maxDimensions(array $data): int
     {
@@ -902,7 +902,7 @@ class Hash
      * @param string $path The path to extract for mapping over.
      * @param callable $function The function to call on each extracted value.
      * @return array An array of the modified values.
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::map
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-map
      */
     public static function map(array $data, string $path, callable $function): array
     {
@@ -918,7 +918,7 @@ class Hash
      * @param string $path The path to extract from $data.
      * @param callable $function The function to call on each extracted value.
      * @return mixed The reduced value.
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::reduce
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-reduce
      */
     public static function reduce(array $data, string $path, callable $function): mixed
     {
@@ -950,7 +950,7 @@ class Hash
      * @param string $path The path to extract from $data.
      * @param callable $function The function to call on each extracted value.
      * @return mixed The results of the applied method.
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::apply
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-apply
      */
     public static function apply(array $data, string $path, callable $function): mixed
     {
@@ -990,7 +990,7 @@ class Hash
      * @param string|int $dir See directions above. Defaults to 'asc'.
      * @param array<string, mixed>|string $type See direction types above. Defaults to 'regular'.
      * @return array Sorted array of data
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::sort
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-sort
      */
     public static function sort(
         array $data,
@@ -1112,7 +1112,7 @@ class Hash
      * @param array $compare Second value
      * @return array Returns the key => value pairs that are not common in $data and $compare
      *    The expression for this function is ($data - $compare) + ($compare - ($data - $compare))
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::diff
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-diff
      */
     public static function diff(array $data, array $compare): array
     {
@@ -1139,7 +1139,7 @@ class Hash
      * @param array $data The data to append onto.
      * @param array $compare The data to compare and append onto.
      * @return array The merged array.
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::mergeDiff
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-mergediff
      */
     public static function mergeDiff(array $data, array $compare): array
     {
@@ -1167,7 +1167,7 @@ class Hash
      * @param bool $assoc If true, $data will be converted to an associative array.
      * @param mixed $default The default value to use when a top level numeric key is converted to associative form.
      * @return array
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::normalize
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-normalize
      */
     public static function normalize(array $data, bool $assoc = true, mixed $default = null): array
     {
@@ -1215,7 +1215,7 @@ class Hash
      * @return array<array> of results, nested
      * @see \Cake\Utility\Hash::extract()
      * @throws \InvalidArgumentException When providing invalid data.
-     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::nest
+     * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-nest
      * @phpstan-param array{idPath?: string, parentPath?: string, children?: string, root?: string|null} $options
      */
     public static function nest(array $data, array $options = []): array

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -81,6 +81,7 @@ class Text
      *
      * @see https://www.ietf.org/rfc/rfc4122.txt
      * @return string RFC 4122 UUID
+     * @link https://book.cakephp.org/5/en/core-libraries/text.html#text-uuid
      * @copyright Matt Farina MIT License https://github.com/lootils/uuid/blob/master/LICENSE
      */
     public static function uuid(): string
@@ -119,6 +120,7 @@ class Text
      * @param string $leftBound The left boundary to ignore separators in.
      * @param string $rightBound The right boundary to ignore separators in.
      * @return array<string> Array of tokens in $data.
+     * @link https://book.cakephp.org/5/en/core-libraries/text.html#text-tokenize
      */
     public static function tokenize(
         string $data,
@@ -215,6 +217,7 @@ class Text
      *     to be replaced with val
      * @param array<string, mixed> $options An array of options, see description above
      * @return string
+     * @link https://book.cakephp.org/5/en/core-libraries/text.html#text-insert
      */
     public static function insert(string $str, array $data, array $options = []): string
     {
@@ -268,6 +271,7 @@ class Text
      * @param array<string, mixed> $options Options list.
      * @return string
      * @see \Cake\Utility\Text::insert()
+     * @link https://book.cakephp.org/5/en/core-libraries/text.html#text-cleaninsert
      */
     public static function cleanInsert(string $str, array $options): string
     {
@@ -338,6 +342,7 @@ class Text
      * @param string $text The text to format.
      * @param array<string, mixed>|int $options Array of options to use, or an integer to wrap the text to.
      * @return string Formatted text.
+     * @link https://book.cakephp.org/5/en/core-libraries/text.html#text-wrap
      */
     public static function wrap(string $text, array|int $options = []): string
     {
@@ -379,6 +384,7 @@ class Text
      * @param string $text The text to format.
      * @param array<string, mixed>|int $options Array of options to use, or an integer to wrap the text to.
      * @return string Formatted text.
+     * @link https://book.cakephp.org/5/en/core-libraries/text.html#text-wrapblock
      */
     public static function wrapBlock(string $text, array|int $options = []): string
     {
@@ -558,6 +564,7 @@ class Text
      * @param int $length Length of returned string, including ellipsis.
      * @param array<string, mixed> $options An array of options.
      * @return string Trimmed string.
+     * @link https://book.cakephp.org/5/en/core-libraries/text.html#text-tail
      */
     public static function tail(string $text, int $length = 100, array $options = []): string
     {
@@ -1115,6 +1122,7 @@ class Text
      *   `setTransliterator()` will be used.
      * @return string
      * @see https://secure.php.net/manual/en/transliterator.transliterate.php
+     * @link https://book.cakephp.org/5/en/core-libraries/text.html#text-transliterate
      */
     public static function transliterate(string $string, Transliterator|string|null $transliterator = null): string
     {
@@ -1150,6 +1158,7 @@ class Text
      * @return string
      * @see setTransliterator()
      * @see setTransliteratorId()
+     * @link https://book.cakephp.org/5/en/core-libraries/text.html#text-slug
      */
     public static function slug(string $string, array|string $options = []): string
     {

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1023,7 +1023,7 @@ class Text
      * @return mixed Number of bytes as integer on success, or $default value on failure
      *   (if $default is not false).
      * @throws \InvalidArgumentException On invalid unit type when $default is false.
-     * @link https://book.cakephp.org/5/en/core-libraries/text.html#Cake\Utility\Text::parseFileSize
+     * @link https://book.cakephp.org/5/en/core-libraries/text.html#text-parsefilesize
      */
     public static function parseFileSize(string $size, mixed $default = false): mixed
     {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2300,7 +2300,7 @@ class FormHelper extends Helper
      * @param string $fieldName The field name.
      * @param array<string, mixed> $options Options & attributes for the select elements.
      * @return string Completed year select input
-     * @link https://book.cakephp.org/5/en/views/helpers/form.html#creating-year-inputs
+     * @link https://book.cakephp.org/5/en/views/helpers/form.html#creating-year-controls
      */
     public function year(string $fieldName, array $options = []): string
     {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -384,7 +384,7 @@ class FormHelper extends Helper
      *   array of meta data. You can use `null` to make a context-less form.
      * @param array<string, mixed> $options An array of html attributes and options.
      * @return string An formatted opening FORM tag.
-     * @link https://book.cakephp.org/5/en/views/helpers/form.html#Cake\View\Helper\FormHelper::create
+     * @link https://book.cakephp.org/5/en/views/helpers/form.html#starting-a-form
      */
     public function create(mixed $context = null, array $options = []): string
     {

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -673,7 +673,7 @@ class HtmlHelper extends Helper
      * @param array<string, string> $data Style data array, keys will be used as property names, values as property values.
      * @param bool $oneLine Whether the style block should be displayed on one line.
      * @return string CSS styling data
-     * @link https://book.cakephp.org/5/en/views/helpers/html.html#creating-css-programmatically
+     * @link https://book.cakephp.org/5/en/views/helpers/html.html#creating-css-programatically
      */
     public function style(array $data, bool $oneLine = true): string
     {

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -316,7 +316,7 @@ class HtmlHelper extends Helper
      * @param array<string, mixed> $options Array of options and HTML attributes.
      * @return string An `<a>` element.
      * @see \Cake\Routing\Router::pathUrl()
-     * @link https://book.cakephp.org/5/en/views/helpers/html.html#creating-links
+     * @link https://book.cakephp.org/5/en/views/helpers/html.html#creating-links-from-route-paths
      */
     public function linkFromPath(string $title, string $path, array $params = [], array $options = []): string
     {
@@ -1054,6 +1054,7 @@ class HtmlHelper extends Helper
      *  Or an array where each item itself can be a path string or an associate array containing keys `src` and `type`
      * @param array<string, mixed> $options Array of HTML attributes, and special options above.
      * @return string Generated media element
+     * @link https://book.cakephp.org/5/en/views/helpers/html.html#linking-to-videos-and-audio-files
      */
     public function media(array|string|null $path, array $options = []): string
     {


### PR DESCRIPTION
## Summary

- Update `@link` annotations to use VitePress-compatible anchor format
- Fix broken `@link` annotations pointing to non-existent pages/anchors
- Add missing `@link` annotations for documented public methods
- The documentation book now uses VitePress which generates anchors differently from the old RST/Sphinx setup

### Anchor Format Updates

**Hash.php**: All `#Cake\Utility\Hash::method` anchors → `#hash-method` format (e.g. `#hash-get`, `#hash-extract`)

**Text.php**: `#Cake\Utility\Text::parseFileSize` → `#text-parsefilesize`

**FormHelper.php**: `#Cake\View\Helper\FormHelper::create` → `#starting-a-form`

**Controller.php**: `#Controller::redirect` → `#redirecting-to-other-pages`

**HtmlHelper.php**: `#creating-css-programmatically` → `#creating-css-programatically` (match docs heading)

**ServerCommand.php**: `console-and-shells.html#hook-methods` → `console-commands/commands.html#lifecycle-callbacks` (page moved)

**ConsoleIo.php**: `console-and-shells.html#ConsoleIo::out/err` → `console-commands/input-output.html#creating-output` (page moved)

**Debugger.php**: `#namespace-Cake\Error` → `#using-the-debugger-class`

**TranslateBehavior.php**: `#retrieving-one-language-without-using-i18n-locale` → `#retrieving-one-language-without-using-i18n-setlocale`

### Broken Link Fixes

**FormHelper.php**: `#creating-year-inputs` → `#creating-year-controls` (anchor doesn't exist)

**Configure.php**: `#reading-and-writing-configuration-files` → `#reading-writing-configuration-files` (anchor doesn't exist)

**SecurityHeadersMiddleware.php**: `controllers/middleware.html#security-header-middleware` → `security/security-headers.html` (page moved)

**CookieCryptTrait.php**: Removed dead `@link` (`controllers/components/cookie.html` returns 404)

### Missing @link Additions

**Text.php**: Added links for `uuid`, `tokenize`, `insert`, `cleanInsert`, `wrap`, `wrapBlock`, `tail`, `transliterate`, `slug`

**HtmlHelper.php**: `linkFromPath` → more specific `#creating-links-from-route-paths`, added `media` → `#linking-to-videos-and-audio-files`

**ConsoleIo.php**: Added links for `out`, `err`

**Controller.php**: Added link for `loadComponent`

**functions.php / functions_global.php**: `#pluginSplit` → `#pluginsplit`

## Related

- cakephp/docs#8157
- cakephp/docs#8158
- cakephp/docs#8160 (remaining missing headers)