### PR TITLE
Fix broken documentation @link anchor URLs for VitePress

### DIFF
--- a/src/Console/Exception/ConsoleException.php
+++ b/src/Console/Exception/ConsoleException.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * Redistributions of files must retain the above copyright notice.
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @link          https://book.cakephp.org/5/en/development/errors.html#error-exception-configuration
+ * @link          https://book.cakephp.org/5/en/development/errors.html#configuration
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */

--- a/src/Console/Exception/MissingOptionException.php
+++ b/src/Console/Exception/MissingOptionException.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * Redistributions of files must retain the above copyright notice.
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @link          https://book.cakephp.org/5/en/development/errors.html#error-exception-configuration
+ * @link          https://book.cakephp.org/5/en/development/errors.html#configuration
  * @since         4.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */

--- a/src/Console/Exception/StopException.php
+++ b/src/Console/Exception/StopException.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * Redistributions of files must retain the above copyright notice.
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @link          https://book.cakephp.org/5/en/development/errors.html#error-exception-configuration
+ * @link          https://book.cakephp.org/5/en/development/errors.html#configuration
  * @since         3.2.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -321,7 +321,7 @@ class Configure
      * @param bool $merge if config files should be merged instead of simply overridden
      * @return bool True if load successful.
      * @throws \Cake\Core\Exception\CakeException if the $config engine is not found
-     * @link https://book.cakephp.org/5/en/development/configuration.html#reading-writing-configuration-files
+     * @link https://book.cakephp.org/5/en/development/configuration.html#reading-and-writing-configuration-files
      */
     public static function load(string $key, string $config = 'default', bool $merge = true): bool
     {


### PR DESCRIPTION
## Summary

- Fix 2 broken `@link` anchor fragments that don't match VitePress-generated heading slugs
- `Configure::load()` — fixed `#reading-writing-configuration-files` → `#reading-and-writing-configuration-files` (missing "and")
- Console exceptions (3 files) — fixed `#error-exception-configuration` → `#configuration` (heading is just "Configuration")

Follow-up to #19221.