### PR TITLE
Fix testConvertColumn expectations for TINYINT(1) UNSIGNED and MariaDB JSON

### DIFF
--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -101,7 +101,7 @@ class MysqlSchemaDialectTest extends TestCase
             ],
             [
                 'TINYINT(1) UNSIGNED',
-                ['type' => 'tinyinteger', 'length' => null],
+                ['type' => 'boolean', 'length' => null],
             ],
             [
                 'TINYINT(3)',
@@ -300,6 +300,20 @@ SQL;
         $connection->execute('DROP TABLE convert_columns');
 
         $data = $table->column('reflection')->toArray();
+
+        /** @var \Cake\Database\Driver\Mysql $driver */
+        // MySQL 8.0.17+ strips display width from integer types, so
+        // TINYINT(1) UNSIGNED becomes TINYINT UNSIGNED and maps to tinyinteger.
+        // MariaDB and older MySQL preserve the display width, mapping to boolean.
+        if ($type === 'TINYINT(1) UNSIGNED' && !$driver->isMariadb() && version_compare($driver->version(), '8.0.17', '>=')) {
+            $expected = ['type' => 'tinyinteger', 'length' => null, 'unsigned' => true];
+        }
+
+        // MariaDB aliases JSON to LONGTEXT
+        // https://mariadb.com/kb/en/json/
+        if ($type === 'JSON' && $driver->isMariadb()) {
+            $expected = ['type' => 'text', 'length' => 4294967295];
+        }
 
         // Collations are a mess in MySQL
         if (isset($expected['collate'])) {


### PR DESCRIPTION
After 5 => 6 merge the 6.x branch seemed to fail in CI.

## Summary

- Fix `TINYINT(1) UNSIGNED` test expectation to `boolean` (matches current code behavior)
- Handle MariaDB JSON-to-LONGTEXT aliasing in `testConvertColumn` — MariaDB internally stores JSON as LONGTEXT, so schema reflection returns `text` type

Test-only changes, no code modifications.