### PR TITLE
Change return type of FixtureInterface::insert() and truncate() to void

### DIFF
--- a/src/Datasource/FixtureInterface.php
+++ b/src/Datasource/FixtureInterface.php
@@ -28,17 +28,17 @@ interface FixtureInterface
      *
      * @param \Cake\Datasource\ConnectionInterface $connection An instance of the connection
      *   into which the records will be inserted.
-     * @return bool
+     * @return void
      */
-    public function insert(ConnectionInterface $connection): bool;
+    public function insert(ConnectionInterface $connection): void;
 
     /**
      * Truncates the current fixture.
      *
      * @param \Cake\Datasource\ConnectionInterface $connection A reference to a db instance
-     * @return bool
+     * @return void
      */
-    public function truncate(ConnectionInterface $connection): bool;
+    public function truncate(ConnectionInterface $connection): void;
 
     /**
      * Get the connection name this fixture should be inserted into.

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -197,7 +197,7 @@ class TestFixture implements FixtureInterface
     /**
      * @inheritDoc
      */
-    public function insert(ConnectionInterface $connection): bool
+    public function insert(ConnectionInterface $connection): void
     {
         assert($connection instanceof Connection);
         if ($this->records) {
@@ -211,8 +211,6 @@ class TestFixture implements FixtureInterface
             }
             $query->execute();
         }
-
-        return true;
     }
 
     /**
@@ -263,15 +261,13 @@ class TestFixture implements FixtureInterface
     /**
      * @inheritDoc
      */
-    public function truncate(ConnectionInterface $connection): bool
+    public function truncate(ConnectionInterface $connection): void
     {
         assert($connection instanceof Connection);
         $sql = $this->_schema->truncateSql($connection);
         foreach ($sql as $stmt) {
             $connection->execute($stmt);
         }
-
-        return true;
     }
 
     /**

--- a/tests/Fixture/OtherArticlesFixture.php
+++ b/tests/Fixture/OtherArticlesFixture.php
@@ -36,9 +36,8 @@ class OtherArticlesFixture implements FixtureInterface
         return true;
     }
 
-    public function insert(ConnectionInterface $connection): bool
+    public function insert(ConnectionInterface $connection): void
     {
-        return true;
     }
 
     public function createConstraints(ConnectionInterface $connection): bool
@@ -51,9 +50,8 @@ class OtherArticlesFixture implements FixtureInterface
         return true;
     }
 
-    public function truncate(ConnectionInterface $connection): bool
+    public function truncate(ConnectionInterface $connection): void
     {
-        return true;
     }
 
     public function connection(): string

--- a/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
@@ -175,7 +175,7 @@ class FixtureHelperTest extends TestCase
             {
             }
 
-            public function insert(ConnectionInterface $connection): bool
+            public function insert(ConnectionInterface $connection): void
             {
                 throw new PDOException('Missing key');
             }
@@ -194,7 +194,7 @@ class FixtureHelperTest extends TestCase
                     {
                     }
 
-                    public function insert(ConnectionInterface $connection): bool
+                    public function insert(ConnectionInterface $connection): void
                     {
                         throw new PDOException('Missing key');
                     }
@@ -242,7 +242,7 @@ class FixtureHelperTest extends TestCase
             {
             }
 
-            public function truncate(ConnectionInterface $connection): bool
+            public function truncate(ConnectionInterface $connection): void
             {
                 throw new PDOException('Missing key');
             }
@@ -261,7 +261,7 @@ class FixtureHelperTest extends TestCase
                     {
                     }
 
-                    public function truncate(ConnectionInterface $connection): bool
+                    public function truncate(ConnectionInterface $connection): void
                     {
                         throw new PDOException('Missing key');
                     }

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -246,7 +246,7 @@ class TestFixtureTest extends TestCase
             ->andReturn($statement)
             ->once();
 
-        $this->assertSame(true, $fixture->insert($db));
+        $fixture->insert($db);
     }
 
     /**
@@ -256,7 +256,7 @@ class TestFixtureTest extends TestCase
     {
         $fixture = new ArticlesFixture();
 
-        $this->assertTrue($fixture->truncate(ConnectionManager::get('test')));
+        $fixture->truncate(ConnectionManager::get('test'));
         $rows = ConnectionManager::get('test')->selectQuery()->select('*')->from('articles')->execute();
         $this->assertEmpty($rows->fetchAll());
     }


### PR DESCRIPTION
## Summary

- Change `FixtureInterface::insert()` return type from `bool` to `void`
- Change `FixtureInterface::truncate()` return type from `bool` to `void`

These methods only ever return `true` or throw exceptions - they never return `false`. The return value is not used anywhere in the codebase (callers catch exceptions instead).

Follow-up to #19220.