### PR TITLE
Improve Association::find() generic type annotation

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -223,10 +223,18 @@ parameters:
 			path: src/TestSuite/TestCase.php
 
 		-
+			message: '#^Parameter \#1 \$methods of method PHPUnit\\Framework\\MockObject\\MockBuilder\<Cake\\ORM\\Table\>\:\:onlyMethods\(\) expects list\<non\-empty\-string\>, array\<int\<0, max\>, non\-falsy\-string\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/TestSuite/TestCase.php
+			reportUnmatched: false
+
+		-
 			message: '#^Parameter \#1 \$methods of method PHPUnit\\Framework\\MockObject\\TestDoubleBuilder\:\:onlyMethods\(\) expects list\<non\-empty\-string\>, array\<int\<0, max\>, non\-falsy\-string\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/TestSuite/TestCase.php
+			reportUnmatched: false
 
 		-
 			message: '#^Strict comparison using \=\=\= between null and null will always evaluate to true\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -223,18 +223,10 @@ parameters:
 			path: src/TestSuite/TestCase.php
 
 		-
-			message: '#^Parameter \#1 \$methods of method PHPUnit\\Framework\\MockObject\\MockBuilder\<Cake\\ORM\\Table\>\:\:onlyMethods\(\) expects list\<non\-empty\-string\>, array\<int\<0, max\>, non\-falsy\-string\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/TestSuite/TestCase.php
-			reportUnmatched: false
-
-		-
 			message: '#^Parameter \#1 \$methods of method PHPUnit\\Framework\\MockObject\\TestDoubleBuilder\:\:onlyMethods\(\) expects list\<non\-empty\-string\>, array\<int\<0, max\>, non\-falsy\-string\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/TestSuite/TestCase.php
-			reportUnmatched: false
 
 		-
 			message: '#^Strict comparison using \=\=\= between null and null will always evaluate to true\.$#'

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -847,7 +847,7 @@ abstract class Association
      *   it will be interpreted as the `$args` parameter
      * @param mixed ...$args Arguments that match up to finder-specific parameters
      * @see \Cake\ORM\Table::find()
-     * @return \Cake\ORM\Query\SelectQuery
+     * @return \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface>
      */
     public function find(array|string|null $type = null, mixed ...$args): SelectQuery
     {

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -617,7 +617,6 @@ class BelongsToMany extends Association
         $table = $this->junction();
         $hasMany = $this->getSource()->getAssociation($table->getAlias());
         if ($this->_cascadeCallbacks) {
-            /** @var \Cake\Datasource\EntityInterface $related */
             foreach ($hasMany->find('all')->where($conditions)->all()->toList() as $related) {
                 $success = $table->delete($related, $options);
                 if (!$success) {

--- a/src/ORM/Association/DependentDeleteHelper.php
+++ b/src/ORM/Association/DependentDeleteHelper.php
@@ -53,7 +53,6 @@ class DependentDeleteHelper
         $conditions = array_combine($foreignKey, $bindingValue);
 
         if ($association->getCascadeCallbacks()) {
-            /** @var \Cake\Datasource\EntityInterface $related */
             foreach ($association->find()->where($conditions)->all()->toList() as $related) {
                 $success = $table->delete($related, $options);
                 if (!$success) {

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -560,7 +560,6 @@ class HasMany extends Association
                 });
                 $query = $this->find()->where($conditions);
 
-                /** @phpstan-ignore argument.type, argument.templateType */
                 $return = $target->deleteMany($query->all(), $options);
                 if ($return === false) {
                     return false;


### PR DESCRIPTION
## Summary

- Annotate `Association::find()` return type as `SelectQuery<EntityInterface>` instead of bare `SelectQuery`
- Remove `@var EntityInterface` casts from `BelongsToMany::cascadeDelete()` and `DependentDeleteHelper::cascadeDelete()`
- Remove `@phpstan-ignore argument.type, argument.templateType` from `HasMany::_unlink()`
- Remove stale `MockBuilder::onlyMethods()` PHPStan baseline entry

`SelectQuery`'s template parameter `TSubject of EntityInterface|array` is set at query construction time by `Table::selectQuery()` — finders don't change it. `findList()`, `findThreaded()`, etc. apply `formatResults()` callbacks that transform output at runtime, but `TSubject` stays the same throughout.

The `|array` half of the union exists solely for the `disableHydration()` case. Associations always work with hydrated entities and don't expose hydration control, so `SelectQuery<EntityInterface>` is the correct narrowing for `Association::find()`.

With #19240's fix making `SelectQuery::all()` return `ResultSetInterface<array-key, TSubject>` instead of `ResultSetInterface<array-key, mixed>`, this annotation completes the generic chain: `Association::find()` → `where()` → `all()` → `deleteMany()`/`delete()` — entity type flows through without workarounds.

The stale `MockBuilder::onlyMethods()` baseline entry was left behind after PHPUnit replaced `MockBuilder` with `TestDoubleBuilder`. Its `reportUnmatched: false` hid the staleness.

Refs #19238, #19240