### PR TITLE
Remove underscore prefix from protected properties in View and TestSuite

### DIFF
--- a/src/Controller/Component/FormProtectionComponent.php
+++ b/src/Controller/Component/FormProtectionComponent.php
@@ -33,7 +33,7 @@ use Closure;
  * - Existing fields have not been removed from the form.
  * - Values of hidden inputs have not been changed.
  *
- * @phpstan-property array{validate:bool, unlockedFields:array, unlockedActions:array, validationFailureCallback:?\Closure} $_config
+ * @phpstan-property array{validate:bool, unlockedFields:array, unlockedActions:array, validationFailureCallback:?\Closure} $config
  */
 class FormProtectionComponent extends Component
 {

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -104,7 +104,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
     /**
      * Constructor
      *
-     * @param array<string, mixed> $config Config options. See $_config for valid keys.
+     * @param array<string, mixed> $config Config options. See $config for valid keys.
      */
     public function __construct(array $config = [])
     {

--- a/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
@@ -80,7 +80,7 @@ class SessionCsrfProtectionMiddleware implements MiddlewareInterface
     /**
      * Constructor
      *
-     * @param array<string, mixed> $config Config options. See $_config for valid keys.
+     * @param array<string, mixed> $config Config options. See $config for valid keys.
      */
     public function __construct(array $config = [])
     {

--- a/src/I18n/PluralRules.php
+++ b/src/I18n/PluralRules.php
@@ -34,7 +34,7 @@ class PluralRules
      *
      * @var array<string, int>
      */
-    protected static array $_rulesMap = [
+    protected static array $rulesMap = [
         'af' => 1,
         'am' => 2,
         'ar' => 13,
@@ -149,15 +149,15 @@ class PluralRules
             throw new InvalidArgumentException('Invalid locale provided');
         }
 
-        if (!isset(static::$_rulesMap[$locale])) {
+        if (!isset(static::$rulesMap[$locale])) {
             $locale = explode('_', $locale)[0];
         }
 
-        if (!isset(static::$_rulesMap[$locale])) {
+        if (!isset(static::$rulesMap[$locale])) {
             return 0;
         }
 
-        return match (static::$_rulesMap[$locale]) {
+        return match (static::$rulesMap[$locale]) {
             0 => 0,
             1 => $n === 1 ? 0 : 1,
             2 => $n > 1 ? 1 : 0,

--- a/src/Log/Engine/SyslogLog.php
+++ b/src/Log/Engine/SyslogLog.php
@@ -68,7 +68,7 @@ class SyslogLog extends BaseLog
      *
      * @var array<int>
      */
-    protected array $_levelMap = [
+    protected array $levelMap = [
         'emergency' => LOG_EMERG,
         'alert' => LOG_ALERT,
         'critical' => LOG_CRIT,
@@ -108,8 +108,8 @@ class SyslogLog extends BaseLog
         }
 
         $priority = LOG_DEBUG;
-        if (isset($this->_levelMap[$level])) {
-            $priority = $this->_levelMap[$level];
+        if (isset($this->levelMap[$level])) {
+            $priority = $this->levelMap[$level];
         }
 
         $lines = explode("\n", $this->interpolate($message, $context));

--- a/src/Mailer/Renderer.php
+++ b/src/Mailer/Renderer.php
@@ -97,7 +97,7 @@ class Renderer
      */
     public function reset(): static
     {
-        $this->_viewBuilder = null;
+        $this->viewBuilder = null;
 
         $this->viewBuilder()
             ->setClassName(View::class)
@@ -112,8 +112,8 @@ class Renderer
      */
     public function __clone()
     {
-        if ($this->_viewBuilder !== null) {
-            $this->_viewBuilder = clone $this->_viewBuilder;
+        if ($this->viewBuilder !== null) {
+            $this->viewBuilder = clone $this->viewBuilder;
         }
     }
 }

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -618,7 +618,7 @@ abstract class Association
     /**
      * Sets the strategy name to be used to fetch associated records.
      *
-     * Valid strategies depend on the association type and are stored in $_validStrategies.
+     * Valid strategies depend on the association type and are stored in $validStrategies.
      * Some association types might only implement a default strategy, making this setting
      * ineffective.
      *

--- a/src/TestSuite/Constraint/EventFired.php
+++ b/src/TestSuite/Constraint/EventFired.php
@@ -31,7 +31,7 @@ class EventFired extends Constraint
      *
      * @var \Cake\Event\EventManager
      */
-    protected EventManager $_eventManager;
+    protected EventManager $eventManager;
 
     /**
      * Constructor
@@ -40,9 +40,9 @@ class EventFired extends Constraint
      */
     public function __construct(EventManager $eventManager)
     {
-        $this->_eventManager = $eventManager;
+        $this->eventManager = $eventManager;
 
-        if ($this->_eventManager->getEventList() === null) {
+        if ($this->eventManager->getEventList() === null) {
             throw new AssertionFailedError(
                 'The event manager you are asserting against is not configured to track events.',
             );
@@ -57,7 +57,7 @@ class EventFired extends Constraint
      */
     public function matches(mixed $other): bool
     {
-        $list = $this->_eventManager->getEventList();
+        $list = $this->eventManager->getEventList();
 
         return $list === null ? false : $list->hasEvent($other);
     }

--- a/src/TestSuite/Constraint/EventFiredWith.php
+++ b/src/TestSuite/Constraint/EventFiredWith.php
@@ -21,21 +21,21 @@ class EventFiredWith extends Constraint
      *
      * @var \Cake\Event\EventManager
      */
-    protected EventManager $_eventManager;
+    protected EventManager $eventManager;
 
     /**
      * Event data key
      *
      * @var string
      */
-    protected string $_dataKey;
+    protected string $dataKey;
 
     /**
      * Event data value
      *
      * @var mixed
      */
-    protected mixed $_dataValue;
+    protected mixed $dataValue;
 
     /**
      * Constructor
@@ -46,11 +46,11 @@ class EventFiredWith extends Constraint
      */
     public function __construct(EventManager $eventManager, string $dataKey, mixed $dataValue)
     {
-        $this->_eventManager = $eventManager;
-        $this->_dataKey = $dataKey;
-        $this->_dataValue = $dataValue;
+        $this->eventManager = $eventManager;
+        $this->dataKey = $dataKey;
+        $this->dataValue = $dataValue;
 
-        if ($this->_eventManager->getEventList() === null) {
+        if ($this->eventManager->getEventList() === null) {
             throw new AssertionFailedError(
                 'The event manager you are asserting against is not configured to track events.',
             );
@@ -67,7 +67,7 @@ class EventFiredWith extends Constraint
     public function matches(mixed $other): bool
     {
         $eventGroup = [];
-        $list = $this->_eventManager->getEventList();
+        $list = $this->eventManager->getEventList();
         if ($list !== null) {
             $eventGroup = new Collection($list)
                 ->groupBy(function (EventInterface $event): string {
@@ -93,11 +93,11 @@ class EventFiredWith extends Constraint
 
         $event = $events[0];
 
-        if (array_key_exists($this->_dataKey, (array)$event->getData()) === false) {
+        if (array_key_exists($this->dataKey, (array)$event->getData()) === false) {
             return false;
         }
 
-        return $event->getData($this->_dataKey) === $this->_dataValue;
+        return $event->getData($this->dataKey) === $this->dataValue;
     }
 
     /**
@@ -107,6 +107,6 @@ class EventFiredWith extends Constraint
      */
     public function toString(): string
     {
-        return "was fired with `{$this->_dataKey}` matching `" . json_encode($this->_dataValue) . '`';
+        return "was fired with `{$this->dataKey}` matching `" . json_encode($this->dataValue) . '`';
     }
 }

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -78,7 +78,7 @@ class TestFixture implements FixtureInterface
      *
      * @var \Cake\Database\Schema\TableSchemaInterface&\Cake\Database\Schema\SqlGeneratorInterface
      */
-    protected TableSchemaInterface&SqlGeneratorInterface $_schema;
+    protected TableSchemaInterface&SqlGeneratorInterface $schema;
 
     /**
      * Whether to be strict about invalid fields.
@@ -181,7 +181,7 @@ class TestFixture implements FixtureInterface
 
             $schema = $ormTable->getSchema();
             assert($schema instanceof TableSchema);
-            $this->_schema = $schema;
+            $this->schema = $schema;
 
             $this->getTableLocator()->clear();
         } catch (CakeException $e) {
@@ -223,7 +223,7 @@ class TestFixture implements FixtureInterface
         $fields = [];
         $values = [];
         $types = [];
-        $columns = $this->_schema->columns();
+        $columns = $this->schema->columns();
         foreach ($this->records as $index => $record) {
             $recordFields = array_keys($record);
             if ($this->strictFields) {
@@ -246,7 +246,7 @@ class TestFixture implements FixtureInterface
         /** @var list<string> $fields */
         $fields = array_values($fields);
         foreach ($fields as $field) {
-            $column = $this->_schema->getColumn($field);
+            $column = $this->schema->getColumn($field);
             assert($column !== null);
             $types[$field] = $column['type'];
         }
@@ -264,7 +264,7 @@ class TestFixture implements FixtureInterface
     public function truncate(ConnectionInterface $connection): void
     {
         assert($connection instanceof Connection);
-        $sql = $this->_schema->truncateSql($connection);
+        $sql = $this->schema->truncateSql($connection);
         foreach ($sql as $stmt) {
             $connection->execute($stmt);
         }
@@ -277,6 +277,6 @@ class TestFixture implements FixtureInterface
      */
     public function getTableSchema(): TableSchemaInterface&SqlGeneratorInterface
     {
-        return $this->_schema;
+        return $this->schema;
     }
 }

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -90,63 +90,63 @@ trait IntegrationTestTrait
      *
      * @var array
      */
-    protected array $_request = [];
+    protected array $request = [];
 
     /**
      * The response for the most recent request.
      *
      * @var \Psr\Http\Message\ResponseInterface|null
      */
-    protected ?ResponseInterface $_response = null;
+    protected ?ResponseInterface $response = null;
 
     /**
      * The exception being thrown if the case.
      *
      * @var \Throwable|null
      */
-    protected ?Throwable $_exception = null;
+    protected ?Throwable $exception = null;
 
     /**
      * Session data to use in the next request.
      *
      * @var array
      */
-    protected array $_session = [];
+    protected array $session = [];
 
     /**
      * Cookie data to use in the next request.
      *
      * @var array
      */
-    protected array $_cookie = [];
+    protected array $cookie = [];
 
     /**
      * The controller used in the last request.
      *
      * @var \Cake\Controller\Controller|null
      */
-    protected ?Controller $_controller = null;
+    protected ?Controller $controller = null;
 
     /**
      * The last rendered view
      *
      * @var string|null
      */
-    protected ?string $_viewName = null;
+    protected ?string $viewName = null;
 
     /**
      * The last rendered layout
      *
      * @var string|null
      */
-    protected ?string $_layoutName = null;
+    protected ?string $layoutName = null;
 
     /**
      * The session instance from the last request
      *
      * @var \Cake\Http\Session|null
      */
-    protected ?Session $_requestSession = null;
+    protected ?Session $requestSession = null;
 
     /**
      * Boolean flag for whether the request should have
@@ -154,7 +154,7 @@ trait IntegrationTestTrait
      *
      * @var bool
      */
-    protected bool $_securityToken = false;
+    protected bool $securityToken = false;
 
     /**
      * Boolean flag for whether the request should have
@@ -162,7 +162,7 @@ trait IntegrationTestTrait
      *
      * @var bool
      */
-    protected bool $_csrfToken = false;
+    protected bool $csrfToken = false;
 
     /**
      * Boolean flag for whether the request should re-store
@@ -170,33 +170,33 @@ trait IntegrationTestTrait
      *
      * @var bool
      */
-    protected bool $_retainFlashMessages = false;
+    protected bool $retainFlashMessages = false;
 
     /**
      * Stored flash messages before render
      *
      * @var array
      */
-    protected array $_flashMessages = [];
+    protected array $flashMessages = [];
 
     /**
      * @var string|null
      */
-    protected ?string $_cookieEncryptionKey = null;
+    protected ?string $cookieEncryptionKey = null;
 
     /**
      * List of fields that are excluded from field validation.
      *
      * @var array<string>
      */
-    protected array $_unlockedFields = [];
+    protected array $unlockedFields = [];
 
     /**
      * The name that will be used when retrieving the csrf token.
      *
      * @var string
      */
-    protected string $_csrfKeyName = 'csrfToken';
+    protected string $csrfKeyName = 'csrfToken';
 
     /**
      * Clears the state used for requests.
@@ -206,19 +206,19 @@ trait IntegrationTestTrait
     #[After]
     public function cleanup(): void
     {
-        $this->_request = [];
-        $this->_session = [];
-        $this->_cookie = [];
-        $this->_response = null;
-        $this->_exception = null;
-        $this->_controller = null;
-        $this->_viewName = null;
-        $this->_layoutName = null;
-        $this->_requestSession = null;
-        $this->_securityToken = false;
-        $this->_csrfToken = false;
-        $this->_retainFlashMessages = false;
-        $this->_flashMessages = [];
+        $this->request = [];
+        $this->session = [];
+        $this->cookie = [];
+        $this->response = null;
+        $this->exception = null;
+        $this->controller = null;
+        $this->viewName = null;
+        $this->layoutName = null;
+        $this->requestSession = null;
+        $this->securityToken = false;
+        $this->csrfToken = false;
+        $this->retainFlashMessages = false;
+        $this->flashMessages = [];
     }
 
     /**
@@ -230,7 +230,7 @@ trait IntegrationTestTrait
      */
     public function enableSecurityToken(): void
     {
-        $this->_securityToken = true;
+        $this->securityToken = true;
     }
 
     /**
@@ -241,7 +241,7 @@ trait IntegrationTestTrait
      */
     public function setUnlockedFields(array $unlockedFields = []): void
     {
-        $this->_unlockedFields = $unlockedFields;
+        $this->unlockedFields = $unlockedFields;
     }
 
     /**
@@ -255,8 +255,8 @@ trait IntegrationTestTrait
      */
     public function enableCsrfToken(string $cookieName = 'csrfToken'): void
     {
-        $this->_csrfToken = true;
-        $this->_csrfKeyName = $cookieName;
+        $this->csrfToken = true;
+        $this->csrfKeyName = $cookieName;
     }
 
     /**
@@ -267,7 +267,7 @@ trait IntegrationTestTrait
      */
     public function enableRetainFlashMessages(): void
     {
-        $this->_retainFlashMessages = true;
+        $this->retainFlashMessages = true;
     }
 
     /**
@@ -284,7 +284,7 @@ trait IntegrationTestTrait
      */
     public function configRequest(array $data): void
     {
-        $this->_request = array_merge_recursive($data, $this->_request);
+        $this->request = array_merge_recursive($data, $this->request);
     }
 
     /**
@@ -295,7 +295,7 @@ trait IntegrationTestTrait
      */
     public function replaceRequest(array $data): void
     {
-        $this->_request = $data;
+        $this->request = $data;
     }
 
     /**
@@ -328,7 +328,7 @@ trait IntegrationTestTrait
      */
     public function session(array $data): void
     {
-        $this->_session = $data + $this->_session;
+        $this->session = $data + $this->session;
     }
 
     /**
@@ -347,7 +347,7 @@ trait IntegrationTestTrait
      */
     public function cookie(string $name, string $value): void
     {
-        $this->_cookie[$name] = $value;
+        $this->cookie[$name] = $value;
     }
 
     /**
@@ -357,7 +357,7 @@ trait IntegrationTestTrait
      */
     protected function getCookieEncryptionKey(): string
     {
-        return $this->_cookieEncryptionKey ?? Security::getSalt();
+        return $this->cookieEncryptionKey ?? Security::getSalt();
     }
 
     /**
@@ -380,8 +380,8 @@ trait IntegrationTestTrait
         string|false $encrypt = 'aes',
         ?string $key = null,
     ): void {
-        $this->_cookieEncryptionKey = $key;
-        $this->_cookie[$name] = $this->encrypt($value, $encrypt);
+        $this->cookieEncryptionKey = $key;
+        $this->cookie[$name] = $this->encrypt($value, $encrypt);
     }
 
     /**
@@ -511,16 +511,16 @@ trait IntegrationTestTrait
         try {
             $request = $this->buildRequest($url, $method, $data);
             $response = $dispatcher->execute($request);
-            $this->_requestSession = $request['session'];
-            if ($this->_retainFlashMessages && $this->_flashMessages) {
-                $_SESSION['Flash'] = $this->_flashMessages;
-                $this->_requestSession->write($_SESSION);
+            $this->requestSession = $request['session'];
+            if ($this->retainFlashMessages && $this->flashMessages) {
+                $_SESSION['Flash'] = $this->flashMessages;
+                $this->requestSession->write($_SESSION);
             }
-            $this->_response = $response;
+            $this->response = $response;
         } catch (PHPUnitException | DatabaseException $e) {
             throw $e;
         } catch (Throwable $e) {
-            $this->_exception = $e;
+            $this->exception = $e;
             // Simulate the global exception handler being invoked.
             $this->handleError($e);
         }
@@ -602,27 +602,27 @@ trait IntegrationTestTrait
             $controller = $event->getSubject();
             assert($controller instanceof Controller);
         }
-        $this->_controller = $controller;
+        $this->controller = $controller;
         $events = $controller->getEventManager();
         $flashCapture = function (EventInterface $event): void {
-            if (!$this->_retainFlashMessages) {
+            if (!$this->retainFlashMessages) {
                 return;
             }
             $controller = $event->getSubject();
-            $this->_flashMessages = Hash::merge(
-                $this->_flashMessages,
+            $this->flashMessages = Hash::merge(
+                $this->flashMessages,
                 $controller->getRequest()->getSession()->read('Flash'),
             );
         };
         $events->on('Controller.beforeRedirect', $flashCapture, ['priority' => -100]);
         $events->on('Controller.beforeRender', $flashCapture, ['priority' => -100]);
         $events->on('View.beforeRender', function ($event, $viewFile): void {
-            if (!$this->_viewName) {
-                $this->_viewName = $viewFile;
+            if (!$this->viewName) {
+                $this->viewName = $viewFile;
             }
         });
         $events->on('View.beforeLayout', function ($event, $viewFile): void {
-            $this->_layoutName = $viewFile;
+            $this->layoutName = $viewFile;
         });
     }
 
@@ -643,7 +643,7 @@ trait IntegrationTestTrait
         }
         /** @var \Cake\Error\Renderer\WebExceptionRenderer $instance */
         $instance = new $class($exception);
-        $this->_response = $instance->render();
+        $this->response = $instance->render();
     }
 
     /**
@@ -680,15 +680,15 @@ trait IntegrationTestTrait
         if (isset($hostInfo['host'])) {
             $env['HTTP_HOST'] = $hostInfo['host'];
         }
-        if (isset($this->_request['headers'])) {
-            foreach ($this->_request['headers'] as $k => $v) {
+        if (isset($this->request['headers'])) {
+            foreach ($this->request['headers'] as $k => $v) {
                 $name = strtoupper(str_replace('-', '_', $k));
                 if (!in_array($name, ['CONTENT_LENGTH', 'CONTENT_TYPE'], true)) {
                     $name = 'HTTP_' . $name;
                 }
                 $env[$name] = $v;
             }
-            unset($this->_request['headers']);
+            unset($this->request['headers']);
         }
         $props = [
             'url' => $url,
@@ -713,10 +713,10 @@ trait IntegrationTestTrait
             $props['post'] = $this->castToString($data);
         }
 
-        $props['cookies'] = $this->_cookie;
-        $session->write($this->_session);
+        $props['cookies'] = $this->cookie;
+        $session->write($this->session);
 
-        return Hash::merge($props, $this->_request);
+        return Hash::merge($props, $this->request);
     }
 
     /**
@@ -729,14 +729,14 @@ trait IntegrationTestTrait
      */
     protected function addTokens(string $url, array $data, string $method): array
     {
-        if ($this->_securityToken === true) {
-            $fields = array_diff_key($data, array_flip($this->_unlockedFields));
+        if ($this->securityToken === true) {
+            $fields = array_diff_key($data, array_flip($this->unlockedFields));
 
             $keys = array_map(function (int|string $field) {
                 return preg_replace('/(\.\d+)+$/', '', (string)$field);
             }, array_keys(Hash::flatten($fields)));
 
-            $formProtector = new FormProtector(['unlockedFields' => $this->_unlockedFields]);
+            $formProtector = new FormProtector(['unlockedFields' => $this->unlockedFields]);
             foreach ($keys as $field) {
                 $formProtector->addField($field);
             }
@@ -752,22 +752,22 @@ trait IntegrationTestTrait
             }
         }
 
-        if ($this->_csrfToken === true) {
+        if ($this->csrfToken === true) {
             $middleware = new CsrfProtectionMiddleware();
-            if (!isset($this->_cookie[$this->_csrfKeyName]) && !isset($this->_session[$this->_csrfKeyName])) {
+            if (!isset($this->cookie[$this->csrfKeyName]) && !isset($this->session[$this->csrfKeyName])) {
                 $token = $middleware->createToken();
-            } elseif (isset($this->_cookie[$this->_csrfKeyName])) {
-                $token = $this->_cookie[$this->_csrfKeyName];
+            } elseif (isset($this->cookie[$this->csrfKeyName])) {
+                $token = $this->cookie[$this->csrfKeyName];
             } else {
-                $token = $this->_session[$this->_csrfKeyName];
+                $token = $this->session[$this->csrfKeyName];
             }
 
             // Add the token to both the session and cookie to cover
             // both types of CSRF tokens. We generate the token with the cookie
             // middleware as cookie tokens will be accepted by session csrf, but not
             // the inverse.
-            $this->_session[$this->_csrfKeyName] = $token;
-            $this->_cookie[$this->_csrfKeyName] = $token;
+            $this->session[$this->csrfKeyName] = $token;
+            $this->cookie[$this->csrfKeyName] = $token;
             if (!isset($data['_csrfToken']) && !in_array($method, ['GET', 'OPTIONS'])) {
                 $data['_csrfToken'] = $token;
             }
@@ -835,11 +835,11 @@ trait IntegrationTestTrait
      */
     protected function getBodyAsString(): string
     {
-        if (!$this->_response) {
+        if (!$this->response) {
             $this->fail('No response set, cannot assert content.');
         }
 
-        return (string)$this->_response->getBody();
+        return (string)$this->response->getBody();
     }
 
     /**
@@ -852,7 +852,7 @@ trait IntegrationTestTrait
      */
     public function viewVariable(string $name): mixed
     {
-        return $this->_controller?->viewBuilder()->getVar($name);
+        return $this->controller?->viewBuilder()->getVar($name);
     }
 
     /**
@@ -864,7 +864,7 @@ trait IntegrationTestTrait
     public function assertResponseOk(string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat(null, new StatusOk($this->_response), $verboseMessage);
+        $this->assertThat(null, new StatusOk($this->response), $verboseMessage);
     }
 
     /**
@@ -876,7 +876,7 @@ trait IntegrationTestTrait
     public function assertResponseSuccess(string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat(null, new StatusSuccess($this->_response), $verboseMessage);
+        $this->assertThat(null, new StatusSuccess($this->response), $verboseMessage);
     }
 
     /**
@@ -887,7 +887,7 @@ trait IntegrationTestTrait
      */
     public function assertResponseError(string $message = ''): void
     {
-        $this->assertThat(null, new StatusError($this->_response), $message);
+        $this->assertThat(null, new StatusError($this->response), $message);
     }
 
     /**
@@ -898,7 +898,7 @@ trait IntegrationTestTrait
      */
     public function assertResponseFailure(string $message = ''): void
     {
-        $this->assertThat(null, new StatusFailure($this->_response), $message);
+        $this->assertThat(null, new StatusFailure($this->response), $message);
     }
 
     /**
@@ -910,7 +910,7 @@ trait IntegrationTestTrait
      */
     public function assertResponseCode(int $code, string $message = ''): void
     {
-        $this->assertThat($code, new StatusCode($this->_response), $message);
+        $this->assertThat($code, new StatusCode($this->response), $message);
     }
 
     /**
@@ -928,20 +928,20 @@ trait IntegrationTestTrait
      */
     public function assertRedirect(array|string|null $url = null, string $message = ''): void
     {
-        if (!$this->_response) {
+        if (!$this->response) {
             $this->fail('No response set, cannot assert header.');
         }
 
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat(null, new HeaderSet($this->_response, 'Location'), $verboseMessage);
+        $this->assertThat(null, new HeaderSet($this->response, 'Location'), $verboseMessage);
 
         if ($url) {
             // Normalize both URLs to absolute for comparison
             $expectedUrl = Router::url($url, true);
-            $actualUrl = Router::url($this->_response->getHeaderLine('Location'), true);
+            $actualUrl = Router::url($this->response->getHeaderLine('Location'), true);
 
             // Create a response with the normalized URL for proper error messages
-            $tempResponse = $this->_response->withHeader('Location', $actualUrl);
+            $tempResponse = $this->response->withHeader('Location', $actualUrl);
 
             $this->assertThat(
                 $expectedUrl,
@@ -960,26 +960,26 @@ trait IntegrationTestTrait
      */
     public function assertRedirectBack(?int $code = null, string $message = ''): void
     {
-        if (!$this->_response) {
+        if (!$this->response) {
             $this->fail('No response set, cannot assert header.');
         }
 
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat(null, new HeaderSet($this->_response, 'Location'), $verboseMessage);
+        $this->assertThat(null, new HeaderSet($this->response, 'Location'), $verboseMessage);
         if ($code !== null) {
-            $this->assertThat($code, new StatusCode($this->_response), $message);
+            $this->assertThat($code, new StatusCode($this->response), $message);
         } else {
-            $this->assertThat(null, new StatusSuccess($this->_response), $verboseMessage);
+            $this->assertThat(null, new StatusSuccess($this->response), $verboseMessage);
         }
 
-        $url = $this->_request['url'] ?? null;
+        $url = $this->request['url'] ?? null;
         if (!$url) {
             $this->fail('No `url` set in request, cannot assert header.');
         }
 
         $this->assertThat(
             Router::url($url, true),
-            new HeaderEquals($this->_response, 'Location'),
+            new HeaderEquals($this->response, 'Location'),
             $verboseMessage,
         );
     }
@@ -993,26 +993,26 @@ trait IntegrationTestTrait
      */
     public function assertRedirectBackToReferer(?int $code = null, string $message = ''): void
     {
-        if (!$this->_response) {
+        if (!$this->response) {
             $this->fail('No response set, cannot assert header.');
         }
 
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat(null, new HeaderSet($this->_response, 'Location'), $verboseMessage);
+        $this->assertThat(null, new HeaderSet($this->response, 'Location'), $verboseMessage);
         if ($code !== null) {
-            $this->assertThat($code, new StatusCode($this->_response), $message);
+            $this->assertThat($code, new StatusCode($this->response), $message);
         } else {
-            $this->assertThat(null, new StatusSuccess($this->_response), $verboseMessage);
+            $this->assertThat(null, new StatusSuccess($this->response), $verboseMessage);
         }
 
-        $referer = $this->_request['environment']['HTTP_REFERER'] ?? null;
+        $referer = $this->request['environment']['HTTP_REFERER'] ?? null;
         if (!$referer) {
             $this->fail('No `HTTP_REFERER` set in request environment, cannot assert header.');
         }
 
         $this->assertThat(
             Router::url($referer, true),
-            new HeaderEquals($this->_response, 'Location'),
+            new HeaderEquals($this->response, 'Location'),
             $verboseMessage,
         );
     }
@@ -1028,20 +1028,20 @@ trait IntegrationTestTrait
      */
     public function assertRedirectEquals(array|string|null $url = null, string $message = ''): void
     {
-        if (!$this->_response) {
+        if (!$this->response) {
             $this->fail('No response set, cannot assert header.');
         }
 
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat(null, new HeaderSet($this->_response, 'Location'), $verboseMessage);
+        $this->assertThat(null, new HeaderSet($this->response, 'Location'), $verboseMessage);
 
         if ($url) {
             // Normalize both URLs to absolute for comparison
             $expectedUrl = Router::url($url, true);
-            $actualUrl = Router::url($this->_response->getHeaderLine('Location'), true);
+            $actualUrl = Router::url($this->response->getHeaderLine('Location'), true);
 
             // Create a response with the normalized URL for proper error messages
-            $tempResponse = $this->_response->withHeader('Location', $actualUrl);
+            $tempResponse = $this->response->withHeader('Location', $actualUrl);
 
             $this->assertThat(
                 $expectedUrl,
@@ -1060,13 +1060,13 @@ trait IntegrationTestTrait
      */
     public function assertRedirectContains(string $url, string $message = ''): void
     {
-        if (!$this->_response) {
+        if (!$this->response) {
             $this->fail('No response set, cannot assert header.');
         }
 
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat(null, new HeaderSet($this->_response, 'Location'), $verboseMessage);
-        $this->assertThat($url, new HeaderContains($this->_response, 'Location'), $verboseMessage);
+        $this->assertThat(null, new HeaderSet($this->response, 'Location'), $verboseMessage);
+        $this->assertThat($url, new HeaderContains($this->response, 'Location'), $verboseMessage);
     }
 
     /**
@@ -1078,13 +1078,13 @@ trait IntegrationTestTrait
      */
     public function assertRedirectNotContains(string $url, string $message = ''): void
     {
-        if (!$this->_response) {
+        if (!$this->response) {
             $this->fail('No response set, cannot assert header.');
         }
 
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat(null, new HeaderSet($this->_response, 'Location'), $verboseMessage);
-        $this->assertThat($url, new HeaderNotContains($this->_response, 'Location'), $verboseMessage);
+        $this->assertThat(null, new HeaderSet($this->response, 'Location'), $verboseMessage);
+        $this->assertThat($url, new HeaderNotContains($this->response, 'Location'), $verboseMessage);
     }
 
     /**
@@ -1096,7 +1096,7 @@ trait IntegrationTestTrait
     public function assertNoRedirect(string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat(null, new HeaderNotSet($this->_response, 'Location'), $verboseMessage);
+        $this->assertThat(null, new HeaderNotSet($this->response, 'Location'), $verboseMessage);
     }
 
     /**
@@ -1109,13 +1109,13 @@ trait IntegrationTestTrait
      */
     public function assertHeader(string $header, string $content, string $message = ''): void
     {
-        if (!$this->_response) {
+        if (!$this->response) {
             $this->fail('No response set, cannot assert header.');
         }
 
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat(null, new HeaderSet($this->_response, $header), $verboseMessage);
-        $this->assertThat($content, new HeaderEquals($this->_response, $header), $verboseMessage);
+        $this->assertThat(null, new HeaderSet($this->response, $header), $verboseMessage);
+        $this->assertThat($content, new HeaderEquals($this->response, $header), $verboseMessage);
     }
 
     /**
@@ -1128,13 +1128,13 @@ trait IntegrationTestTrait
      */
     public function assertHeaderContains(string $header, string $content, string $message = ''): void
     {
-        if (!$this->_response) {
+        if (!$this->response) {
             $this->fail('No response set, cannot assert header.');
         }
 
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat(null, new HeaderSet($this->_response, $header), $verboseMessage);
-        $this->assertThat($content, new HeaderContains($this->_response, $header), $verboseMessage);
+        $this->assertThat(null, new HeaderSet($this->response, $header), $verboseMessage);
+        $this->assertThat($content, new HeaderContains($this->response, $header), $verboseMessage);
     }
 
     /**
@@ -1147,13 +1147,13 @@ trait IntegrationTestTrait
      */
     public function assertHeaderNotContains(string $header, string $content, string $message = ''): void
     {
-        if (!$this->_response) {
+        if (!$this->response) {
             $this->fail('No response set, cannot assert header.');
         }
 
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat(null, new HeaderSet($this->_response, $header), $verboseMessage);
-        $this->assertThat($content, new HeaderNotContains($this->_response, $header), $verboseMessage);
+        $this->assertThat(null, new HeaderSet($this->response, $header), $verboseMessage);
+        $this->assertThat($content, new HeaderNotContains($this->response, $header), $verboseMessage);
     }
 
     /**
@@ -1166,7 +1166,7 @@ trait IntegrationTestTrait
     public function assertContentType(string $type, string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat($type, new ContentType($this->_response), $verboseMessage);
+        $this->assertThat($type, new ContentType($this->response), $verboseMessage);
     }
 
     /**
@@ -1182,7 +1182,7 @@ trait IntegrationTestTrait
         if ($this->isDebug()) {
             $verboseMessage .= $this->responseBody();
         }
-        $this->assertThat($content, new BodyEquals($this->_response), $verboseMessage);
+        $this->assertThat($content, new BodyEquals($this->response), $verboseMessage);
     }
 
     /**
@@ -1198,7 +1198,7 @@ trait IntegrationTestTrait
         if ($this->isDebug()) {
             $verboseMessage .= $this->responseBody();
         }
-        $this->assertThat($content, new BodyNotEquals($this->_response), $verboseMessage);
+        $this->assertThat($content, new BodyNotEquals($this->response), $verboseMessage);
     }
 
     /**
@@ -1211,7 +1211,7 @@ trait IntegrationTestTrait
      */
     public function assertResponseContains(string $content, string $message = '', bool $ignoreCase = false): void
     {
-        if (!$this->_response) {
+        if (!$this->response) {
             $this->fail('No response set, cannot assert content.');
         }
 
@@ -1219,7 +1219,7 @@ trait IntegrationTestTrait
         if ($this->isDebug()) {
             $verboseMessage .= $this->responseBody();
         }
-        $this->assertThat($content, new BodyContains($this->_response, $ignoreCase), $verboseMessage);
+        $this->assertThat($content, new BodyContains($this->response, $ignoreCase), $verboseMessage);
     }
 
     /**
@@ -1232,7 +1232,7 @@ trait IntegrationTestTrait
      */
     public function assertResponseNotContains(string $content, string $message = '', bool $ignoreCase = false): void
     {
-        if (!$this->_response) {
+        if (!$this->response) {
             $this->fail('No response set, cannot assert content.');
         }
 
@@ -1240,7 +1240,7 @@ trait IntegrationTestTrait
         if ($this->isDebug()) {
             $verboseMessage .= $this->responseBody();
         }
-        $this->assertThat($content, new BodyNotContains($this->_response, $ignoreCase), $verboseMessage);
+        $this->assertThat($content, new BodyNotContains($this->response, $ignoreCase), $verboseMessage);
     }
 
     /**
@@ -1256,7 +1256,7 @@ trait IntegrationTestTrait
         if ($this->isDebug()) {
             $verboseMessage .= $this->responseBody();
         }
-        $this->assertThat($pattern, new BodyRegExp($this->_response), $verboseMessage);
+        $this->assertThat($pattern, new BodyRegExp($this->response), $verboseMessage);
     }
 
     /**
@@ -1272,7 +1272,7 @@ trait IntegrationTestTrait
         if ($this->isDebug()) {
             $verboseMessage .= $this->responseBody();
         }
-        $this->assertThat($pattern, new BodyNotRegExp($this->_response), $verboseMessage);
+        $this->assertThat($pattern, new BodyNotRegExp($this->response), $verboseMessage);
     }
 
     /**
@@ -1286,7 +1286,7 @@ trait IntegrationTestTrait
         if ($this->isDebug()) {
             $message .= $this->responseBody();
         }
-        $this->assertThat(null, new BodyNotEmpty($this->_response), $message);
+        $this->assertThat(null, new BodyNotEmpty($this->response), $message);
     }
 
     /**
@@ -1300,7 +1300,7 @@ trait IntegrationTestTrait
         if ($this->isDebug()) {
             $message .= $this->responseBody();
         }
-        $this->assertThat(null, new BodyEmpty($this->_response), $message);
+        $this->assertThat(null, new BodyEmpty($this->response), $message);
     }
 
     /**
@@ -1313,7 +1313,7 @@ trait IntegrationTestTrait
     public function assertTemplate(string $content, string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat($content, new TemplateFileEquals($this->_viewName), $verboseMessage);
+        $this->assertThat($content, new TemplateFileEquals($this->viewName), $verboseMessage);
     }
 
     /**
@@ -1326,7 +1326,7 @@ trait IntegrationTestTrait
     public function assertLayout(string $content, string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat($content, new LayoutFileEquals($this->_layoutName), $verboseMessage);
+        $this->assertThat($content, new LayoutFileEquals($this->layoutName), $verboseMessage);
     }
 
     /**
@@ -1380,7 +1380,7 @@ trait IntegrationTestTrait
     public function assertFlashMessage(string $expected, string $key = 'flash', string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat($expected, new FlashParamEquals($this->_requestSession, $key, 'message'), $verboseMessage);
+        $this->assertThat($expected, new FlashParamEquals($this->requestSession, $key, 'message'), $verboseMessage);
     }
 
     /**
@@ -1397,7 +1397,7 @@ trait IntegrationTestTrait
         $verboseMessage = $this->extractVerboseMessage($message);
         $this->assertThat(
             $expected,
-            new FlashParamEquals($this->_requestSession, $key, 'message', $at),
+            new FlashParamEquals($this->requestSession, $key, 'message', $at),
             $verboseMessage,
         );
     }
@@ -1420,7 +1420,7 @@ trait IntegrationTestTrait
         $verboseMessage = $this->extractVerboseMessage($message);
         $this->assertThat(
             $expected,
-            new FlashParamContains($this->_requestSession, $key, 'message', null, $ignoreCase),
+            new FlashParamContains($this->requestSession, $key, 'message', null, $ignoreCase),
             $verboseMessage,
         );
     }
@@ -1445,7 +1445,7 @@ trait IntegrationTestTrait
         $verboseMessage = $this->extractVerboseMessage($message);
         $this->assertThat(
             $expected,
-            new FlashParamContains($this->_requestSession, $key, 'message', $at, $ignoreCase),
+            new FlashParamContains($this->requestSession, $key, 'message', $at, $ignoreCase),
             $verboseMessage,
         );
     }
@@ -1463,7 +1463,7 @@ trait IntegrationTestTrait
         $verboseMessage = $this->extractVerboseMessage($message);
         $this->assertThat(
             $expected,
-            new FlashParamEquals($this->_requestSession, $key, 'element'),
+            new FlashParamEquals($this->requestSession, $key, 'element'),
             $verboseMessage,
         );
     }
@@ -1482,7 +1482,7 @@ trait IntegrationTestTrait
         $verboseMessage = $this->extractVerboseMessage($message);
         $this->assertThat(
             $expected,
-            new FlashParamEquals($this->_requestSession, $key, 'element', $at),
+            new FlashParamEquals($this->requestSession, $key, 'element', $at),
             $verboseMessage,
         );
     }
@@ -1498,8 +1498,8 @@ trait IntegrationTestTrait
     public function assertCookie(mixed $expected, string $name, string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat($name, new CookieSet($this->_response), $verboseMessage);
-        $this->assertThat($expected, new CookieEquals($this->_response, $name), $verboseMessage);
+        $this->assertThat($name, new CookieSet($this->response), $verboseMessage);
+        $this->assertThat($expected, new CookieEquals($this->response, $name), $verboseMessage);
     }
 
     /**
@@ -1515,7 +1515,7 @@ trait IntegrationTestTrait
     public function assertCookieIsSet(string $name, string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat($name, new CookieSet($this->_response), $verboseMessage);
+        $this->assertThat($name, new CookieSet($this->response), $verboseMessage);
     }
 
     /**
@@ -1528,7 +1528,7 @@ trait IntegrationTestTrait
     public function assertCookieNotSet(string $cookie, string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat($cookie, new CookieNotSet($this->_response), $verboseMessage);
+        $this->assertThat($cookie, new CookieNotSet($this->response), $verboseMessage);
     }
 
     /**
@@ -1569,12 +1569,12 @@ trait IntegrationTestTrait
         string $message = '',
     ): void {
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat($name, new CookieSet($this->_response), $verboseMessage);
+        $this->assertThat($name, new CookieSet($this->response), $verboseMessage);
 
-        $this->_cookieEncryptionKey = $key;
+        $this->cookieEncryptionKey = $key;
         $this->assertThat(
             $expected,
-            new CookieEncryptedEquals($this->_response, $name, $encrypt, $this->getCookieEncryptionKey()),
+            new CookieEncryptedEquals($this->response, $name, $encrypt, $this->getCookieEncryptionKey()),
         );
     }
 
@@ -1588,13 +1588,13 @@ trait IntegrationTestTrait
     public function assertFileResponse(string $expected, string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        $this->assertThat(null, new FileSent($this->_response), $verboseMessage);
-        $this->assertThat($expected, new FileSentAs($this->_response), $verboseMessage);
+        $this->assertThat(null, new FileSent($this->response), $verboseMessage);
+        $this->assertThat($expected, new FileSentAs($this->response), $verboseMessage);
 
-        if (!$this->_response) {
+        if (!$this->response) {
             return;
         }
-        $this->_response->getBody()->close();
+        $this->response->getBody()->close();
     }
 
     /**
@@ -1605,13 +1605,13 @@ trait IntegrationTestTrait
      */
     protected function extractVerboseMessage(string $message): string
     {
-        if ($this->_exception instanceof Exception) {
-            $message .= $this->extractExceptionMessage($this->_exception);
+        if ($this->exception instanceof Exception) {
+            $message .= $this->extractExceptionMessage($this->exception);
         }
-        if ($this->_controller === null) {
+        if ($this->controller === null) {
             return $message;
         }
-        $error = $this->_controller->viewBuilder()->getVar('error');
+        $error = $this->controller->viewBuilder()->getVar('error');
         if ($error instanceof Exception) {
             $message .= $this->extractExceptionMessage($this->viewVariable('error'));
         }
@@ -1677,6 +1677,6 @@ trait IntegrationTestTrait
      */
     protected function responseBody(): string
     {
-        return PHP_EOL . '------' . PHP_EOL . $this->_response->getBody() . PHP_EOL . '------' . PHP_EOL;
+        return PHP_EOL . '------' . PHP_EOL . $this->response->getBody() . PHP_EOL . '------' . PHP_EOL;
     }
 }

--- a/src/TestSuite/StringCompareTrait.php
+++ b/src/TestSuite/StringCompareTrait.php
@@ -33,7 +33,7 @@ trait StringCompareTrait
      *
      * @var string
      */
-    protected string $_compareBasePath = '';
+    protected string $compareBasePath = '';
 
     /**
      * Update comparisons to match test changes
@@ -42,7 +42,7 @@ trait StringCompareTrait
      *
      * @var bool
      */
-    protected bool $_updateComparisons;
+    protected bool $updateComparisons;
 
     /**
      * Compare the result to the contents of the file
@@ -59,12 +59,12 @@ trait StringCompareTrait
     public function assertSameAsFile(string $path, string $result): void
     {
         if (!file_exists($path)) {
-            $path = $this->_compareBasePath . $path;
+            $path = $this->compareBasePath . $path;
         }
 
-        $this->_updateComparisons ??= (bool)env('UPDATE_TEST_COMPARISON_FILES');
+        $this->updateComparisons ??= (bool)env('UPDATE_TEST_COMPARISON_FILES');
 
-        if ($this->_updateComparisons) {
+        if ($this->updateComparisons) {
             file_put_contents($path, $result);
         }
 

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -70,7 +70,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @var array
      */
-    protected array $_configure = [];
+    protected array $configure = [];
 
     /**
      * Plugins to be loaded after app instance is created ContainerStubTrait::creatApp()
@@ -82,7 +82,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * @var \Cake\Error\PhpError|null
      */
-    private ?PhpError $_capturedError = null;
+    private ?PhpError $capturedError = null;
 
     /**
      * Overrides SimpleTestCase::skipIf to provide a boolean return value
@@ -132,12 +132,12 @@ abstract class TestCase extends BaseTestCase
         $default = error_reporting();
         error_reporting($errorLevel);
 
-        $this->_capturedError = null;
+        $this->capturedError = null;
         set_error_handler(
             function (int $code, string $description, string $file, int $line) {
                 $trace = Debugger::trace(['start' => 1, 'format' => 'points']);
                 assert(is_array($trace));
-                $this->_capturedError = new PhpError($code, $description, $file, $line, $trace);
+                $this->capturedError = new PhpError($code, $description, $file, $line, $trace);
 
                 return true;
             },
@@ -150,11 +150,11 @@ abstract class TestCase extends BaseTestCase
             restore_error_handler();
             error_reporting($default);
         }
-        if ($this->_capturedError === null) {
+        if ($this->capturedError === null) {
             $this->fail('No error was captured');
         }
-        /** @var \Cake\Error\PhpError $this->_capturedError */
-        return $this->_capturedError;
+
+        return $this->capturedError;
     }
 
     /**
@@ -242,8 +242,8 @@ abstract class TestCase extends BaseTestCase
         parent::setUp();
         $this->setupFixtures();
 
-        if (!$this->_configure) {
-            $this->_configure = Configure::read();
+        if (!$this->configure) {
+            $this->configure = Configure::read();
         }
         if (class_exists(Router::class, false)) {
             Router::reload();
@@ -268,12 +268,12 @@ abstract class TestCase extends BaseTestCase
         parent::tearDown();
         $this->teardownFixtures();
 
-        if ($this->_configure) {
+        if ($this->configure) {
             Configure::clear();
-            Configure::write($this->_configure);
+            Configure::write($this->configure);
         }
         $this->getTableLocator()->clear();
-        $this->_configure = [];
+        $this->configure = [];
         $this->tableLocator = null;
         if (class_exists(Mockery::class)) {
             Mockery::close();

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -40,7 +40,7 @@ trait CookieCryptTrait
     abstract protected function getCookieEncryptionKey(): string;
 
     /**
-     * Encrypts $value using public $type method in Security class
+     * Encrypts $value using $hashType method in Security class
      *
      * @param array|string $value Value to encrypt
      * @param string|false $encrypt Encryption mode to use. False
@@ -86,7 +86,7 @@ trait CookieCryptTrait
     }
 
     /**
-     * Decrypts $value using public $type method in Security class
+     * Decrypts $value using $hashType method in Security class
      *
      * @param array<string>|string $values Values to decrypt
      * @param string|false $mode Encryption mode

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -44,14 +44,14 @@ trait ValidatorAwareTrait
      *
      * @var string
      */
-    protected string $_validatorClass = Validator::class;
+    protected string $validatorClass = Validator::class;
 
     /**
      * A list of validation objects indexed by name
      *
      * @var array<\Cake\Validation\Validator>
      */
-    protected array $_validators = [];
+    protected array $validators = [];
 
     /**
      * Returns the validation rules tagged with $name. It is possible to have
@@ -90,11 +90,11 @@ trait ValidatorAwareTrait
     public function getValidator(?string $name = null): Validator
     {
         $name = $name ?: static::DEFAULT_VALIDATOR;
-        if (!isset($this->_validators[$name])) {
+        if (!isset($this->validators[$name])) {
             $this->setValidator($name, $this->createValidator($name));
         }
 
-        return $this->_validators[$name];
+        return $this->validators[$name];
     }
 
     /**
@@ -116,7 +116,7 @@ trait ValidatorAwareTrait
             throw new InvalidArgumentException($message);
         }
 
-        $validator = new $this->_validatorClass();
+        $validator = new $this->validatorClass();
         $validator = $this->$method($validator);
         if ($this instanceof EventDispatcherInterface) {
             $event = defined(static::class . '::BUILD_VALIDATOR_EVENT')
@@ -162,7 +162,7 @@ trait ValidatorAwareTrait
             $validator->setProvider(static::VALIDATOR_PROVIDER_NAME, $this);
         }
 
-        $this->_validators[$name] = $validator;
+        $this->validators[$name] = $validator;
 
         return $this;
     }
@@ -180,7 +180,7 @@ trait ValidatorAwareTrait
             return true;
         }
 
-        return isset($this->_validators[$name]);
+        return isset($this->validators[$name]);
     }
 
     /**

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -107,14 +107,14 @@ abstract class Cell implements EventDispatcherInterface, Stringable
      *
      * @var array<string>
      */
-    protected array $_validCellOptions = [];
+    protected array $validCellOptions = [];
 
     /**
      * Caching setup.
      *
      * @var array|bool
      */
-    protected array|bool $_cache = false;
+    protected array|bool $cache = false;
 
     /**
      * Constructor.
@@ -136,14 +136,14 @@ abstract class Cell implements EventDispatcherInterface, Stringable
         $this->request = $request;
         $this->response = $response;
 
-        $this->_validCellOptions = array_merge(['action', 'args', 'plugin'], $this->_validCellOptions);
-        foreach ($this->_validCellOptions as $var) {
+        $this->validCellOptions = array_merge(['action', 'args', 'plugin'], $this->validCellOptions);
+        foreach ($this->validCellOptions as $var) {
             if (isset($cellOptions[$var])) {
                 $this->{$var} = $cellOptions[$var];
             }
         }
         if (!empty($cellOptions['cache'])) {
-            $this->_cache = $cellOptions['cache'];
+            $this->cache = $cellOptions['cache'];
         }
 
         $this->initialize();
@@ -168,14 +168,14 @@ abstract class Cell implements EventDispatcherInterface, Stringable
      */
     public function viewBuilder(): ViewBuilder
     {
-        if ($this->_viewBuilder === null) {
-            $this->_viewBuilder = new ViewBuilder();
+        if ($this->viewBuilder === null) {
+            $this->viewBuilder = new ViewBuilder();
             if ($this->plugin !== null) {
-                $this->_viewBuilder->setPlugin($this->plugin);
+                $this->viewBuilder->setPlugin($this->plugin);
             }
         }
 
-        return $this->_viewBuilder;
+        return $this->viewBuilder;
     }
 
     /**
@@ -189,7 +189,7 @@ abstract class Cell implements EventDispatcherInterface, Stringable
     public function render(?string $template = null): string
     {
         $cache = [];
-        if ($this->_cache) {
+        if ($this->cache) {
             $cache = $this->cacheConfig($this->action, $template);
         }
 
@@ -257,7 +257,7 @@ abstract class Cell implements EventDispatcherInterface, Stringable
      */
     protected function cacheConfig(string $action, ?string $template = null): array
     {
-        if (!$this->_cache) {
+        if (!$this->cache) {
             return [];
         }
         $template = $template ?: 'default';
@@ -267,11 +267,11 @@ abstract class Cell implements EventDispatcherInterface, Stringable
             'config' => 'default',
             'key' => $key,
         ];
-        if ($this->_cache === true) {
+        if ($this->cache === true) {
             return $default;
         }
 
-        return $this->_cache + $default;
+        return $this->cache + $default;
     }
 
     /**

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -76,7 +76,7 @@ class ArrayContext implements ContextInterface
      *
      * @var array<string, mixed>
      */
-    protected array $_context;
+    protected array $context;
 
     /**
      * Constructor.
@@ -92,7 +92,7 @@ class ArrayContext implements ContextInterface
             'defaults' => [],
             'errors' => [],
         ];
-        $this->_context = $context;
+        $this->context = $context;
     }
 
     /**
@@ -103,12 +103,12 @@ class ArrayContext implements ContextInterface
     public function getPrimaryKey(): array
     {
         if (
-            empty($this->_context['schema']['_constraints']) ||
-            !is_array($this->_context['schema']['_constraints'])
+            empty($this->context['schema']['_constraints']) ||
+            !is_array($this->context['schema']['_constraints'])
         ) {
             return [];
         }
-        foreach ($this->_context['schema']['_constraints'] as $data) {
+        foreach ($this->context['schema']['_constraints'] as $data) {
             if (isset($data['type']) && $data['type'] === 'primary') {
                 return (array)($data['columns'] ?? []);
             }
@@ -140,7 +140,7 @@ class ArrayContext implements ContextInterface
     {
         $primary = $this->getPrimaryKey();
 
-        return array_all($primary, fn($column) => empty($this->_context['defaults'][$column]));
+        return array_all($primary, fn($column) => empty($this->context['defaults'][$column]));
     }
 
     /**
@@ -165,23 +165,23 @@ class ArrayContext implements ContextInterface
             'schemaDefault' => true,
         ];
 
-        if (Hash::check($this->_context['data'], $field)) {
-            return Hash::get($this->_context['data'], $field);
+        if (Hash::check($this->context['data'], $field)) {
+            return Hash::get($this->context['data'], $field);
         }
 
         if ($options['default'] !== null || !$options['schemaDefault']) {
             return $options['default'];
         }
-        if (empty($this->_context['defaults']) || !is_array($this->_context['defaults'])) {
+        if (empty($this->context['defaults']) || !is_array($this->context['defaults'])) {
             return null;
         }
 
         // Using Hash::check here in case the default value is actually null
-        if (Hash::check($this->_context['defaults'], $field)) {
-            return Hash::get($this->_context['defaults'], $field);
+        if (Hash::check($this->context['defaults'], $field)) {
+            return Hash::get($this->context['defaults'], $field);
         }
 
-        return Hash::get($this->_context['defaults'], $this->stripNesting($field));
+        return Hash::get($this->context['defaults'], $this->stripNesting($field));
     }
 
     /**
@@ -194,12 +194,12 @@ class ArrayContext implements ContextInterface
      */
     public function isRequired(string $field): ?bool
     {
-        if (!is_array($this->_context['required'])) {
+        if (!is_array($this->context['required'])) {
             return null;
         }
 
-        $required = Hash::get($this->_context['required'], $field)
-            ?? Hash::get($this->_context['required'], $this->stripNesting($field));
+        $required = Hash::get($this->context['required'], $field)
+            ?? Hash::get($this->context['required'], $this->stripNesting($field));
 
         if ($required || $required === '0') {
             return true;
@@ -213,11 +213,11 @@ class ArrayContext implements ContextInterface
      */
     public function getRequiredMessage(string $field): ?string
     {
-        if (!is_array($this->_context['required'])) {
+        if (!is_array($this->context['required'])) {
             return null;
         }
-        $required = Hash::get($this->_context['required'], $field)
-            ?? Hash::get($this->_context['required'], $this->stripNesting($field));
+        $required = Hash::get($this->context['required'], $field)
+            ?? Hash::get($this->context['required'], $this->stripNesting($field));
 
         if ($required === false) {
             return null;
@@ -240,11 +240,11 @@ class ArrayContext implements ContextInterface
      */
     public function getMaxLength(string $field): ?int
     {
-        if (!is_array($this->_context['schema'])) {
+        if (!is_array($this->context['schema'])) {
             return null;
         }
 
-        return Hash::get($this->_context['schema'], "{$field}.length");
+        return Hash::get($this->context['schema'], "{$field}.length");
     }
 
     /**
@@ -252,7 +252,7 @@ class ArrayContext implements ContextInterface
      */
     public function fieldNames(): array
     {
-        $schema = $this->_context['schema'];
+        $schema = $this->context['schema'];
         unset($schema['_constraints'], $schema['_indexes']);
 
         /** @var array<string> */
@@ -268,12 +268,12 @@ class ArrayContext implements ContextInterface
      */
     public function type(string $field): ?string
     {
-        if (!is_array($this->_context['schema'])) {
+        if (!is_array($this->context['schema'])) {
             return null;
         }
 
-        $schema = Hash::get($this->_context['schema'], $field)
-            ?? Hash::get($this->_context['schema'], $this->stripNesting($field));
+        $schema = Hash::get($this->context['schema'], $field)
+            ?? Hash::get($this->context['schema'], $this->stripNesting($field));
 
         return $schema['type'] ?? null;
     }
@@ -286,11 +286,11 @@ class ArrayContext implements ContextInterface
      */
     public function attributes(string $field): array
     {
-        if (!is_array($this->_context['schema'])) {
+        if (!is_array($this->context['schema'])) {
             return [];
         }
-        $schema = Hash::get($this->_context['schema'], $field)
-            ?? Hash::get($this->_context['schema'], $this->stripNesting($field));
+        $schema = Hash::get($this->context['schema'], $field)
+            ?? Hash::get($this->context['schema'], $this->stripNesting($field));
 
         return array_intersect_key(
             (array)$schema,
@@ -306,11 +306,11 @@ class ArrayContext implements ContextInterface
      */
     public function hasError(string $field): bool
     {
-        if (empty($this->_context['errors'])) {
+        if (empty($this->context['errors'])) {
             return false;
         }
 
-        return Hash::check($this->_context['errors'], $field);
+        return Hash::check($this->context['errors'], $field);
     }
 
     /**
@@ -322,11 +322,11 @@ class ArrayContext implements ContextInterface
      */
     public function error(string $field): array
     {
-        if (empty($this->_context['errors'])) {
+        if (empty($this->context['errors'])) {
             return [];
         }
 
-        return (array)Hash::get($this->_context['errors'], $field);
+        return (array)Hash::get($this->context['errors'], $field);
     }
 
     /**

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -60,14 +60,14 @@ class EntityContext implements ContextInterface
      *
      * @var array<string, mixed>
      */
-    protected array $_context;
+    protected array $context;
 
     /**
      * The name of the top level entity/table object.
      *
      * @var string
      */
-    protected string $_rootName;
+    protected string $rootName;
 
     /**
      * Boolean to track whether the entity is a
@@ -75,21 +75,21 @@ class EntityContext implements ContextInterface
      *
      * @var bool
      */
-    protected bool $_isCollection = false;
+    protected bool $isCollection = false;
 
     /**
      * A dictionary of tables
      *
      * @var array<\Cake\ORM\Table>
      */
-    protected array $_tables = [];
+    protected array $tables = [];
 
     /**
      * Dictionary of validators.
      *
      * @var array<\Cake\Validation\Validator>
      */
-    protected array $_validator = [];
+    protected array $validator = [];
 
     /**
      * Constructor.
@@ -103,7 +103,7 @@ class EntityContext implements ContextInterface
             'table' => null,
             'validator' => [],
         ];
-        $this->_context = $context;
+        $this->context = $context;
         $this->prepare();
     }
 
@@ -124,14 +124,14 @@ class EntityContext implements ContextInterface
      */
     protected function prepare(): void
     {
-        $table = $this->_context['table'];
+        $table = $this->context['table'];
 
         /** @var \Cake\Datasource\EntityInterface|iterable<\Cake\Datasource\EntityInterface|array> $entity */
-        $entity = $this->_context['entity'];
-        $this->_isCollection = is_iterable($entity);
+        $entity = $this->context['entity'];
+        $this->isCollection = is_iterable($entity);
 
         if (!$table) {
-            if ($this->_isCollection) {
+            if ($this->isCollection) {
                 /** @var iterable<\Cake\Datasource\EntityInterface|array> $entity */
                 foreach ($entity as $e) {
                     $entity = $e;
@@ -155,8 +155,8 @@ class EntityContext implements ContextInterface
             throw new CakeException('Unable to find table class for current entity.');
         }
         $alias = $table->getAlias();
-        $this->_rootName = $alias;
-        $this->_tables[$alias] = $table;
+        $this->rootName = $alias;
+        $this->tables[$alias] = $table;
     }
 
     /**
@@ -168,7 +168,7 @@ class EntityContext implements ContextInterface
      */
     public function getPrimaryKey(): array
     {
-        return (array)$this->_tables[$this->_rootName]->getPrimaryKey();
+        return (array)$this->tables[$this->rootName]->getPrimaryKey();
     }
 
     /**
@@ -199,7 +199,7 @@ class EntityContext implements ContextInterface
      */
     public function isCreate(): bool
     {
-        $entity = $this->_context['entity'];
+        $entity = $this->context['entity'];
         if (is_iterable($entity)) {
             foreach ($entity as $e) {
                 $entity = $e;
@@ -234,7 +234,7 @@ class EntityContext implements ContextInterface
             'schemaDefault' => true,
         ];
 
-        if (!$this->_context['entity']) {
+        if (!$this->context['entity']) {
             return $options['default'];
         }
         $parts = explode('.', $field);
@@ -333,19 +333,19 @@ class EntityContext implements ContextInterface
     public function entity(?array $path = null): EntityInterface|iterable|null
     {
         if ($path === null) {
-            return $this->_context['entity'];
+            return $this->context['entity'];
         }
 
         $oneElement = count($path) === 1;
-        if ($oneElement && $this->_isCollection) {
+        if ($oneElement && $this->isCollection) {
             return null;
         }
-        $entity = $this->_context['entity'];
+        $entity = $this->context['entity'];
         if ($oneElement) {
             return $entity;
         }
 
-        if ($path[0] === $this->_rootName) {
+        if ($path[0] === $this->rootName) {
             $path = array_slice($path, 1);
         }
 
@@ -392,22 +392,22 @@ class EntityContext implements ContextInterface
     protected function leafEntity(?array $path = null): array
     {
         if ($path === null) {
-            return $this->_context['entity'];
+            return $this->context['entity'];
         }
 
         $oneElement = count($path) === 1;
-        if ($oneElement && $this->_isCollection) {
+        if ($oneElement && $this->isCollection) {
             throw new CakeException(sprintf(
                 'Unable to fetch property `%s`.',
                 implode('.', $path),
             ));
         }
-        $entity = $this->_context['entity'];
+        $entity = $this->context['entity'];
         if ($oneElement) {
             return [$entity, $path];
         }
 
-        if ($path[0] === $this->_rootName) {
+        if ($path[0] === $this->rootName) {
             $path = array_slice($path, 1);
         }
 
@@ -581,12 +581,12 @@ class EntityContext implements ContextInterface
         $key = implode('.', $keyParts);
         $entity = $this->entity($parts);
 
-        if (isset($this->_validator[$key])) {
+        if (isset($this->validator[$key])) {
             if (is_object($entity)) {
-                $this->_validator[$key]->setProvider('entity', $entity);
+                $this->validator[$key]->setProvider('entity', $entity);
             }
 
-            return $this->_validator[$key];
+            return $this->validator[$key];
         }
 
         $table = $this->getTable($parts);
@@ -596,10 +596,10 @@ class EntityContext implements ContextInterface
         $alias = $table->getAlias();
 
         $method = 'default';
-        if (is_string($this->_context['validator'])) {
-            $method = $this->_context['validator'];
-        } elseif (isset($this->_context['validator'][$alias])) {
-            $method = $this->_context['validator'][$alias];
+        if (is_string($this->context['validator'])) {
+            $method = $this->context['validator'];
+        } elseif (isset($this->context['validator'][$alias])) {
+            $method = $this->context['validator'][$alias];
         }
 
         $validator = $table->getValidator($method);
@@ -608,7 +608,7 @@ class EntityContext implements ContextInterface
             $validator->setProvider('entity', $entity);
         }
 
-        return $this->_validator[$key] = $validator;
+        return $this->validator[$key] = $validator;
     }
 
     /**
@@ -622,7 +622,7 @@ class EntityContext implements ContextInterface
     protected function getTable(EntityInterface|array|string $parts, bool $fallback = true): ?Table
     {
         if (!is_array($parts) || count($parts) === 1) {
-            return $this->_tables[$this->_rootName];
+            return $this->tables[$this->rootName];
         }
 
         $normalized = array_slice(array_filter($parts, function (string $part) {
@@ -630,15 +630,15 @@ class EntityContext implements ContextInterface
         }), 0, -1);
 
         $path = implode('.', $normalized);
-        if (isset($this->_tables[$path])) {
-            return $this->_tables[$path];
+        if (isset($this->tables[$path])) {
+            return $this->tables[$path];
         }
 
-        if (current($normalized) === $this->_rootName) {
+        if (current($normalized) === $this->rootName) {
             $normalized = array_slice($normalized, 1);
         }
 
-        $table = $this->_tables[$this->_rootName];
+        $table = $this->tables[$this->rootName];
         $assoc = null;
         foreach ($normalized as $part) {
             if ($assoc instanceof BelongsToMany && $part === $assoc->getJunctionProperty()) {
@@ -660,7 +660,7 @@ class EntityContext implements ContextInterface
             $table = $assoc->getTarget();
         }
 
-        return $this->_tables[$path] = $table;
+        return $this->tables[$path] = $table;
     }
 
     /**

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -32,14 +32,14 @@ class FormContext implements ContextInterface
      *
      * @var \Cake\Form\Form
      */
-    protected Form $_form;
+    protected Form $form;
 
     /**
      * Validator name.
      *
      * @var string|null
      */
-    protected ?string $_validator = null;
+    protected ?string $validator = null;
 
     /**
      * Constructor.
@@ -58,8 +58,8 @@ class FormContext implements ContextInterface
             "`\$context['entity']` must be an instance of " . Form::class,
         );
 
-        $this->_form = $context['entity'];
-        $this->_validator = $context['validator'] ?? null;
+        $this->form = $context['entity'];
+        $this->validator = $context['validator'] ?? null;
     }
 
     /**
@@ -96,7 +96,7 @@ class FormContext implements ContextInterface
             'schemaDefault' => true,
         ];
 
-        $val = $this->_form->getData($field);
+        $val = $this->form->getData($field);
         if ($val !== null) {
             return $val;
         }
@@ -116,7 +116,7 @@ class FormContext implements ContextInterface
      */
     protected function schemaDefault(string $field): mixed
     {
-        $field = $this->_form->getSchema()->field($field);
+        $field = $this->form->getSchema()->field($field);
         if (!$field) {
             return null;
         }
@@ -129,7 +129,7 @@ class FormContext implements ContextInterface
      */
     public function isRequired(string $field): ?bool
     {
-        $validator = $this->_form->getValidator($this->_validator);
+        $validator = $this->form->getValidator($this->validator);
         if (!$validator->hasField($field)) {
             return null;
         }
@@ -147,7 +147,7 @@ class FormContext implements ContextInterface
     {
         $parts = explode('.', $field);
 
-        $validator = $this->_form->getValidator($this->_validator);
+        $validator = $this->form->getValidator($this->validator);
         $fieldName = array_pop($parts);
         if (!$validator->hasField($fieldName)) {
             return null;
@@ -166,7 +166,7 @@ class FormContext implements ContextInterface
      */
     public function getMaxLength(string $field): ?int
     {
-        $validator = $this->_form->getValidator($this->_validator);
+        $validator = $this->form->getValidator($this->validator);
         if (!$validator->hasField($field)) {
             return null;
         }
@@ -189,7 +189,7 @@ class FormContext implements ContextInterface
      */
     public function fieldNames(): array
     {
-        return $this->_form->getSchema()->fields();
+        return $this->form->getSchema()->fields();
     }
 
     /**
@@ -197,7 +197,7 @@ class FormContext implements ContextInterface
      */
     public function type(string $field): ?string
     {
-        return $this->_form->getSchema()->fieldType($field);
+        return $this->form->getSchema()->fieldType($field);
     }
 
     /**
@@ -206,7 +206,7 @@ class FormContext implements ContextInterface
     public function attributes(string $field): array
     {
         return array_intersect_key(
-            (array)$this->_form->getSchema()->field($field),
+            (array)$this->form->getSchema()->field($field),
             array_flip(static::VALID_ATTRIBUTES),
         );
     }
@@ -226,6 +226,6 @@ class FormContext implements ContextInterface
      */
     public function error(string $field): array
     {
-        return (array)Hash::get($this->_form->getErrors(), $field, []);
+        return (array)Hash::get($this->form->getErrors(), $field, []);
     }
 }

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -70,7 +70,7 @@ class Helper implements EventListenerInterface
      *
      * @var \Cake\View\View
      */
-    protected View $_View;
+    protected View $View;
 
     /**
      * Default Constructor
@@ -80,7 +80,7 @@ class Helper implements EventListenerInterface
      */
     public function __construct(View $view, array $config = [])
     {
-        $this->_View = $view;
+        $this->View = $view;
         $this->setConfig($config);
 
         if ($this->helpers) {
@@ -105,7 +105,7 @@ class Helper implements EventListenerInterface
         if (isset($this->helpers[$name])) {
             $config = ['enabled' => false] + $this->helpers[$name];
 
-            return $this->helperInstances[$name] = $this->_View->loadHelper($name, $config);
+            return $this->helperInstances[$name] = $this->View->loadHelper($name, $config);
         }
 
         return null;
@@ -118,7 +118,7 @@ class Helper implements EventListenerInterface
      */
     public function getView(): View
     {
-        return $this->_View;
+        return $this->View;
     }
 
     /**

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -69,7 +69,7 @@ class FlashHelper extends Helper
      */
     public function render(string $key = 'flash', array $options = []): ?string
     {
-        $messages = $this->_View->getRequest()->getFlash()->consume($key);
+        $messages = $this->View->getRequest()->getFlash()->consume($key);
         if ($messages === null) {
             return null;
         }
@@ -77,7 +77,7 @@ class FlashHelper extends Helper
         $out = '';
         foreach ($messages as $message) {
             $message = $options + $message;
-            $out .= $this->_View->element($message['element'], $message);
+            $out .= $this->View->element($message['element'], $message);
         }
 
         return $out;

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -182,7 +182,7 @@ class FormHelper extends Helper
      *
      * @var array<string, array<string>>
      */
-    protected array $_defaultWidgets = [
+    protected array $defaultWidgets = [
         'button' => ['Button'],
         'checkbox' => ['Checkbox'],
         'label' => ['Label'],
@@ -216,21 +216,21 @@ class FormHelper extends Helper
      *
      * @var \Cake\View\Widget\WidgetLocator
      */
-    protected WidgetLocator $_locator;
+    protected WidgetLocator $locator;
 
     /**
      * Context for the current form.
      *
      * @var \Cake\View\Form\ContextInterface|null
      */
-    protected ?ContextInterface $_context = null;
+    protected ?ContextInterface $context = null;
 
     /**
      * Context factory.
      *
      * @var \Cake\View\Form\ContextFactory|null
      */
-    protected ?ContextFactory $_contextFactory = null;
+    protected ?ContextFactory $contextFactory = null;
 
     /**
      * The action attribute value of the last created form.
@@ -238,7 +238,7 @@ class FormHelper extends Helper
      *
      * @var string
      */
-    protected string $_lastAction = '';
+    protected string $lastAction = '';
 
     /**
      * The supported sources that can be used to populate input values.
@@ -257,14 +257,14 @@ class FormHelper extends Helper
      * @see FormHelper::$supportedValueSources for valid values.
      * @var array<string>
      */
-    protected array $_valueSources = ['data', 'context'];
+    protected array $valueSources = ['data', 'context'];
 
     /**
      * Grouped input types.
      *
      * @var array<string>
      */
-    protected array $_groupedInputTypes = ['radio', 'multicheckbox'];
+    protected array $groupedInputTypes = ['radio', 'multicheckbox'];
 
     /**
      * Form protector
@@ -282,7 +282,7 @@ class FormHelper extends Helper
     public function __construct(View $view, array $config = [])
     {
         $locator = null;
-        $widgets = $this->_defaultWidgets;
+        $widgets = $this->defaultWidgets;
         if (isset($config['locator'])) {
             $locator = $config['locator'];
             unset($config['locator']);
@@ -296,17 +296,17 @@ class FormHelper extends Helper
         }
 
         if (isset($config['groupedInputTypes'])) {
-            $this->_groupedInputTypes = $config['groupedInputTypes'];
+            $this->groupedInputTypes = $config['groupedInputTypes'];
             unset($config['groupedInputTypes']);
         }
 
         parent::__construct($view, $config);
 
         if (!$locator) {
-            $locator = new WidgetLocator($this->templater(), $this->_View, $widgets);
+            $locator = new WidgetLocator($this->templater(), $this->View, $widgets);
         }
         $this->setWidgetLocator($locator);
-        $this->_idPrefix = $this->getConfig('idPrefix');
+        $this->idPrefix = $this->getConfig('idPrefix');
     }
 
     /**
@@ -317,7 +317,7 @@ class FormHelper extends Helper
      */
     public function getWidgetLocator(): WidgetLocator
     {
-        return $this->_locator;
+        return $this->locator;
     }
 
     /**
@@ -329,7 +329,7 @@ class FormHelper extends Helper
      */
     public function setWidgetLocator(WidgetLocator $instance): static
     {
-        $this->_locator = $instance;
+        $this->locator = $instance;
 
         return $this;
     }
@@ -344,11 +344,11 @@ class FormHelper extends Helper
     public function contextFactory(?ContextFactory $instance = null, array $contexts = []): ContextFactory
     {
         if ($instance === null) {
-            return $this->_contextFactory ??= ContextFactory::createWithDefaults($contexts);
+            return $this->contextFactory ??= ContextFactory::createWithDefaults($contexts);
         }
-        $this->_contextFactory = $instance;
+        $this->contextFactory = $instance;
 
-        return $this->_contextFactory;
+        return $this->contextFactory;
     }
 
     /**
@@ -415,7 +415,7 @@ class FormHelper extends Helper
         }
 
         if ($options['idPrefix'] !== null) {
-            $this->_idPrefix = $options['idPrefix'];
+            $this->idPrefix = $options['idPrefix'];
         }
         $templater = $this->templater();
 
@@ -427,7 +427,7 @@ class FormHelper extends Helper
         unset($options['templates']);
 
         if ($options['url'] === false) {
-            $url = $this->_View->getRequest()->getRequestTarget();
+            $url = $this->View->getRequest()->getRequestTarget();
             $action = null;
         } else {
             $url = $this->formUrl($context, $options);
@@ -475,7 +475,7 @@ class FormHelper extends Helper
         $htmlAttributes += $options;
 
         if ($this->requestType !== 'get') {
-            $formTokenData = $this->_View->getRequest()->getAttribute('formTokenData');
+            $formTokenData = $this->View->getRequest()->getAttribute('formTokenData');
             if ($formTokenData !== null) {
                 $this->formProtector = $this->createFormProtector($formTokenData);
             }
@@ -504,7 +504,7 @@ class FormHelper extends Helper
      */
     protected function formUrl(ContextInterface $context, array $options): array|string
     {
-        $request = $this->_View->getRequest();
+        $request = $this->View->getRequest();
 
         if ($options['url'] === null) {
             return $request->getRequestTarget();
@@ -521,7 +521,7 @@ class FormHelper extends Helper
         }
 
         $actionDefaults = [
-            'plugin' => $this->_View->getPlugin(),
+            'plugin' => $this->View->getPlugin(),
             'controller' => $request->getParam('controller'),
             'action' => $request->getParam('action'),
         ];
@@ -542,7 +542,7 @@ class FormHelper extends Helper
         $query = $query ? '?' . $query : '';
 
         $path = parse_url($action, PHP_URL_PATH) ?: '';
-        $this->_lastAction = $path . $query;
+        $this->lastAction = $path . $query;
     }
 
     /**
@@ -553,7 +553,7 @@ class FormHelper extends Helper
      */
     protected function csrfField(): string
     {
-        $request = $this->_View->getRequest();
+        $request = $this->View->getRequest();
 
         $csrfToken = $request->getAttribute('csrfToken');
         if (!$csrfToken) {
@@ -581,16 +581,16 @@ class FormHelper extends Helper
     {
         $out = '';
 
-        if ($this->requestType !== 'get' && $this->_View->getRequest()->getAttribute('formTokenData') !== null) {
+        if ($this->requestType !== 'get' && $this->View->getRequest()->getAttribute('formTokenData') !== null) {
             $out .= $this->secure([], $secureAttributes);
         }
         $out .= $this->formatTemplate('formEnd', []);
 
         $this->templater()->pop();
         $this->requestType = null;
-        $this->_context = null;
-        $this->_valueSources = ['data', 'context'];
-        $this->_idPrefix = $this->getConfig('idPrefix');
+        $this->context = null;
+        $this->valueSources = ['data', 'context'];
+        $this->idPrefix = $this->getConfig('idPrefix');
         $this->formProtector = null;
 
         return $out;
@@ -633,7 +633,7 @@ class FormHelper extends Helper
         $secureAttributes['secure'] = static::SECURE_SKIP;
 
         $tokenData = $this->formProtector->buildTokenData(
-            $this->_lastAction,
+            $this->lastAction,
             $this->getFormProtectorSessionId(),
         );
         $tokenFields = array_merge($secureAttributes, [
@@ -681,7 +681,7 @@ class FormHelper extends Helper
      */
     protected function getFormProtectorSessionId(): string
     {
-        return $this->_View->getRequest()->getSession()->id();
+        return $this->View->getRequest()->getSession()->id();
     }
 
     /**
@@ -708,7 +708,7 @@ class FormHelper extends Helper
      */
     protected function createFormProtector(array $formTokenData): FormProtector
     {
-        $session = $this->_View->getRequest()->getSession();
+        $session = $this->View->getRequest()->getSession();
         $session->start();
 
         return new FormProtector(
@@ -1013,7 +1013,7 @@ class FormHelper extends Helper
         if ($legend === true) {
             $isCreate = $context->isCreate();
             $modelName = Inflector::humanize(
-                Inflector::singularize($this->_View->getRequest()->getParam('controller')),
+                Inflector::singularize($this->View->getRequest()->getParam('controller')),
             );
             if (!$isCreate) {
                 $legend = __d('cake', 'Edit {0}', $modelName);
@@ -1380,7 +1380,7 @@ class FormHelper extends Helper
         $varName = Inflector::variable(
             $pluralize ? Inflector::pluralize($fieldName) : $fieldName,
         );
-        $varOptions = $this->_View->get($varName);
+        $varOptions = $this->View->get($varName);
         if (!is_iterable($varOptions)) {
             return $options;
         }
@@ -1554,7 +1554,7 @@ class FormHelper extends Helper
         }
 
         $labelOptions['for'] = $options['id'];
-        if (in_array($options['type'], $this->_groupedInputTypes, true)) {
+        if (in_array($options['type'], $this->groupedInputTypes, true)) {
             $labelOptions['for'] = false;
         }
         if ($options['nestedInput']) {
@@ -1648,7 +1648,7 @@ class FormHelper extends Helper
     public function radio(string $fieldName, iterable $options = [], array $attributes = []): string
     {
         $attributes['options'] = $options;
-        $attributes['idPrefix'] = $this->_idPrefix;
+        $attributes['idPrefix'] = $this->idPrefix;
         $attributes['nestedInput'] ??= $this->getConfig('nestedCheckboxAndRadio');
 
         $generatedHiddenId = false;
@@ -1929,7 +1929,7 @@ class FormHelper extends Helper
         }
         $templater = $this->templater();
 
-        $restoreAction = $this->_lastAction;
+        $restoreAction = $this->lastAction;
         $this->lastAction($url);
         $restoreFormProtector = $this->formProtector;
 
@@ -1947,7 +1947,7 @@ class FormHelper extends Helper
         ]);
         $out .= $this->csrfField();
 
-        $formTokenData = $this->_View->getRequest()->getAttribute('formTokenData');
+        $formTokenData = $this->View->getRequest()->getAttribute('formTokenData');
         if ($formTokenData !== null) {
             $this->formProtector = $this->createFormProtector($formTokenData);
         }
@@ -1963,14 +1963,14 @@ class FormHelper extends Helper
         $out .= $this->secure($fields);
         $out .= $this->formatTemplate('formEnd', []);
 
-        $this->_lastAction = $restoreAction;
+        $this->lastAction = $restoreAction;
         $this->formProtector = $restoreFormProtector;
 
         if ($options['block']) {
             if ($options['block'] === true) {
                 $options['block'] = __FUNCTION__;
             }
-            $this->_View->append($options['block'], $out);
+            $this->View->append($options['block'], $out);
             $out = '';
         }
 
@@ -1990,7 +1990,7 @@ class FormHelper extends Helper
         }
 
         $script = null;
-        if ($this->_View->getRequest()->getAttribute('cspScriptNonce')) {
+        if ($this->View->getRequest()->getAttribute('cspScriptNonce')) {
             $options['id'] ??= $this->domId('link-' . $formName);
             $script = $this->templater()->format('postLinkJs', [
                 'linkId' => $options['id'],
@@ -2268,7 +2268,7 @@ class FormHelper extends Helper
 
         $attributes = $this->initInputField($fieldName, $attributes);
         $attributes['options'] = $options;
-        $attributes['idPrefix'] = $this->_idPrefix;
+        $attributes['idPrefix'] = $this->idPrefix;
 
         $hidden = '';
         if ($attributes['hiddenField']) {
@@ -2439,7 +2439,7 @@ class FormHelper extends Helper
     {
         $options += ['fieldName' => $field];
 
-        $options['secure'] ??= $this->_View->getRequest()->getAttribute('formTokenData') !== null;
+        $options['secure'] ??= $this->View->getRequest()->getAttribute('formTokenData') !== null;
         $context = $this->getContext();
 
         if (isset($options['id']) && $options['id'] === true) {
@@ -2556,7 +2556,7 @@ class FormHelper extends Helper
     public function context(?ContextInterface $context = null): ContextInterface
     {
         if ($context instanceof ContextInterface) {
-            $this->_context = $context;
+            $this->context = $context;
         }
 
         return $this->getContext();
@@ -2574,13 +2574,13 @@ class FormHelper extends Helper
      */
     protected function getContext(array $data = []): ContextInterface
     {
-        if ($this->_context !== null && !$data) {
-            return $this->_context;
+        if ($this->context !== null && !$data) {
+            return $this->context;
         }
         $data += ['entity' => null];
 
-        return $this->_context = $this->contextFactory()
-            ->get($this->_View->getRequest(), $data);
+        return $this->context = $this->contextFactory()
+            ->get($this->View->getRequest(), $data);
     }
 
     /**
@@ -2595,7 +2595,7 @@ class FormHelper extends Helper
      */
     public function addWidget(string $name, WidgetInterface|array|string $spec): void
     {
-        $this->_locator->add([$name => $spec]);
+        $this->locator->add([$name => $spec]);
     }
 
     /**
@@ -2617,7 +2617,7 @@ class FormHelper extends Helper
             $secure = $data['secure'];
             unset($data['secure']);
         }
-        $widget = $this->_locator->get($name);
+        $widget = $this->locator->get($name);
         $out = $widget->render($data, $this->context());
         if (
             $this->formProtector !== null &&
@@ -2664,7 +2664,7 @@ class FormHelper extends Helper
      */
     public function getValueSources(): array
     {
-        return $this->_valueSources;
+        return $this->valueSources;
     }
 
     /**
@@ -2705,7 +2705,7 @@ class FormHelper extends Helper
         $sources = (array)$sources;
 
         $this->validateValueSources($sources);
-        $this->_valueSources = $sources;
+        $this->valueSources = $sources;
 
         return $this;
     }
@@ -2732,7 +2732,7 @@ class FormHelper extends Helper
             }
             if (isset($valueMap[$valuesSource])) {
                 $method = $valueMap[$valuesSource];
-                $value = $this->_View->getRequest()->{$method}($fieldname);
+                $value = $this->View->getRequest()->{$method}($fieldname);
                 if ($value !== null) {
                     return $value;
                 }

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -86,14 +86,14 @@ class HtmlHelper extends Helper
      *
      * @var array<string, array>
      */
-    protected array $_includedAssets = [];
+    protected array $includedAssets = [];
 
     /**
      * Options for the currently opened script block buffer if any.
      *
      * @var array<string, mixed>
      */
-    protected array $_scriptBlockOptions = [];
+    protected array $scriptBlockOptions = [];
 
     /**
      * Creates a link to an external resource and handles basic meta tags
@@ -159,7 +159,7 @@ class HtmlHelper extends Helper
             }
 
             if ($type === 'csrf-token') {
-                $types['csrf-token']['content'] = $this->_View->getRequest()->getAttribute('csrfToken');
+                $types['csrf-token']['content'] = $this->View->getRequest()->getAttribute('csrfToken');
             }
 
             if (isset($types[$type])) {
@@ -203,7 +203,7 @@ class HtmlHelper extends Helper
         if ($options['block'] === true) {
             $options['block'] = __FUNCTION__;
         }
-        $this->_View->append($options['block'], $out);
+        $this->View->append($options['block'], $out);
 
         return null;
     }
@@ -378,7 +378,7 @@ class HtmlHelper extends Helper
             'once' => true,
             'block' => $this->getConfig('defaultCssBlock'),
             'rel' => 'stylesheet',
-            'nonce' => $this->_View->getRequest()->getAttribute('cspStyleNonce'),
+            'nonce' => $this->View->getRequest()->getAttribute('cspStyleNonce'),
         ];
 
         if (is_array($path)) {
@@ -396,11 +396,11 @@ class HtmlHelper extends Helper
         $url = $this->Url->css($path, $options);
         $options = array_diff_key($options, ['fullBase' => null, 'pathPrefix' => null]);
 
-        if ($options['once'] && isset($this->_includedAssets[__METHOD__][$path])) {
+        if ($options['once'] && isset($this->includedAssets[__METHOD__][$path])) {
             return null;
         }
         unset($options['once']);
-        $this->_includedAssets[__METHOD__][$path] = true;
+        $this->includedAssets[__METHOD__][$path] = true;
 
         $templater = $this->templater();
         if ($options['rel'] === 'import') {
@@ -422,7 +422,7 @@ class HtmlHelper extends Helper
         if ($options['block'] === true) {
             $options['block'] = __FUNCTION__;
         }
-        $this->_View->append($options['block'], $out);
+        $this->View->append($options['block'], $out);
 
         return null;
     }
@@ -477,7 +477,7 @@ class HtmlHelper extends Helper
         $defaults = [
             'block' => $this->getConfig('defaultScriptBlock'),
             'once' => true,
-            'nonce' => $this->_View->getRequest()->getAttribute('cspScriptNonce'),
+            'nonce' => $this->View->getRequest()->getAttribute('cspScriptNonce'),
         ];
         $options += $defaults;
 
@@ -496,10 +496,10 @@ class HtmlHelper extends Helper
         $url = $this->Url->script($url, $options);
         $options = array_diff_key($options, ['fullBase' => null, 'pathPrefix' => null]);
 
-        if ($options['once'] && isset($this->_includedAssets[__METHOD__][$url])) {
+        if ($options['once'] && isset($this->includedAssets[__METHOD__][$url])) {
             return null;
         }
-        $this->_includedAssets[__METHOD__][$url] = true;
+        $this->includedAssets[__METHOD__][$url] = true;
 
         $out = $this->formatTemplate('javascriptlink', [
             'url' => $url,
@@ -512,7 +512,7 @@ class HtmlHelper extends Helper
         if ($options['block'] === true) {
             $options['block'] = __FUNCTION__;
         }
-        $this->_View->append($options['block'], $out);
+        $this->View->append($options['block'], $out);
 
         return null;
     }
@@ -596,7 +596,7 @@ class HtmlHelper extends Helper
     {
         $options += [
             'block' => $this->getConfig('defaultScriptBlock'),
-            'nonce' => $this->_View->getRequest()->getAttribute('cspScriptNonce'),
+            'nonce' => $this->View->getRequest()->getAttribute('cspScriptNonce'),
         ];
 
         $out = $this->formatTemplate('javascriptblock', [
@@ -610,7 +610,7 @@ class HtmlHelper extends Helper
         if ($options['block'] === true) {
             $options['block'] = 'script';
         }
-        $this->_View->append($options['block'], $out);
+        $this->View->append($options['block'], $out);
 
         return null;
     }
@@ -631,7 +631,7 @@ class HtmlHelper extends Helper
      */
     public function scriptStart(array $options = []): void
     {
-        $this->_scriptBlockOptions = $options;
+        $this->scriptBlockOptions = $options;
         ob_start();
     }
 
@@ -650,8 +650,8 @@ class HtmlHelper extends Helper
         if ($matches) {
             $buffer = $matches[1];
         }
-        $options = $this->_scriptBlockOptions;
-        $this->_scriptBlockOptions = [];
+        $options = $this->scriptBlockOptions;
+        $this->scriptBlockOptions = [];
 
         return $this->scriptBlock($buffer, $options);
     }

--- a/src/View/Helper/IdGeneratorTrait.php
+++ b/src/View/Helper/IdGeneratorTrait.php
@@ -29,14 +29,14 @@ trait IdGeneratorTrait
      *
      * @var string|null
      */
-    protected ?string $_idPrefix = null;
+    protected ?string $idPrefix = null;
 
     /**
      * A list of id suffixes used in the current rendering.
      *
      * @var array<string>
      */
-    protected array $_idSuffixes = [];
+    protected array $idSuffixes = [];
 
     /**
      * Clear the stored ID suffixes.
@@ -45,7 +45,7 @@ trait IdGeneratorTrait
      */
     protected function clearIds(): void
     {
-        $this->_idSuffixes = [];
+        $this->idSuffixes = [];
     }
 
     /**
@@ -78,10 +78,10 @@ trait IdGeneratorTrait
         $idSuffix = mb_strtolower(str_replace(['/', '@', '<', '>', ' ', '"', "'"], '-', $val));
         $count = 1;
         $check = $idSuffix;
-        while (in_array($check, $this->_idSuffixes, true)) {
+        while (in_array($check, $this->idSuffixes, true)) {
             $check = $idSuffix . $count++;
         }
-        $this->_idSuffixes[] = $check;
+        $this->idSuffixes[] = $check;
 
         return $check;
     }
@@ -95,8 +95,8 @@ trait IdGeneratorTrait
     protected function domId(string $value): string
     {
         $domId = mb_strtolower(Text::slug($value, '-'));
-        if ($this->_idPrefix) {
-            return $this->_idPrefix . '-' . $domId;
+        if ($this->idPrefix) {
+            return $this->idPrefix . '-' . $domId;
         }
 
         return $domId;

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -114,11 +114,11 @@ class PaginatorHelper extends Helper
     {
         parent::__construct($view, $config);
 
-        $query = $this->_View->getRequest()->getQueryParams();
+        $query = $this->View->getRequest()->getQueryParams();
         unset($query['page'], $query['limit'], $query['sort'], $query['direction']);
         $this->setConfig(
             'options.url',
-            array_merge($this->_View->getRequest()->getParam('pass', []), ['?' => $query]),
+            array_merge($this->View->getRequest()->getParam('pass', []), ['?' => $query]),
         );
     }
 
@@ -143,8 +143,8 @@ class PaginatorHelper extends Helper
     protected function paginated(): PaginatedInterface
     {
         if (!isset($this->paginated)) {
-            foreach ($this->_View->getVars() as $name) {
-                $value = $this->_View->get($name);
+            foreach ($this->View->getVars() as $name) {
+                $value = $this->View->get($name);
                 if ($value instanceof PaginatedInterface) {
                     $this->paginated = $value;
                 }
@@ -1145,7 +1145,7 @@ class PaginatorHelper extends Helper
         }
 
         if ($options['block']) {
-            $this->_View->append($options['block'], $out);
+            $this->View->append($options['block'], $out);
 
             return null;
         }
@@ -1188,7 +1188,7 @@ class PaginatorHelper extends Helper
         assert($scope === null || is_string($scope));
 
         $currentPage = $this->paginated()->currentPage();
-        $query = $this->_View->getRequest()->getQueryParams();
+        $query = $this->View->getRequest()->getQueryParams();
 
         // Prepare query params to preserve as hidden fields
         $hiddenFields = $query;
@@ -1215,11 +1215,11 @@ class PaginatorHelper extends Helper
             $scope .= '.';
         }
 
-        $out = $this->Form->create(null, ['type' => 'get', 'url' => $this->_View->getRequest()->getPath()]);
+        $out = $this->Form->create(null, ['type' => 'get', 'url' => $this->View->getRequest()->getPath()]);
 
         $out .= $this->generateHiddenFields($hiddenFields);
 
-        $limit = $this->_View->getRequest()->getQuery('limit');
+        $limit = $this->View->getRequest()->getQuery('limit');
         $out .= $this->Form->control($scope . 'limit', $options + [
             'type' => 'select',
             'label' => __('View'),

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -51,7 +51,7 @@ class TextHelper extends Helper
      *
      * @var array<string, array>
      */
-    protected array $_placeholders = [];
+    protected array $placeholders = [];
 
     /**
      * Call methods from String utility class
@@ -83,7 +83,7 @@ class TextHelper extends Helper
      */
     public function autoLinkUrls(string $text, array $options = []): string
     {
-        $this->_placeholders = [];
+        $this->placeholders = [];
         $options += ['escape' => true];
 
         // phpcs:disable Generic.Files.LineLength
@@ -141,7 +141,7 @@ class TextHelper extends Helper
             $match = $matches['url_bare'];
         }
         $key = hash_hmac('sha1', $match, Security::getSalt());
-        $this->_placeholders[$key] = [
+        $this->placeholders[$key] = [
             'content' => $match,
             'envelope' => $envelope,
         ];
@@ -159,7 +159,7 @@ class TextHelper extends Helper
     protected function linkUrls(string $text, array $htmlOptions): string
     {
         $replace = [];
-        foreach ($this->_placeholders as $hash => $content) {
+        foreach ($this->placeholders as $hash => $content) {
             $link = $content['content'];
             $url = $content['content'];
             $envelope = $content['envelope'];
@@ -212,7 +212,7 @@ class TextHelper extends Helper
     protected function linkEmails(string $text, array $options): string
     {
         $replace = [];
-        foreach ($this->_placeholders as $hash => $content) {
+        foreach ($this->placeholders as $hash => $content) {
             $url = $content['content'];
             $envelope = $content['envelope'];
             $replace[$hash] = $envelope[0] . $this->Html->link($url, 'mailto:' . $url, $options) . $envelope[1];
@@ -236,7 +236,7 @@ class TextHelper extends Helper
     public function autoLinkEmails(string $text, array $options = []): string
     {
         $options += ['escape' => true];
-        $this->_placeholders = [];
+        $this->placeholders = [];
 
         $atom = '[\p{L}0-9!#$%&\'*+\/=?^_`{|}~-]';
         $text = preg_replace_callback(

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -42,7 +42,7 @@ class UrlHelper extends Helper
      *
      * @var class-string<\Cake\Routing\Asset>
      */
-    protected string $_assetUrlClassName;
+    protected string $assetUrlClassName;
 
     /**
      * Check proper configuration
@@ -61,7 +61,7 @@ class UrlHelper extends Helper
             throw new CakeException(sprintf('Class for `%s` could not be found.', $engineClassConfig));
         }
 
-        $this->_assetUrlClassName = $engineClass;
+        $this->assetUrlClassName = $engineClass;
     }
 
     /**
@@ -135,9 +135,9 @@ class UrlHelper extends Helper
      */
     public function image(string $path, array $options = []): string
     {
-        $options += ['theme' => $this->_View->getTheme()];
+        $options += ['theme' => $this->View->getTheme()];
 
-        return h($this->_assetUrlClassName::imageUrl($path, $options));
+        return h($this->assetUrlClassName::imageUrl($path, $options));
     }
 
     /**
@@ -160,9 +160,9 @@ class UrlHelper extends Helper
      */
     public function css(string $path, array $options = []): string
     {
-        $options += ['theme' => $this->_View->getTheme()];
+        $options += ['theme' => $this->View->getTheme()];
 
-        return h($this->_assetUrlClassName::cssUrl($path, $options));
+        return h($this->assetUrlClassName::cssUrl($path, $options));
     }
 
     /**
@@ -185,9 +185,9 @@ class UrlHelper extends Helper
      */
     public function script(string $path, array $options = []): string
     {
-        $options += ['theme' => $this->_View->getTheme()];
+        $options += ['theme' => $this->View->getTheme()];
 
-        return h($this->_assetUrlClassName::scriptUrl($path, $options));
+        return h($this->assetUrlClassName::scriptUrl($path, $options));
     }
 
     /**
@@ -214,9 +214,9 @@ class UrlHelper extends Helper
      */
     public function assetUrl(string $path, array $options = []): string
     {
-        $options += ['theme' => $this->_View->getTheme()];
+        $options += ['theme' => $this->View->getTheme()];
 
-        return h($this->_assetUrlClassName::url($path, $options));
+        return h($this->assetUrlClassName::url($path, $options));
     }
 
     /**
@@ -230,7 +230,7 @@ class UrlHelper extends Helper
      */
     public function assetTimestamp(string $path, string|bool|null $timestamp = null): string
     {
-        return h($this->_assetUrlClassName::assetTimestamp($path, $timestamp));
+        return h($this->assetUrlClassName::assetTimestamp($path, $timestamp));
     }
 
     /**
@@ -241,9 +241,9 @@ class UrlHelper extends Helper
      */
     public function webroot(string $file): string
     {
-        $options = ['theme' => $this->_View->getTheme()];
+        $options = ['theme' => $this->View->getTheme()];
 
-        return h($this->_assetUrlClassName::webroot($file, $options));
+        return h($this->assetUrlClassName::webroot($file, $options));
     }
 
     /**

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -41,7 +41,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
      *
      * @var \Cake\View\View
      */
-    protected View $_View;
+    protected View $View;
 
     /**
      * Constructor
@@ -50,7 +50,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
      */
     public function __construct(View $view)
     {
-        $this->_View = $view;
+        $this->View = $view;
         $this->setEventManager($view->getEventManager());
     }
 
@@ -73,7 +73,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
         try {
             $this->load($name);
         } catch (MissingHelperException $exception) {
-            $plugin = $this->_View->getPlugin();
+            $plugin = $this->View->getPlugin();
             if ($plugin) {
                 $this->load($name, ['className' => $plugin . '.' . $name]);
 
@@ -154,7 +154,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
             return $class;
         }
 
-        $instance = new $class($this->_View, $config);
+        $instance = new $class($this->View, $config);
 
         if ($config['enabled'] ?? true) {
             $this->getEventManager()->on($instance);

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -41,7 +41,7 @@ class StringTemplate
      *
      * @var array<string, bool>
      */
-    protected array $_compactAttributes = [
+    protected array $compactAttributes = [
         'allowfullscreen' => true,
         'async' => true,
         'autofocus' => true,
@@ -98,14 +98,14 @@ class StringTemplate
      *
      * @var array
      */
-    protected array $_configStack = [];
+    protected array $configStack = [];
 
     /**
      * Contains the list of compiled templates
      *
      * @var array<string, array>
      */
-    protected array $_compiled = [];
+    protected array $compiled = [];
 
     /**
      * Constructor.
@@ -124,9 +124,9 @@ class StringTemplate
      */
     public function push(): void
     {
-        $this->_configStack[] = [
+        $this->configStack[] = [
             $this->config,
-            $this->_compiled,
+            $this->compiled,
         ];
     }
 
@@ -137,10 +137,10 @@ class StringTemplate
      */
     public function pop(): void
     {
-        if (!$this->_configStack) {
+        if (!$this->configStack) {
             return;
         }
-        [$this->config, $this->_compiled] = array_pop($this->_configStack);
+        [$this->config, $this->compiled] = array_pop($this->configStack);
     }
 
     /**
@@ -190,7 +190,7 @@ class StringTemplate
 
             $template = str_replace('%', '%%', $template);
             preg_match_all('#\{\{([\w\.]+)\}\}#', $template, $matches);
-            $this->_compiled[$name] = [
+            $this->compiled[$name] = [
                 str_replace($matches[0], '%s', $template),
                 $matches[1],
             ];
@@ -227,7 +227,7 @@ class StringTemplate
     public function remove(string $name): void
     {
         $this->deleteConfig($name);
-        unset($this->_compiled[$name]);
+        unset($this->compiled[$name]);
     }
 
     /**
@@ -240,10 +240,10 @@ class StringTemplate
      */
     public function format(string $name, array $data): string
     {
-        if (!isset($this->_compiled[$name])) {
+        if (!isset($this->compiled[$name])) {
             throw new InvalidArgumentException(sprintf('Cannot find template named `%s`.', $name));
         }
-        [$template, $placeholders] = $this->_compiled[$name];
+        [$template, $placeholders] = $this->compiled[$name];
 
         if (isset($data['templateVars'])) {
             $data += $data['templateVars'];
@@ -330,7 +330,7 @@ class StringTemplate
             return "{$value}=\"{$value}\"";
         }
         $truthy = [1, '1', true, 'true', $key];
-        $isMinimized = isset($this->_compactAttributes[$key]);
+        $isMinimized = isset($this->compactAttributes[$key]);
         if (!preg_match('/\A(\w|[.-])+\z/', $key)) {
             $key = h($key);
         }

--- a/src/View/StringTemplateTrait.php
+++ b/src/View/StringTemplateTrait.php
@@ -31,7 +31,7 @@ trait StringTemplateTrait
      *
      * @var \Cake\View\StringTemplate|null
      */
-    protected ?StringTemplate $_templater = null;
+    protected ?StringTemplate $templater = null;
 
     /**
      * Sets templates to use.
@@ -86,22 +86,22 @@ trait StringTemplateTrait
      */
     public function templater(): StringTemplate
     {
-        if ($this->_templater === null) {
+        if ($this->templater === null) {
             /** @var class-string<\Cake\View\StringTemplate> $class */
             $class = $this->getConfig('templateClass') ?: StringTemplate::class;
-            $this->_templater = new $class();
+            $this->templater = new $class();
 
             $templates = $this->getConfig('templates');
             if ($templates) {
                 if (is_string($templates)) {
-                    $this->_templater->add($this->defaultConfig['templates']);
-                    $this->_templater->load($templates);
+                    $this->templater->add($this->defaultConfig['templates']);
+                    $this->templater->load($templates);
                 } else {
-                    $this->_templater->add($templates);
+                    $this->templater->add($templates);
                 }
             }
         }
 
-        return $this->_templater;
+        return $this->templater;
     }
 }

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -91,7 +91,7 @@ class View implements EventDispatcherInterface
      *
      * @var \Cake\View\HelperRegistry|null
      */
-    protected ?HelperRegistry $_helpers = null;
+    protected ?HelperRegistry $helperRegistry = null;
 
     /**
      * ViewBlock instance.
@@ -172,7 +172,7 @@ class View implements EventDispatcherInterface
      *
      * @var string
      */
-    protected string $_ext = '.php';
+    protected string $ext = '.php';
 
     /**
      * Sub-directory for this template file. This is often used for extension based routing.
@@ -228,7 +228,7 @@ class View implements EventDispatcherInterface
      *
      * @var array<string>
      */
-    protected array $_passedVars = [
+    protected array $passedVars = [
         'viewVars', 'autoLayout', 'helpers', 'template', 'layout', 'name', 'theme',
         'layoutPath', 'templatePath', 'plugin', 'configMergeStrategy',
     ];
@@ -245,28 +245,28 @@ class View implements EventDispatcherInterface
      *
      * @var array<string>
      */
-    protected array $_paths = [];
+    protected array $paths = [];
 
     /**
      * Holds an array of plugin paths.
      *
      * @var array<string, array<string>>
      */
-    protected array $_pathsForPlugin = [];
+    protected array $pathsForPlugin = [];
 
     /**
      * The names of views and their parents used with View::extend();
      *
      * @var array<string, string>
      */
-    protected array $_parents = [];
+    protected array $parents = [];
 
     /**
      * The currently rendering view file. Used for resolving parent files.
      *
      * @var string
      */
-    protected string $_current = '';
+    protected string $current = '';
 
     /**
      * Currently rendering an element. Used for finding parent fragments
@@ -274,14 +274,14 @@ class View implements EventDispatcherInterface
      *
      * @var string
      */
-    protected string $_currentType = '';
+    protected string $currentType = '';
 
     /**
      * Content stack, used for nested templates that all use View::extend();
      *
      * @var array<string>
      */
-    protected array $_stack = [];
+    protected array $stack = [];
 
     /**
      * ViewBlock class.
@@ -289,7 +289,7 @@ class View implements EventDispatcherInterface
      * @var string
      * @phpstan-var class-string<\Cake\View\ViewBlock>
      */
-    protected string $_viewBlockClass = ViewBlock::class;
+    protected string $viewBlockClass = ViewBlock::class;
 
     /**
      * Constant for view file type 'template'.
@@ -355,7 +355,7 @@ class View implements EventDispatcherInterface
             $this->setEventManager($eventManager);
         }
 
-        foreach ($this->_passedVars as $var) {
+        foreach ($this->passedVars as $var) {
             if (isset($viewOptions[$var])) {
                 $this->{$var} = $viewOptions[$var];
             }
@@ -366,7 +366,7 @@ class View implements EventDispatcherInterface
 
         $config = array_diff_key(
             $viewOptions,
-            array_flip($this->_passedVars),
+            array_flip($this->passedVars),
         );
 
         if ($this->configMergeStrategy === ViewBuilder::MERGE_SHALLOW) {
@@ -378,7 +378,7 @@ class View implements EventDispatcherInterface
         $request ??= Router::getRequest() ?: new ServerRequest(['base' => '', 'url' => '', 'webroot' => '/']);
         $this->request = $request;
         $this->response = $response ?: new Response();
-        $this->Blocks = new $this->_viewBlockClass();
+        $this->Blocks = new $this->viewBlockClass();
         $this->initialize();
         $this->loadHelpers();
     }
@@ -697,7 +697,7 @@ class View implements EventDispatcherInterface
 
         [$plugin, $elementName] = $this->pluginSplit($name, $pluginCheck);
         $paths = iterator_to_array($this->getElementPaths($plugin));
-        throw new MissingElementException([$name . $this->_ext, $elementName . $this->_ext], $paths);
+        throw new MissingElementException([$name . $this->ext, $elementName . $this->ext], $paths);
     }
 
     /**
@@ -795,7 +795,7 @@ class View implements EventDispatcherInterface
         }
 
         $templateFileName = $this->getTemplateFileName($template);
-        $this->_currentType = static::TYPE_TEMPLATE;
+        $this->currentType = static::TYPE_TEMPLATE;
         $this->dispatchEvent('View.beforeRender', [$templateFileName]);
         $this->Blocks->set('content', $this->renderFile($templateFileName));
         $this->dispatchEvent('View.afterRender', [$templateFileName]);
@@ -848,7 +848,7 @@ class View implements EventDispatcherInterface
             $this->Blocks->set('title', $title);
         }
 
-        $this->_currentType = static::TYPE_LAYOUT;
+        $this->currentType = static::TYPE_LAYOUT;
         $this->Blocks->set('content', $this->renderFile($layoutFileName));
 
         $this->dispatchEvent('View.afterLayout', [$layoutFileName]);
@@ -1067,7 +1067,7 @@ class View implements EventDispatcherInterface
      */
     public function extend(string $name): static
     {
-        $type = str_starts_with($name, '/') ? static::TYPE_TEMPLATE : $this->_currentType;
+        $type = str_starts_with($name, '/') ? static::TYPE_TEMPLATE : $this->currentType;
         switch ($type) {
             case static::TYPE_ELEMENT:
                 $parent = $this->getElementFileName($name);
@@ -1077,7 +1077,7 @@ class View implements EventDispatcherInterface
                     $defaultPath = $paths[0] . static::TYPE_ELEMENT . DIRECTORY_SEPARATOR;
                     throw new LogicException(sprintf(
                         'You cannot extend an element which does not exist (%s).',
-                        $defaultPath . $name . $this->_ext,
+                        $defaultPath . $name . $this->ext,
                     ));
                 }
                 break;
@@ -1088,13 +1088,13 @@ class View implements EventDispatcherInterface
                 $parent = $this->getTemplateFileName($name);
         }
 
-        if ($parent === $this->_current) {
+        if ($parent === $this->current) {
             throw new LogicException('You cannot have templates extend themselves.');
         }
-        if (isset($this->_parents[$parent]) && $this->_parents[$parent] === $this->_current) {
+        if (isset($this->parents[$parent]) && $this->parents[$parent] === $this->current) {
             throw new LogicException('You cannot have templates extend in a loop.');
         }
-        $this->_parents[$this->_current] = $parent;
+        $this->parents[$this->current] = $parent;
 
         return $this;
     }
@@ -1106,7 +1106,7 @@ class View implements EventDispatcherInterface
      */
     public function getCurrentType(): string
     {
-        return $this->_currentType;
+        return $this->currentType;
     }
 
     /**
@@ -1151,7 +1151,7 @@ class View implements EventDispatcherInterface
         if (!$data) {
             $data = $this->viewVars;
         }
-        $this->_current = $templateFile;
+        $this->current = $templateFile;
         $initialBlocks = count($this->Blocks->unclosed());
 
         $this->dispatchEvent('View.beforeRenderFile', [$templateFile]);
@@ -1163,12 +1163,12 @@ class View implements EventDispatcherInterface
             $content = $afterEvent->getResult();
         }
 
-        if (isset($this->_parents[$templateFile])) {
-            $this->_stack[] = $this->fetch('content');
+        if (isset($this->parents[$templateFile])) {
+            $this->stack[] = $this->fetch('content');
             $this->assign('content', $content);
 
-            $content = $this->renderFile($this->_parents[$templateFile]);
-            $this->assign('content', array_pop($this->_stack));
+            $content = $this->renderFile($this->parents[$templateFile]);
+            $this->assign('content', array_pop($this->stack));
         }
 
         $remainingBlocks = count($this->Blocks->unclosed());
@@ -1218,7 +1218,7 @@ class View implements EventDispatcherInterface
      */
     public function helpers(): HelperRegistry
     {
-        return $this->_helpers ??= new HelperRegistry($this);
+        return $this->helperRegistry ??= new HelperRegistry($this);
     }
 
     /**
@@ -1380,7 +1380,7 @@ class View implements EventDispatcherInterface
             }
         }
 
-        $name .= $this->_ext;
+        $name .= $this->ext;
         $paths = $this->paths($plugin);
         foreach ($paths as $path) {
             if (is_file($path . $name)) {
@@ -1474,7 +1474,7 @@ class View implements EventDispatcherInterface
             $name = $this->layout;
         }
         [$plugin, $name] = $this->pluginSplit($name);
-        $name .= $this->_ext;
+        $name .= $this->ext;
 
         foreach ($this->getLayoutPaths($plugin) as $path) {
             if (is_file($path . $name)) {
@@ -1518,7 +1518,7 @@ class View implements EventDispatcherInterface
     {
         [$plugin, $name] = $this->pluginSplit($name, $pluginCheck);
 
-        $name .= $this->_ext;
+        $name .= $this->ext;
         foreach ($this->getElementPaths($plugin) as $path) {
             if (is_file($path . $name)) {
                 return $path . $name;
@@ -1584,11 +1584,11 @@ class View implements EventDispatcherInterface
     protected function paths(?string $plugin = null, bool $cached = true): array
     {
         if ($cached) {
-            if ($plugin === null && $this->_paths !== []) {
-                return $this->_paths;
+            if ($plugin === null && $this->paths !== []) {
+                return $this->paths;
             }
-            if ($plugin !== null && isset($this->_pathsForPlugin[$plugin])) {
-                return $this->_pathsForPlugin[$plugin];
+            if ($plugin !== null && isset($this->pathsForPlugin[$plugin])) {
+                return $this->pathsForPlugin[$plugin];
             }
         }
         $templatePaths = array_values(App::path(static::NAME_TEMPLATE));
@@ -1627,10 +1627,10 @@ class View implements EventDispatcherInterface
         );
 
         if ($plugin !== null) {
-            return $this->_pathsForPlugin[$plugin] = $paths;
+            return $this->pathsForPlugin[$plugin] = $paths;
         }
 
-        return $this->_paths = $paths;
+        return $this->paths = $paths;
     }
 
     /**
@@ -1693,9 +1693,9 @@ class View implements EventDispatcherInterface
      */
     protected function renderElement(string $file, array $data, array $options): string
     {
-        $current = $this->_current;
-        $restore = $this->_currentType;
-        $this->_currentType = static::TYPE_ELEMENT;
+        $current = $this->current;
+        $restore = $this->currentType;
+        $this->currentType = static::TYPE_ELEMENT;
 
         if ($options['callbacks']) {
             $this->dispatchEvent('View.beforeRender', [$file]);
@@ -1707,8 +1707,8 @@ class View implements EventDispatcherInterface
             $this->dispatchEvent('View.afterRender', [$file, $element]);
         }
 
-        $this->_currentType = $restore;
-        $this->_current = $current;
+        $this->currentType = $restore;
+        $this->current = $current;
 
         return $element;
     }

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -52,14 +52,14 @@ class ViewBlock
      *
      * @var array<string, string>
      */
-    protected array $_blocks = [];
+    protected array $blocks = [];
 
     /**
      * The active blocks being captured.
      *
      * @var array<string, string>
      */
-    protected array $_active = [];
+    protected array $active = [];
 
     /**
      * Should the currently captured content be discarded on ViewBlock::end()
@@ -67,7 +67,7 @@ class ViewBlock
      * @see \Cake\View\ViewBlock::end()
      * @var bool
      */
-    protected bool $_discardActiveBufferOnEnd = false;
+    protected bool $discardActiveBufferOnEnd = false;
 
     /**
      * Start capturing output for a 'block'
@@ -87,10 +87,10 @@ class ViewBlock
      */
     public function start(string $name, string $mode = ViewBlock::OVERRIDE): void
     {
-        if (array_key_exists($name, $this->_active)) {
+        if (array_key_exists($name, $this->active)) {
             throw new CakeException(sprintf('A view block with the name `%s` is already/still open.', $name));
         }
-        $this->_active[$name] = $mode;
+        $this->active[$name] = $mode;
         ob_start();
     }
 
@@ -102,26 +102,26 @@ class ViewBlock
      */
     public function end(): void
     {
-        if ($this->_discardActiveBufferOnEnd) {
-            $this->_discardActiveBufferOnEnd = false;
+        if ($this->discardActiveBufferOnEnd) {
+            $this->discardActiveBufferOnEnd = false;
             ob_end_clean();
 
             return;
         }
 
-        if (!$this->_active) {
+        if (!$this->active) {
             return;
         }
 
-        $mode = end($this->_active);
-        $active = key($this->_active);
+        $mode = end($this->active);
+        $active = key($this->active);
         $content = (string)ob_get_clean();
         if ($mode === ViewBlock::OVERRIDE) {
-            $this->_blocks[$active] = $content;
+            $this->blocks[$active] = $content;
         } else {
             $this->concat($active, $content, $mode);
         }
-        array_pop($this->_active);
+        array_pop($this->active);
     }
 
     /**
@@ -147,13 +147,13 @@ class ViewBlock
             return;
         }
 
-        if (!isset($this->_blocks[$name])) {
-            $this->_blocks[$name] = '';
+        if (!isset($this->blocks[$name])) {
+            $this->blocks[$name] = '';
         }
         if ($mode === ViewBlock::PREPEND) {
-            $this->_blocks[$name] = $value . $this->_blocks[$name];
+            $this->blocks[$name] = $value . $this->blocks[$name];
         } else {
-            $this->_blocks[$name] .= $value;
+            $this->blocks[$name] .= $value;
         }
     }
 
@@ -168,7 +168,7 @@ class ViewBlock
      */
     public function set(string $name, mixed $value): void
     {
-        $this->_blocks[$name] = (string)$value;
+        $this->blocks[$name] = (string)$value;
     }
 
     /**
@@ -180,7 +180,7 @@ class ViewBlock
      */
     public function get(string $name, string $default = ''): string
     {
-        return $this->_blocks[$name] ?? $default;
+        return $this->blocks[$name] ?? $default;
     }
 
     /**
@@ -191,7 +191,7 @@ class ViewBlock
      */
     public function exists(string $name): bool
     {
-        return isset($this->_blocks[$name]);
+        return isset($this->blocks[$name]);
     }
 
     /**
@@ -201,7 +201,7 @@ class ViewBlock
      */
     public function keys(): array
     {
-        return array_keys($this->_blocks);
+        return array_keys($this->blocks);
     }
 
     /**
@@ -212,7 +212,7 @@ class ViewBlock
     public function active(): ?string
     {
         /** @var string|null */
-        return array_key_last($this->_active);
+        return array_key_last($this->active);
     }
 
     /**
@@ -222,6 +222,6 @@ class ViewBlock
      */
     public function unclosed(): array
     {
-        return $this->_active;
+        return $this->active;
     }
 }

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -55,56 +55,56 @@ class ViewBuilder implements JsonSerializable
      *
      * @var string|null
      */
-    protected ?string $_templatePath = null;
+    protected ?string $templatePath = null;
 
     /**
      * The template file to render.
      *
      * @var string|null
      */
-    protected ?string $_template = null;
+    protected ?string $template = null;
 
     /**
      * The plugin name to use.
      *
      * @var string|null
      */
-    protected ?string $_plugin = null;
+    protected ?string $plugin = null;
 
     /**
      * The theme name to use.
      *
      * @var string|null
      */
-    protected ?string $_theme = null;
+    protected ?string $theme = null;
 
     /**
      * The layout name to render.
      *
      * @var string|null
      */
-    protected ?string $_layout = null;
+    protected ?string $layout = null;
 
     /**
      * Whether autoLayout should be enabled.
      *
      * @var bool
      */
-    protected bool $_autoLayout = true;
+    protected bool $autoLayout = true;
 
     /**
      * The layout path to build the view with.
      *
      * @var string|null
      */
-    protected ?string $_layoutPath = null;
+    protected ?string $layoutPath = null;
 
     /**
      * The view variables to use
      *
      * @var string|null
      */
-    protected ?string $_name = null;
+    protected ?string $name = null;
 
     /**
      * The view class name to use.
@@ -114,7 +114,7 @@ class ViewBuilder implements JsonSerializable
      * @var string|null
      * @phpstan-var class-string<\Cake\View\View>|string|null
      */
-    protected ?string $_className = null;
+    protected ?string $className = null;
 
     /**
      * Additional options used when constructing the view.
@@ -124,7 +124,7 @@ class ViewBuilder implements JsonSerializable
      *
      * @var array<string, mixed>
      */
-    protected array $_options = [];
+    protected array $options = [];
 
     /**
      * The merge strategy for config options.
@@ -132,21 +132,21 @@ class ViewBuilder implements JsonSerializable
      *
      * @var self::MERGE_DEEP|self::MERGE_SHALLOW
      */
-    protected string $_configMergeStrategy = self::MERGE_DEEP;
+    protected string $configMergeStrategy = self::MERGE_DEEP;
 
     /**
      * The helpers to use
      *
      * @var array
      */
-    protected array $_helpers = [];
+    protected array $helpers = [];
 
     /**
      * View vars
      *
      * @var array<string, mixed>
      */
-    protected array $_vars = [];
+    protected array $vars = [];
 
     /**
      * Saves a variable for use inside a template.
@@ -157,7 +157,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function setVar(string $name, mixed $value = null): static
     {
-        $this->_vars[$name] = $value;
+        $this->vars[$name] = $value;
 
         return $this;
     }
@@ -172,9 +172,9 @@ class ViewBuilder implements JsonSerializable
     public function setVars(array $data, bool $merge = true): static
     {
         if ($merge) {
-            $this->_vars = $data + $this->_vars;
+            $this->vars = $data + $this->vars;
         } else {
-            $this->_vars = $data;
+            $this->vars = $data;
         }
 
         return $this;
@@ -188,7 +188,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function hasVar(string $name): bool
     {
-        return array_key_exists($name, $this->_vars);
+        return array_key_exists($name, $this->vars);
     }
 
     /**
@@ -199,7 +199,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function getVar(string $name): mixed
     {
-        return $this->_vars[$name] ?? null;
+        return $this->vars[$name] ?? null;
     }
 
     /**
@@ -209,7 +209,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function getVars(): array
     {
-        return $this->_vars;
+        return $this->vars;
     }
 
     /**
@@ -220,7 +220,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function setTemplatePath(?string $path): static
     {
-        $this->_templatePath = $path;
+        $this->templatePath = $path;
 
         return $this;
     }
@@ -232,7 +232,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function getTemplatePath(): ?string
     {
-        return $this->_templatePath;
+        return $this->templatePath;
     }
 
     /**
@@ -243,7 +243,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function setLayoutPath(?string $path): static
     {
-        $this->_layoutPath = $path;
+        $this->layoutPath = $path;
 
         return $this;
     }
@@ -255,7 +255,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function getLayoutPath(): ?string
     {
-        return $this->_layoutPath;
+        return $this->layoutPath;
     }
 
     /**
@@ -268,7 +268,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function enableAutoLayout(bool $enable = true): static
     {
-        $this->_autoLayout = $enable;
+        $this->autoLayout = $enable;
 
         return $this;
     }
@@ -283,7 +283,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function disableAutoLayout(): static
     {
-        $this->_autoLayout = false;
+        $this->autoLayout = false;
 
         return $this;
     }
@@ -296,7 +296,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function isAutoLayoutEnabled(): bool
     {
-        return $this->_autoLayout;
+        return $this->autoLayout;
     }
 
     /**
@@ -308,7 +308,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function setPlugin(?string $name): static
     {
-        $this->_plugin = $name;
+        $this->plugin = $name;
 
         return $this;
     }
@@ -320,7 +320,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function getPlugin(): ?string
     {
-        return $this->_plugin;
+        return $this->plugin;
     }
 
     /**
@@ -338,7 +338,7 @@ class ViewBuilder implements JsonSerializable
             $options['className'] = $helper;
         }
 
-        $this->_helpers[$name] = $options;
+        $this->helpers[$name] = $options;
 
         return $this;
     }
@@ -371,7 +371,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function setHelpers(array $helpers): static
     {
-        $this->_helpers = [];
+        $this->helpers = [];
 
         foreach ($helpers as $helper => $config) {
             if (is_int($helper)) {
@@ -391,7 +391,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function getHelpers(): array
     {
-        return $this->_helpers;
+        return $this->helpers;
     }
 
     /**
@@ -403,7 +403,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function setTheme(?string $theme): static
     {
-        $this->_theme = $theme;
+        $this->theme = $theme;
 
         return $this;
     }
@@ -415,7 +415,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function getTheme(): ?string
     {
-        return $this->_theme;
+        return $this->theme;
     }
 
     /**
@@ -427,7 +427,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function setTemplate(?string $name): static
     {
-        $this->_template = $name;
+        $this->template = $name;
 
         return $this;
     }
@@ -440,7 +440,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function getTemplate(): ?string
     {
-        return $this->_template;
+        return $this->template;
     }
 
     /**
@@ -453,7 +453,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function setLayout(?string $name): static
     {
-        $this->_layout = $name;
+        $this->layout = $name;
 
         return $this;
     }
@@ -465,7 +465,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function getLayout(): ?string
     {
-        return $this->_layout;
+        return $this->layout;
     }
 
     /**
@@ -476,7 +476,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function getOption(string $name): mixed
     {
-        return $this->_options[$name] ?? null;
+        return $this->options[$name] ?? null;
     }
 
     /**
@@ -488,7 +488,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function setOption(string $name, mixed $value): static
     {
-        $this->_options[$name] = $value;
+        $this->options[$name] = $value;
 
         return $this;
     }
@@ -505,9 +505,9 @@ class ViewBuilder implements JsonSerializable
     public function setOptions(array $options, bool $merge = true): static
     {
         if ($merge) {
-            $options += $this->_options;
+            $options += $this->options;
         }
-        $this->_options = $options;
+        $this->options = $options;
 
         return $this;
     }
@@ -519,7 +519,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function getOptions(): array
     {
-        return $this->_options;
+        return $this->options;
     }
 
     /**
@@ -541,7 +541,7 @@ class ViewBuilder implements JsonSerializable
             throw new InvalidArgumentException('Invalid merge strategy. Valid options are: `deep`, `shallow`.');
         }
 
-        $this->_configMergeStrategy = $strategy;
+        $this->configMergeStrategy = $strategy;
 
         return $this;
     }
@@ -553,7 +553,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function getConfigMergeStrategy(): string
     {
-        return $this->_configMergeStrategy;
+        return $this->configMergeStrategy;
     }
 
     /**
@@ -564,7 +564,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function setName(?string $name): static
     {
-        $this->_name = $name;
+        $this->name = $name;
 
         return $this;
     }
@@ -576,7 +576,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function getName(): ?string
     {
-        return $this->_name;
+        return $this->name;
     }
 
     /**
@@ -591,7 +591,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function setClassName(?string $name): static
     {
-        $this->_className = $name;
+        $this->className = $name;
 
         return $this;
     }
@@ -603,7 +603,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function getClassName(): ?string
     {
-        return $this->_className;
+        return $this->className;
     }
 
     /**
@@ -623,30 +623,30 @@ class ViewBuilder implements JsonSerializable
         ?Response $response = null,
         ?EventManagerInterface $events = null,
     ): View {
-        $className = $this->_className ?? App::className('App', 'View', 'View') ?? View::class;
+        $className = $this->className ?? App::className('App', 'View', 'View') ?? View::class;
         if ($className === 'View') {
             $className = App::className($className, 'View');
         } else {
             $className = App::className($className, 'View', 'View');
         }
         if ($className === null) {
-            throw new MissingViewException(['class' => $this->_className]);
+            throw new MissingViewException(['class' => $this->className]);
         }
 
         $data = [
-            'name' => $this->_name,
-            'templatePath' => $this->_templatePath,
-            'template' => $this->_template,
-            'plugin' => $this->_plugin,
-            'theme' => $this->_theme,
-            'layout' => $this->_layout,
-            'autoLayout' => $this->_autoLayout,
-            'layoutPath' => $this->_layoutPath,
-            'helpers' => $this->_helpers,
-            'viewVars' => $this->_vars,
-            'configMergeStrategy' => $this->_configMergeStrategy,
+            'name' => $this->name,
+            'templatePath' => $this->templatePath,
+            'template' => $this->template,
+            'plugin' => $this->plugin,
+            'theme' => $this->theme,
+            'layout' => $this->layout,
+            'autoLayout' => $this->autoLayout,
+            'layoutPath' => $this->layoutPath,
+            'helpers' => $this->helpers,
+            'viewVars' => $this->vars,
+            'configMergeStrategy' => $this->configMergeStrategy,
         ];
-        $data += $this->_options;
+        $data += $this->options;
 
         /** @var \Cake\View\View */
         return new $className($request, $response, $events, $data);
@@ -668,8 +668,8 @@ class ViewBuilder implements JsonSerializable
     public function jsonSerialize(): array
     {
         $properties = [
-            '_templatePath', '_template', '_plugin', '_theme', '_layout', '_autoLayout',
-            '_layoutPath', '_name', '_className', '_options', '_helpers', '_vars', '_configMergeStrategy',
+            'templatePath', 'template', 'plugin', 'theme', 'layout', 'autoLayout',
+            'layoutPath', 'name', 'className', 'options', 'helpers', 'vars', 'configMergeStrategy',
         ];
 
         $array = [];
@@ -679,7 +679,7 @@ class ViewBuilder implements JsonSerializable
         }
 
         /** @phpstan-ignore-next-line argument.type */
-        array_walk_recursive($array['_vars'], $this->checkViewVars(...));
+        array_walk_recursive($array['vars'], $this->checkViewVars(...));
 
         return array_filter($array, function (array|bool|string|null $i) {
             return !is_array($i) && strlen((string)$i) || !empty($i);

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -30,7 +30,7 @@ trait ViewVarsTrait
      *
      * @var \Cake\View\ViewBuilder|null
      */
-    protected ?ViewBuilder $_viewBuilder = null;
+    protected ?ViewBuilder $viewBuilder = null;
 
     /**
      * Get the view builder being used.
@@ -39,7 +39,7 @@ trait ViewVarsTrait
      */
     public function viewBuilder(): ViewBuilder
     {
-        return $this->_viewBuilder ??= new ViewBuilder();
+        return $this->viewBuilder ??= new ViewBuilder();
     }
 
     /**

--- a/src/View/Widget/BasicWidget.php
+++ b/src/View/Widget/BasicWidget.php
@@ -33,7 +33,7 @@ class BasicWidget implements WidgetInterface
      *
      * @var \Cake\View\StringTemplate
      */
-    protected StringTemplate $_templates;
+    protected StringTemplate $templates;
 
     /**
      * Data defaults.
@@ -55,7 +55,7 @@ class BasicWidget implements WidgetInterface
      */
     public function __construct(StringTemplate $templates)
     {
-        $this->_templates = $templates;
+        $this->templates = $templates;
     }
 
     /**
@@ -99,11 +99,11 @@ class BasicWidget implements WidgetInterface
             }
         }
 
-        return $this->_templates->format('input', [
+        return $this->templates->format('input', [
             'name' => $data['name'],
             'type' => $data['type'],
             'templateVars' => $data['templateVars'],
-            'attrs' => $this->_templates->formatAttributes(
+            'attrs' => $this->templates->formatAttributes(
                 $data,
                 ['name', 'type'],
             ),

--- a/src/View/Widget/ButtonWidget.php
+++ b/src/View/Widget/ButtonWidget.php
@@ -34,7 +34,7 @@ class ButtonWidget implements WidgetInterface
      *
      * @var \Cake\View\StringTemplate
      */
-    protected StringTemplate $_templates;
+    protected StringTemplate $templates;
 
     /**
      * Constructor.
@@ -43,7 +43,7 @@ class ButtonWidget implements WidgetInterface
      */
     public function __construct(StringTemplate $templates)
     {
-        $this->_templates = $templates;
+        $this->templates = $templates;
     }
 
     /**
@@ -73,10 +73,10 @@ class ButtonWidget implements WidgetInterface
             'templateVars' => [],
         ];
 
-        return $this->_templates->format('button', [
+        return $this->templates->format('button', [
             'text' => $data['escape'] ? h($data['text']) : $data['text'],
             'templateVars' => $data['templateVars'],
-            'attrs' => $this->_templates->formatAttributes($data, ['text', 'escapeAttributes']),
+            'attrs' => $this->templates->formatAttributes($data, ['text', 'escapeAttributes']),
         ]);
     }
 

--- a/src/View/Widget/CheckboxWidget.php
+++ b/src/View/Widget/CheckboxWidget.php
@@ -65,12 +65,12 @@ class CheckboxWidget extends BasicWidget
         }
         unset($data['val']);
 
-        $attrs = $this->_templates->formatAttributes(
+        $attrs = $this->templates->formatAttributes(
             $data,
             ['name', 'value'],
         );
 
-        return $this->_templates->format('checkbox', [
+        return $this->templates->format('checkbox', [
             'name' => $data['name'],
             'value' => $data['value'],
             'templateVars' => $data['templateVars'],

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -41,7 +41,7 @@ class DateTimeWidget extends BasicWidget
      *
      * @var \Cake\View\StringTemplate
      */
-    protected StringTemplate $_templates;
+    protected StringTemplate $templates;
 
     /**
      * Data defaults.
@@ -125,11 +125,11 @@ class DateTimeWidget extends BasicWidget
         $data['value'] = $this->formatDateTime($data['val'] === true ? new DateTimeImmutable() : $data['val'], $data);
         unset($data['val'], $data['timezone'], $data['format']);
 
-        return $this->_templates->format('input', [
+        return $this->templates->format('input', [
             'name' => $data['name'],
             'type' => $data['type'],
             'templateVars' => $data['templateVars'],
-            'attrs' => $this->_templates->formatAttributes(
+            'attrs' => $this->templates->formatAttributes(
                 $data,
                 ['name', 'type'],
             ),

--- a/src/View/Widget/LabelWidget.php
+++ b/src/View/Widget/LabelWidget.php
@@ -33,14 +33,14 @@ class LabelWidget implements WidgetInterface
      *
      * @var \Cake\View\StringTemplate
      */
-    protected StringTemplate $_templates;
+    protected StringTemplate $templates;
 
     /**
      * The template to use.
      *
      * @var string
      */
-    protected string $_labelTemplate = 'label';
+    protected string $labelTemplate = 'label';
 
     /**
      * Constructor.
@@ -54,7 +54,7 @@ class LabelWidget implements WidgetInterface
      */
     public function __construct(StringTemplate $templates)
     {
-        $this->_templates = $templates;
+        $this->templates = $templates;
     }
 
     /**
@@ -82,12 +82,12 @@ class LabelWidget implements WidgetInterface
             'templateVars' => [],
         ];
 
-        return $this->_templates->format($this->_labelTemplate, [
+        return $this->templates->format($this->labelTemplate, [
             'text' => $data['escape'] ? h($data['text']) : $data['text'],
             'input' => $data['input'],
             'hidden' => $data['hidden'],
             'templateVars' => $data['templateVars'],
-            'attrs' => $this->_templates->formatAttributes($data, ['text', 'input', 'hidden']),
+            'attrs' => $this->templates->formatAttributes($data, ['text', 'input', 'hidden']),
         ]);
     }
 

--- a/src/View/Widget/MultiCheckboxWidget.php
+++ b/src/View/Widget/MultiCheckboxWidget.php
@@ -53,7 +53,7 @@ class MultiCheckboxWidget extends BasicWidget
      *
      * @var \Cake\View\Widget\LabelWidget
      */
-    protected LabelWidget $_label;
+    protected LabelWidget $label;
 
     /**
      * Render multi-checkbox widget.
@@ -76,7 +76,7 @@ class MultiCheckboxWidget extends BasicWidget
         parent::__construct($templates);
 
         $this->defaults['nestedInput'] = $label instanceof NestingLabelWidget;
-        $this->_label = $label;
+        $this->label = $label;
     }
 
     /**
@@ -125,7 +125,7 @@ class MultiCheckboxWidget extends BasicWidget
     {
         $data += $this->mergeDefaults($data, $context);
 
-        $this->_idPrefix = $data['idPrefix'];
+        $this->idPrefix = $data['idPrefix'];
         $this->clearIds();
 
         return implode('', $this->renderInputs($data, $context));
@@ -145,8 +145,8 @@ class MultiCheckboxWidget extends BasicWidget
             // Grouped inputs in a fieldset.
             if (is_string($key) && is_array($val) && !isset($val['text'], $val['value'])) {
                 $inputs = $this->renderInputs(['options' => $val] + $data, $context);
-                $label = $this->_templates->format('multicheckboxLabel', ['text' => $key]);
-                $out[] = $this->_templates->format('multicheckboxWrapper', [
+                $label = $this->templates->format('multicheckboxLabel', ['text' => $key]);
+                $out[] = $this->templates->format('multicheckboxWrapper', [
                     'content' => $label . implode('', $inputs),
                 ]);
                 continue;
@@ -198,11 +198,11 @@ class MultiCheckboxWidget extends BasicWidget
         $nestedInput = $checkbox['nestedInput'];
         unset($checkbox['nestedInput']);
 
-        $input = $this->_templates->format('checkbox', [
+        $input = $this->templates->format('checkbox', [
             'name' => $checkbox['name'] . '[]',
             'value' => $checkbox['escape'] ? h($checkbox['value']) : $checkbox['value'],
             'templateVars' => $checkbox['templateVars'],
-            'attrs' => $this->_templates->formatAttributes(
+            'attrs' => $this->templates->formatAttributes(
                 $checkbox,
                 ['name', 'value', 'text', 'options', 'label', 'val', 'type'],
             ),
@@ -210,7 +210,7 @@ class MultiCheckboxWidget extends BasicWidget
 
         if (
             $checkbox['label'] === false
-            && ($nestedInput || !str_contains($this->_templates->get('checkboxWrapper'), '{{input}}'))
+            && ($nestedInput || !str_contains($this->templates->get('checkboxWrapper'), '{{input}}'))
         ) {
             $label = $input;
             $input = '';
@@ -233,14 +233,14 @@ class MultiCheckboxWidget extends BasicWidget
             }
 
             if ($checkbox['checked']) {
-                $selectedClass = $this->_templates->format('selectedClass', []);
-                $labelAttrs = (array)$this->_templates->addClass($labelAttrs, $selectedClass);
+                $selectedClass = $this->templates->format('selectedClass', []);
+                $labelAttrs = (array)$this->templates->addClass($labelAttrs, $selectedClass);
             }
 
-            $label = $this->_label->render($labelAttrs, $context);
+            $label = $this->label->render($labelAttrs, $context);
         }
 
-        return $this->_templates->format('checkboxWrapper', [
+        return $this->templates->format('checkboxWrapper', [
             'templateVars' => $checkbox['templateVars'],
             'label' => $label,
             'input' => $input,

--- a/src/View/Widget/NestingLabelWidget.php
+++ b/src/View/Widget/NestingLabelWidget.php
@@ -29,5 +29,5 @@ class NestingLabelWidget extends LabelWidget
      *
      * @var string
      */
-    protected string $_labelTemplate = 'nestingLabel';
+    protected string $labelTemplate = 'nestingLabel';
 }

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -55,7 +55,7 @@ class RadioWidget extends BasicWidget
      *
      * @var \Cake\View\Widget\LabelWidget
      */
-    protected LabelWidget $_label;
+    protected LabelWidget $label;
 
     /**
      * Constructor
@@ -76,7 +76,7 @@ class RadioWidget extends BasicWidget
         parent::__construct($templates);
 
         $this->defaults['nestedInput'] = $label instanceof NestingLabelWidget;
-        $this->_label = $label;
+        $this->label = $label;
     }
 
     /**
@@ -115,7 +115,7 @@ class RadioWidget extends BasicWidget
         }
         unset($data['empty']);
 
-        $this->_idPrefix = $data['idPrefix'];
+        $this->idPrefix = $data['idPrefix'];
         $this->clearIds();
         $opts = [];
         foreach ($options as $val => $text) {
@@ -192,8 +192,8 @@ class RadioWidget extends BasicWidget
         }
 
         if (!is_bool($data['label']) && isset($radio['checked']) && $radio['checked']) {
-            $selectedClass = $this->_templates->format('selectedClass', []);
-            $data['label'] = $this->_templates->addClass((array)$data['label'], $selectedClass);
+            $selectedClass = $this->templates->format('selectedClass', []);
+            $data['label'] = $this->templates->addClass((array)$data['label'], $selectedClass);
         }
 
         $radio['disabled'] = $this->isDisabled($radio, $data['disabled']);
@@ -207,11 +207,11 @@ class RadioWidget extends BasicWidget
         $nestedInput = $data['nestedInput'];
         unset($data['nestedInput']);
 
-        $input = $this->_templates->format('radio', [
+        $input = $this->templates->format('radio', [
             'name' => $radio['name'],
             'value' => $escape ? h($radio['value']) : $radio['value'],
             'templateVars' => $radio['templateVars'],
-            'attrs' => $this->_templates->formatAttributes(
+            'attrs' => $this->templates->formatAttributes(
                 $radio + $data,
                 ['name', 'value', 'text', 'options', 'label', 'val', 'type'],
             ),
@@ -219,7 +219,7 @@ class RadioWidget extends BasicWidget
 
         if (
             $data['label'] === false &&
-            ($nestedInput || !str_contains($this->_templates->get('radioWrapper'), '{{input}}'))
+            ($nestedInput || !str_contains($this->templates->get('radioWrapper'), '{{input}}'))
         ) {
             $label = $input;
             $input = '';
@@ -240,7 +240,7 @@ class RadioWidget extends BasicWidget
             );
         }
 
-        return $this->_templates->format('radioWrapper', [
+        return $this->templates->format('radioWrapper', [
             'input' => $input,
             'label' => $label,
             'templateVars' => $data['templateVars'],
@@ -281,6 +281,6 @@ class RadioWidget extends BasicWidget
             'input' => $input,
         ];
 
-        return $this->_label->render($labelAttrs, $context);
+        return $this->label->render($labelAttrs, $context);
     }
 }

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -135,9 +135,9 @@ class SelectBoxWidget extends BasicWidget
             $template = 'selectMultiple';
             unset($data['multiple']);
         }
-        $attrs = $this->_templates->formatAttributes($data);
+        $attrs = $this->templates->formatAttributes($data);
 
-        return $this->_templates->format($template, [
+        return $this->templates->format($template, [
             'name' => $name,
             'templateVars' => $data['templateVars'],
             'attrs' => $attrs,
@@ -222,11 +222,11 @@ class SelectBoxWidget extends BasicWidget
         }
         $groupOptions = $this->renderOptions($opts, $disabled, $selected, $templateVars, $escape);
 
-        return $this->_templates->format('optgroup', [
+        return $this->templates->format('optgroup', [
             'label' => $escape ? h($label) : $label,
             'content' => implode('', $groupOptions),
             'templateVars' => $templateVars,
-            'attrs' => $this->_templates->formatAttributes($attrs, ['text', 'options']),
+            'attrs' => $this->templates->formatAttributes($attrs, ['text', 'options']),
         ]);
     }
 
@@ -296,11 +296,11 @@ class SelectBoxWidget extends BasicWidget
             }
             $optAttrs['escape'] = $escape;
 
-            $out[] = $this->_templates->format('option', [
+            $out[] = $this->templates->format('option', [
                 'value' => $escape ? h($optAttrs['value']) : $optAttrs['value'],
                 'text' => $escape ? h($optAttrs['text']) : $optAttrs['text'],
                 'templateVars' => $optAttrs['templateVars'],
-                'attrs' => $this->_templates->formatAttributes($optAttrs, ['text', 'value']),
+                'attrs' => $this->templates->formatAttributes($optAttrs, ['text', 'value']),
             ]);
         }
 

--- a/src/View/Widget/TextareaWidget.php
+++ b/src/View/Widget/TextareaWidget.php
@@ -66,11 +66,11 @@ class TextareaWidget extends BasicWidget
             $data = $this->setMaxLength($data, $context, $data['fieldName']);
         }
 
-        return $this->_templates->format('textarea', [
+        return $this->templates->format('textarea', [
             'name' => $data['name'],
             'value' => $data['escape'] ? h($data['val']) : $data['val'],
             'templateVars' => $data['templateVars'],
-            'attrs' => $this->_templates->formatAttributes(
+            'attrs' => $this->templates->formatAttributes(
                 $data,
                 ['name', 'val'],
             ),

--- a/src/View/Widget/WidgetLocator.php
+++ b/src/View/Widget/WidgetLocator.php
@@ -45,21 +45,21 @@ class WidgetLocator
      *
      * @var array
      */
-    protected array $_widgets = [];
+    protected array $widgets = [];
 
     /**
      * Templates to use.
      *
      * @var \Cake\View\StringTemplate
      */
-    protected StringTemplate $_templates;
+    protected StringTemplate $templates;
 
     /**
      * View instance.
      *
      * @var \Cake\View\View
      */
-    protected View $_view;
+    protected View $view;
 
     /**
      * Constructor
@@ -70,8 +70,8 @@ class WidgetLocator
      */
     public function __construct(StringTemplate $templates, View $view, array $widgets = [])
     {
-        $this->_templates = $templates;
-        $this->_view = $view;
+        $this->templates = $templates;
+        $this->view = $view;
 
         $this->add($widgets);
     }
@@ -133,7 +133,7 @@ class WidgetLocator
                 );
             }
 
-            $this->_widgets[$key] = $widget;
+            $this->widgets[$key] = $widget;
         }
 
         foreach ($files as $file) {
@@ -155,19 +155,19 @@ class WidgetLocator
      */
     public function get(string $name): WidgetInterface
     {
-        if (!isset($this->_widgets[$name])) {
-            if (empty($this->_widgets['_default'])) {
+        if (!isset($this->widgets[$name])) {
+            if (empty($this->widgets['_default'])) {
                 throw new InvalidArgumentException(sprintf('Unknown widget `%s`', $name));
             }
 
             $name = '_default';
         }
 
-        if ($this->_widgets[$name] instanceof WidgetInterface) {
-            return $this->_widgets[$name];
+        if ($this->widgets[$name] instanceof WidgetInterface) {
+            return $this->widgets[$name];
         }
 
-        return $this->_widgets[$name] = $this->resolveWidget($this->_widgets[$name]);
+        return $this->widgets[$name] = $this->resolveWidget($this->widgets[$name]);
     }
 
     /**
@@ -177,7 +177,7 @@ class WidgetLocator
      */
     public function clear(): void
     {
-        $this->_widgets = [];
+        $this->widgets = [];
     }
 
     /**
@@ -200,10 +200,10 @@ class WidgetLocator
         }
         if ($config !== []) {
             $reflection = new ReflectionClass($className);
-            $arguments = [$this->_templates];
+            $arguments = [$this->templates];
             foreach ($config as $requirement) {
                 if ($requirement === '_view') {
-                    $arguments[] = $this->_view;
+                    $arguments[] = $this->view;
                 } else {
                     $arguments[] = $this->get($requirement);
                 }
@@ -214,6 +214,6 @@ class WidgetLocator
         }
 
         /** @var \Cake\View\Widget\WidgetInterface */
-        return new $className($this->_templates);
+        return new $className($this->templates);
     }
 }

--- a/src/View/Widget/YearWidget.php
+++ b/src/View/Widget/YearWidget.php
@@ -49,7 +49,7 @@ class YearWidget extends BasicWidget
      *
      * @var \Cake\View\Widget\SelectBoxWidget
      */
-    protected SelectBoxWidget $_select;
+    protected SelectBoxWidget $select;
 
     /**
      * Constructor
@@ -61,7 +61,7 @@ class YearWidget extends BasicWidget
     {
         parent::__construct($templates);
 
-        $this->_select = $selectBox;
+        $this->select = $selectBox;
     }
 
     /**
@@ -111,6 +111,6 @@ class YearWidget extends BasicWidget
 
         unset($data['order'], $data['min'], $data['max']);
 
-        return $this->_select->render($data, $context);
+        return $this->select->render($data, $context);
     }
 }

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -169,7 +169,7 @@ TEXT;
         $result = Debugger::exportVar($View);
         $expected = <<<TEXT
 object(Cake\View\View) id:0 {
-  [protected] _helpers => object(Cake\View\HelperRegistry) id:1 {}
+  [protected] helperRegistry => object(Cake\View\HelperRegistry) id:1 {}
   [protected] Blocks => object(Cake\View\ViewBlock) id:2 {}
   [protected] plugin => null
   [protected] name => ''
@@ -187,14 +187,14 @@ object(Cake\View\View) id:0 {
   [protected] layoutPath => ''
   [protected] autoLayout => true
   [protected] viewVars => []
-  [protected] _ext => '.php'
+  [protected] ext => '.php'
   [protected] subDir => ''
   [protected] theme => null
   [protected] request => object(Cake\Http\ServerRequest) id:3 {}
   [protected] response => object(Cake\Http\Response) id:4 {}
   [protected] elementCache => 'default'
   [protected] configMergeStrategy => 'deep'
-  [protected] _passedVars => [
+  [protected] passedVars => [
     (int) 0 => 'viewVars',
     (int) 1 => 'autoLayout',
     (int) 2 => 'helpers',
@@ -208,13 +208,13 @@ object(Cake\View\View) id:0 {
     (int) 10 => 'configMergeStrategy'
   ]
   [protected] defaultConfig => []
-  [protected] _paths => []
-  [protected] _pathsForPlugin => []
-  [protected] _parents => []
-  [protected] _current => ''
-  [protected] _currentType => ''
-  [protected] _stack => []
-  [protected] _viewBlockClass => 'Cake\View\ViewBlock'
+  [protected] paths => []
+  [protected] pathsForPlugin => []
+  [protected] parents => []
+  [protected] current => ''
+  [protected] currentType => ''
+  [protected] stack => []
+  [protected] viewBlockClass => 'Cake\View\ViewBlock'
   [protected] eventManager => object(Cake\Event\EventManager) id:5 {}
   [protected] eventClass => 'Cake\Event\Event'
   [protected] config => []

--- a/tests/TestCase/TestSuite/Fixture/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TestFixtureTest.php
@@ -42,7 +42,7 @@ class TestFixtureTest extends TestCase
 
             protected function schemaFromReflection(): void
             {
-                $this->_schema = new TableSchema(
+                $this->schema = new TableSchema(
                     'my_table',
                     [],
                 );

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -189,8 +189,8 @@ class IntegrationTestTraitTest extends TestCase
                 'X-CSRF-Token' => 'test321',
             ],
         ]);
-        $this->assertSame('test321', $this->_request['headers']['X-CSRF-Token']);
-        $this->assertArrayNotHasKey('webroot', $this->_request);
+        $this->assertSame('test321', $this->request['headers']['X-CSRF-Token']);
+        $this->assertArrayNotHasKey('webroot', $this->request);
     }
 
     /**
@@ -330,7 +330,7 @@ class IntegrationTestTraitTest extends TestCase
 
         $this->configApplication(Configure::read('App.namespace') . '\ApplicationWithExceptionsInMiddleware', null);
 
-        $this->_request['headers'] = ['Accept' => 'application/json'];
+        $this->request['headers'] = ['Accept' => 'application/json'];
         $this->get('/json_response/api_get_data');
         $this->assertResponseCode(403);
         $this->assertHeader('Content-Type', 'application/json');
@@ -343,11 +343,11 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testHead(): void
     {
-        $this->assertNull($this->_response);
+        $this->assertNull($this->response);
 
         $this->head('/request_action/test_request_action');
-        $this->assertNotEmpty($this->_response);
-        $this->assertInstanceOf(Response::class, $this->_response);
+        $this->assertNotEmpty($this->response);
+        $this->assertInstanceOf(Response::class, $this->response);
         $this->assertResponseSuccess();
     }
 
@@ -365,11 +365,11 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testOptions(): void
     {
-        $this->assertNull($this->_response);
+        $this->assertNull($this->response);
 
         $this->options('/request_action/test_request_action');
-        $this->assertNotEmpty($this->_response);
-        $this->assertInstanceOf(Response::class, $this->_response);
+        $this->assertNotEmpty($this->response);
+        $this->assertInstanceOf(Response::class, $this->response);
         $this->assertResponseSuccess();
     }
 
@@ -389,7 +389,7 @@ class IntegrationTestTraitTest extends TestCase
     {
         $this->get('/get/request_action/test_request_action');
         $this->assertResponseOk();
-        $this->assertSame('This is a test', (string)$this->_response->getBody());
+        $this->assertSame('This is a test', (string)$this->response->getBody());
     }
 
     /**
@@ -408,12 +408,12 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testGetHttpServer(): void
     {
-        $this->assertNull($this->_response);
+        $this->assertNull($this->response);
 
         $this->get('/request_action/test_request_action');
-        $this->assertNotEmpty($this->_response);
-        $this->assertInstanceOf(Response::class, $this->_response);
-        $this->assertSame('This is a test', (string)$this->_response->getBody());
+        $this->assertNotEmpty($this->response);
+        $this->assertInstanceOf(Response::class, $this->response);
+        $this->assertSame('This is a test', (string)$this->response->getBody());
         $this->assertHeader('X-Middleware', 'true');
     }
 
@@ -429,7 +429,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->assertResponseContains('"contentType":"text\/plain"');
         $this->assertHeader('X-Middleware', 'true');
 
-        $request = $this->_controller->getRequest();
+        $request = $this->controller->getRequest();
         $this->assertStringContainsString('/request_action/params_pass?q=query', $request->getRequestTarget());
     }
 
@@ -445,7 +445,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->assertResponseContains('"contentType":"text\/plain"');
         $this->assertHeader('X-Middleware', 'true');
 
-        $request = $this->_controller->getRequest();
+        $request = $this->controller->getRequest();
         $this->assertStringContainsString('/request_action/params_pass?q=query', $request->getRequestTarget());
         $this->assertStringContainsString('/request_action/params_pass', $request->getAttribute('here'));
     }
@@ -468,7 +468,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testPostDataHttpServer(): void
     {
         $this->post('/request_action/post_pass', ['title' => 'value']);
-        $data = json_decode('' . $this->_response->getBody());
+        $data = json_decode('' . $this->response->getBody());
         $this->assertSame('value', $data->title);
         $this->assertHeader('X-Middleware', 'true');
     }
@@ -485,7 +485,7 @@ class IntegrationTestTraitTest extends TestCase
         ]);
         $this->put('/request_action/post_pass', ['title' => 'value']);
         $this->assertResponseOk();
-        $data = json_decode('' . $this->_response->getBody());
+        $data = json_decode('' . $this->response->getBody());
         $this->assertSame('value', $data->title);
     }
 
@@ -530,7 +530,7 @@ class IntegrationTestTraitTest extends TestCase
         ]);
         $this->post('/request_action/uploaded_files');
         $this->assertHeader('X-Middleware', 'true');
-        $data = json_decode((string)$this->_response->getBody(), true);
+        $data = json_decode((string)$this->response->getBody(), true);
 
         $this->assertSame([
             'file' => 'Uploaded file',
@@ -546,10 +546,10 @@ class IntegrationTestTraitTest extends TestCase
     public function testInputDataHttpServer(): void
     {
         $this->post('/request_action/input_test', '{"hello":"world"}');
-        if ($this->_response->getBody()->isSeekable()) {
-            $this->_response->getBody()->rewind();
+        if ($this->response->getBody()->isSeekable()) {
+            $this->response->getBody()->rewind();
         }
-        $this->assertSame('world', $this->_response->getBody()->getContents());
+        $this->assertSame('world', $this->response->getBody()->getContents());
         $this->assertHeader('X-Middleware', 'true');
     }
 
@@ -561,7 +561,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->enableSecurityToken();
 
         $this->post('/request_action/input_test', '{"hello":"world"}');
-        $this->assertSame('world', '' . $this->_response->getBody());
+        $this->assertSame('world', '' . $this->response->getBody());
         $this->assertHeader('X-Middleware', 'true');
     }
 
@@ -583,11 +583,11 @@ class IntegrationTestTraitTest extends TestCase
     public function testRequestSetsProperties(): void
     {
         $this->post('/posts/index');
-        $this->assertInstanceOf(Controller::class, $this->_controller);
-        $this->assertNotEmpty($this->_viewName, 'View name not set');
-        $this->assertStringContainsString('templates' . DS . 'Posts' . DS . 'index.php', $this->_viewName);
-        $this->assertNotEmpty($this->_layoutName, 'Layout name not set');
-        $this->assertStringContainsString('templates' . DS . 'layout' . DS . 'default.php', $this->_layoutName);
+        $this->assertInstanceOf(Controller::class, $this->controller);
+        $this->assertNotEmpty($this->viewName, 'View name not set');
+        $this->assertStringContainsString('templates' . DS . 'Posts' . DS . 'index.php', $this->viewName);
+        $this->assertNotEmpty($this->layoutName, 'Layout name not set');
+        $this->assertStringContainsString('templates' . DS . 'layout' . DS . 'default.php', $this->layoutName);
 
         $this->assertTemplate('index');
         $this->assertLayout('default');
@@ -600,11 +600,11 @@ class IntegrationTestTraitTest extends TestCase
     public function testRequestSetsPropertiesHttpServer(): void
     {
         $this->post('/posts/index');
-        $this->assertInstanceOf(Controller::class, $this->_controller);
-        $this->assertNotEmpty($this->_viewName, 'View name not set');
-        $this->assertStringContainsString('templates' . DS . 'Posts' . DS . 'index.php', $this->_viewName);
-        $this->assertNotEmpty($this->_layoutName, 'Layout name not set');
-        $this->assertStringContainsString('templates' . DS . 'layout' . DS . 'default.php', $this->_layoutName);
+        $this->assertInstanceOf(Controller::class, $this->controller);
+        $this->assertNotEmpty($this->viewName, 'View name not set');
+        $this->assertStringContainsString('templates' . DS . 'Posts' . DS . 'index.php', $this->viewName);
+        $this->assertNotEmpty($this->layoutName, 'Layout name not set');
+        $this->assertStringContainsString('templates' . DS . 'layout' . DS . 'default.php', $this->layoutName);
 
         $this->assertTemplate('index');
         $this->assertLayout('default');
@@ -627,7 +627,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertTemplateAfterCellRender(): void
     {
         $this->get('/posts/get');
-        $this->assertStringContainsString('templates' . DS . 'Posts' . DS . 'get.php', $this->_viewName);
+        $this->assertStringContainsString('templates' . DS . 'Posts' . DS . 'get.php', $this->viewName);
         $this->assertTemplate('get');
         $this->assertResponseContains('cellcontent');
     }
@@ -734,7 +734,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->assertFlashElement('flash/error');
         $this->assertSession(true, 'test');
 
-        $result = $this->_requestSession->read('Flash.flash');
+        $result = $this->requestSession->read('Flash.flash');
         $this->assertSame(['flash/error'], Hash::extract($result, '{n}.element'));
     }
 
@@ -1185,36 +1185,36 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertResponseStatusCodes(): void
     {
-        $this->_response = new Response();
+        $this->response = new Response();
 
-        $this->_response = $this->_response->withStatus(200);
+        $this->response = $this->response->withStatus(200);
         $this->assertResponseOk();
 
-        $this->_response = $this->_response->withStatus(201);
+        $this->response = $this->response->withStatus(201);
         $this->assertResponseOk();
 
-        $this->_response = $this->_response->withStatus(204);
+        $this->response = $this->response->withStatus(204);
         $this->assertResponseOk();
 
-        $this->_response = $this->_response->withStatus(202);
+        $this->response = $this->response->withStatus(202);
         $this->assertResponseSuccess();
 
-        $this->_response = $this->_response->withStatus(302);
+        $this->response = $this->response->withStatus(302);
         $this->assertResponseSuccess();
 
-        $this->_response = $this->_response->withStatus(400);
+        $this->response = $this->response->withStatus(400);
         $this->assertResponseError();
 
-        $this->_response = $this->_response->withStatus(417);
+        $this->response = $this->response->withStatus(417);
         $this->assertResponseError();
 
-        $this->_response = $this->_response->withStatus(500);
+        $this->response = $this->response->withStatus(500);
         $this->assertResponseFailure();
 
-        $this->_response = $this->_response->withStatus(505);
+        $this->response = $this->response->withStatus(505);
         $this->assertResponseFailure();
 
-        $this->_response = $this->_response->withStatus(301);
+        $this->response = $this->response->withStatus(301);
         $this->assertResponseCode(301);
     }
 
@@ -1223,8 +1223,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertRedirect(): void
     {
-        $this->_response = new Response();
-        $this->_response = $this->_response->withHeader('Location', 'http://localhost/get/tasks/index');
+        $this->response = new Response();
+        $this->response = $this->response->withHeader('Location', 'http://localhost/get/tasks/index');
 
         $this->assertRedirect();
         $this->assertRedirect('/get/tasks/index');
@@ -1238,11 +1238,11 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertRedirectBack(): void
     {
-        $this->_response = new Response();
-        $this->_request = [
+        $this->response = new Response();
+        $this->request = [
             'url' => '/get/tasks/index',
         ];
-        $this->_response = $this->_response
+        $this->response = $this->response
             ->withStatus(302)
             ->withHeader('Location', 'http://localhost/get/tasks/index');
 
@@ -1254,11 +1254,11 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertRedirectBackSpecificCode(): void
     {
-        $this->_response = new Response();
-        $this->_request = [
+        $this->response = new Response();
+        $this->request = [
             'url' => '/get/tasks/index',
         ];
-        $this->_response = $this->_response
+        $this->response = $this->response
             ->withStatus(301)
             ->withHeader('Location', 'http://localhost/get/tasks/index');
 
@@ -1270,11 +1270,11 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertRedirectBackInvalid(): void
     {
-        $this->_response = new Response();
-        $this->_request = [
+        $this->response = new Response();
+        $this->request = [
             'url' => '/get/tasks/edit',
         ];
-        $this->_response = $this->_response
+        $this->response = $this->response
             ->withStatus(302)
             ->withHeader('Location', 'http://localhost/get/tasks/index');
 
@@ -1288,13 +1288,13 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertRedirectBackToReferer(): void
     {
-        $this->_response = new Response();
-        $this->_request = [
+        $this->response = new Response();
+        $this->request = [
             'environment' => [
                 'HTTP_REFERER' => 'http://localhost/get/tasks/index',
             ],
         ];
-        $this->_response = $this->_response
+        $this->response = $this->response
             ->withStatus(302)
             ->withHeader('Location', 'http://localhost/get/tasks/index');
 
@@ -1306,13 +1306,13 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertRedirectBackToRefererSpecificCode(): void
     {
-        $this->_response = new Response();
-        $this->_request = [
+        $this->response = new Response();
+        $this->request = [
             'environment' => [
                 'HTTP_REFERER' => 'http://localhost/get/tasks/index',
             ],
         ];
-        $this->_response = $this->_response
+        $this->response = $this->response
             ->withStatus(301)
             ->withHeader('Location', 'http://localhost/get/tasks/index');
 
@@ -1324,13 +1324,13 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertRedirectBackToRefererInvalid(): void
     {
-        $this->_response = new Response();
-        $this->_request = [
+        $this->response = new Response();
+        $this->request = [
             'environment' => [
                 'HTTP_REFERER' => 'http://localhost/get/tasks/index',
             ],
         ];
-        $this->_response = $this->_response
+        $this->response = $this->response
             ->withStatus(302)
             ->withHeader('Location', 'http://localhost/get/tasks/view/1');
 
@@ -1344,8 +1344,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertRedirectEquals(): void
     {
-        $this->_response = new Response();
-        $this->_response = $this->_response->withHeader('Location', '/get/tasks/index');
+        $this->response = new Response();
+        $this->response = $this->response->withHeader('Location', '/get/tasks/index');
 
         $this->assertRedirect();
         $this->assertRedirectEquals('/get/tasks/index');
@@ -1359,8 +1359,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertRedirectNotContains(): void
     {
-        $this->_response = new Response();
-        $this->_response = $this->_response->withHeader('Location', 'http://localhost/tasks/index');
+        $this->response = new Response();
+        $this->response = $this->response->withHeader('Location', 'http://localhost/tasks/index');
         $this->assertRedirectNotContains('test');
     }
 
@@ -1369,7 +1369,7 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertNoRedirect(): void
     {
-        $this->_response = new Response();
+        $this->response = new Response();
 
         $this->assertNoRedirect();
     }
@@ -1379,8 +1379,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertRedirectContains(): void
     {
-        $this->_response = new Response();
-        $this->_response = $this->_response->withHeader('Location', 'http://localhost/tasks/index');
+        $this->response = new Response();
+        $this->response = $this->response->withHeader('Location', 'http://localhost/tasks/index');
 
         $this->assertRedirectContains('/tasks/index');
     }
@@ -1390,9 +1390,9 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertRedirectWithRelativeUrl(): void
     {
-        $this->_response = new Response();
+        $this->response = new Response();
         // Simulate authentication plugin returning relative URL
-        $this->_response = $this->_response->withHeader('Location', '/get/users/login');
+        $this->response = $this->response->withHeader('Location', '/get/users/login');
 
         // Should work with string URL
         $this->assertRedirect('/get/users/login');
@@ -1406,9 +1406,9 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertRedirectEqualsWithRelativeUrl(): void
     {
-        $this->_response = new Response();
+        $this->response = new Response();
         // Simulate authentication plugin returning relative URL
-        $this->_response = $this->_response->withHeader('Location', '/get/users/login');
+        $this->response = $this->response->withHeader('Location', '/get/users/login');
 
         // Should work with string URL
         $this->assertRedirectEquals('/get/users/login');
@@ -1428,9 +1428,9 @@ class IntegrationTestTraitTest extends TestCase
             ['_name' => 'login:form'],
         );
 
-        $this->_response = new Response();
+        $this->response = new Response();
         // Simulate authentication plugin returning relative URL
-        $this->_response = $this->_response->withHeader('Location', '/user/signin');
+        $this->response = $this->response->withHeader('Location', '/user/signin');
 
         // Should work with named route
         $this->assertRedirect(['_name' => 'login:form']);
@@ -1442,15 +1442,15 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertRedirectMixedUrlFormats(): void
     {
-        $this->_response = new Response();
+        $this->response = new Response();
 
         // Test with absolute URL in header, checking with relative path
-        $this->_response = $this->_response->withHeader('Location', 'http://localhost/get/tasks/view/1');
+        $this->response = $this->response->withHeader('Location', 'http://localhost/get/tasks/view/1');
         $this->assertRedirect('/get/tasks/view/1');
         $this->assertRedirectEquals('/get/tasks/view/1');
 
         // Test with relative URL in header, checking with absolute URL
-        $this->_response = $this->_response->withHeader('Location', '/get/tasks/edit/2');
+        $this->response = $this->response->withHeader('Location', '/get/tasks/edit/2');
         $this->assertRedirect('http://localhost/get/tasks/edit/2');
         $this->assertRedirectEquals('http://localhost/get/tasks/edit/2');
     }
@@ -1460,8 +1460,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertHeader(): void
     {
-        $this->_response = new Response();
-        $this->_response = $this->_response->withHeader('Etag', 'abc123');
+        $this->response = new Response();
+        $this->response = $this->response->withHeader('Etag', 'abc123');
 
         $this->assertHeader('Etag', 'abc123');
     }
@@ -1471,8 +1471,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertHeaderContains(): void
     {
-        $this->_response = new Response();
-        $this->_response = $this->_response->withHeader('Etag', 'abc123');
+        $this->response = new Response();
+        $this->response = $this->response->withHeader('Etag', 'abc123');
 
         $this->assertHeaderContains('Etag', 'abc');
     }
@@ -1482,8 +1482,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertHeaderNotContains(): void
     {
-        $this->_response = new Response();
-        $this->_response = $this->_response->withHeader('Etag', 'abc123');
+        $this->response = new Response();
+        $this->response = $this->response->withHeader('Etag', 'abc123');
 
         $this->assertHeaderNotContains('Etag', 'xyz');
     }
@@ -1493,8 +1493,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertContentType(): void
     {
-        $this->_response = new Response();
-        $this->_response = $this->_response->withType('json');
+        $this->response = new Response();
+        $this->response = $this->response->withType('json');
 
         $this->assertContentType('json');
         $this->assertContentType('application/json');
@@ -1516,8 +1516,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertResponseEquals(): void
     {
-        $this->_response = new Response();
-        $this->_response = $this->_response->withStringBody('Some content');
+        $this->response = new Response();
+        $this->response = $this->response->withStringBody('Some content');
 
         $this->assertResponseEquals('Some content');
     }
@@ -1527,8 +1527,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertResponseNotEquals(): void
     {
-        $this->_response = new Response();
-        $this->_response = $this->_response->withStringBody('Some content');
+        $this->response = new Response();
+        $this->response = $this->response->withStringBody('Some content');
 
         $this->assertResponseNotEquals('Some Content');
     }
@@ -1538,8 +1538,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertResponseContains(): void
     {
-        $this->_response = new Response();
-        $this->_response = $this->_response->withStringBody('Some content');
+        $this->response = new Response();
+        $this->response = $this->response->withStringBody('Some content');
 
         $this->assertResponseContains('content');
     }
@@ -1549,8 +1549,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertResponseContainsWithIgnoreCaseFlag(): void
     {
-        $this->_response = new Response();
-        $this->_response = $this->_response->withStringBody('Some content');
+        $this->response = new Response();
+        $this->response = $this->response->withStringBody('Some content');
 
         $this->assertResponseContains('some', 'Failed asserting that the body contains given content', true);
     }
@@ -1560,8 +1560,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertResponseNotContains(): void
     {
-        $this->_response = new Response();
-        $this->_response = $this->_response->withStringBody('Some content');
+        $this->response = new Response();
+        $this->response = $this->response->withStringBody('Some content');
 
         $this->assertResponseNotContains('contents');
     }
@@ -1571,8 +1571,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertResponseRegExp(): void
     {
-        $this->_response = new Response();
-        $this->_response = $this->_response->withStringBody('Some content');
+        $this->response = new Response();
+        $this->response = $this->response->withStringBody('Some content');
 
         $this->assertResponseRegExp('/cont/');
     }
@@ -1592,8 +1592,8 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testAssertResponseNotRegExp(): void
     {
-        $this->_response = new Response();
-        $this->_response = $this->_response->withStringBody('Some content');
+        $this->response = new Response();
+        $this->response = $this->response->withStringBody('Some content');
 
         $this->assertResponseNotRegExp('/cant/');
     }
@@ -1932,7 +1932,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
-        $this->_response = $this->_response->withCookie(new Cookie('cookie', 'value'));
+        $this->response = $this->response->withCookie(new Cookie('cookie', 'value'));
         $this->assertCookieNotSet('cookie');
     }
 
@@ -1944,7 +1944,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
-        $this->_response = $this->_response->withHeader('Location', '/redirect');
+        $this->response = $this->response->withHeader('Location', '/redirect');
         $this->assertNoRedirect();
     }
 
@@ -1967,7 +1967,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
-        $this->_response = $this->_response->withStringBody('body');
+        $this->response = $this->response->withStringBody('body');
         $this->assertResponseNotEquals('body');
     }
 
@@ -1979,7 +1979,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
-        $this->_response = $this->_response->withStringBody('body');
+        $this->response = $this->response->withStringBody('body');
         $this->assertResponseRegExp('/patternNotFound/');
     }
 
@@ -1994,7 +1994,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Possibly related to `OutOfBoundsException`: "oh no!"');
         $this->get('/posts/throw_exception');
-        $this->_requestSession = new Session();
+        $this->requestSession = new Session();
         $this->$assertMethod(...$rest);
     }
 
@@ -2018,7 +2018,7 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testViewVariableNotFoundShouldReturnNull(): void
     {
-        $this->_controller = new Controller(new ServerRequest());
+        $this->controller = new Controller(new ServerRequest());
         $this->assertNull($this->viewVariable('notFound'));
     }
 

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -261,7 +261,7 @@ class TestCaseTest extends TestCase
      */
     public function testSetupBackUpValues(): void
     {
-        $this->assertArrayHasKey('debug', $this->_configure);
+        $this->assertArrayHasKey('debug', $this->configure);
     }
 
     /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7315,7 +7315,7 @@ class FormHelperTest extends TestCase
         $fields = $this->Form->getFormProtector()->__debugInfo()['fields'];
         $this->assertEquals(['title'], $fields);
         $this->assertStringContainsString($hash, $result, 'Should contain the correct hash.');
-        $reflect = new ReflectionProperty($this->Form, '_lastAction');
+        $reflect = new ReflectionProperty($this->Form, 'lastAction');
         $this->assertSame('/Articles/add', $reflect->getValue($this->Form), 'lastAction was should be restored.');
     }
 

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -299,12 +299,12 @@ class ViewBuilderTest extends TestCase
         $result = json_decode(json_encode($builder), true);
 
         $expected = [
-            '_template' => 'default',
-            '_layout' => 'test',
-            '_helpers' => ['Html' => []],
-            '_className' => 'JsonView',
-            '_autoLayout' => true,
-            '_configMergeStrategy' => 'deep',
+            'template' => 'default',
+            'layout' => 'test',
+            'autoLayout' => true,
+            'className' => 'JsonView',
+            'helpers' => ['Html' => []],
+            'configMergeStrategy' => 'deep',
         ];
         $this->assertEquals($expected, $result);
 

--- a/tests/test_app/TestApp/View/Cell/ArticlesCell.php
+++ b/tests/test_app/TestApp/View/Cell/ArticlesCell.php
@@ -27,7 +27,7 @@ class ArticlesCell extends Cell
      *
      * @var array<string>
      */
-    protected array $_validCellOptions = ['limit', 'page'];
+    protected array $validCellOptions = ['limit', 'page'];
 
     /**
      * Counter used to test the cache cell feature

--- a/tests/test_app/TestApp/View/Helper/TestBeforeAfterHelper.php
+++ b/tests/test_app/TestApp/View/Helper/TestBeforeAfterHelper.php
@@ -32,6 +32,6 @@ class TestBeforeAfterHelper extends Helper
      */
     public function afterLayout(EventInterface $event, string $layoutFile): void
     {
-        $this->_View->append('content', 'modified in the afterlife');
+        $this->View->append('content', 'modified in the afterlife');
     }
 }

--- a/tests/test_app/TestApp/View/TestView.php
+++ b/tests/test_app/TestApp/View/TestView.php
@@ -51,6 +51,6 @@ class TestView extends AppView
      */
     public function ext(string $ext): void
     {
-        $this->_ext = $ext;
+        $this->ext = $ext;
     }
 }


### PR DESCRIPTION
## Summary
Applies PSR naming conventions to protected properties, removing underscore prefixes (e.g., `$_helpers` becomes `$helpers`).

### Main changes:
- **View package**: View, ViewBuilder, ViewBlock, Cell, Helper, FormHelper, HtmlHelper, TextHelper, UrlHelper, StringTemplate, all Widgets, Form contexts
- **TestSuite**: IntegrationTestTrait, TestCase, StringCompareTrait, EventFired constraints
- **Validation**: ValidatorAwareTrait  
- **Log**: SyslogLog

### Special cases:
- `View::$_helpers` renamed to `$helperRegistry` (conflicts with existing `$helpers` config array)
- I18n `_toStringFormat` properties unchanged (conflicts with Chronos parent class methods)


Also fixes outdated docblock comments in CookieCryptTrait.

## Related
- Upgrade tool PR: https://github.com/cakephp/upgrade/pull/386