### PR TITLE
Change units of Number::toReadableSize() from KB, etc to KiB, etc

### DIFF
--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -70,6 +70,13 @@ class Number
     protected static ?string $_defaultCurrencyFormat = null;
 
     /**
+     * Default byte units used by Number::toReadableSize()
+     *
+     * @var string|null
+     */
+    protected static bool $useIecUnits = false;
+
+    /**
      * Formats a number with a level of precision.
      *
      * Options:
@@ -90,24 +97,44 @@ class Number
     }
 
     /**
-     * Returns a formatted-for-humans file size.
+     * Returns a formatted-for-humans file size. By default, the units are exponent of ten KB, MB, etc.
      *
      * @param string|float|int $size Size in bytes
+     * @param bool $useIecUnits Wether to use exponent of two (ISO/IEC 80000-13) or ten for units (KiB, MiB, etc. or KB, MB, etc.)
      * @return string Human readable size
      * @link https://book.cakephp.org/5/en/core-libraries/number.html#interacting-with-human-readable-values
      */
-    public static function toReadableSize(string|float|int $size): string
+    public static function toReadableSize(string|float|int $size, ?bool $useIecUnits = null): string
     {
+        $useIec = $useIecUnits ?? static::$useIecUnits;
+
+        $units = $useIec
+        ? ['KiB', 'MiB', 'GiB', 'TiB']
+        : ['KB', 'MB', 'GB', 'TB'];
+
+        $divisor = $useIec ? 1024 : 1000;
+
         $size = (int)$size;
 
         return match (true) {
-            $size < 1024 => __dn('cake', '{0,number,integer} Byte', '{0,number,integer} Bytes', $size, $size),
-            round($size / 1024) < 1024 => __d('cake', '{0,number,#,###.##} KiB', $size / 1024),
-            round($size / 1024 / 1024, 2) < 1024 => __d('cake', '{0,number,#,###.##} MiB', $size / 1024 / 1024),
-            round($size / 1024 / 1024 / 1024, 2) < 1024 =>
-                __d('cake', '{0,number,#,###.##} GiB', $size / 1024 / 1024 / 1024),
-            default => __d('cake', '{0,number,#,###.##} TiB', $size / 1024 / 1024 / 1024 / 1024),
+            $size < $divisor => __dn('cake', '{0,number,integer} Byte', '{0,number,integer} Bytes', $size, $size),
+            round($size / $divisor) < $divisor => __d('cake', '{0,number,#,###.##}' . $units[0], $size / $divisor),
+            round($size / $divisor / $divisor, 2) < $divisor => __d('cake', '{0,number,#,###.##}' . $units[1], $size / $divisor / $divisor),
+            round($size / $divisor / $divisor / $divisor, 2) < $divisor =>
+            __d('cake', '{0,number,#,###.##}' . $units[2], $size / $divisor / $divisor / $divisor),
+            default => __d('cake', '{0,number,#,###.##}' . $units[3], $size / $divisor / $divisor / $divisor / $divisor),
         };
+    }
+
+    /**
+     * Setter for default byte units
+     *
+     * @param bool $useIec Wether to use exponent of two or ten for units (KiB, MiB, etc. or KB, MB, etc.)  {@link toReadableSize()}
+     * @return void
+     */
+    public static function setUseIecUnits(bool $useIec): void
+    {
+        static::$useIecUnits = $useIec;
     }
 
     /**

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -103,7 +103,7 @@ class Number
      * 1 KB  = 1000 Bytes
      *
      * @param string|float|int $size Size in bytes
-     * @param bool $useIecUnits Whether to use exponent of two or ten for units (KiB, MiB, etc. or KB, MB, etc.)
+     * @param bool|null $useIecUnits Whether to use exponent of two or ten for units (KiB, MiB, etc. or KB, MB, etc.)
      * @return string Human readable size
      * @link https://book.cakephp.org/5/en/core-libraries/number.html#interacting-with-human-readable-values
      */

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -118,12 +118,12 @@ class Number
 
         return match (true) {
             $size < $divisor => __dn('cake', '{0,number,integer} Byte', '{0,number,integer} Bytes', $size, $size),
-            round($size / $divisor) < $divisor => __d('cake', '{0,number,#,###.##} ' . $units[0], $size / $divisor),
+            round($size / $divisor) < $divisor => __d('cake', '{0,number,#,###.##} {1}', $size / $divisor, $units[0]),
             round($size / pow($divisor, 2), 2) < $divisor =>
-            __d('cake', '{0,number,#,###.##} ' . $units[1], $size / pow($divisor, 2)),
+            __d('cake', '{0,number,#,###.##} {1}', $size / pow($divisor, 2), $units[1]),
             round($size / pow($divisor, 3), 2) < $divisor =>
-            __d('cake', '{0,number,#,###.##} ' . $units[2], $size / pow($divisor, 3)),
-            default => __d('cake', '{0,number,#,###.##} ' . $units[3], $size / pow($divisor, 4)),
+            __d('cake', '{0,number,#,###.##} {1}', $size / pow($divisor, 3), $units[2]),
+            default => __d('cake', '{0,number,#,###.##} {1}', $size / pow($divisor, 4), $units[3]),
         };
     }
 

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -102,11 +102,11 @@ class Number
 
         return match (true) {
             $size < 1024 => __dn('cake', '{0,number,integer} Byte', '{0,number,integer} Bytes', $size, $size),
-            round($size / 1024) < 1024 => __d('cake', '{0,number,#,###.##} KB', $size / 1024),
-            round($size / 1024 / 1024, 2) < 1024 => __d('cake', '{0,number,#,###.##} MB', $size / 1024 / 1024),
+            round($size / 1024) < 1024 => __d('cake', '{0,number,#,###.##} KiB', $size / 1024),
+            round($size / 1024 / 1024, 2) < 1024 => __d('cake', '{0,number,#,###.##} MiB', $size / 1024 / 1024),
             round($size / 1024 / 1024 / 1024, 2) < 1024 =>
-                __d('cake', '{0,number,#,###.##} GB', $size / 1024 / 1024 / 1024),
-            default => __d('cake', '{0,number,#,###.##} TB', $size / 1024 / 1024 / 1024 / 1024),
+                __d('cake', '{0,number,#,###.##} GiB', $size / 1024 / 1024 / 1024),
+            default => __d('cake', '{0,number,#,###.##} TiB', $size / 1024 / 1024 / 1024 / 1024),
         };
     }
 

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -70,7 +70,7 @@ class Number
     protected static ?string $_defaultCurrencyFormat = null;
 
     /**
-     * Default byte units used by Number::toReadableSize()
+     * Default units used by Number::toReadableSize()
      *
      * @var bool
      */
