### PR TITLE
Fix MysqlSchemaDialect column conversion test failures

### DIFF
--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -339,15 +339,15 @@ class MysqlSchemaDialect extends SchemaDialect
             return ['type' => $typeName, 'length' => null, 'precision' => $length];
         }
 
-        if (($col === 'tinyint' && $length === 1) || $col === 'boolean') {
+        $unsigned = (isset($matches[3]) && strtolower($matches[3]) === 'unsigned');
+
+        if (($col === 'tinyint' && $length === 1 && !$unsigned) || $col === 'boolean') {
             return ['type' => TableSchemaInterface::TYPE_BOOLEAN, 'length' => null];
         }
 
         if ($col === 'bit') {
             return ['type' => TableSchemaInterface::TYPE_BIT, 'length' => $length];
         }
-
-        $unsigned = (isset($matches[3]) && strtolower($matches[3]) === 'unsigned');
         if (str_contains($col, 'bigint')) {
             return ['type' => TableSchemaInterface::TYPE_BIGINTEGER, 'length' => null, 'unsigned' => $unsigned];
         }

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -301,6 +301,13 @@ SQL;
 
         $data = $table->column('reflection')->toArray();
 
+        // MariaDB aliases JSON to LONGTEXT
+        // https://mariadb.com/kb/en/json/
+        /** @var \Cake\Database\Driver\Mysql $driver */
+        if ($type === 'JSON' && $driver->isMariadb()) {
+            $expected = ['type' => 'text', 'length' => 4294967295];
+        }
+
         // Collations are a mess in MySQL
         if (isset($expected['collate'])) {
             $db = $driver->config()['database'];


### PR DESCRIPTION
## Summary

- Fix `TINYINT(1) UNSIGNED` incorrectly mapped to `boolean` instead of `tinyinteger` by moving unsigned detection before the boolean check in `convertColumn()`
- Fix `testConvertColumn` for MariaDB where `JSON` columns are aliased to `LONGTEXT` internally, adjusting expected values accordingly

Fixes CI failures on `testsuite (8.4, mariadb, highest)` and `testsuite (8.4, mysql, lowest)`.