### PR TITLE
Remove trailing spaces from GROUP BY and HAVING SQL templates

### DIFF
--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -37,8 +37,8 @@ class QueryCompiler
     protected array $_templates = [
         'delete' => 'DELETE',
         'where' => ' WHERE %s',
-        'group' => ' GROUP BY %s ',
-        'having' => ' HAVING %s ',
+        'group' => ' GROUP BY %s',
+        'having' => ' HAVING %s',
         'order' => ' %s',
         'limit' => ' LIMIT %s',
         'offset' => ' OFFSET %s',


### PR DESCRIPTION
## Summary

- Remove trailing spaces from `group` and `having` templates in `QueryCompiler`, which caused double spaces in compiled SQL (e.g. `GROUP BY author_id  ORDER BY` instead of `GROUP BY author_id ORDER BY`).
- This aligns the base compiler with `PostgresCompiler` and `SqlserverCompiler`, which already use templates without trailing spaces.

Fixes #19232