### PR TITLE
Refactor TranslateTrait for consistent return type

### DIFF
--- a/src/ORM/Behavior/Translate/TranslateTrait.php
+++ b/src/ORM/Behavior/Translate/TranslateTrait.php
@@ -19,11 +19,24 @@ namespace Cake\ORM\Behavior\Translate;
 use Cake\Datasource\EntityInterface;
 
 /**
- * Contains a translation method aimed to help managing multiple translations
+ * Contains translation methods aimed to help managing multiple translations
  * for an entity.
  */
 trait TranslateTrait
 {
+    /**
+     * Checks whether a translation exists for the given language.
+     *
+     * @param string $language Language to check.
+     * @return bool
+     */
+    public function hasTranslation(string $language): bool
+    {
+        $i18n = $this->get('_translations');
+
+        return isset($i18n[$language]) && $i18n[$language] instanceof EntityInterface;
+    }
+
     /**
      * Returns the entity containing the translated fields for this object and for
      * the specified language. If the translation for the passed language is not
@@ -31,26 +44,15 @@ trait TranslateTrait
      * it.
      *
      * @param string $language Language to return entity for.
-     * @return \Cake\Datasource\EntityInterface|$this
+     * @return \Cake\Datasource\EntityInterface
      */
-    public function translation(string $language)
+    public function translation(string $language): EntityInterface
     {
-        if ($language === $this->get('_locale')) {
-            return $this;
-        }
-
-        $i18n = $this->has('_translations') ? $this->get('_translations') : null;
+        $i18n = $this->get('_translations') ?? [];
         $created = false;
 
-        if (!$i18n) {
-            $i18n = [];
-            $created = true;
-        }
-
-        if ($created || empty($i18n[$language]) || !($i18n[$language] instanceof EntityInterface)) {
-            $className = static::class;
-
-            $i18n[$language] = new $className();
+        if (!isset($i18n[$language]) || !($i18n[$language] instanceof EntityInterface)) {
+            $i18n[$language] = new static();
             $created = true;
         }
 

--- a/src/ORM/Behavior/Translate/TranslateTrait.php
+++ b/src/ORM/Behavior/Translate/TranslateTrait.php
@@ -39,28 +39,41 @@ trait TranslateTrait
 
     /**
      * Returns the entity containing the translated fields for this object and for
-     * the specified language. If the translation for the passed language is not
-     * present, a new empty entity will be created so that values can be added to
-     * it.
+     * the specified language, or null if the translation does not exist.
+     *
+     * @param string $language Language to return entity for.
+     * @return \Cake\Datasource\EntityInterface|null
+     */
+    public function translation(string $language): ?EntityInterface
+    {
+        $i18n = $this->get('_translations');
+
+        if (isset($i18n[$language]) && $i18n[$language] instanceof EntityInterface) {
+            return $i18n[$language];
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the entity containing the translated fields for this object and for
+     * the specified language. If the translation for the passed language does not
+     * exist, a new empty entity will be created.
+     *
+     * This method marks `_translations` as dirty to facilitate saving.
      *
      * @param string $language Language to return entity for.
      * @return \Cake\Datasource\EntityInterface
      */
-    public function translation(string $language): EntityInterface
+    public function getOrCreateTranslation(string $language): EntityInterface
     {
         $i18n = $this->get('_translations') ?? [];
-        $created = false;
 
         if (!isset($i18n[$language]) || !($i18n[$language] instanceof EntityInterface)) {
             $i18n[$language] = new static();
-            $created = true;
-        }
-
-        if ($created) {
             $this->set('_translations', $i18n);
         }
 
-        // Assume the user will modify any of the internal translations, helps with saving
         $this->setDirty('_translations', true);
 
         return $i18n[$language];

--- a/tests/TestCase/ORM/Behavior/Translate/TranslateTraitTest.php
+++ b/tests/TestCase/ORM/Behavior/Translate/TranslateTraitTest.php
@@ -26,25 +26,19 @@ use TestApp\Model\Entity\TranslateTestEntity;
 class TranslateTraitTest extends TestCase
 {
     /**
-     * Tests that missing translation entries are created automatically
+     * Tests that translation() returns null for non-existent translations
      */
-    public function testTranslationCreate(): void
+    public function testTranslationReturnsNull(): void
     {
         $entity = new TranslateTestEntity();
-        $entity->translation('eng')->set('title', 'My Title');
-        $this->assertSame('My Title', $entity->translation('eng')->get('title'));
-
-        $this->assertTrue($entity->isDirty('_translations'));
-
-        $entity->translation('spa')->set('body', 'Contenido');
-        $this->assertSame('My Title', $entity->translation('eng')->get('title'));
-        $this->assertSame('Contenido', $entity->translation('spa')->get('body'));
+        $this->assertNull($entity->translation('eng'));
+        $this->assertNull($entity->translation('spa'));
     }
 
     /**
-     * Tests that modifying existing translation entries work
+     * Tests that translation() returns existing translations
      */
-    public function testTranslationModify(): void
+    public function testTranslationReturnsExisting(): void
     {
         $entity = new TranslateTestEntity();
         $entity->set('_translations', [
@@ -53,36 +47,50 @@ class TranslateTraitTest extends TestCase
         ]);
         $this->assertSame('My Title', $entity->translation('eng')->get('title'));
         $this->assertSame('Titulo', $entity->translation('spa')->get('title'));
+        $this->assertNull($entity->translation('fra'));
     }
 
     /**
-     * Tests empty translations.
+     * Tests that getOrCreateTranslation() creates missing translations
      */
-    public function testTranslationEmpty(): void
+    public function testGetOrCreateTranslation(): void
+    {
+        $entity = new TranslateTestEntity();
+        $entity->getOrCreateTranslation('eng')->set('title', 'My Title');
+        $this->assertSame('My Title', $entity->translation('eng')->get('title'));
+
+        $this->assertTrue($entity->isDirty('_translations'));
+
+        $entity->getOrCreateTranslation('spa')->set('body', 'Contenido');
+        $this->assertSame('My Title', $entity->translation('eng')->get('title'));
+        $this->assertSame('Contenido', $entity->translation('spa')->get('body'));
+    }
+
+    /**
+     * Tests that getOrCreateTranslation() returns correct entity type
+     */
+    public function testGetOrCreateTranslationEntityType(): void
     {
         $entity = new TranslateTestEntity();
         $entity->set('_translations', [
             'eng' => new Entity(['title' => 'My Title']),
-            'spa' => new Entity(['title' => 'Titulo']),
         ]);
-        $this->assertTrue($entity->translation('pol')->isNew());
-        $this->assertInstanceOf(TranslateTestEntity::class, $entity->translation('pol'));
+        $translation = $entity->getOrCreateTranslation('pol');
+        $this->assertTrue($translation->isNew());
+        $this->assertInstanceOf(TranslateTestEntity::class, $translation);
     }
 
     /**
-     * Tests that just accessing the translation will mark the property as dirty, this
-     * is to facilitate the saving process by not having to remember to mark the property
-     * manually
+     * Tests that getOrCreateTranslation() marks _translations as dirty
      */
-    public function testTranslationDirty(): void
+    public function testGetOrCreateTranslationDirty(): void
     {
         $entity = new TranslateTestEntity();
         $entity->set('_translations', [
             'eng' => new Entity(['title' => 'My Title']),
-            'spa' => new Entity(['title' => 'Titulo']),
         ]);
         $entity->clean();
-        $this->assertSame('My Title', $entity->translation('eng')->get('title'));
+        $entity->getOrCreateTranslation('eng');
         $this->assertTrue($entity->isDirty('_translations'));
     }
 
@@ -101,19 +109,5 @@ class TranslateTraitTest extends TestCase
         $this->assertTrue($entity->hasTranslation('eng'));
         $this->assertTrue($entity->hasTranslation('spa'));
         $this->assertFalse($entity->hasTranslation('fra'));
-    }
-
-    /**
-     * Tests that translation() always returns a distinct entity, never $this
-     */
-    public function testTranslationReturnsDistinctEntity(): void
-    {
-        $entity = new TranslateTestEntity();
-        $entity->set('_locale', 'eng');
-        $entity->set('title', 'Original Title');
-
-        $translation = $entity->translation('eng');
-        $this->assertNotSame($entity, $translation);
-        $this->assertNull($translation->get('title'));
     }
 }

--- a/tests/TestCase/ORM/Behavior/Translate/TranslateTraitTest.php
+++ b/tests/TestCase/ORM/Behavior/Translate/TranslateTraitTest.php
@@ -85,4 +85,35 @@ class TranslateTraitTest extends TestCase
         $this->assertSame('My Title', $entity->translation('eng')->get('title'));
         $this->assertTrue($entity->isDirty('_translations'));
     }
+
+    /**
+     * Tests hasTranslation() method
+     */
+    public function testHasTranslation(): void
+    {
+        $entity = new TranslateTestEntity();
+        $this->assertFalse($entity->hasTranslation('eng'));
+
+        $entity->set('_translations', [
+            'eng' => new Entity(['title' => 'My Title']),
+            'spa' => new Entity(['title' => 'Titulo']),
+        ]);
+        $this->assertTrue($entity->hasTranslation('eng'));
+        $this->assertTrue($entity->hasTranslation('spa'));
+        $this->assertFalse($entity->hasTranslation('fra'));
+    }
+
+    /**
+     * Tests that translation() always returns a distinct entity, never $this
+     */
+    public function testTranslationReturnsDistinctEntity(): void
+    {
+        $entity = new TranslateTestEntity();
+        $entity->set('_locale', 'eng');
+        $entity->set('title', 'Original Title');
+
+        $translation = $entity->translation('eng');
+        $this->assertNotSame($entity, $translation);
+        $this->assertNull($translation->get('title'));
+    }
 }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -1260,7 +1260,7 @@ class TranslateBehaviorEavTest extends TestCase
 
         $article = $table->get(1);
         foreach ($translations as $lang => $data) {
-            $article->translation($lang)->patch($data, ['guard' => false]);
+            $article->getOrCreateTranslation($lang)->patch($data, ['guard' => false]);
         }
 
         $table->save($article);

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -815,7 +815,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
 
         $article = $table->get(1);
-        $article->translation('xyz')->title = 'XYZ title';
+        $article->getOrCreateTranslation('xyz')->title = 'XYZ title';
 
         $this->assertNotFalse($table->save($article), 'The save should succeed');
     }


### PR DESCRIPTION
## Summary

- Add `hasTranslation(string $language): bool` method to check if a translation exists
- Refactor `translation()` to be a pure getter that returns `null` if no translation exists
- Add `getOrCreateTranslation()` for create-on-access behavior with dirty marking
- Remove the inconsistent `return $this` when `_locale === $language`

**Before:**
```php
$article->translation('eng');  // Returns $this if _locale === 'eng', creates entity if missing
$article->translation('fra');  // Creates entity if missing, marks dirty
```

**After:**
```php
$article->translation('eng');           // Returns EntityInterface|null (pure getter)
$article->hasTranslation('eng');        // Check if translation exists
$article->getOrCreateTranslation('eng'); // Creates if missing, marks dirty
```

This separates read and write concerns - `translation()` no longer has side effects (creating entities, marking dirty). Use `getOrCreateTranslation()` when you need the create-on-access behavior.