@@ -97,10 +97,13 @@ class Number
     }
 
     /**
-     * Returns a formatted-for-humans file size. By default, the units are exponent of ten KB, MB, etc.
+     * Returns a formatted-for-humans file size. By default, the units are exponents of ten (KB, MB, etc.).
+     * setUseIecUnits() can be used to swap to ISO/IEC 80000-13 units (KiB, MiB, etc).
+     * 1 KiB = 1024 Bytes
+     * 1 KB  = 1000 Bytes
      *
      * @param string|float|int $size Size in bytes
-     * @param bool $useIecUnits Wether to use exponent of two (ISO/IEC 80000-13) or ten for units (KiB, MiB, etc. or KB, MB, etc.)
+     * @param bool $useIecUnits Whether to use exponent of two or ten for units (KiB, MiB, etc. or KB, MB, etc.)
      * @return string Human readable size
      * @link https://book.cakephp.org/5/en/core-libraries/number.html#interacting-with-human-readable-values
      */
@@ -128,9 +131,10 @@ class Number
     }
 
     /**
-     * Setter for default byte units
+     * Setter for units to use in toReadableSize(). If set to true, it will use IEC units, as defined in ISO/IEC 80000-13 
+     * (KiB, MiB, etc.). Else it will use natural units (MB, KB, etc).
      *
-     * @param bool $useIec Wether to use exponent of two or ten for units (KiB, MiB, etc. or KB, MB, etc.)  {@link toReadableSize()}
+     * @param bool $useIec Whether to use exponents of two or ten for units (KiB, MiB, etc. or KB, MB, etc.)  {@link toReadableSize()}
      * @return void
      */
     public static function setUseIecUnits(bool $useIec): void

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -72,7 +72,7 @@ class Number
     /**
      * Default byte units used by Number::toReadableSize()
      *
-     * @var bool
+     * @var string|null
      */
     protected static bool $useIecUnits = false;
 
