### PR TITLE
Remove underscore prefix from protected/private properties in tests

### DIFF
--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -33,7 +33,7 @@ class TableRegistryTest extends TestCase
      *
      * @var \Cake\ORM\Locator\LocatorInterface
      */
-    protected $_originalLocator;
+    protected $originalLocator;
 
     /**
      * Remember original instance to set it back on tearDown() just to make sure
@@ -42,7 +42,7 @@ class TableRegistryTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->_originalLocator = TableRegistry::getTableLocator();
+        $this->originalLocator = TableRegistry::getTableLocator();
     }
 
     /**
@@ -51,7 +51,7 @@ class TableRegistryTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
-        TableRegistry::setTableLocator($this->_originalLocator);
+        TableRegistry::setTableLocator($this->originalLocator);
     }
 
     /**

--- a/tests/test_app/TestApp/Database/ColumnSchemaAwareTypeValueObject.php
+++ b/tests/test_app/TestApp/Database/ColumnSchemaAwareTypeValueObject.php
@@ -5,15 +5,15 @@ namespace TestApp\Database;
 
 class ColumnSchemaAwareTypeValueObject
 {
-    protected $_value;
+    protected $value;
 
     public function __construct(string $value)
     {
-        $this->_value = $value;
+        $this->value = $value;
     }
 
     public function value(): string
     {
-        return $this->_value;
+        return $this->value;
     }
 }

--- a/tests/test_app/TestApp/Datasource/FakeConnection.php
+++ b/tests/test_app/TestApp/Datasource/FakeConnection.php
@@ -10,7 +10,7 @@ use RuntimeException;
 
 class FakeConnection implements ConnectionInterface
 {
-    protected $_config = [];
+    protected $config = [];
 
     /**
      * Constructor.
@@ -19,7 +19,7 @@ class FakeConnection implements ConnectionInterface
      */
     public function __construct($config = [])
     {
-        $this->_config = $config;
+        $this->config = $config;
     }
 
     /**
@@ -29,7 +29,7 @@ class FakeConnection implements ConnectionInterface
      */
     public function config(): array
     {
-        return $this->_config;
+        return $this->config;
     }
 
     /**
@@ -37,11 +37,11 @@ class FakeConnection implements ConnectionInterface
      */
     public function configName(): string
     {
-        if (empty($this->_config['name'])) {
+        if (empty($this->config['name'])) {
             return '';
         }
 
-        return $this->_config['name'];
+        return $this->config['name'];
     }
 
     public function getDriver(string $role = self::ROLE_WRITE): object

--- a/tests/test_app/TestApp/Http/Client/Adapter/CakeStreamWrapper.php
+++ b/tests/test_app/TestApp/Http/Client/Adapter/CakeStreamWrapper.php
@@ -8,11 +8,11 @@ use Exception;
 
 class CakeStreamWrapper implements ArrayAccess
 {
-    private $_stream;
+    private $stream;
 
-    private $_query = [];
+    private $query = [];
 
-    private $_data = [
+    private $data = [
         'headers' => [
             'HTTP/1.1 200 OK',
         ],
@@ -28,33 +28,33 @@ class CakeStreamWrapper implements ArrayAccess
 
         $query = parse_url($path, PHP_URL_QUERY);
         if ($query) {
-            parse_str($query, $this->_query);
+            parse_str($query, $this->query);
         }
 
-        $this->_stream = fopen('php://memory', 'rb+');
-        fwrite($this->_stream, str_repeat('x', 20000));
-        rewind($this->_stream);
+        $this->stream = fopen('php://memory', 'rb+');
+        fwrite($this->stream, str_repeat('x', 20000));
+        rewind($this->stream);
 
         return true;
     }
 
     public function stream_close(): bool
     {
-        return fclose($this->_stream);
+        return fclose($this->stream);
     }
 
     public function stream_read(int $count): string
     {
-        if (isset($this->_query['sleep'])) {
+        if (isset($this->query['sleep'])) {
             sleep(1);
         }
 
-        return fread($this->_stream, $count);
+        return fread($this->stream, $count);
     }
 
     public function stream_eof(): bool
     {
-        return feof($this->_stream);
+        return feof($this->stream);
     }
 
     public function stream_set_option(int $option, int $arg1, int $arg2): bool
@@ -67,7 +67,7 @@ class CakeStreamWrapper implements ArrayAccess
      */
     public function offsetExists(mixed $offset): bool
     {
-        return isset($this->_data[$offset]);
+        return isset($this->data[$offset]);
     }
 
     /**
@@ -75,7 +75,7 @@ class CakeStreamWrapper implements ArrayAccess
      */
     public function offsetGet(mixed $offset): mixed
     {
-        return $this->_data[$offset];
+        return $this->data[$offset];
     }
 
     /**
@@ -83,7 +83,7 @@ class CakeStreamWrapper implements ArrayAccess
      */
     public function offsetSet(mixed $offset, mixed $value): void
     {
-        $this->_data[$offset] = $value;
+        $this->data[$offset] = $value;
     }
 
     /**
@@ -91,6 +91,6 @@ class CakeStreamWrapper implements ArrayAccess
      */
     public function offsetUnset(mixed $offset): void
     {
-        unset($this->_data[$offset]);
+        unset($this->data[$offset]);
     }
 }

--- a/tests/test_app/TestApp/View/Widget/TestUsingViewWidget.php
+++ b/tests/test_app/TestApp/View/Widget/TestUsingViewWidget.php
@@ -22,19 +22,19 @@ use Cake\View\Widget\WidgetInterface;
 
 class TestUsingViewWidget implements WidgetInterface
 {
-    protected $_templates;
+    protected $templates;
 
-    protected $_view;
+    protected $view;
 
     public function __construct(StringTemplate $templates, View $view)
     {
-        $this->_templates = $templates;
-        $this->_view = $view;
+        $this->templates = $templates;
+        $this->view = $view;
     }
 
     public function getView(): View
     {
-        return $this->_view;
+        return $this->view;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Applies PSR naming conventions to properties in test classes
- Removes the underscore prefix from protected/private properties