### PR TITLE
Change return type of HasMany::unlink() from void to bool.

### DIFF
--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -560,6 +560,7 @@ class HasMany extends Association
                 });
                 $query = $this->find()->where($conditions);
 
+                /** @phpstan-ignore argument.templateType */
                 $return = $target->deleteMany($query->all(), $options);
                 if ($return === false) {
                     return false;

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -370,9 +370,9 @@ class HasMany extends Association
      *   If boolean it will be used a value for "cleanProperty" option.
      * @throws \InvalidArgumentException if non persisted entities are passed or if
      * any of them is lacking a primary key value
-     * @return void
+     * @return bool
      */
-    public function unlink(EntityInterface $sourceEntity, array $targetEntities, array|bool $options = []): void
+    public function unlink(EntityInterface $sourceEntity, array $targetEntities, array|bool $options = []): bool
     {
         if (is_bool($options)) {
             $options = [
@@ -382,7 +382,7 @@ class HasMany extends Association
             $options += ['cleanProperty' => true];
         }
         if ($targetEntities === []) {
-            return;
+            return true;
         }
 
         $foreignKey = (array)$this->getForeignKey();
@@ -399,7 +399,10 @@ class HasMany extends Association
                 ->toList(),
         ];
 
-        $this->_unlink($foreignKey, $target, $conditions, $options);
+        $return = $this->_unlink($foreignKey, $target, $conditions, $options);
+        if (!$return) {
+            return false;
+        }
 
         $result = $sourceEntity->get($property);
         if ($options['cleanProperty'] && $result !== null) {
@@ -416,6 +419,8 @@ class HasMany extends Association
         }
 
         $sourceEntity->setDirty($property, false);
+
+        return true;
     }
 
     /**
@@ -554,12 +559,13 @@ class HasMany extends Association
                     }
                 });
                 $query = $this->find()->where($conditions);
-                $ok = true;
-                foreach ($query->all() as $assoc) {
-                    $ok = $ok && $target->delete($assoc, $options);
+
+                $return = $target->deleteMany($query->all(), $options);
+                if ($return === false) {
+                    return false;
                 }
 
-                return $ok;
+                return true;
             }
 
             $this->deleteAll($conditions);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -4683,7 +4683,7 @@ class TableTest extends TestCase
     public function testReplaceHasManyOnErrorDependentCascadeCallbacks(): void
     {
         $articles = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['delete'])
+            ->onlyMethods(['deleteMany'])
             ->setConstructorArgs([[
                 'connection' => $this->connection,
                 'alias' => 'Articles',
@@ -4691,7 +4691,7 @@ class TableTest extends TestCase
             ]])
             ->getMock();
 
-        $articles->method('delete')->willReturn(false);
+        $articles->method('deleteMany')->willReturn(false);
 
         $associations = new AssociationCollection();
 


### PR DESCRIPTION
The method now returns true on success or false if unlinking/deleting the dependent records fails.

While the method signature change is a BC break it would only affect someone who has overridden the method, chances of which are rare. So I am hoping we can get this in since 5.3 is till pretty new.



Refs https://github.com/cakephp/cakephp/pull/19220