@@ -119,10 +119,11 @@ class Number
         return match (true) {
             $size < $divisor => __dn('cake', '{0,number,integer} Byte', '{0,number,integer} Bytes', $size, $size),
             round($size / $divisor) < $divisor => __d('cake', '{0,number,#,###.##}' . $units[0], $size / $divisor),
-            round($size / $divisor / $divisor, 2) < $divisor => __d('cake', '{0,number,#,###.##}' . $units[1], $size / $divisor / $divisor),
-            round($size / $divisor / $divisor / $divisor, 2) < $divisor =>
-            __d('cake', '{0,number,#,###.##}' . $units[2], $size / $divisor / $divisor / $divisor),
-            default => __d('cake', '{0,number,#,###.##}' . $units[3], $size / $divisor / $divisor / $divisor / $divisor),
+            round($size / pow($divisor, 2), 2) < $divisor =>
+            __d('cake', '{0,number,#,###.##}' . $units[1], $size / pow($divisor, 2)),
+            round($size / pow($divisor, 3), 2) < $divisor =>
+            __d('cake', '{0,number,#,###.##}' . $units[2], $size / pow($divisor, 3)),
+            default => __d('cake', '{0,number,#,###.##}' . $units[3], $size / pow($divisor, 4)),
         };
     }
 
@@ -395,7 +396,7 @@ class Number
     {
         static::$_formatters[$locale][$type] = static::_setAttributes(
             new NumberFormatter($locale, $type),
-            $options,
+                                                                      $options,
         );
     }
 

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -131,7 +131,7 @@ class Number
     }
 
     /**
-     * Setter for units to use in toReadableSize(). If set to true, it will use IEC units, as defined in ISO/IEC 80000-13 
+     * Setter for units to use in toReadableSize(). If set to true, it will use IEC units, as defined in ISO/IEC 80000-13
      * (KiB, MiB, etc.). Else it will use natural units (MB, KB, etc).
      *
      * @param bool $useIec Whether to use exponents of two or ten for units (KiB, MiB, etc. or KB, MB, etc.)  {@link toReadableSize()}

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -396,7 +396,7 @@ class Number
     {
         static::$_formatters[$locale][$type] = static::_setAttributes(
             new NumberFormatter($locale, $type),
-                                                                      $options,
+            $options,
         );
     }
 

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -118,12 +118,12 @@ class Number
 
         return match (true) {
             $size < $divisor => __dn('cake', '{0,number,integer} Byte', '{0,number,integer} Bytes', $size, $size),
-            round($size / $divisor) < $divisor => __d('cake', '{0,number,#,###.##}' . $units[0], $size / $divisor),
+            round($size / $divisor) < $divisor => __d('cake', '{0,number,#,###.##} ' . $units[0], $size / $divisor),
             round($size / pow($divisor, 2), 2) < $divisor =>
-            __d('cake', '{0,number,#,###.##}' . $units[1], $size / pow($divisor, 2)),
+            __d('cake', '{0,number,#,###.##} ' . $units[1], $size / pow($divisor, 2)),
             round($size / pow($divisor, 3), 2) < $divisor =>
-            __d('cake', '{0,number,#,###.##}' . $units[2], $size / pow($divisor, 3)),
-            default => __d('cake', '{0,number,#,###.##}' . $units[3], $size / pow($divisor, 4)),
+            __d('cake', '{0,number,#,###.##} ' . $units[2], $size / pow($divisor, 3)),
+            default => __d('cake', '{0,number,#,###.##} ' . $units[3], $size / pow($divisor, 4)),
         };
     }
 

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -72,7 +72,7 @@ class Number
     /**
      * Default byte units used by Number::toReadableSize()
      *
-     * @var string|null
+     * @var bool
      */
     protected static bool $useIecUnits = false;
 

--- a/tests/TestCase/I18n/NumberTest.php
+++ b/tests/TestCase/I18n/NumberTest.php
@@ -512,53 +512,117 @@ class NumberTest extends TestCase
         $expected = '45 Bytes';
         $this->assertSame($expected, $result);
 
