### PR TITLE
Widen conditions type to ExpressionInterface in Table methods

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -25,6 +25,7 @@ use Cake\Core\Exception\CakeException;
 use Cake\Database\Connection;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ExpressionInterface;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionManager;
@@ -1767,12 +1768,12 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * first load a collection of records and update them.
      *
      * @param \Cake\Database\Expression\QueryExpression|\Closure|array|string $fields A hash of field => new value.
-     * @param \Cake\Database\Expression\QueryExpression|\Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
      * @return int Count Returns the affected rows.
      */
     public function updateAll(
         QueryExpression|Closure|array|string $fields,
-        QueryExpression|Closure|array|string|null $conditions,
+        ExpressionInterface|Closure|array|string|null $conditions,
     ): int {
         $statement = $this->updateQuery()
             ->set($fields)
@@ -1792,11 +1793,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * use database foreign keys + ON CASCADE rules if you need cascading deletes combined
      * with this method.
      *
-     * @param \Cake\Database\Expression\QueryExpression|\Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions Conditions to be used, accepts anything Query::where()
      * can take.
      * @return int Returns the number of affected rows.
      */
-    public function deleteAll(QueryExpression|Closure|array|string|null $conditions): int
+    public function deleteAll(ExpressionInterface|Closure|array|string|null $conditions): int
     {
         $statement = $this->deleteQuery()
             ->where($conditions)
@@ -1808,7 +1809,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * @inheritDoc
      */
-    public function exists(QueryExpression|Closure|array|string|null $conditions): bool
+    public function exists(ExpressionInterface|Closure|array|string|null $conditions): bool
     {
         return (bool)count(
             $this->find('all')

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -24,6 +24,7 @@ use Cake\Core\Exception\CakeException;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Exception\DatabaseException;
+use Cake\Database\Expression\ComparisonExpression;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchema;
@@ -1170,6 +1171,20 @@ class TableTest extends TestCase
     }
 
     /**
+     * Test updateAll with ExpressionInterface conditions.
+     */
+    public function testUpdateAllWithExpressionConditions(): void
+    {
+        $table = new Table([
+            'table' => 'users',
+            'connection' => $this->connection,
+        ]);
+        $conditions = new ComparisonExpression('id', 1, 'integer', '<');
+        $result = $table->updateAll(['username' => 'changed'], $conditions);
+        $this->assertSame(0, $result);
+    }
+
+    /**
      * Test that exceptions from the Query bubble up.
      */
     public function testUpdateAllFailure(): void
@@ -1222,6 +1237,24 @@ class TableTest extends TestCase
             'connection' => $this->connection,
         ]);
         $result = $table->deleteAll(['Managers.id <' => 4]);
+        $this->assertSame(3, $result);
+
+        $result = $table->find('all')->toArray();
+        $this->assertCount(1, $result, 'Only one record should remain');
+        $this->assertSame(4, $result[0]['id']);
+    }
+
+    /**
+     * Test deleteAll with ExpressionInterface conditions.
+     */
+    public function testDeleteAllWithExpressionConditions(): void
+    {
+        $table = new Table([
+            'table' => 'users',
+            'connection' => $this->connection,
+        ]);
+        $conditions = new ComparisonExpression('id', 4, 'integer', '<');
+        $result = $table->deleteAll($conditions);
         $this->assertSame(3, $result);
 
         $result = $table->find('all')->toArray();
@@ -1862,6 +1895,19 @@ class TableTest extends TestCase
         $this->assertTrue($table->exists(['id' => 1]));
         $this->assertFalse($table->exists(['id' => 501]));
         $this->assertTrue($table->exists(['id' => 3, 'username' => 'larry']));
+    }
+
+    /**
+     * Test exists with ExpressionInterface conditions.
+     */
+    public function testExistsWithExpressionConditions(): void
+    {
+        $table = $this->getTableLocator()->get('users');
+        $conditions = new ComparisonExpression('id', 1, 'integer', '=');
+        $this->assertTrue($table->exists($conditions));
+
+        $conditions = new ComparisonExpression('id', 501, 'integer', '=');
+        $this->assertFalse($table->exists($conditions));
     }
 
     /**


### PR DESCRIPTION
## Summary

Widens the `$conditions` parameter type from `QueryExpression` to `ExpressionInterface` in `Table::updateAll()`, `Table::deleteAll()` and `Table::exists()`.

This allows passing any expression type that implements `ExpressionInterface`, not just `QueryExpression`.

Only `Table.php` is changed — the `RepositoryInterface` is left untouched to avoid a circular dependency between the `Datasource` and `Database` packages (as discussed in #19104).

Refs #19104