### PR TITLE
Fix broken i18n function @link anchor URLs for VitePress

### DIFF
--- a/src/I18n/functions.php
+++ b/src/I18n/functions.php
@@ -26,7 +26,7 @@ use Throwable;
  * @param string $singular Text to translate.
  * @param mixed ...$args Array with arguments or multiple arguments in function.
  * @return string The translated text.
- * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__
+ * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#global-functions
  */
 function __(string $singular, mixed ...$args): string
 {
@@ -49,7 +49,7 @@ function __(string $singular, mixed ...$args): string
  * @param int $count Count.
  * @param mixed ...$args Array with arguments or multiple arguments in function.
  * @return string Plural form of translated string.
- * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__n
+ * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#n
  */
 function __n(string $singular, string $plural, int $count, mixed ...$args): string
 {
@@ -73,7 +73,7 @@ function __n(string $singular, string $plural, int $count, mixed ...$args): stri
  * @param string $msg String to translate.
  * @param mixed ...$args Array with arguments or multiple arguments in function.
  * @return string Translated string.
- * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__d
+ * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#d
  */
 function __d(string $domain, string $msg, mixed ...$args): string
 {
@@ -98,7 +98,7 @@ function __d(string $domain, string $msg, mixed ...$args): string
  * @param int $count Count.
  * @param mixed ...$args Array with arguments or multiple arguments in function.
  * @return string Plural form of translated string.
- * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__dn
+ * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#dn
  */
 function __dn(string $domain, string $singular, string $plural, int $count, mixed ...$args): string
 {
@@ -124,7 +124,7 @@ function __dn(string $domain, string $singular, string $plural, int $count, mixe
  * @param string $singular Text to translate.
  * @param mixed ...$args Array with arguments or multiple arguments in function.
  * @return string Translated string.
- * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__x
+ * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#x
  */
 function __x(string $context, string $singular, mixed ...$args): string
 {
@@ -150,7 +150,7 @@ function __x(string $context, string $singular, mixed ...$args): string
  * @param int $count Count.
  * @param mixed ...$args Array with arguments or multiple arguments in function.
  * @return string Plural form of translated string.
- * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__xn
+ * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#xn
  */
 function __xn(string $context, string $singular, string $plural, int $count, mixed ...$args): string
 {
@@ -177,7 +177,7 @@ function __xn(string $context, string $singular, string $plural, int $count, mix
  * @param string $msg String to translate.
  * @param mixed ...$args Array with arguments or multiple arguments in function.
  * @return string Translated string.
- * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__dx
+ * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#dx
  */
 function __dx(string $domain, string $context, string $msg, mixed ...$args): string
 {
@@ -207,7 +207,7 @@ function __dx(string $domain, string $context, string $msg, mixed ...$args): str
  * @param int $count Count.
  * @param mixed ...$args Array with arguments or multiple arguments in function.
  * @return string Plural form of translated string.
- * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__dxn
+ * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#dxn
  */
 function __dxn(
     string $domain,

--- a/src/I18n/functions_global.php
+++ b/src/I18n/functions_global.php
@@ -36,7 +36,7 @@ if (!function_exists('__')) {
      * @param string $singular Text to translate.
      * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string The translated text.
-     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__
+     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#global-functions
      */
     function __(string $singular, mixed ...$args): string
     {
@@ -54,7 +54,7 @@ if (!function_exists('__n')) {
      * @param int $count Count.
      * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string Plural form of translated string.
-     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__n
+     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#n
      */
     function __n(string $singular, string $plural, int $count, mixed ...$args): string
     {
@@ -70,7 +70,7 @@ if (!function_exists('__d')) {
      * @param string $msg String to translate.
      * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string Translated string.
-     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__d
+     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#d
      */
     function __d(string $domain, string $msg, mixed ...$args): string
     {
@@ -90,7 +90,7 @@ if (!function_exists('__dn')) {
      * @param int $count Count.
      * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string Plural form of translated string.
-     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__dn
+     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#dn
      */
     function __dn(string $domain, string $singular, string $plural, int $count, mixed ...$args): string
     {
@@ -108,7 +108,7 @@ if (!function_exists('__x')) {
      * @param string $singular Text to translate.
      * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string Translated string.
-     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__x
+     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#x
      */
     function __x(string $context, string $singular, mixed ...$args): string
     {
@@ -129,7 +129,7 @@ if (!function_exists('__xn')) {
      * @param int $count Count.
      * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string Plural form of translated string.
-     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__xn
+     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#xn
      */
     function __xn(string $context, string $singular, string $plural, int $count, mixed ...$args): string
     {
@@ -148,7 +148,7 @@ if (!function_exists('__dx')) {
      * @param string $msg String to translate.
      * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string Translated string.
-     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__dx
+     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#dx
      */
     function __dx(string $domain, string $context, string $msg, mixed ...$args): string
     {
@@ -170,7 +170,7 @@ if (!function_exists('__dxn')) {
      * @param int $count Count.
      * @param mixed ...$args Array with arguments or multiple arguments in function.
      * @return string Plural form of translated string.
-     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#__dxn
+     * @link https://book.cakephp.org/5/en/core-libraries/global-constants-and-functions.html#dxn
      */
     function __dxn(
         string $domain,


### PR DESCRIPTION
## Summary

- Fix 8 broken `@link` anchor fragments for i18n functions in `functions.php` and `functions_global.php`
- VitePress strips leading underscores from heading slugs, so `### __()` has no usable anchor, `### __d()` becomes `#d`, etc.
- `__()` → linked to `#global-functions` section instead (no individual anchor exists)
- `__n()` → `#n`, `__d()` → `#d`, `__dn()` → `#dn`, `__x()` → `#x`, `__xn()` → `#xn`, `__dx()` → `#dx`, `__dxn()` → `#dxn`

Follow-up to #19239.