### PR TITLE
Fix BelongsToMany::unlink() always returning true.

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -954,14 +954,11 @@ class BelongsToMany extends Association
         $this->_checkPersistenceStatus($sourceEntity, $targetEntities);
         $property = $this->getProperty();
 
-        $this->junction()->getConnection()->transactional(
-            function () use ($sourceEntity, $targetEntities, $options): void {
-                $links = $this->_collectJointEntities($sourceEntity, $targetEntities);
-                foreach ($links as $entity) {
-                    $this->_junctionTable->delete($entity, $options);
-                }
-            },
-        );
+        $links = $this->_collectJointEntities($sourceEntity, $targetEntities);
+        $return = $this->_junctionTable->deleteMany($links, $options);
+        if ($return === false) {
+            return false;
+        }
 
         /** @var array<\Cake\Datasource\EntityInterface> $existing */
         $existing = $sourceEntity->get($property) ?: [];

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -817,6 +817,34 @@ class BelongsToManyTest extends TestCase
     }
 
     /**
+     * Tests that unlink returns false when junction table deleteMany fails
+     */
+    public function testUnlinkFailure(): void
+    {
+        $connection = ConnectionManager::get('test');
+        $joint = $this->getMockBuilder(Table::class)
+            ->onlyMethods(['deleteMany'])
+            ->setConstructorArgs([['alias' => 'SpecialTags', 'table' => 'special_tags', 'connection' => $connection]])
+            ->getMock();
+
+        $articles = $this->getTableLocator()->get('Articles');
+
+        $assoc = $articles->belongsToMany('Tags', [
+            'through' => $joint,
+        ]);
+
+        $entity = $articles->get(2, contain: ['Tags']);
+        $this->assertCount(1, $entity->tags);
+
+        $joint->expects($this->once())
+            ->method('deleteMany')
+            ->willReturn(false);
+
+        $this->assertFalse($assoc->unlink($entity, $entity->tags));
+        $this->assertCount(1, $entity->tags);
+    }
+
+    /**
      * Tests that replaceLink requires the sourceEntity to have primaryKey values
      * for the source entity
      */


### PR DESCRIPTION
It now returns false if deleting assocation link records fails.

Refs https://github.com/cakephp/cakephp/pull/19220