+        $result = $this->Number->toReadableSize(1000);
+        $expected = '1 KB';
+        $this->assertSame($expected, $result);
+
+        $result = $this->Number->toReadableSize(1024);
+        $expected = '1.02 KB';
+        $this->assertSame($expected, $result);
+
+        $result = $this->Number->toReadableSize(1024 + 123);
+        $expected = '1.15 KB';
+        $this->assertSame($expected, $result);
+
+        $result = $this->Number->toReadableSize(1024 * 512);
+        $expected = '524.29 KB';
+        $this->assertSame($expected, $result);
+
+        $result = $this->Number->toReadableSize(1024 * 1024 - 1);
+        $expected = '1.05 MB';
+        $this->assertSame($expected, $result);
+
+        $result = $this->Number->toReadableSize(512.05 * 1024 * 1024);
+        $expected = '536.92 MB';
+        $this->assertSame($expected, $result);
+
+        $result = $this->Number->toReadableSize(1024 * 1024 * 1024 - 1);
+        $expected = '1.07 GB';
+        $this->assertSame($expected, $result);
+
+        $result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 512);
+        $expected = '549.76 GB';
+        $this->assertSame($expected, $result);
+
+        $result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 1024 - 1);
+        $expected = '1.1 TB';
+        $this->assertSame($expected, $result);
+
+        $result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 1024 * 512);
+        $expected = '562.95 TB';
+        $this->assertSame($expected, $result);
+
+        $result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 1024 * 1024 - 1);
+        $expected = '1,125.9 TB';
+        $this->assertSame($expected, $result);
+
+        $result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 1024 * 1024 * 1024);
+        $expected = '1,152,921.5 TB';
+        $this->assertSame($expected, $result);
+
+        $this->Number->setUseIecUnits(true);
+
+        $result = $this->Number->toReadableSize(0);
+        $expected = '0 Bytes';
+        $this->assertSame($expected, $result);
+
+        $result = $this->Number->toReadableSize(1);
+        $expected = '1 Byte';
+        $this->assertSame($expected, $result);
+
+        $result = $this->Number->toReadableSize(45);
+        $expected = '45 Bytes';
+        $this->assertSame($expected, $result);
+
         $result = $this->Number->toReadableSize(1023);
         $expected = '1,023 Bytes';
         $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024);
-        $expected = '1 KB';
+        $expected = '1 KiB';
         $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 + 123);
-        $expected = '1.12 KB';
+        $expected = '1.12 KiB';
         $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 512);
-        $expected = '512 KB';
+        $expected = '512 KiB';
         $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 1024 - 1);
-        $expected = '1 MB';
+        $expected = '1 MiB';
         $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(512.05 * 1024 * 1024);
-        $expected = '512.05 MB';
+        $expected = '512.05 MiB';
         $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 1024 * 1024 - 1);
-        $expected = '1 GB';
+        $expected = '1 GiB';
         $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 512);
-        $expected = '512 GB';
+        $expected = '512 GiB';
         $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 1024 - 1);
-        $expected = '1 TB';
+        $expected = '1 TiB';
         $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 1024 * 512);
-        $expected = '512 TB';
+        $expected = '512 TiB';
         $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 1024 * 1024 - 1);
-        $expected = '1,024 TB';
+        $expected = '1,024 TiB';
         $this->assertSame($expected, $result);
 
         $result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 1024 * 1024 * 1024);
-        $expected = '1,048,576 TB';
+        $expected = '1,048,576 TiB';
         $this->assertSame($expected, $result);
+
+        $this->Number->setUseIecUnits(false);
     }
 
     /**
@@ -568,10 +632,18 @@ class NumberTest extends TestCase
     {
         I18n::setLocale('fr_FR');
         $result = $this->Number->toReadableSize(1321205);
-        $this->assertSame('1,26 MB', $result);
+        $this->assertSame('1,32 MB', $result);
 
         $result = $this->Number->toReadableSize(512.05 * 1024 * 1024 * 1024);
-        $this->assertSame('512,05 GB', $result);
+        $this->assertSame('549,81 GB', $result);
+
+        $this->Number->setUseIecUnits(true);
+
+        $result = $this->Number->toReadableSize(1321205);
+        $this->assertSame('1,26 MiB', $result);
+
+        $result = $this->Number->toReadableSize(512.05 * 1024 * 1024 * 1024);
+        $this->assertSame('512,05 GiB', $result);
     }
 
     /**


### PR DESCRIPTION
The function `Number::toReadableSize()` converts bytes to a human-readable format in KB (Kilobyte), MB (Megabyte), etc. To do this, it uses an exponent of two, which means the resulting units, in accordance with ISO/IEC 80000-13, should be KiB (Kibibyte), MiB (mebibyte), etc., and not KB, MB, GB, etc., which are based on an exponent of ten.