### PR TITLE
Add BIT type support to MysqlSchemaDialect

### DIFF
--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -382,6 +382,10 @@ class MysqlSchemaDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_BOOLEAN, 'length' => null];
         }
 
+        if ($col === 'bit') {
+            return ['type' => TableSchemaInterface::TYPE_BIT, 'length' => $length];
+        }
+
         $unsigned = (isset($matches[3]) && strtolower($matches[3]) === 'unsigned');
         if (str_contains($col, 'bigint')) {
             return ['type' => TableSchemaInterface::TYPE_BIGINTEGER, 'length' => null, 'unsigned' => $unsigned];
@@ -714,6 +718,7 @@ SQL;
             TableSchemaInterface::TYPE_POINT => ' POINT',
             TableSchemaInterface::TYPE_LINESTRING => ' LINESTRING',
             TableSchemaInterface::TYPE_POLYGON => ' POLYGON',
+            TableSchemaInterface::TYPE_BIT => ' BIT',
         ];
         $specialMap = [
             'string' => true,
@@ -774,6 +779,7 @@ SQL;
             TableSchemaInterface::TYPE_TINYINTEGER,
             TableSchemaInterface::TYPE_STRING,
             TableSchemaInterface::TYPE_BINARY,
+            TableSchemaInterface::TYPE_BIT,
         ];
         if (!isset($typeMap[$column['type']]) && !isset($specialMap[$column['type']])) {
             $out .= ' ' . strtoupper($column['type']);

--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -256,6 +256,15 @@ interface TableSchemaInterface extends SchemaInterface
     public const TYPE_MACADDR = 'macaddr';
 
     /**
+     * Bit type.
+     *
+     * Currently only implemented in MySQL.
+     *
+     * @var string
+     */
+    public const TYPE_BIT = 'bit';
+
+    /**
      * Geospatial column types
      *
      * @var array

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -259,6 +259,18 @@ class MysqlSchemaDialectTest extends TestCase
                 'POLYGON',
                 ['type' => 'polygon', 'length' => null],
             ],
+            [
+                'BIT(1)',
+                ['type' => 'bit', 'length' => 1],
+            ],
+            [
+                'BIT(8)',
+                ['type' => 'bit', 'length' => 8],
+            ],
+            [
+                'BIT(64)',
+                ['type' => 'bit', 'length' => 64],
+            ],
         ];
     }
 
@@ -1493,6 +1505,22 @@ SQL;
                 'p',
                 ['type' => 'polygon', 'null' => false, 'srid' => 4326],
                 '`p` POLYGON NOT NULL SRID 4326',
+            ],
+            // Bit
+            [
+                'active',
+                ['type' => 'bit', 'length' => 1],
+                '`active` BIT(1)',
+            ],
+            [
+                'flags',
+                ['type' => 'bit', 'length' => 8, 'null' => false],
+                '`flags` BIT(8) NOT NULL',
+            ],
+            [
+                'permissions',
+                ['type' => 'bit', 'length' => 64],
+                '`permissions` BIT(64)',
             ],
         ];
     }


### PR DESCRIPTION
## Summary

- Adds MySQL `BIT` column type support to `MysqlSchemaDialect`
- Enables schema reflection and SQL generation for tables with `BIT` columns
- Useful for migrations from Phinx to CakePHP's built-in migrations

## Changes

- Add `TYPE_BIT` constant to `TableSchemaInterface`
- Handle `bit` type in `_convertColumn()` for schema reflection
- Add `bit` to `$typeMap` in `columnDefinitionSql()` for SQL generation
- Include `bit` in `$hasLength` array to properly output length (e.g., `BIT(8)`)
- Add unit tests for both column parsing and SQL generation

Fixes #19222