### PR TITLE
Fix TINYINT(1) UNSIGNED incorrectly mapped to boolean

### DIFF
--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -378,15 +378,15 @@ class MysqlSchemaDialect extends SchemaDialect
             return ['type' => $typeName, 'length' => null, 'precision' => $length];
         }
 
-        if (($col === 'tinyint' && $length === 1) || $col === 'boolean') {
+        $unsigned = (isset($matches[3]) && strtolower($matches[3]) === 'unsigned');
+
+        if (($col === 'tinyint' && $length === 1 && !$unsigned) || $col === 'boolean') {
             return ['type' => TableSchemaInterface::TYPE_BOOLEAN, 'length' => null];
         }
 
         if ($col === 'bit') {
             return ['type' => TableSchemaInterface::TYPE_BIT, 'length' => $length];
         }
-
-        $unsigned = (isset($matches[3]) && strtolower($matches[3]) === 'unsigned');
         if (str_contains($col, 'bigint')) {
             return ['type' => TableSchemaInterface::TYPE_BIGINTEGER, 'length' => null, 'unsigned' => $unsigned];
         }

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -101,7 +101,7 @@ class MysqlSchemaDialectTest extends TestCase
             ],
             [
                 'TINYINT(1) UNSIGNED',
-                ['type' => 'boolean', 'length' => null],
+                ['type' => 'tinyinteger', 'length' => null, 'unsigned' => true],
             ],
             [
                 'TINYINT(3)',


### PR DESCRIPTION
## Summary

- Fix `TINYINT(1) UNSIGNED` being incorrectly mapped to `boolean` type instead of `tinyinteger`
- Move unsigned detection before the boolean check in `_convertColumn()` so only `TINYINT(1)` without `UNSIGNED` is treated as boolean

Fixes CI failures introduced after merge of 5.x changes into 6.x where `testConvertColumn` was refactored to use real database connections.