### PR TITLE
Remove underscore prefix from protected test helper methods

### DIFF
--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -40,7 +40,7 @@ trait CookieCryptTrait
     abstract protected function getCookieEncryptionKey(): string;
 
     /**
-     * Encrypts $value using public $type method in Security class
+     * Encrypts $value using $hashType method in Security class
      *
      * @param array|string $value Value to encrypt
      * @param string|false $encrypt Encryption mode to use. False
@@ -86,7 +86,7 @@ trait CookieCryptTrait
     }
 
     /**
-     * Decrypts $value using public $type method in Security class
+     * Decrypts $value using $hashType method in Security class
      *
      * @param array<string>|string $values Values to decrypt
      * @param string|false $mode Encryption mode

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -61,7 +61,7 @@ class CacheTest extends TestCase
     /**
      * Configure cache settings for test
      */
-    protected function _configCache(): void
+    protected function configCache(): void
     {
         Cache::setConfig('tests', [
             'engine' => 'File',
@@ -229,7 +229,7 @@ class CacheTest extends TestCase
     public function testNonFatalErrorsWithCacheDisable(): void
     {
         Cache::disable();
-        $this->_configCache();
+        $this->configCache();
 
         $this->assertTrue(Cache::write('no_save', 'Noooo!', 'tests'));
         $this->assertNull(Cache::read('no_save', 'tests'));
@@ -241,7 +241,7 @@ class CacheTest extends TestCase
      */
     public function testNullEngineWhenCacheDisable(): void
     {
-        $this->_configCache();
+        $this->configCache();
         Cache::disable();
 
         $result = Cache::pool('tests');
@@ -618,7 +618,7 @@ class CacheTest extends TestCase
      */
     public function testWriteEmptyValues(): void
     {
-        $this->_configCache();
+        $this->configCache();
         Cache::write('App.falseTest', false, 'tests');
         $this->assertFalse(Cache::read('App.falseTest', 'tests'));
 
@@ -640,7 +640,7 @@ class CacheTest extends TestCase
      */
     public function testWriteEmptyKey(): void
     {
-        $this->_configCache();
+        $this->configCache();
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('A cache key must be a non-empty string');
@@ -653,7 +653,7 @@ class CacheTest extends TestCase
      */
     public function testReadWriteMany(): void
     {
-        $this->_configCache();
+        $this->configCache();
         $data = [
             'App.falseTest' => false,
             'App.trueTest' => true,
@@ -677,7 +677,7 @@ class CacheTest extends TestCase
      */
     public function testDeleteMany(): void
     {
-        $this->_configCache();
+        $this->configCache();
         $data = [
             'App.falseTest' => false,
             'App.trueTest' => true,
@@ -703,7 +703,7 @@ class CacheTest extends TestCase
      */
     public function testDeleteManyPartialFailure(): void
     {
-        $this->_configCache();
+        $this->configCache();
         $data = [
             'App.exists' => 'yes',
             'App.exists2' => 'yes',
@@ -829,7 +829,7 @@ class CacheTest extends TestCase
      */
     public function testRemember(): void
     {
-        $this->_configCache();
+        $this->configCache();
         $counter = 0;
         $cacher = function () use ($counter) {
             return 'This is some data ' . $counter;
@@ -848,7 +848,7 @@ class CacheTest extends TestCase
      */
     public function testAdd(): void
     {
-        $this->_configCache();
+        $this->configCache();
         Cache::delete('test_add_key', 'tests');
 
         $result = Cache::add('test_add_key', 'test data', 'tests');
@@ -886,7 +886,7 @@ class CacheTest extends TestCase
      */
     public function testPool(): void
     {
-        $this->_configCache();
+        $this->configCache();
 
         $pool = Cache::pool('tests');
         $this->assertInstanceOf(SimpleCacheInterface::class, $pool);

--- a/tests/TestCase/Cache/Engine/ApcuEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ApcuEngineTest.php
@@ -69,7 +69,7 @@ class ApcuEngineTest extends TestCase
         }
 
         Cache::enable();
-        $this->_configCache();
+        $this->configCache();
         Cache::clearAll();
     }
 
@@ -88,7 +88,7 @@ class ApcuEngineTest extends TestCase
      *
      * @param array $config
      */
-    protected function _configCache(array $config = []): void
+    protected function configCache(array $config = []): void
     {
         $defaults = [
             'className' => 'Apcu',
@@ -105,7 +105,7 @@ class ApcuEngineTest extends TestCase
      */
     public function testReadAndWriteCache(): void
     {
-        $this->_configCache(['duration' => 1]);
+        $this->configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'apcu');
         $this->assertNull($result);
@@ -155,7 +155,7 @@ class ApcuEngineTest extends TestCase
      */
     public function testExpiry(): void
     {
-        $this->_configCache(['duration' => 1]);
+        $this->configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'apcu');
         $this->assertNull($result);
@@ -175,7 +175,7 @@ class ApcuEngineTest extends TestCase
      */
     public function testSetWithTtl(): void
     {
-        $this->_configCache(['duration' => 99]);
+        $this->configCache(['duration' => 99]);
         $engine = Cache::pool('apcu');
         $this->assertNull($engine->get('test'));
 

--- a/tests/TestCase/Cache/Engine/ArrayEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ArrayEngineTest.php
@@ -34,7 +34,7 @@ class ArrayEngineTest extends TestCase
         parent::setUp();
 
         Cache::enable();
-        $this->_configCache();
+        $this->configCache();
         Cache::clearAll();
     }
 
@@ -53,7 +53,7 @@ class ArrayEngineTest extends TestCase
      *
      * @param array $config
      */
-    protected function _configCache($config = []): void
+    protected function configCache($config = []): void
     {
         $defaults = [
             'className' => 'Array',
@@ -70,7 +70,7 @@ class ArrayEngineTest extends TestCase
      */
     public function testReadAndWriteCache(): void
     {
-        $this->_configCache(['duration' => 1]);
+        $this->configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'array');
         $this->assertNull($result);
@@ -91,7 +91,7 @@ class ArrayEngineTest extends TestCase
      */
     public function testExpiry(): void
     {
-        $this->_configCache(['duration' => 1]);
+        $this->configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'array');
         $this->assertNull($result);

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -36,7 +36,7 @@ class FileEngineTest extends TestCase
     {
         parent::setUp();
         Cache::enable();
-        $this->_configCache();
+        $this->configCache();
         Cache::clear('file_test');
     }
 
@@ -57,7 +57,7 @@ class FileEngineTest extends TestCase
      *
      * @param array $config
      */
-    protected function _configCache($config = []): void
+    protected function configCache($config = []): void
     {
         $defaults = [
             'className' => 'File',
@@ -88,7 +88,7 @@ class FileEngineTest extends TestCase
      */
     public function testReadAndWriteCacheExpired(): void
     {
-        $this->_configCache(['duration' => 1]);
+        $this->configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'file_test');
         $this->assertNull($result);
@@ -134,7 +134,7 @@ class FileEngineTest extends TestCase
      */
     public function testExpiry(): void
     {
-        $this->_configCache(['duration' => 1]);
+        $this->configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'file_test');
         $this->assertNull($result);
@@ -148,7 +148,7 @@ class FileEngineTest extends TestCase
         $this->assertNull($result, 'Expired key no result.');
         $this->assertSame(0, Cache::pool('file_test')->get('other_test', 0), 'expired values get default.');
 
-        $this->_configCache(['duration' => '+1 second']);
+        $this->configCache(['duration' => '+1 second']);
 
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('other_test', $data, 'file_test');
@@ -164,7 +164,7 @@ class FileEngineTest extends TestCase
      */
     public function testSetWithTtl(): void
     {
-        $this->_configCache(['duration' => 99]);
+        $this->configCache(['duration' => 99]);
         $engine = Cache::pool('file_test');
         $this->assertNull($engine->get('test'));
 
@@ -215,12 +215,12 @@ class FileEngineTest extends TestCase
      */
     public function testSerialize(): void
     {
-        $this->_configCache(['serialize' => true]);
+        $this->configCache(['serialize' => true]);
         $data = 'this is a test of the emergency broadcasting system';
         $write = Cache::write('serialize_test', $data, 'file_test');
         $this->assertTrue($write);
 
-        $this->_configCache(['serialize' => false]);
+        $this->configCache(['serialize' => false]);
         $read = Cache::read('serialize_test', 'file_test');
 
         Cache::delete('serialize_test', 'file_test');
@@ -233,7 +233,7 @@ class FileEngineTest extends TestCase
      */
     public function testClear(): void
     {
-        $this->_configCache(['duration' => 0]);
+        $this->configCache(['duration' => 0]);
 
         $data = 'this is a test of the emergency broadcasting system';
         Cache::write('serialize_test1', $data, 'file_test');
@@ -636,7 +636,7 @@ class FileEngineTest extends TestCase
      */
     public function testClearIsRestrictedToConfiguredPath(): void
     {
-        $this->_configCache([
+        $this->configCache([
             'prefix' => '',
             'path' => TMP . 'tests',
         ]);

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -53,7 +53,7 @@ class MemcachedEngineTest extends TestCase
         $this->skipIf(!$socket, 'Memcached is not running.');
         fclose($socket);
 
-        $this->_configCache();
+        $this->configCache();
     }
 
     /**
@@ -61,7 +61,7 @@ class MemcachedEngineTest extends TestCase
      *
      * @param array $config
      */
-    protected function _configCache($config = []): void
+    protected function configCache($config = []): void
     {
         $defaults = [
             'className' => 'Memcached',
@@ -458,7 +458,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testReadAndWriteCache(): void
     {
-        $this->_configCache(['duration' => 1]);
+        $this->configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'memcached');
         $this->assertNull($result);
@@ -494,7 +494,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testReadMany(): void
     {
-        $this->_configCache(['duration' => 2]);
+        $this->configCache(['duration' => 2]);
         $data = [
             'App.falseTest' => false,
             'App.trueTest' => true,
@@ -523,7 +523,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testReadManyTreatNullAsValidCacheValue(): void
     {
-        $this->_configCache(['duration' => 2]);
+        $this->configCache(['duration' => 2]);
         $data = [
             'App.falseTest' => false,
             'App.trueTest' => true,
@@ -551,7 +551,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testWriteMany(): void
     {
-        $this->_configCache(['duration' => 2]);
+        $this->configCache(['duration' => 2]);
         $data = [
             'App.falseTest' => false,
             'App.trueTest' => true,
@@ -573,7 +573,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testExpiry(): void
     {
-        $this->_configCache(['duration' => 1]);
+        $this->configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'memcached');
         $this->assertNull($result);
@@ -586,7 +586,7 @@ class MemcachedEngineTest extends TestCase
         $result = Cache::read('other_test', 'memcached');
         $this->assertNull($result);
 
-        $this->_configCache(['duration' => '+1 second']);
+        $this->configCache(['duration' => '+1 second']);
 
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('other_test', $data, 'memcached');
@@ -599,7 +599,7 @@ class MemcachedEngineTest extends TestCase
         $result = Cache::read('other_test', 'memcached');
         $this->assertNull($result);
 
-        $this->_configCache(['duration' => '+29 days']);
+        $this->configCache(['duration' => '+29 days']);
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('long_expiry_test', $data, 'memcached');
         $this->assertTrue($result);
@@ -615,7 +615,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testSetWithTtl(): void
     {
-        $this->_configCache(['duration' => 99]);
+        $this->configCache(['duration' => 99]);
         $engine = Cache::pool('memcached');
         $this->assertNull($engine->get('test'));
 
@@ -648,7 +648,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testDeleteMany(): void
     {
-        $this->_configCache();
+        $this->configCache();
         $data = [
             'App.falseTest' => false,
             'App.trueTest' => true,
@@ -752,7 +752,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testIncrementDecrementExpiring(): void
     {
-        $this->_configCache(['duration' => 1]);
+        $this->configCache(['duration' => 1]);
         Cache::write('test_increment', 1, 'memcached');
         Cache::write('test_decrement', 1, 'memcached');
 
@@ -856,7 +856,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testZeroDuration(): void
     {
-        $this->_configCache(['duration' => 0]);
+        $this->configCache(['duration' => 0]);
         $result = Cache::write('test_key', 'written!', 'memcached');
 
         $this->assertTrue($result);

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -62,7 +62,7 @@ class RedisEngineTest extends TestCase
         $this->skipIf($this->skipTest, 'Redis is not running.');
 
         Cache::enable();
-        $this->_configCache();
+        $this->configCache();
     }
 
     /**
@@ -84,7 +84,7 @@ class RedisEngineTest extends TestCase
      *
      * @param array $config
      */
-    protected function _configCache($config = []): void
+    protected function configCache($config = []): void
     {
         $defaults = [
             'className' => 'Redis',
@@ -495,7 +495,7 @@ class RedisEngineTest extends TestCase
      */
     public function testReadAndWriteCache(): void
     {
-        $this->_configCache(['duration' => 1]);
+        $this->configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'redis');
         $this->assertNull($result);
@@ -558,7 +558,7 @@ class RedisEngineTest extends TestCase
      */
     public function testExpiry(): void
     {
-        $this->_configCache(['duration' => 1]);
+        $this->configCache(['duration' => 1]);
 
         $result = Cache::read('test', 'redis');
         $this->assertNull($result);
@@ -571,7 +571,7 @@ class RedisEngineTest extends TestCase
         $result = Cache::read('other_test', 'redis');
         $this->assertNull($result);
 
-        $this->_configCache(['duration' => '+1 second']);
+        $this->configCache(['duration' => '+1 second']);
 
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('other_test', $data, 'redis');
@@ -586,7 +586,7 @@ class RedisEngineTest extends TestCase
         $result = Cache::read('other_test', 'redis');
         $this->assertNull($result);
 
-        $this->_configCache(['duration' => '+29 days']);
+        $this->configCache(['duration' => '+29 days']);
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('long_expiry_test', $data, 'redis');
         $this->assertTrue($result);
@@ -602,7 +602,7 @@ class RedisEngineTest extends TestCase
      */
     public function testSetWithTtl(): void
     {
-        $this->_configCache(['duration' => 99]);
+        $this->configCache(['duration' => 99]);
         $engine = Cache::pool('redis');
         $this->assertNull($engine->get('test'));
 
@@ -708,7 +708,7 @@ class RedisEngineTest extends TestCase
      */
     public function testIncrementDecrementForvever(): void
     {
-        $this->_configCache(['duration' => 0]);
+        $this->configCache(['duration' => 0]);
         Cache::delete('test_increment', 'redis');
         Cache::delete('test_decrement', 'redis');
 
@@ -727,7 +727,7 @@ class RedisEngineTest extends TestCase
      */
     public function testIncrementDecrementExpiring(): void
     {
-        $this->_configCache(['duration' => 1]);
+        $this->configCache(['duration' => 1]);
         Cache::delete('test_increment', 'redis');
         Cache::delete('test_decrement', 'redis');
 
@@ -849,7 +849,7 @@ class RedisEngineTest extends TestCase
      */
     public function testZeroDuration(): void
     {
-        $this->_configCache(['duration' => 0]);
+        $this->configCache(['duration' => 0]);
         $result = Cache::write('test_key', 'written!', 'redis');
 
         $this->assertTrue($result);

--- a/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
@@ -45,7 +45,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
         TypeFactory::map('ordered_uuid', OrderedUuidType::class);
     }
 
-    protected function _insert(): void
+    protected function insert(): void
     {
         $query = $this->connection->insertQuery();
         $query
@@ -64,7 +64,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
      */
     public function testInsert(): void
     {
-        $this->_insert();
+        $this->insert();
         $query = $this->connection->selectQuery('id', 'ordered_uuid_items')
             ->orderBy('id')
             ->setDefaultTypes(['id' => 'ordered_uuid']);
@@ -82,7 +82,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
      */
     public function testSelectWithConditions(): void
     {
-        $this->_insert();
+        $this->insert();
         $result = $this->connection->selectQuery('id', 'ordered_uuid_items')
             ->where(['id' => '48298a29-81c0-4c26-a7fb-413140cf8569'], ['id' => 'ordered_uuid'])
             ->execute()
@@ -97,7 +97,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
      */
     public function testSelectWithConditionsValueObject(): void
     {
-        $this->_insert();
+        $this->insert();
         $result = $this->connection->selectQuery('id', 'ordered_uuid_items')
             ->where(['id' => new UuidValue('48298a29-81c0-4c26-a7fb-413140cf8569')], ['id' => 'ordered_uuid'])
             ->execute()
@@ -114,7 +114,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
      */
     public function testSelectWithInCondition(): void
     {
-        $this->_insert();
+        $this->insert();
         $result = $this->connection->selectQuery('id', 'ordered_uuid_items')
             ->where(
                 ['id' => ['48298a29-81c0-4c26-a7fb-413140cf8569', '482b7756-8da0-419a-b21f-27da40cf8569']],
@@ -134,7 +134,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
      */
     public function testSelectWithBetween(): void
     {
-        $this->_insert();
+        $this->insert();
         $result = $this->connection->selectQuery(fields: 'id', table: 'ordered_uuid_items')
             ->where(function (QueryExpression $exp) {
                 return $exp->between(
@@ -155,7 +155,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
      */
     public function testSelectWithFunction(): void
     {
-        $this->_insert();
+        $this->insert();
         $result = $this->connection->selectQuery(fields: 'id', table: 'ordered_uuid_items')
             ->where(function (QueryExpression $exp, Query $q) {
                 return $exp->eq(

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -45,7 +45,7 @@ class MysqlSchemaDialectTest extends TestCase
     /**
      * Helper method for skipping tests that need a real connection.
      */
-    protected function _needsConnection(): void
+    protected function needsConnection(): void
     {
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(!str_contains($config['driver'], 'Mysql'), 'Not using Mysql for test config');
@@ -284,7 +284,7 @@ class MysqlSchemaDialectTest extends TestCase
     #[DataProvider('convertColumnProvider')]
     public function testConvertColumn(string $type, array $expected): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('test');
         $sql = <<<SQL
@@ -339,9 +339,9 @@ SQL;
      *
      * @param \Cake\Datasource\ConnectionInterface $connection
      */
-    protected function _createTables($connection): void
+    protected function createTables($connection): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection->execute('DROP TABLE IF EXISTS schema_articles');
         $connection->execute('DROP TABLE IF EXISTS schema_authors');
         $connection->execute('DROP TABLE IF EXISTS schema_json');
@@ -402,7 +402,7 @@ SQL;
      */
     public function testConvertColumnJson(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('test');
         $driver = $connection->getDriver();
@@ -431,7 +431,7 @@ SQL;
      */
     public function testConvertColumnUuid(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('test');
         $driver = $connection->getDriver();
@@ -460,7 +460,7 @@ SQL;
     public function testListTables(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
         $schema = new SchemaCollection($connection);
 
         $result = $schema->listTables();
@@ -481,7 +481,7 @@ SQL;
     public function testDescribeTable(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $dialect = $connection->getDriver()->schemaDialect();
         $result = $dialect->describe('schema_articles');
@@ -678,7 +678,7 @@ SQL;
     public function testDescribeTableDatabasePrefix(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $config = $connection->getDriver()->config();
         $dialect = $connection->getDriver()->schemaDialect();
@@ -692,7 +692,7 @@ SQL;
      */
     public function testDescribeTableGeometry(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection = ConnectionManager::get('test');
         $driver = $connection->getDriver();
 
@@ -773,7 +773,7 @@ SQL;
      */
     public function testDescribeTableGeometryNoSrid(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection = ConnectionManager::get('test');
 
         $table = <<<SQL
@@ -850,7 +850,7 @@ SQL;
     public function testDescribeTableIndexes(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $database = $connection->getDriver()->config()['database'];
         $dialect = $connection->getDriver()->schemaDialect();
@@ -989,7 +989,7 @@ SQL;
      */
     public function testDescribeTableConditionalConstraint(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection = ConnectionManager::get('test');
         $connection->execute('DROP TABLE IF EXISTS conditional_constraint');
         $table = <<<SQL
@@ -1019,7 +1019,7 @@ SQL;
 
     public function testDescribeTableFunctionalIndex(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection = ConnectionManager::get('test');
         $connection->execute('DROP TABLE IF EXISTS functional_index');
         $table = <<<SQL
@@ -1056,7 +1056,7 @@ SQL;
 
     public function testDescribeTableCheckConstraints(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection = ConnectionManager::get('test');
         $driver = $connection->getDriver();
         $this->skipIf(!$driver->supports(DriverFeatureEnum::CHECK_CONSTRAINTS), 'This test requires check constraint support');
@@ -1091,7 +1091,7 @@ SQL;
     public function testDescribeTableOptions(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $dialect = $connection->getDriver()->schemaDialect();
         $result = $dialect->describeOptions('schema_articles');
@@ -1101,7 +1101,7 @@ SQL;
 
     public function testDescribeNonPrimaryAutoIncrement(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection = ConnectionManager::get('test');
 
         $sql = <<<SQL
@@ -1128,7 +1128,7 @@ SQL;
     public function testDescribeDecimalPrecisionReflection(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_needsConnection();
+        $this->needsConnection();
 
         $connection->execute('DROP TABLE IF EXISTS test_decimal_precision');
 
@@ -1603,7 +1603,7 @@ SQL;
     #[DataProvider('columnSqlProvider')]
     public function testColumnSql(string $name, array $data, string $expected): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $dialect = new MysqlSchemaDialect($driver);
 
         $table = new TableSchema('articles')->addColumn($name, $data);
@@ -1684,7 +1684,7 @@ SQL;
     #[DataProvider('constraintSqlProvider')]
     public function testConstraintSql(string $name, array $data, string $expected): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $schema = new MysqlSchemaDialect($driver);
 
         $table = new TableSchema('articles')->addColumn('title', [
@@ -1724,7 +1724,7 @@ SQL;
     #[DataProvider('indexSqlProvider')]
     public function testIndexSql(string $name, array $data, string $expected): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $schema = new MysqlSchemaDialect($driver);
 
         $table = new TableSchema('articles')->addColumn('title', [
@@ -1742,7 +1742,7 @@ SQL;
      */
     public function testAddConstraintSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1791,7 +1791,7 @@ SQL;
      */
     public function testDropConstraintSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1840,7 +1840,7 @@ SQL;
      */
     public function testColumnSqlPrimaryKey(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $schema = new MysqlSchemaDialect($driver);
 
         $table = new TableSchema('articles');
@@ -1873,7 +1873,7 @@ SQL;
      */
     public function testCreateSql(): void
     {
-        $driver = $this->_getMockedDriver('5.6.0');
+        $driver = $this->getMockedDriver('5.6.0');
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1935,7 +1935,7 @@ SQL;
      */
     public function testCreateSqlJson(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1982,7 +1982,7 @@ SQL;
      */
     public function testCreateTemporary(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -2002,7 +2002,7 @@ SQL;
      */
     public function testCreateSqlCompositeIntegerKey(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -2066,7 +2066,7 @@ SQL;
      */
     public function testDropSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -2084,7 +2084,7 @@ SQL;
      */
     public function testTruncateSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -2114,7 +2114,7 @@ SQL;
     public function testDescribeJson(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
         $this->skipIf(!$connection->getDriver()->supports(DriverFeatureEnum::JSON), 'Does not support native json');
         $this->skipIf($connection->getDriver()->isMariadb(), 'MariaDb internally uses TEXT for JSON columns');
 
@@ -2139,9 +2139,9 @@ SQL;
     /**
      * Get a schema instance with a mocked driver/pdo instances
      */
-    protected function _getMockedDriver($version = '8.0.7'): Driver
+    protected function getMockedDriver($version = '8.0.7'): Driver
     {
-        $this->_needsConnection();
+        $this->needsConnection();
 
         $this->pdo = $this->getMockBuilder(PDOMocked::class)
             ->onlyMethods(['quote', 'getAttribute', 'quoteIdentifier'])

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -42,7 +42,7 @@ class PostgresSchemaDialectTest extends TestCase
     /**
      * Helper method for skipping tests that need a real connection.
      */
-    protected function _needsConnection(): void
+    protected function needsConnection(): void
     {
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(!str_contains($config['driver'], 'Postgres'), 'Not using Postgres for test config');
@@ -53,9 +53,9 @@ class PostgresSchemaDialectTest extends TestCase
      *
      * @param \Cake\Datasource\ConnectionInterface $connection
      */
-    protected function _createTables($connection): void
+    protected function createTables($connection): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
 
         $connection->execute('DROP VIEW IF EXISTS schema_articles_v');
         $connection->execute('DROP TABLE IF EXISTS schema_articles');
@@ -307,7 +307,7 @@ SQL;
     #[DataProvider('convertColumnProvider')]
     public function testConvertColumn(string $field, array $expected): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('test');
         $sql = <<<SQL
@@ -336,7 +336,7 @@ SQL;
     public function testListTables(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
         $schema = new SchemaCollection($connection);
 
         $result = $schema->listTables();
@@ -357,7 +357,7 @@ SQL;
     public function testDescribeWithSchemaName(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('public.schema_articles');
@@ -372,7 +372,7 @@ SQL;
     public function testDescribeTable(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $dialect = $connection->getDriver()->schemaDialect();
         $result = $dialect->describe('schema_articles');
@@ -576,7 +576,7 @@ SQL;
      */
     public function testDescribeTableCompositeKey(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection = ConnectionManager::get('test');
         $sql = <<<SQL
 CREATE TABLE schema_composite (
@@ -601,7 +601,7 @@ SQL;
      */
     public function testDescribeTableCiText(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection = ConnectionManager::get('test');
 
         $sql = 'CREATE EXTENSION IF NOT EXISTS citext';
@@ -637,7 +637,7 @@ SQL;
     public function testDescribeTableWithDefaults(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('schema_authors');
@@ -699,7 +699,7 @@ SQL;
 
     public function testDescribeTableGeospatialTypes(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('test');
 
@@ -794,7 +794,7 @@ SQL;
     public function testDescribeTableConstraintsWithKeywords(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('schema_authors');
@@ -821,7 +821,7 @@ SQL;
 
     public function testDescribeTableConstraintsColumnOrdering(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection = ConnectionManager::get('test');
 
         $queries = [
@@ -862,7 +862,7 @@ SQL;
     public function testDescribeTableCheckConstraints(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('schema_articles');
@@ -882,7 +882,7 @@ SQL;
     public function testDescribeTableIndexes(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $dialect = $connection->getDriver()->schemaDialect();
         $result = $dialect->describe('schema_articles');
@@ -1001,7 +1001,7 @@ SQL;
      */
     public function testDescribeTableIndexesNullsFirst(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection = ConnectionManager::get('test');
         $connection->execute('DROP TABLE IF EXISTS schema_index');
 
@@ -1043,7 +1043,7 @@ SQL;
      */
     public function testDescribeTableFunctionDefaultValue(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection = ConnectionManager::get('test');
         $sql = <<<SQL
 CREATE TABLE schema_function_defaults (
@@ -1423,7 +1423,7 @@ SQL;
     #[DataProvider('columnSqlProvider')]
     public function testColumnSql(string $name, array $data, string $expected): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $schema = new PostgresSchemaDialect($driver);
 
         $table = new TableSchema('schema_articles')->addColumn($name, $data);
@@ -1438,7 +1438,7 @@ SQL;
      */
     public function testColumnSqlPrimaryKey(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $schema = new PostgresSchemaDialect($driver);
 
         $table = new TableSchema('schema_articles');
@@ -1529,7 +1529,7 @@ SQL;
     #[DataProvider('constraintSqlProvider')]
     public function testConstraintSql(string $name, array $data, string $expected): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $schema = new PostgresSchemaDialect($driver);
 
         $table = new TableSchema('schema_articles')->addColumn('title', [
@@ -1569,7 +1569,7 @@ SQL;
     #[DataProvider('indexSqlProvider')]
     public function testIndexSql(string $name, array $data, string $expected): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $schema = new PostgresSchemaDialect($driver);
 
         $table = new TableSchema('schema_articles')->addColumn('title', [
@@ -1587,7 +1587,7 @@ SQL;
      */
     public function testAddConstraintSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1636,7 +1636,7 @@ SQL;
      */
     public function testDropConstraintSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1685,7 +1685,7 @@ SQL;
      */
     public function testCreateSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1752,7 +1752,7 @@ SQL;
 
     public function testCreateSqlGeospacialTypes(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1795,7 +1795,7 @@ SQL;
      */
     public function testCreateInSchema(): void
     {
-        $driver = $this->_getMockedDriver(['schema' => 'notpublic']);
+        $driver = $this->getMockedDriver(['schema' => 'notpublic']);
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1816,7 +1816,7 @@ SQL;
      */
     public function testCreateTemporary(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1836,7 +1836,7 @@ SQL;
      */
     public function testCreateSqlCompositeIntegerKey(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1900,7 +1900,7 @@ SQL;
      */
     public function testDropSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1918,7 +1918,7 @@ SQL;
      */
     public function testTruncateSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1938,7 +1938,7 @@ SQL;
 
     public function testDescribeIndexIncludedFields(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection = ConnectionManager::get('test');
         $sql = <<<SQL
 CREATE TABLE schema_index_include (
@@ -1974,7 +1974,7 @@ SQL;
      */
     public function testHasIndexPrimaryKeyName(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
 
         $connection = ConnectionManager::get('test');
         $dialect = new PostgresSchemaDialect($connection->getDriver());
@@ -1984,9 +1984,9 @@ SQL;
     /**
      * Get a schema instance with a mocked driver/pdo instances
      */
-    protected function _getMockedDriver(array $config = []): Driver
+    protected function getMockedDriver(array $config = []): Driver
     {
-        $this->_needsConnection();
+        $this->needsConnection();
 
         $config += [
             'database' => 'cake',

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -60,7 +60,7 @@ class SqliteSchemaDialectTest extends TestCase
     /**
      * Helper method for skipping tests that need a real connection.
      */
-    protected function _needsConnection(): void
+    protected function needsConnection(): void
     {
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(!str_contains($config['driver'], 'Sqlite'), 'Not using Sqlite for test config');
@@ -71,9 +71,9 @@ class SqliteSchemaDialectTest extends TestCase
      *
      * @param \Cake\Database\Connection $connection
      */
-    protected function _createTables($connection): void
+    protected function createTables($connection): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
 
         $schema = new SchemaCollection($connection);
         $result = $schema->listTables();
@@ -321,7 +321,7 @@ SQL;
     #[DataProvider('convertColumnProvider')]
     public function testConvertColumn(string $type, array $expected): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('test');
         $sql = <<<SQL
@@ -350,7 +350,7 @@ SQL;
     public function testListTables(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
         $schema = new SchemaCollection($connection);
 
         $result = $schema->listTables();
@@ -372,7 +372,7 @@ SQL;
     public function testDescribeTable(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('schema_articles');
@@ -487,7 +487,7 @@ SQL;
     public function testDescribeView(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('view_schema_articles');
@@ -517,7 +517,7 @@ SQL;
     public function testDescribeTableCompositeKey(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('schema_composite');
 
@@ -532,7 +532,7 @@ SQL;
     public function testDescribeTableIndexes(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $dialect = $connection->getDriver()->schemaDialect();
         $result = $dialect->describe('schema_articles');
@@ -736,7 +736,7 @@ SQL;
 
     public function testDescribeIndexesTextPrimaryKey(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection = ConnectionManager::get('test');
         $dialect = $connection->getDriver()->schemaDialect();
 
@@ -763,7 +763,7 @@ SQL;
     public function testDescribeTableForeignKeys(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         /** @var \Cake\Database\Schema\SqliteSchemaDialect  $dialect */
         $dialect = $connection->getDriver()->schemaDialect();
@@ -830,7 +830,7 @@ SQL;
     public function testDescribeColumns(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
         /** @var \Cake\Database\Schema\SqliteSchemaDialect  $dialect */
         $dialect = $connection->getDriver()->schemaDialect();
 
@@ -957,7 +957,7 @@ SQL;
     public function testDescribeTableCheckConstraints(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('schema_articles');
@@ -1218,7 +1218,7 @@ SQL;
      */
     public function testAddConstraintSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1236,7 +1236,7 @@ SQL;
      */
     public function testDropConstraintSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1254,7 +1254,7 @@ SQL;
     #[DataProvider('columnSqlProvider')]
     public function testColumnSql(string $name, array $data, string $expected): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $dialect = new SqliteSchemaDialect($driver);
 
         $table = new TableSchema('articles')->addColumn($name, $data);
@@ -1269,7 +1269,7 @@ SQL;
      */
     public function testColumnSqlPrimaryKey(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $schema = new SqliteSchemaDialect($driver);
 
         $table = new TableSchema('articles');
@@ -1295,7 +1295,7 @@ SQL;
      */
     public function testColumnSqlPrimaryKeyBigInt(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $schema = new SqliteSchemaDialect($driver);
 
         $table = new TableSchema('articles');
@@ -1388,7 +1388,7 @@ SQL;
     #[DataProvider('constraintSqlProvider')]
     public function testConstraintSql(string $name, array $data, string $expected): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $schema = new SqliteSchemaDialect($driver);
 
         $table = new TableSchema('articles')->addColumn('title', [
@@ -1423,7 +1423,7 @@ SQL;
     #[DataProvider('indexSqlProvider')]
     public function testIndexSql(string $name, array $data, string $expected): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $schema = new SqliteSchemaDialect($driver);
 
         $table = new TableSchema('articles')->addColumn('title', [
@@ -1441,7 +1441,7 @@ SQL;
      */
     public function testCreateSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1491,7 +1491,7 @@ SQL;
      */
     public function testCreateTemporary(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1511,7 +1511,7 @@ SQL;
      */
     public function testCreateSqlCompositeIntegerKey(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1577,7 +1577,7 @@ SQL;
      */
     public function testDropSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1595,7 +1595,7 @@ SQL;
      */
     public function testTruncateSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1626,7 +1626,7 @@ SQL;
      */
     public function testTruncateSqlNoSequences(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1654,9 +1654,9 @@ SQL;
     /**
      * Get a schema instance with a mocked driver/pdo instances
      */
-    protected function _getMockedDriver(): Driver
+    protected function getMockedDriver(): Driver
     {
-        $this->_needsConnection();
+        $this->needsConnection();
 
         $this->pdo = $this->getMockBuilder(PDO::class)
             ->onlyMethods(['quote', 'prepare'])

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -39,7 +39,7 @@ class SqlserverSchemaDialectTest extends TestCase
     /**
      * Helper method for skipping tests that need a real connection.
      */
-    protected function _needsConnection(): void
+    protected function needsConnection(): void
     {
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(!str_contains($config['driver'], 'Sqlserver'), 'Not using Sqlserver for test config');
@@ -48,9 +48,9 @@ class SqlserverSchemaDialectTest extends TestCase
     /**
      * Helper method for testing methods.
      */
-    protected function _createTables(ConnectionInterface $connection): void
+    protected function createTables(ConnectionInterface $connection): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
 
         $connection->execute("IF OBJECT_ID('schema_articles_v', 'V') IS NOT NULL DROP VIEW schema_articles_v");
         $connection->execute("IF OBJECT_ID('schema_articles', 'U') IS NOT NULL DROP TABLE schema_articles");
@@ -233,7 +233,7 @@ SQL;
     #[DataProvider('convertColumnProvider')]
     public function testConvertColumn(string $type, array $expected): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('test');
         $sql = <<<SQL
@@ -262,7 +262,7 @@ SQL;
     public function testListTables(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
         $schema = new SchemaCollection($connection);
 
         $result = $schema->listTables();
@@ -283,7 +283,7 @@ SQL;
     public function testDescribeTable(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $dialect = $connection->getDriver()->schemaDialect();
         $result = $dialect->describe('schema_articles');
@@ -457,7 +457,7 @@ SQL;
      */
     public function testDescribeTableCompositeKey(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection = ConnectionManager::get('test');
         $sql = <<<SQL
 CREATE TABLE schema_composite (
@@ -483,7 +483,7 @@ SQL;
     public function testDescribeWithSchemaName(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('dbo.schema_articles');
@@ -497,7 +497,7 @@ SQL;
     public function testDescribeTableIndexes(): void
     {
         $connection = ConnectionManager::get('test');
-        $this->_createTables($connection);
+        $this->createTables($connection);
 
         $dialect = $connection->getDriver()->schemaDialect();
         $result = $dialect->describe('schema_articles');
@@ -587,7 +587,7 @@ SQL;
      */
     public function testDescribeIndexIncludedFields(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
         $connection = ConnectionManager::get('test');
         $sql = <<<SQL
 CREATE TABLE schema_index_include (
@@ -915,7 +915,7 @@ SQL;
     #[DataProvider('columnSqlProvider')]
     public function testColumnSql(string $name, array $data, string $expected): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $schema = new SqlserverSchemaDialect($driver);
 
         $table = new TableSchema('schema_articles')->addColumn($name, $data);
@@ -982,7 +982,7 @@ SQL;
     #[DataProvider('constraintSqlProvider')]
     public function testConstraintSql(string $name, array $data, string $expected): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $schema = new SqlserverSchemaDialect($driver);
 
         $table = new TableSchema('schema_articles')->addColumn('title', [
@@ -1000,7 +1000,7 @@ SQL;
      */
     public function testAddConstraintSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1049,7 +1049,7 @@ SQL;
      */
     public function testDropConstraintSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1120,7 +1120,7 @@ SQL;
     #[DataProvider('indexSqlProvider')]
     public function testIndexSql(string $name, array $data, string $expected): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $schema = new SqlserverSchemaDialect($driver);
 
         $table = new TableSchema('schema_articles')->addColumn('title', [
@@ -1138,7 +1138,7 @@ SQL;
      */
     public function testCreateSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1212,7 +1212,7 @@ SQL;
      */
     public function testDropSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1230,7 +1230,7 @@ SQL;
      */
     public function testTruncateSql(): void
     {
-        $driver = $this->_getMockedDriver();
+        $driver = $this->getMockedDriver();
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1255,7 +1255,7 @@ SQL;
 
     public function testCreateTableColumnComment(): void
     {
-        $this->_needsConnection();
+        $this->needsConnection();
 
         $columns = [
             'id' => [
@@ -1297,9 +1297,9 @@ SQL;
     /**
      * Get a schema instance with a mocked driver/pdo instances
      */
-    protected function _getMockedDriver(): Driver
+    protected function getMockedDriver(): Driver
     {
-        $this->_needsConnection();
+        $this->needsConnection();
 
         $mock = $this->getMockBuilder(PDO::class)
             ->onlyMethods(['quote'])

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -83,7 +83,7 @@ trait PaginatorTestTrait
     #[AllowMockObjectsWithoutExpectations]
     public function testPageParamCasting(): void
     {
-        $query = $this->_getMockFindQuery();
+        $query = $this->getMockFindQuery();
 
         $post = $this->createStub(RepositoryInterface::class);
         $post->method('getAlias')->willReturn('Posts');
@@ -109,8 +109,8 @@ trait PaginatorTestTrait
                 'order' => ['PaginatorPosts.id' => 'ASC'],
             ],
         ];
-        $table = $this->_getMockPosts(['selectQuery']);
-        $query = $this->_getMockFindQuery();
+        $table = $this->getMockPosts(['selectQuery']);
+        $query = $this->getMockFindQuery();
 
         $table->expects($this->once())
             ->method('selectQuery')
@@ -184,8 +184,8 @@ trait PaginatorTestTrait
             'maxLimit' => 10,
         ];
 
-        $table = $this->_getMockPosts(['selectQuery']);
-        $query = $this->_getMockFindQuery();
+        $table = $this->getMockPosts(['selectQuery']);
+        $query = $this->getMockFindQuery();
 
         $table->expects($this->once())
             ->method('selectQuery')
@@ -214,8 +214,8 @@ trait PaginatorTestTrait
             'order' => ['PaginatorPosts.id' => 'DESC', 'PaginatorPosts.title' => 'ASC'],
         ];
 
-        $table = $this->_getMockPosts(['selectQuery']);
-        $query = $this->_getMockFindQuery();
+        $table = $this->getMockPosts(['selectQuery']);
+        $query = $this->getMockFindQuery();
 
         $table->expects($this->once())
             ->method('selectQuery')
@@ -246,8 +246,8 @@ trait PaginatorTestTrait
             'maxLimit' => 10,
         ];
 
-        $table = $this->_getMockPosts(['selectQuery']);
-        $query = $this->_getMockFindQuery();
+        $table = $this->getMockPosts(['selectQuery']);
+        $query = $this->getMockFindQuery();
 
         $table->expects($this->once())
             ->method('selectQuery')
@@ -604,8 +604,8 @@ trait PaginatorTestTrait
      */
     public function testValidateSortInvalid(): void
     {
-        $table = $this->_getMockPosts(['selectQuery']);
-        $query = $this->_getMockFindQuery();
+        $table = $this->getMockPosts(['selectQuery']);
+        $query = $this->getMockFindQuery();
 
         $table->expects($this->once())
             ->method('selectQuery')
@@ -650,8 +650,8 @@ trait PaginatorTestTrait
      */
     public function testValidaSortInitialSortAndDirection(): void
     {
-        $table = $this->_getMockPosts(['selectQuery']);
-        $query = $this->_getMockFindQuery();
+        $table = $this->getMockPosts(['selectQuery']);
+        $query = $this->getMockFindQuery();
 
         $table->expects($this->once())
             ->method('selectQuery')
@@ -683,8 +683,8 @@ trait PaginatorTestTrait
      */
     public function testValidateSortAndDirectionAliased(): void
     {
-        $table = $this->_getMockPosts(['selectQuery']);
-        $query = $this->_getMockFindQuery();
+        $table = $this->getMockPosts(['selectQuery']);
+        $query = $this->getMockFindQuery();
 
         $table->expects($this->once())
             ->method('selectQuery')
@@ -725,8 +725,8 @@ trait PaginatorTestTrait
      */
     public function testValidateSortRetainsOriginalSortValue(): void
     {
-        $table = $this->_getMockPosts(['selectQuery']);
-        $query = $this->_getMockFindQuery();
+        $table = $this->getMockPosts(['selectQuery']);
+        $query = $this->getMockFindQuery();
 
         $table->expects($this->once())
             ->method('selectQuery')
@@ -1147,8 +1147,8 @@ trait PaginatorTestTrait
                 'order' => ['PaginatorPosts.id' => 'ASC'],
             ],
         ];
-        $table = $this->_getMockPosts(['find']);
-        $query = $this->_getMockFindQuery($table);
+        $table = $this->getMockPosts(['find']);
+        $query = $this->getMockFindQuery($table);
         $table->expects($this->never())->method('find');
         $query->expects($this->once())
             ->method('applyOptions')
@@ -1194,8 +1194,8 @@ trait PaginatorTestTrait
                 'order' => ['PaginatorPosts.id' => 'ASC'],
             ],
         ];
-        $table = $this->_getMockPosts(['find']);
-        $query = $this->_getMockFindQuery($table);
+        $table = $this->getMockPosts(['find']);
+        $query = $this->getMockFindQuery($table);
         $query->limit(2);
         $table->expects($this->never())->method('find');
         $query->expects($this->once())
@@ -1214,7 +1214,7 @@ trait PaginatorTestTrait
      * @param array $methods
      * @return \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function _getMockPosts($methods = [])
+    protected function getMockPosts($methods = [])
     {
         return $this->getMockBuilder(PaginatorPostsTable::class)
             ->onlyMethods($methods)
@@ -1239,7 +1239,7 @@ trait PaginatorTestTrait
      * @param string|null $table
      * @return \Cake\ORM\Query\SelectQuery|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function _getMockFindQuery($table = null)
+    protected function getMockFindQuery($table = null)
     {
         /** @var \Cake\ORM\Query\SelectQuery|\PHPUnit\Framework\MockObject\MockObject $query */
         $query = $this->getMockBuilder(SelectQuery::class)

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -608,7 +608,7 @@ TEXT;
         );
     }
 
-    protected function _makeException(): RuntimeException
+    protected function makeException(): RuntimeException
     {
         return new RuntimeException('testing');
     }
@@ -619,7 +619,7 @@ TEXT;
     public function testGetUniqueFrames(): void
     {
         $parent = new RuntimeException('parent');
-        $child = $this->_makeException();
+        $child = $this->makeException();
 
         $result = Debugger::getUniqueFrames($child, $parent);
         $this->assertCount(1, $result);

--- a/tests/TestCase/Http/Middleware/CspMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CspMiddlewareTest.php
@@ -33,7 +33,7 @@ class CspMiddlewareTest extends TestCase
     /**
      * Provides the request handler
      */
-    protected function _getRequestHandler(): RequestHandlerInterface
+    protected function getRequestHandler(): RequestHandlerInterface
     {
         return new TestRequestHandler(function ($request) {
             return new Response();
@@ -58,7 +58,7 @@ class CspMiddlewareTest extends TestCase
             ],
         ]);
 
-        $response = $middleware->process($request, $this->_getRequestHandler());
+        $response = $middleware->process($request, $this->getRequestHandler());
         $policy = $response->getHeaderLine('Content-Security-Policy');
 
         $expected = "script-src 'self' https://www.google-analytics.com";
@@ -131,7 +131,7 @@ class CspMiddlewareTest extends TestCase
         $cspBuilder = new CSPBuilder($config);
         $middleware = new CspMiddleware($cspBuilder);
 
-        $response = $middleware->process($request, $this->_getRequestHandler());
+        $response = $middleware->process($request, $this->getRequestHandler());
         $policy = $response->getHeaderLine('Content-Security-Policy');
         $expected = "script-src 'self' https://www.google-analytics.com";
 

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -75,7 +75,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
     /**
      * Provides the request handler
      */
-    protected function _getRequestHandler(): RequestHandlerInterface
+    protected function getRequestHandler(): RequestHandlerInterface
     {
         return new TestRequestHandler(function () {
             return new Response();
@@ -190,7 +190,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
         // No exception means the test is valid
         $middleware = new CsrfProtectionMiddleware();
-        $response = $middleware->process($request, $this->_getRequestHandler());
+        $response = $middleware->process($request, $this->getRequestHandler());
         $this->assertInstanceOf(Response::class, $response);
     }
 
@@ -210,7 +210,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
         $middleware = new CsrfProtectionMiddleware();
         /** @var \Cake\Http\Response $response */
-        $response = $middleware->process($request, $this->_getRequestHandler());
+        $response = $middleware->process($request, $this->getRequestHandler());
         $this->assertInstanceOf(Response::class, $response);
         $this->assertGreaterThan(32, strlen($response->getCookie('csrfToken')['value']));
     }
@@ -286,7 +286,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $response = new Response();
 
         // No exception means the test is valid
-        $response = $middleware->process($request, $this->_getRequestHandler());
+        $response = $middleware->process($request, $this->getRequestHandler());
         $this->assertInstanceOf(Response::class, $response);
     }
 
@@ -310,7 +310,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $response = new Response();
 
         // No exception means the test is valid
-        $response = $middleware->process($request, $this->_getRequestHandler());
+        $response = $middleware->process($request, $this->getRequestHandler());
         $this->assertInstanceOf(Response::class, $response);
     }
 
@@ -332,7 +332,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $middleware = new CsrfProtectionMiddleware();
 
         try {
-            $middleware->process($request, $this->_getRequestHandler());
+            $middleware->process($request, $this->getRequestHandler());
 
             $this->fail();
         } catch (InvalidCsrfTokenException $exception) {
@@ -417,7 +417,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
             'cookies' => ['csrfToken' => ["\x20\x26"]],
         ]);
         $middleware = new CsrfProtectionMiddleware();
-        $middleware->process($request, $this->_getRequestHandler());
+        $middleware->process($request, $this->getRequestHandler());
     }
 
     /**
@@ -437,7 +437,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
             'cookies' => ['csrfToken' => '*(&'],
         ]);
         $middleware = new CsrfProtectionMiddleware();
-        $middleware->process($request, $this->_getRequestHandler());
+        $middleware->process($request, $this->getRequestHandler());
     }
 
     /**
@@ -454,7 +454,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
             'cookies' => ['csrfToken' => ['nope']],
         ]);
         $middleware = new CsrfProtectionMiddleware();
-        $middleware->process($request, $this->_getRequestHandler());
+        $middleware->process($request, $this->getRequestHandler());
     }
 
     /**
@@ -474,7 +474,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $middleware = new CsrfProtectionMiddleware();
 
         try {
-            $middleware->process($request, $this->_getRequestHandler());
+            $middleware->process($request, $this->getRequestHandler());
 
             $this->fail();
         } catch (InvalidCsrfTokenException $exception) {
@@ -503,7 +503,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $middleware = new CsrfProtectionMiddleware();
 
         $this->expectException(InvalidCsrfTokenException::class);
-        $middleware->process($request, $this->_getRequestHandler());
+        $middleware->process($request, $this->getRequestHandler());
     }
 
     /**
@@ -521,7 +521,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
         $middleware = new CsrfProtectionMiddleware();
         $this->expectException(InvalidCsrfTokenException::class);
-        $middleware->process($request, $this->_getRequestHandler());
+        $middleware->process($request, $this->getRequestHandler());
     }
 
     /**
@@ -541,7 +541,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $middleware = new CsrfProtectionMiddleware();
 
         try {
-            $middleware->process($request, $this->_getRequestHandler());
+            $middleware->process($request, $this->getRequestHandler());
 
             $this->fail();
         } catch (InvalidCsrfTokenException $exception) {
@@ -567,7 +567,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
             'httponly' => true,
             'samesite' => CookieInterface::SAMESITE_STRICT,
         ]);
-        $response = $middleware->process($request, $this->_getRequestHandler());
+        $response = $middleware->process($request, $this->getRequestHandler());
 
         $this->assertEmpty($response->getCookie('csrfToken'));
         $cookie = $response->getCookie('token');
@@ -600,7 +600,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
         ]);
         $response = new Response();
 
-        $response = $middleware->process($request, $this->_getRequestHandler());
+        $response = $middleware->process($request, $this->getRequestHandler());
         $this->assertInstanceOf(Response::class, $response);
     }
 

--- a/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
@@ -61,7 +61,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
     /**
      * Provides the request handler
      */
-    protected function _getRequestHandler(): RequestHandlerInterface
+    protected function getRequestHandler(): RequestHandlerInterface
     {
         return new TestRequestHandler(function () {
             return new Response();
@@ -115,7 +115,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
 
         // No exception means the test is valid
         $middleware = new SessionCsrfProtectionMiddleware();
-        $response = $middleware->process($request, $this->_getRequestHandler());
+        $response = $middleware->process($request, $this->getRequestHandler());
         $this->assertInstanceOf(Response::class, $response);
     }
 
@@ -140,7 +140,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
         $response = new Response();
 
         // No exception means the test is valid
-        $response = $middleware->process($request, $this->_getRequestHandler());
+        $response = $middleware->process($request, $this->getRequestHandler());
         $this->assertInstanceOf(Response::class, $response);
     }
 
@@ -164,7 +164,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
         $response = new Response();
 
         // No exception means the test is valid
-        $response = $middleware->process($request, $this->_getRequestHandler());
+        $response = $middleware->process($request, $this->getRequestHandler());
         $this->assertInstanceOf(Response::class, $response);
     }
 
@@ -186,7 +186,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
         $middleware = new SessionCsrfProtectionMiddleware();
 
         try {
-            $middleware->process($request, $this->_getRequestHandler());
+            $middleware->process($request, $this->getRequestHandler());
 
             $this->fail();
         } catch (InvalidCsrfTokenException) {
@@ -273,7 +273,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
         $middleware = new SessionCsrfProtectionMiddleware();
 
         $this->expectException(InvalidCsrfTokenException::class);
-        $middleware->process($request, $this->_getRequestHandler());
+        $middleware->process($request, $this->getRequestHandler());
     }
 
     /**
@@ -291,7 +291,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
 
         $middleware = new SessionCsrfProtectionMiddleware();
         $this->expectException(InvalidCsrfTokenException::class);
-        $middleware->process($request, $this->_getRequestHandler());
+        $middleware->process($request, $this->getRequestHandler());
     }
 
     /**
@@ -311,7 +311,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
         $middleware = new SessionCsrfProtectionMiddleware();
 
         try {
-            $middleware->process($request, $this->_getRequestHandler());
+            $middleware->process($request, $this->getRequestHandler());
 
             $this->fail();
         } catch (InvalidCsrfTokenException) {
@@ -333,7 +333,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
         $middleware = new SessionCsrfProtectionMiddleware([
             'key' => 'csrf',
         ]);
-        $middleware->process($request, $this->_getRequestHandler());
+        $middleware->process($request, $this->getRequestHandler());
 
         $session = $request->getSession();
         $this->assertEmpty($session->read('csrfToken'));
@@ -360,7 +360,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
         ]);
         $request->getSession()->write('csrf', $token);
 
-        $response = $middleware->process($request, $this->_getRequestHandler());
+        $response = $middleware->process($request, $this->getRequestHandler());
         $this->assertInstanceOf(Response::class, $response);
     }
 

--- a/tests/TestCase/Log/Engine/FileLogTest.php
+++ b/tests/TestCase/Log/Engine/FileLogTest.php
@@ -31,7 +31,7 @@ class FileLogTest extends TestCase
      */
     public function testLogFileWriting(): void
     {
-        $this->_deleteLogs(LOGS);
+        $this->deleteLogs(LOGS);
 
         $log = new FileLog(['path' => LOGS]);
         $log->log('warning', 'Test warning');
@@ -59,7 +59,7 @@ class FileLogTest extends TestCase
     public function testPathSetting(): void
     {
         $path = TMP . 'tests' . DS;
-        $this->_deleteLogs($path);
+        $this->deleteLogs($path);
 
         $log = new FileLog(compact('path'));
         $log->log('warning', 'Test warning');
@@ -72,7 +72,7 @@ class FileLogTest extends TestCase
     public function testRotation(): void
     {
         $path = TMP . 'tests' . DS;
-        $this->_deleteLogs($path);
+        $this->deleteLogs($path);
 
         file_put_contents($path . 'error.log', "this text is under 35 bytes\n");
         $log = new FileLog([
@@ -155,7 +155,7 @@ class FileLogTest extends TestCase
         }
 
         $path = TMP . 'tests' . DS;
-        $this->_deleteLogs($path);
+        $this->deleteLogs($path);
 
         $log = new FileLog(['path' => $path, 'mask' => 0666]);
         $log->log('warning', 'Test warning one');
@@ -184,7 +184,7 @@ class FileLogTest extends TestCase
      *
      * @param string $dir
      */
-    protected function _deleteLogs($dir): void
+    protected function deleteLogs($dir): void
     {
         $files = array_merge(glob($dir . '*.log'), glob($dir . '*.log.*'));
         foreach ($files as $file) {
@@ -197,7 +197,7 @@ class FileLogTest extends TestCase
      */
     public function testDateFormat(): void
     {
-        $this->_deleteLogs(LOGS);
+        $this->deleteLogs(LOGS);
 
         // 'c': ISO 8601 date (added in PHP 5)
         $log = new FileLog(['path' => LOGS, 'formatter.dateFormat' => 'c']);

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -214,7 +214,7 @@ class LogTest extends TestCase
      */
     public function testLogFileWriting(): void
     {
-        $this->_resetLogConfig();
+        $this->resetLogConfig();
         if (file_exists(LOGS . 'error.log')) {
             unlink(LOGS . 'error.log');
         }
@@ -323,7 +323,7 @@ class LogTest extends TestCase
         }
     }
 
-    protected function _resetLogConfig(): void
+    protected function resetLogConfig(): void
     {
         Log::setConfig('debug', [
             'engine' => 'File',
@@ -339,7 +339,7 @@ class LogTest extends TestCase
         ]);
     }
 
-    protected function _deleteLogs(): void
+    protected function deleteLogs(): void
     {
         if (file_exists(LOGS . 'shops.log')) {
             unlink(LOGS . 'shops.log');
@@ -366,8 +366,8 @@ class LogTest extends TestCase
      */
     public function testScopedLogging(): void
     {
-        $this->_deleteLogs();
-        $this->_resetLogConfig();
+        $this->deleteLogs();
+        $this->resetLogConfig();
         Log::setConfig('shops', [
             'engine' => 'File',
             'path' => LOGS,
@@ -381,21 +381,21 @@ class LogTest extends TestCase
         $this->assertFileExists(LOGS . 'shops.log');
         $this->assertFileExists(LOGS . 'debug.log');
 
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         Log::write('warning', 'warning message', 'orders');
         $this->assertFileExists(LOGS . 'error.log');
         $this->assertFileExists(LOGS . 'shops.log');
         $this->assertFileDoesNotExist(LOGS . 'debug.log');
 
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         Log::write('error', 'error message', ['scope' => 'orders']);
         $this->assertFileExists(LOGS . 'error.log');
         $this->assertFileDoesNotExist(LOGS . 'debug.log');
         $this->assertFileDoesNotExist(LOGS . 'shops.log');
 
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         Log::drop('shops');
     }
@@ -405,7 +405,7 @@ class LogTest extends TestCase
      */
     public function testScopedLoggingStrict(): void
     {
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         Log::setConfig('debug', [
             'engine' => 'File',
@@ -426,13 +426,13 @@ class LogTest extends TestCase
         $this->assertFileDoesNotExist(LOGS . 'shops.log');
         $this->assertFileExists(LOGS . 'debug.log');
 
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         Log::write('debug', 'debug message', 'orders');
         $this->assertFileExists(LOGS . 'shops.log');
         $this->assertFileDoesNotExist(LOGS . 'debug.log');
 
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         Log::drop('shops');
     }
@@ -452,7 +452,7 @@ class LogTest extends TestCase
             unlink(LOGS . 'debug.log');
         }
 
-        $this->_resetLogConfig();
+        $this->resetLogConfig();
         Log::setConfig('shops', [
             'engine' => 'File',
             'path' => LOGS,
@@ -466,21 +466,21 @@ class LogTest extends TestCase
         $this->assertFileExists(LOGS . 'shops.log');
         $this->assertFileExists(LOGS . 'debug.log');
 
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         Log::error('error message', 'orders');
         $this->assertFileExists(LOGS . 'error.log');
         $this->assertFileDoesNotExist(LOGS . 'debug.log');
         $this->assertFileDoesNotExist(LOGS . 'shops.log');
 
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         Log::warning('warning message', 'orders');
         $this->assertFileExists(LOGS . 'error.log');
         $this->assertFileExists(LOGS . 'shops.log');
         $this->assertFileDoesNotExist(LOGS . 'debug.log');
 
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         Log::drop('shops');
     }
@@ -490,7 +490,7 @@ class LogTest extends TestCase
      */
     public function testScopedLoggingExclusive(): void
     {
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         Log::setConfig('shops', [
             'engine' => 'File',
@@ -511,7 +511,7 @@ class LogTest extends TestCase
         $this->assertFileDoesNotExist(LOGS . 'eggs.log');
         $this->assertFileExists(LOGS . 'shops.log');
 
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         Log::write('debug', 'eggs message', ['scope' => ['eggs']]);
         $this->assertFileExists(LOGS . 'eggs.log');
@@ -553,7 +553,7 @@ class LogTest extends TestCase
      */
     public function testConvenienceMethods(): void
     {
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         Log::setConfig('debug', [
             'engine' => 'File',
@@ -573,56 +573,56 @@ class LogTest extends TestCase
         $contents = file_get_contents(LOGS . 'error.log');
         $this->assertMatchesRegularExpression('/(emergency|critical): ' . $testMessage . '/', $contents);
         $this->assertFileDoesNotExist(LOGS . 'debug.log');
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         $testMessage = 'alert message';
         Log::alert($testMessage);
         $contents = file_get_contents(LOGS . 'error.log');
         $this->assertMatchesRegularExpression('/(alert|critical): ' . $testMessage . '/', $contents);
         $this->assertFileDoesNotExist(LOGS . 'debug.log');
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         $testMessage = 'critical message';
         Log::critical($testMessage);
         $contents = file_get_contents(LOGS . 'error.log');
         $this->assertStringContainsString('critical: ' . $testMessage, $contents);
         $this->assertFileDoesNotExist(LOGS . 'debug.log');
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         $testMessage = 'error message';
         Log::error($testMessage);
         $contents = file_get_contents(LOGS . 'error.log');
         $this->assertStringContainsString('error: ' . $testMessage, $contents);
         $this->assertFileDoesNotExist(LOGS . 'debug.log');
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         $testMessage = 'warning message';
         Log::warning($testMessage);
         $contents = file_get_contents(LOGS . 'error.log');
         $this->assertStringContainsString('warning: ' . $testMessage, $contents);
         $this->assertFileDoesNotExist(LOGS . 'debug.log');
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         $testMessage = 'notice message';
         Log::notice($testMessage);
         $contents = file_get_contents(LOGS . 'debug.log');
         $this->assertMatchesRegularExpression('/(notice|debug): ' . $testMessage . '/', $contents);
         $this->assertFileDoesNotExist(LOGS . 'error.log');
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         $testMessage = 'info message';
         Log::info($testMessage);
         $contents = file_get_contents(LOGS . 'debug.log');
         $this->assertMatchesRegularExpression('/(info|debug): ' . $testMessage . '/', $contents);
         $this->assertFileDoesNotExist(LOGS . 'error.log');
-        $this->_deleteLogs();
+        $this->deleteLogs();
 
         $testMessage = 'debug message';
         Log::debug($testMessage);
         $contents = file_get_contents(LOGS . 'debug.log');
         $this->assertStringContainsString('debug: ' . $testMessage, $contents);
         $this->assertFileDoesNotExist(LOGS . 'error.log');
-        $this->_deleteLogs();
+        $this->deleteLogs();
     }
 
     /**

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -1147,7 +1147,7 @@ class MailerTest extends TestCase
         $this->assertContains('Content-Type: text/html; charset=UTF-8', $message);
 
         // UTF-8 is 8bit
-        $this->assertTrue($this->_checkContentTransferEncoding($message, '8bit'));
+        $this->assertTrue($this->checkContentTransferEncoding($message, '8bit'));
 
         $this->mailer->setCharset('ISO-2022-JP');
         $this->mailer->send();
@@ -1156,7 +1156,7 @@ class MailerTest extends TestCase
         $this->assertContains('Content-Type: text/html; charset=ISO-2022-JP', $message);
 
         // ISO-2022-JP is 7bit
-        $this->assertTrue($this->_checkContentTransferEncoding($message, '7bit'));
+        $this->assertTrue($this->checkContentTransferEncoding($message, '7bit'));
     }
 
     /**
@@ -1320,7 +1320,7 @@ class MailerTest extends TestCase
     /**
      * @param array|string $message
      */
-    protected function _checkContentTransferEncoding($message, string $charset): bool
+    protected function checkContentTransferEncoding($message, string $charset): bool
     {
         $boundary = '--' . $this->mailer->getBoundary();
         $result['text'] = false;

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -1239,10 +1239,10 @@ HTML;
 
         // Header Charset : null (used by default UTF-8)
         //   Body Charset : ISO-2022-JP
-        $oldStyleEmail = $this->_getEmailByOldStyleCharset('iso-2022-jp', null);
+        $oldStyleEmail = $this->getEmailByOldStyleCharset('iso-2022-jp', null);
         $oldStyleHeaders = $oldStyleEmail->getHeaders($checkHeaders);
 
-        $newStyleEmail = $this->_getEmailByNewStyleCharset('iso-2022-jp', null);
+        $newStyleEmail = $this->getEmailByNewStyleCharset('iso-2022-jp', null);
         $newStyleHeaders = $newStyleEmail->getHeaders($checkHeaders);
 
         $this->assertSame($oldStyleHeaders['From'], $newStyleHeaders['From']);
@@ -1252,10 +1252,10 @@ HTML;
 
         // Header Charset : UTF-8
         //   Boby Charset : ISO-2022-JP
-        $oldStyleEmail = $this->_getEmailByOldStyleCharset('iso-2022-jp', 'utf-8');
+        $oldStyleEmail = $this->getEmailByOldStyleCharset('iso-2022-jp', 'utf-8');
         $oldStyleHeaders = $oldStyleEmail->getHeaders($checkHeaders);
 
-        $newStyleEmail = $this->_getEmailByNewStyleCharset('iso-2022-jp', 'utf-8');
+        $newStyleEmail = $this->getEmailByNewStyleCharset('iso-2022-jp', 'utf-8');
         $newStyleHeaders = $newStyleEmail->getHeaders($checkHeaders);
 
         $this->assertSame($oldStyleHeaders['From'], $newStyleHeaders['From']);
@@ -1265,10 +1265,10 @@ HTML;
 
         // Header Charset : ISO-2022-JP
         //   Boby Charset : UTF-8
-        $oldStyleEmail = $this->_getEmailByOldStyleCharset('utf-8', 'iso-2022-jp');
+        $oldStyleEmail = $this->getEmailByOldStyleCharset('utf-8', 'iso-2022-jp');
         $oldStyleHeaders = $oldStyleEmail->getHeaders($checkHeaders);
 
-        $newStyleEmail = $this->_getEmailByNewStyleCharset('utf-8', 'iso-2022-jp');
+        $newStyleEmail = $this->getEmailByNewStyleCharset('utf-8', 'iso-2022-jp');
         $newStyleHeaders = $newStyleEmail->getHeaders($checkHeaders);
 
         $this->assertSame($oldStyleHeaders['From'], $newStyleHeaders['From']);
@@ -1281,7 +1281,7 @@ HTML;
      * @param mixed $charset
      * @param mixed $headerCharset
      */
-    protected function _getEmailByOldStyleCharset($charset, $headerCharset): Message
+    protected function getEmailByOldStyleCharset($charset, $headerCharset): Message
     {
         $message = new Message(['transport' => 'debug']);
 
@@ -1305,7 +1305,7 @@ HTML;
      * @param mixed $charset
      * @param mixed $headerCharset
      */
-    protected function _getEmailByNewStyleCharset($charset, $headerCharset): Message
+    protected function getEmailByNewStyleCharset($charset, $headerCharset): Message
     {
         $message = new Message();
 

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -334,7 +334,7 @@ class SocketTest extends TestCase
     /**
      * _connectSocketToSslTls
      */
-    protected function _connectSocketToSslTls(): void
+    protected function connectSocketToSslTls(): void
     {
         $this->skipIf(!extension_loaded('openssl'), 'OpenSSL is not enabled cannot test SSL.');
         $configSslTls = ['host' => 'smtp.gmail.com', 'port' => 465, 'timeout' => 5];
@@ -353,7 +353,7 @@ class SocketTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         // testing wrong encryption mode
-        $this->_connectSocketToSslTls();
+        $this->connectSocketToSslTls();
         $this->Socket->enableCrypto('doesntExistMode', 'server');
         $this->Socket->disconnect();
     }
@@ -363,7 +363,7 @@ class SocketTest extends TestCase
      */
     public function testEnableCrypto(): void
     {
-        $this->_connectSocketToSslTls();
+        $this->connectSocketToSslTls();
         $this->Socket->enableCrypto('tls', 'client');
         $result = $this->Socket->disconnect();
         $this->assertTrue($result);
@@ -376,7 +376,7 @@ class SocketTest extends TestCase
     {
         $this->expectException(SocketException::class);
         // testing on tls server
-        $this->_connectSocketToSslTls();
+        $this->connectSocketToSslTls();
         $this->Socket->enableCrypto('tls', 'client');
         $this->expectWarningMessageMatches('/^Unable to perform enableCrypto operation on the current socket$/', function (): void {
             $this->Socket->enableCrypto('tls', 'client');
@@ -389,7 +389,7 @@ class SocketTest extends TestCase
     public function testEnableCryptoExceptionDisableTwice(): void
     {
         $this->expectException(SocketException::class);
-        $this->_connectSocketToSslTls();
+        $this->connectSocketToSslTls();
         $this->Socket->enableCrypto('tls', 'client', false);
     }
 
@@ -398,7 +398,7 @@ class SocketTest extends TestCase
      */
     public function testEnableCryptoEnableTls12(): void
     {
-        $this->_connectSocketToSslTls();
+        $this->connectSocketToSslTls();
         $this->assertFalse($this->Socket->isEncrypted());
         $this->Socket->enableCrypto('tlsv12', 'client', true);
         $this->assertTrue($this->Socket->isEncrypted());
@@ -409,7 +409,7 @@ class SocketTest extends TestCase
      */
     public function testEnableCryptoEnableStatus(): void
     {
-        $this->_connectSocketToSslTls();
+        $this->connectSocketToSslTls();
         $this->assertFalse($this->Socket->isEncrypted());
         $this->Socket->enableCrypto('tls', 'client', true);
         $this->assertTrue($this->Socket->isEncrypted());

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -139,10 +139,10 @@ class CounterCacheBehaviorTest extends TestCase
             ],
         ]);
 
-        $before = $this->_getUser();
-        $entity = $this->_getEntity();
+        $before = $this->getUser();
+        $entity = $this->getEntity();
         $this->post->save($entity);
-        $after = $this->_getUser();
+        $after = $this->getUser();
 
         $this->assertSame(2, $before->get('post_count'));
         $this->assertSame(3, $after->get('post_count'));
@@ -161,10 +161,10 @@ class CounterCacheBehaviorTest extends TestCase
             ],
         ]);
 
-        $before = $this->_getUser();
-        $entity = $this->_getEntity();
+        $before = $this->getUser();
+        $entity = $this->getEntity();
         $this->post->save($entity, ['ignoreCounterCache' => true]);
-        $after = $this->_getUser();
+        $after = $this->getUser();
 
         $this->assertSame(2, $before->get('post_count'));
         $this->assertSame(2, $after->get('post_count'));
@@ -187,10 +187,10 @@ class CounterCacheBehaviorTest extends TestCase
             ],
         ]);
 
-        $before = $this->_getUser();
-        $entity = $this->_getEntity()->set('published', true);
+        $before = $this->getUser();
+        $entity = $this->getEntity()->set('published', true);
         $this->post->save($entity);
-        $after = $this->_getUser();
+        $after = $this->getUser();
 
         $this->assertSame(1, $before->get('posts_published'));
         $this->assertSame(2, $after->get('posts_published'));
@@ -227,10 +227,10 @@ class CounterCacheBehaviorTest extends TestCase
             ],
         ]);
 
-        $before = $this->_getUser();
+        $before = $this->getUser();
         $post = $this->post->find('all')->first();
         $this->post->delete($post);
-        $after = $this->_getUser();
+        $after = $this->getUser();
 
         $this->assertSame(2, $before->get('post_count'));
         $this->assertSame(1, $after->get('post_count'));
@@ -249,11 +249,11 @@ class CounterCacheBehaviorTest extends TestCase
             ],
         ]);
 
-        $before = $this->_getUser();
+        $before = $this->getUser();
         $post = $this->post->find('all')
             ->first();
         $this->post->delete($post, ['ignoreCounterCache' => true]);
-        $after = $this->_getUser();
+        $after = $this->getUser();
 
         $this->assertSame(2, $before->get('post_count'));
         $this->assertSame(2, $after->get('post_count'));
@@ -276,10 +276,10 @@ class CounterCacheBehaviorTest extends TestCase
             ],
         ]);
 
-        $user1 = $this->_getUser(1);
-        $user2 = $this->_getUser(2);
-        $category1 = $this->_getCategory(1);
-        $category2 = $this->_getCategory(2);
+        $user1 = $this->getUser(1);
+        $user2 = $this->getUser(2);
+        $category1 = $this->getCategory(1);
+        $category2 = $this->getCategory(2);
         $post = $this->post->find('all')->first();
         $this->assertSame(2, $user1->get('post_count'));
         $this->assertSame(1, $user2->get('post_count'));
@@ -289,10 +289,10 @@ class CounterCacheBehaviorTest extends TestCase
         $entity = $this->post->patchEntity($post, ['user_id' => 2, 'category_id' => 2]);
         $this->post->save($entity);
 
-        $user1 = $this->_getUser(1);
-        $user2 = $this->_getUser(2);
-        $category1 = $this->_getCategory(1);
-        $category2 = $this->_getCategory(2);
+        $user1 = $this->getUser(1);
+        $user2 = $this->getUser(2);
+        $category1 = $this->getCategory(1);
+        $category2 = $this->getCategory(2);
         $this->assertSame(1, $user1->get('post_count'));
         $this->assertSame(2, $user2->get('post_count'));
         $this->assertSame(0, $category1->get('post_count'));
@@ -301,16 +301,16 @@ class CounterCacheBehaviorTest extends TestCase
         $entity = $this->post->patchEntity($post, ['user_id' => null, 'category_id' => null]);
         $this->post->save($entity);
 
-        $user2 = $this->_getUser(2);
-        $category2 = $this->_getCategory(2);
+        $user2 = $this->getUser(2);
+        $category2 = $this->getCategory(2);
         $this->assertSame(1, $user2->get('post_count'));
         $this->assertSame(2, $category2->get('post_count'));
 
         $entity = $this->post->patchEntity($post, ['user_id' => 2, 'category_id' => 2]);
         $this->post->save($entity);
 
-        $user2 = $this->_getUser(2);
-        $category2 = $this->_getCategory(2);
+        $user2 = $this->getUser(2);
+        $category2 = $this->getCategory(2);
         $this->assertSame(2, $user2->get('post_count'));
         $this->assertSame(3, $category2->get('post_count'));
     }
@@ -330,10 +330,10 @@ class CounterCacheBehaviorTest extends TestCase
             ],
         ]);
 
-        $before = $this->_getUser();
-        $entity = $this->_getEntity()->set('published', true);
+        $before = $this->getUser();
+        $entity = $this->getEntity()->set('published', true);
         $this->post->save($entity);
-        $after = $this->_getUser();
+        $after = $this->getUser();
 
         $this->assertSame(1, $before->get('posts_published'));
         $this->assertSame(2, $after->get('posts_published'));
@@ -352,10 +352,10 @@ class CounterCacheBehaviorTest extends TestCase
             ],
         ]);
 
-        $before = $this->_getUser();
-        $entity = $this->_getEntity()->set('published', true);
+        $before = $this->getUser();
+        $entity = $this->getEntity()->set('published', true);
         $this->post->save($entity);
-        $after = $this->_getUser();
+        $after = $this->getUser();
 
         $this->assertSame(1, $before->get('posts_published'));
         $this->assertSame(2, $after->get('posts_published'));
@@ -369,7 +369,7 @@ class CounterCacheBehaviorTest extends TestCase
         $this->post->belongsTo('Users');
 
         $table = $this->post;
-        $entity = $this->_getEntity();
+        $entity = $this->getEntity();
 
         $this->post->addBehavior('CounterCache', [
             'Users' => [
@@ -382,9 +382,9 @@ class CounterCacheBehaviorTest extends TestCase
             ],
         ]);
 
-        $before = $this->_getUser();
+        $before = $this->getUser();
         $this->post->save($entity);
-        $after = $this->_getUser();
+        $after = $this->getUser();
 
         $this->assertSame(1, $before->get('posts_published'));
         $this->assertSame(2, $after->get('posts_published'));
@@ -398,7 +398,7 @@ class CounterCacheBehaviorTest extends TestCase
         $this->post->belongsTo('Users');
 
         $table = $this->post;
-        $entity = $this->_getEntity();
+        $entity = $this->getEntity();
 
         $this->post->addBehavior('CounterCache', [
             'Users' => [
@@ -411,9 +411,9 @@ class CounterCacheBehaviorTest extends TestCase
             ],
         ]);
 
-        $before = $this->_getUser();
+        $before = $this->getUser();
         $this->post->save($entity);
-        $after = $this->_getUser();
+        $after = $this->getUser();
 
         $this->assertSame(1, $before->get('posts_published'));
         $this->assertSame(1, $after->get('posts_published'));
@@ -427,7 +427,7 @@ class CounterCacheBehaviorTest extends TestCase
         $this->post->belongsTo('Users');
 
         $table = $this->post;
-        $entity = $this->_getEntity();
+        $entity = $this->getEntity();
 
         $this->post->addBehavior('CounterCache', [
             'Users' => [
@@ -445,11 +445,11 @@ class CounterCacheBehaviorTest extends TestCase
         ]);
 
         $this->post->save($entity);
-        $between = $this->_getUser();
+        $between = $this->getUser();
         $entity->user_id = 2;
         $this->post->save($entity);
-        $afterUser1 = $this->_getUser(1);
-        $afterUser2 = $this->_getUser(2);
+        $afterUser1 = $this->getUser(1);
+        $afterUser2 = $this->getUser(2);
 
         $this->assertSame(2, $between->get('posts_published'));
         $this->assertSame(1, $afterUser1->get('posts_published'));
@@ -471,10 +471,10 @@ class CounterCacheBehaviorTest extends TestCase
             ],
         ]);
 
-        $before = $this->_getUser();
-        $entity = $this->_getEntity();
+        $before = $this->getUser();
+        $entity = $this->getEntity();
         $this->post->save($entity);
-        $after = $this->_getUser();
+        $after = $this->getUser();
 
         $this->assertSame(1, $before->get('posts_published'));
         $this->assertSame(4, $after->get('posts_published'));
@@ -498,10 +498,10 @@ class CounterCacheBehaviorTest extends TestCase
             ],
         ]);
 
-        $before = $this->_getUser();
-        $entity = $this->_getEntity()->set('published', true);
+        $before = $this->getUser();
+        $entity = $this->getEntity()->set('published', true);
         $this->post->save($entity);
-        $after = $this->_getUser();
+        $after = $this->getUser();
 
         $this->assertSame(1, $before->get('posts_published'));
         $this->assertSame(2, $after->get('posts_published'));
@@ -527,7 +527,7 @@ class CounterCacheBehaviorTest extends TestCase
         $before = $this->userCategoryPosts->find()
             ->where(['user_id' => 1, 'category_id' => 2])
             ->first();
-        $entity = $this->_getEntity()->set('category_id', 2);
+        $entity = $this->getEntity()->set('category_id', 2);
         $this->post->save($entity);
         $after = $this->userCategoryPosts->find()
             ->where(['user_id' => 1, 'category_id' => 2])
@@ -556,7 +556,7 @@ class CounterCacheBehaviorTest extends TestCase
             ],
         ]);
 
-        $user = $this->_getUser(1);
+        $user = $this->getUser(1);
         $this->assertSame(2, $user->get('post_count'));
         $this->assertSame(2, $user->get('comment_count'));
         $this->assertSame(1, $user->get('posts_published'));
@@ -575,7 +575,7 @@ class CounterCacheBehaviorTest extends TestCase
         ]);
         $this->post->save($post);
 
-        $user = $this->_getUser(1);
+        $user = $this->getUser(1);
         $this->assertSame(10, $user->get('post_count'));
         $this->assertSame(10, $user->get('comment_count'));
         $this->assertSame(1, $user->get('posts_published'));
@@ -597,7 +597,7 @@ class CounterCacheBehaviorTest extends TestCase
             ],
         ]);
 
-        $user = $this->_getUser(1);
+        $user = $this->getUser(1);
         $this->assertSame(2, $user->get('post_count'));
         $this->assertSame(2, $user->get('comment_count'));
         $this->assertSame(1, $user->get('posts_published'));
@@ -615,7 +615,7 @@ class CounterCacheBehaviorTest extends TestCase
         ]);
         $this->post->save($post);
 
-        $user = $this->_getUser(1);
+        $user = $this->getUser(1);
         $this->assertSame(10, $user->get('post_count'));
         $this->assertSame(2, $user->get('comment_count'));
         $this->assertSame(1, $user->get('posts_published'));
@@ -635,30 +635,30 @@ class CounterCacheBehaviorTest extends TestCase
 
         $this->user->updateAll(['post_count' => 0], []);
 
-        $user = $this->_getUser(1);
+        $user = $this->getUser(1);
         $this->assertSame(0, $user->get('post_count'));
 
         $this->post->getBehavior('CounterCache')->updateCounterCache('Users');
 
-        $user = $this->_getUser(1);
+        $user = $this->getUser(1);
         $this->assertSame(2, $user->get('post_count'));
-        $user = $this->_getUser(2);
+        $user = $this->getUser(2);
         $this->assertSame(1, $user->get('post_count'));
 
         $this->user->updateAll(['post_count' => 0], []);
 
         $this->post->getBehavior('CounterCache')->updateCounterCache(limit: 1, page: 2);
 
-        $user = $this->_getUser(1);
+        $user = $this->getUser(1);
         $this->assertSame(0, $user->get('post_count'));
-        $user = $this->_getUser(2);
+        $user = $this->getUser(2);
         $this->assertSame(1, $user->get('post_count'));
     }
 
     /**
      * Get a new Entity
      */
-    protected function _getEntity(): Entity
+    protected function getEntity(): Entity
     {
         return new Entity([
             'title' => 'Test 123',
@@ -669,7 +669,7 @@ class CounterCacheBehaviorTest extends TestCase
     /**
      * Returns entity for user
      */
-    protected function _getUser(int $id = 1): Entity
+    protected function getUser(int $id = 1): Entity
     {
         return $this->user->get($id);
     }
@@ -677,7 +677,7 @@ class CounterCacheBehaviorTest extends TestCase
     /**
      * Returns entity for category
      */
-    protected function _getCategory(int $id = 1): Entity
+    protected function getCategory(int $id = 1): Entity
     {
         return $this->category->find('all')->where(['id' => $id])->first();
     }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -85,7 +85,7 @@ class TranslateBehaviorEavTest extends TestCase
      *
      * @param \Traversable|array $data
      */
-    protected function _extractTranslations($data): CollectionInterface
+    protected function extractTranslations($data): CollectionInterface
     {
         return new Collection($data)->map(function (EntityInterface $row) {
             $translations = $row->get('_translations');
@@ -497,7 +497,7 @@ class TranslateBehaviorEavTest extends TestCase
             ],
         ];
 
-        $translations = $this->_extractTranslations($results);
+        $translations = $this->extractTranslations($results);
         $this->assertEquals($expected, $translations->toArray());
         $expected = [
             1 => ['First Article' => 'First Article Body'],
@@ -513,7 +513,7 @@ class TranslateBehaviorEavTest extends TestCase
 
         $expected = [[]];
         $result = $table->find('translations')->where(['Articles.id' => $entity->id])->all();
-        $this->assertEquals($expected, $this->_extractTranslations($result)->toArray());
+        $this->assertEquals($expected, $this->extractTranslations($result)->toArray());
 
         $entity = $result->first();
         $this->assertSame('Fourth Title', $entity->title);
@@ -542,7 +542,7 @@ class TranslateBehaviorEavTest extends TestCase
             ],
         ];
 
-        $translations = $this->_extractTranslations($results);
+        $translations = $this->extractTranslations($results);
         $this->assertEquals($expected, $translations->toArray());
 
         $expected = [
@@ -603,7 +603,7 @@ class TranslateBehaviorEavTest extends TestCase
             ],
         ];
 
-        $translations = $this->_extractTranslations($results);
+        $translations = $this->extractTranslations($results);
         $this->assertEquals($expected, $translations->toArray());
 
         $expected = [
@@ -686,7 +686,7 @@ class TranslateBehaviorEavTest extends TestCase
             ],
         ];
 
-        $translations = $this->_extractTranslations($comments);
+        $translations = $this->extractTranslations($comments);
         $this->assertEquals($expected, $translations->toArray());
     }
 
@@ -735,7 +735,7 @@ class TranslateBehaviorEavTest extends TestCase
                 'spa' => ['comment' => 'Comentario #4', 'locale' => 'spa'],
             ],
         ];
-        $translations = $this->_extractTranslations($comments);
+        $translations = $this->extractTranslations($comments);
         $this->assertEquals($expected, $translations->toArray());
 
         $this->assertSame('Titulek #1', $results->first()->title);
@@ -1488,7 +1488,7 @@ class TranslateBehaviorEavTest extends TestCase
             ],
         ];
         $result = $table->find('translations')->where(['Articles.id' => $result->id])->all();
-        $this->assertEquals($expected, $this->_extractTranslations($result)->toArray());
+        $this->assertEquals($expected, $this->extractTranslations($result)->toArray());
 
         $entity = $result->first();
         $this->assertSame('Title EN', $entity->title);
@@ -1539,7 +1539,7 @@ class TranslateBehaviorEavTest extends TestCase
             ],
         ];
         $result = $table->find('translations')->where(['id' => $result->id]);
-        $this->assertEquals($expected, $this->_extractTranslations($result)->toArray());
+        $this->assertEquals($expected, $this->extractTranslations($result)->toArray());
     }
 
     /**
@@ -1565,7 +1565,7 @@ class TranslateBehaviorEavTest extends TestCase
 
         $this->assertNotFalse($table->save($article));
 
-        $results = $this->_extractTranslations(
+        $results = $this->extractTranslations(
             $table->find('translations')->where(['id' => 1]),
         )->first();
 
@@ -1603,7 +1603,7 @@ class TranslateBehaviorEavTest extends TestCase
 
         $this->assertNotFalse($table->save($article));
 
-        $results = $this->_extractTranslations(
+        $results = $this->extractTranslations(
             $table->find('translations')->where(['id' => 1]),
         )->first();
 

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -97,7 +97,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         ];
         $this->assertEquals($expected, $config, 'Used aliases should match the main table object');
 
-        $this->_testFind();
+        $this->testFind();
     }
 
     /**
@@ -134,7 +134,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
             'It should be a different object to the one in the no-plugin prefix',
         );
 
-        $this->_testFind('SomeRandomPlugin.Articles');
+        $this->testFind('SomeRandomPlugin.Articles');
     }
 
     /**
@@ -709,7 +709,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
             ],
         ];
 
-        $translations = $this->_extractTranslations($results);
+        $translations = $this->extractTranslations($results);
         $this->assertEquals($expected, $translations->toArray());
         $expected = [
             1 => ['First Article' => 'First Article Body'],
@@ -725,7 +725,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
 
         $expected = [[]];
         $result = $table->find('translations')->where(['Articles.id' => $entity->id])->all();
-        $this->assertEquals($expected, $this->_extractTranslations($result)->toArray());
+        $this->assertEquals($expected, $this->extractTranslations($result)->toArray());
 
         $entity = $result->first();
         $this->assertSame('Fourth Title', $entity->title);
@@ -900,7 +900,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
 
         $this->assertNotFalse($table->save($article));
 
-        $results = $this->_extractTranslations(
+        $results = $this->extractTranslations(
             $table->find('translations')->where(['id' => 1]),
         )->first();
 
@@ -971,7 +971,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
             ],
         ];
         $result = $table->find('translations')->where(['Articles.id' => $result->id])->all();
-        $this->assertEquals($expected, $this->_extractTranslations($result)->toArray());
+        $this->assertEquals($expected, $this->extractTranslations($result)->toArray());
 
         $entity = $result->first();
         $this->assertSame('Title EN', $entity->title);
@@ -1192,7 +1192,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
      *
      * @param string $tableAlias
      */
-    protected function _testFind($tableAlias = 'Articles'): void
+    protected function testFind($tableAlias = 'Articles'): void
     {
         $table = $this->getTableLocator()->get($tableAlias);
         $table->getBehavior('Translate')->setLocale('eng');

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -453,7 +453,7 @@ class EagerLoaderTest extends TestCase
             'orders__id' => 'orders.id', 'orders__total' => 'orders.total',
             'orders__placed' => 'orders.placed',
         ];
-        $expected = $this->_quoteArray($expected);
+        $expected = $this->quoteArray($expected);
         $this->assertEquals($expected, $select);
 
         $contains['clients']['fields'] = ['name'];
@@ -466,7 +466,7 @@ class EagerLoaderTest extends TestCase
             // Primary key is now auto-added to ensure proper entity hydration
             'clients__id' => 'clients.id',
         ];
-        $expected = $this->_quoteArray($expected);
+        $expected = $this->quoteArray($expected);
         $this->assertEquals($expected, $select);
 
         $contains['clients']['fields'] = [];
@@ -480,7 +480,7 @@ class EagerLoaderTest extends TestCase
             'clients__name' => 'clients.name',
             'clients__phone' => 'clients.phone',
         ];
-        $expected = $this->_quoteArray($expected);
+        $expected = $this->quoteArray($expected);
         $this->assertEquals($expected, $select);
     }
 
@@ -604,7 +604,7 @@ class EagerLoaderTest extends TestCase
      * @param array $elements
      * @return array
      */
-    protected function _quoteArray($elements): array
+    protected function quoteArray($elements): array
     {
         if ($this->connection->getDriver()->isAutoQuotingEnabled()) {
             $quoter = function ($e) {

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -59,7 +59,7 @@ class TableRegistryTest extends TestCase
      *
      * @return \Cake\ORM\Locator\LocatorInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function _setMockLocator()
+    protected function setMockLocator()
     {
         $locator = $this->createStub(LocatorInterface::class);
         TableRegistry::setTableLocator($locator);
@@ -72,7 +72,7 @@ class TableRegistryTest extends TestCase
      */
     public function testSetLocator(): void
     {
-        $locator = $this->_setMockLocator();
+        $locator = $this->setMockLocator();
 
         $this->assertSame($locator, TableRegistry::getTableLocator());
     }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -3540,7 +3540,7 @@ class RouterTest extends TestCase
     /**
      * Connect some fallback routes for testing router behavior.
      */
-    protected function _connectDefaultRoutes(): void
+    protected function connectDefaultRoutes(): void
     {
         Router::scope('/', function (RouteBuilder $routes): void {
             $routes->fallbacks('InflectedRoute');

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -47,7 +47,7 @@ class EntityContextTest extends TestCase
      */
     public function testGetRequiredMessage(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $context = new EntityContext([
             'entity' => new Article(),
@@ -88,7 +88,7 @@ class EntityContextTest extends TestCase
      */
     public function testIsPrimaryKey(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $row = new Article();
         $context = new EntityContext([
@@ -361,7 +361,7 @@ class EntityContextTest extends TestCase
     #[DataProvider('collectionProvider')]
     public function testSchemaOnCollections($collection): void
     {
-        $this->_setupTables();
+        $this->setupTables();
         $context = new EntityContext([
             'entity' => $collection,
             'table' => 'Articles',
@@ -389,7 +389,7 @@ class EntityContextTest extends TestCase
     #[DataProvider('collectionProvider')]
     public function testValidatorsOnCollections($collection): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $context = new EntityContext([
             'entity' => $collection,
@@ -616,7 +616,7 @@ class EntityContextTest extends TestCase
      */
     public function testValAssociatedCustomIds(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $row = new Article([
             'title' => 'First post',
@@ -707,7 +707,7 @@ class EntityContextTest extends TestCase
      */
     public function testIsRequiredBooleanField(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $context = new EntityContext([
             'entity' => new Entity(),
@@ -732,7 +732,7 @@ class EntityContextTest extends TestCase
      */
     public function testIsRequiredStringValidator(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $context = new EntityContext([
             'entity' => new Entity(),
@@ -753,7 +753,7 @@ class EntityContextTest extends TestCase
      */
     public function testIsRequiredAssociatedHasMany(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $comments = $this->getTableLocator()->get('Comments');
         $validator = $comments->getValidator();
@@ -785,7 +785,7 @@ class EntityContextTest extends TestCase
      */
     public function testIsRequiredAssociatedHasManyBoolean(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $comments = $this->getTableLocator()->get('Comments');
         $comments->getSchema()->addColumn('starred', 'boolean');
@@ -814,7 +814,7 @@ class EntityContextTest extends TestCase
      */
     public function testIsRequiredAssociatedCustomValidator(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
         $articles = $this->getTableLocator()->get('Articles');
 
         $validator = $articles->getValidator();
@@ -840,7 +840,7 @@ class EntityContextTest extends TestCase
      */
     public function testIsRequiredAssociatedHasManyMissingObject(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $comments = $this->getTableLocator()->get('Comments');
         $validator = $comments->getValidator();
@@ -875,7 +875,7 @@ class EntityContextTest extends TestCase
      */
     public function testIsRequiredAssociatedValidator(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $row = new Article([
             'title' => 'My title',
@@ -904,7 +904,7 @@ class EntityContextTest extends TestCase
      */
     public function testIsRequiredAssociatedBelongsTo(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $row = new Article([
             'title' => 'My title',
@@ -928,7 +928,7 @@ class EntityContextTest extends TestCase
      */
     public function testIsRequiredAssociatedJoinTable(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $row = new Article([
             'tags' => [
@@ -954,7 +954,7 @@ class EntityContextTest extends TestCase
      */
     public function testType(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $row = new Article([
             'title' => 'My title',
@@ -976,7 +976,7 @@ class EntityContextTest extends TestCase
      */
     public function testTypeAssociated(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $row = new Article([
             'title' => 'My title',
@@ -997,7 +997,7 @@ class EntityContextTest extends TestCase
      */
     public function testTypeAssociatedJoinData(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $row = new Article([
             'tags' => [
@@ -1029,7 +1029,7 @@ class EntityContextTest extends TestCase
      */
     public function testAttributes(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $row = new Article([
             'title' => 'My title',
@@ -1078,7 +1078,7 @@ class EntityContextTest extends TestCase
      */
     public function testHasError(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $row = new Article([
             'title' => 'My title',
@@ -1103,7 +1103,7 @@ class EntityContextTest extends TestCase
      */
     public function testHasErrorAssociated(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $row = new Article([
             'title' => 'My title',
@@ -1127,7 +1127,7 @@ class EntityContextTest extends TestCase
      */
     public function testError(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $row = new Article([
             'title' => 'My title',
@@ -1158,7 +1158,7 @@ class EntityContextTest extends TestCase
      */
     public function testErrorAssociatedHasMany(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $row = new Article([
             'title' => 'My title',
@@ -1191,7 +1191,7 @@ class EntityContextTest extends TestCase
      */
     public function testErrorAssociatedJoinTable(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $row = new Article([
             'tags' => [
@@ -1218,7 +1218,7 @@ class EntityContextTest extends TestCase
      */
     public function testErrorNestedValidator(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $row = new Article([
             'title' => 'My title',
@@ -1239,7 +1239,7 @@ class EntityContextTest extends TestCase
      */
     public function testErrorAssociatedNestedValidator(): void
     {
-        $this->_setupTables();
+        $this->setupTables();
 
         $tagOne = new Tag(['name' => 'first-post']);
         $tagTwo = new Tag(['name' => 'second-post']);
@@ -1268,7 +1268,7 @@ class EntityContextTest extends TestCase
     /**
      * Setup tables for tests.
      */
-    protected function _setupTables(): void
+    protected function setupTables(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsTo('Users');

--- a/tests/test_app/TestApp/Controller/SomePagesController.php
+++ b/tests/test_app/TestApp/Controller/SomePagesController.php
@@ -52,7 +52,7 @@ class SomePagesController extends Controller
         return $this->response->withStringBody('new response');
     }
 
-    protected function _fail()
+    protected function fail()
     {
     }
 }

--- a/tests/test_app/TestApp/Model/Table/ArticlesTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTable.php
@@ -84,7 +84,7 @@ class ArticlesTable extends Table
     /**
      * Example protected method
      */
-    protected function _innerMethod(): void
+    protected function innerMethod(): void
     {
     }
 }


### PR DESCRIPTION
## Summary
- Applies PSR naming conventions to protected helper methods in test classes
- Removes the underscore prefix (e.g., `_configCache` becomes `configCache`)
- Fixes outdated docblock comments in CookieCryptTrait

Note: Entity accessor/mutator methods (`_getName`, `_setName`, etc.) are unchanged as they are CakePHP framework conventions.