### PR TITLE
Fix autowiring issues and CI failures for Container

### DIFF
--- a/src/Container/Argument/ArgumentResolverTrait.php
+++ b/src/Container/Argument/ArgumentResolverTrait.php
@@ -106,7 +106,7 @@ trait ArgumentResolverTrait
             throw new NotFoundException(sprintf(
                 'Unable to resolve a value for parameter (%s) in the function/method (%s)',
                 $name,
-                $method->getName()
+                $method->getName(),
             ));
         }
 

--- a/src/Container/Argument/ArgumentResolverTrait.php
+++ b/src/Container/Argument/ArgumentResolverTrait.php
@@ -20,7 +20,7 @@ trait ArgumentResolverTrait
     {
         try {
             $container = $this->getContainer();
-        } catch (ContainerException $e) {
+        } catch (ContainerException) {
             $container = $this instanceof ReflectionContainer ? $this : null;
         }
 
@@ -52,7 +52,7 @@ trait ArgumentResolverTrait
                     }
 
                     continue;
-                } catch (NotFoundException $e) {
+                } catch (NotFoundException) {
                 }
             }
 

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -51,7 +51,7 @@ class Container implements DefinitionContainerInterface
     public function __construct(
         ?DefinitionAggregateInterface $definitions = null,
         ?ServiceProviderAggregateInterface $providers = null,
-        ?InflectorAggregateInterface $inflectors = null
+        ?InflectorAggregateInterface $inflectors = null,
     ) {
         $this->definitions = $definitions ?? new DefinitionAggregate();
         $this->providers = $providers ?? new ServiceProviderAggregate();
@@ -159,7 +159,7 @@ class Container implements DefinitionContainerInterface
 
         throw new NotFoundException(sprintf(
             'Unable to extend alias (%s) as it is not being managed as a definition',
-            $id
+            $id,
         ));
     }
 
@@ -198,6 +198,29 @@ class Container implements DefinitionContainerInterface
     }
 
     /**
+     * Resolve an entry with specific constructor arguments.
+     *
+     * Unlike `get()`, this method allows passing specific constructor arguments
+     * that will be used during autowiring. Arguments can be passed by name.
+     *
+     * Example:
+     * ```
+     * $container->make(MyService::class, ['configValue' => 'foo']);
+     * ```
+     *
+     * @template RequestedType
+     * @param class-string<RequestedType>|string $id
+     * @param array<string, mixed> $args Named arguments to pass to the constructor
+     * @return RequestedType|mixed
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
+     */
+    public function make(string $id, array $args = []): mixed
+    {
+        return $this->resolve($id, true, $args);
+    }
+
+    /**
      * @inheritDoc
      */
     public function has($id): bool
@@ -221,6 +244,14 @@ class Container implements DefinitionContainerInterface
         }
 
         return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasDefinition(string $id): bool
+    {
+        return $this->definitions->has($id);
     }
 
     /**
@@ -266,11 +297,12 @@ class Container implements DefinitionContainerInterface
     /**
      * @param mixed $id
      * @param bool $new
+     * @param array<string, mixed> $args
      * @return mixed|object|array|null|void
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
      */
-    protected function resolve(mixed $id, bool $new = false): mixed
+    protected function resolve(mixed $id, bool $new = false, array $args = []): mixed
     {
         if ($this->definitions->has($id)) {
             $resolved = $new === true ? $this->definitions->resolveNew($id) : $this->definitions->resolve($id);
@@ -297,12 +329,19 @@ class Container implements DefinitionContainerInterface
                 throw new ContainerException(sprintf('Service provider lied about providing (%s) service', $id));
             }
 
-            return $this->resolve($id, $new);
+            return $this->resolve($id, $new, $args);
         }
 
         foreach ($this->delegates as $delegate) {
             if ($delegate->has($id)) {
-                $resolved = $delegate->get($id);
+                // Use getNew() for ReflectionContainer when $new is true or args are provided
+                if ($delegate instanceof ReflectionContainer) {
+                    $resolved = $new || $args !== []
+                        ? $delegate->getNew($id, $args)
+                        : $delegate->get($id, $args);
+                } else {
+                    $resolved = $delegate->get($id);
+                }
 
                 return $this->inflectors->inflect($resolved);
             }

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -29,14 +29,14 @@ class Container implements DefinitionContainerInterface
     protected array $delegates = [];
 
     /**
-     * @param \Cake\Container\Definition\DefinitionAggregateInterface|null $definitions
-     * @param \Cake\Container\ServiceProvider\ServiceProviderAggregateInterface|null $providers
-     * @param \Cake\Container\Inflector\InflectorAggregateInterface|null $inflectors
+     * @param \Cake\Container\Definition\DefinitionAggregateInterface $definitions
+     * @param \Cake\Container\ServiceProvider\ServiceProviderAggregateInterface $providers
+     * @param \Cake\Container\Inflector\InflectorAggregateInterface $inflectors
      */
     public function __construct(
-        protected ?DefinitionAggregateInterface $definitions = new DefinitionAggregate(),
-        protected ?ServiceProviderAggregateInterface $providers = new ServiceProviderAggregate(),
-        protected ?InflectorAggregateInterface $inflectors = new InflectorAggregate(),
+        protected DefinitionAggregateInterface $definitions = new DefinitionAggregate(),
+        protected ServiceProviderAggregateInterface $providers = new ServiceProviderAggregate(),
+        protected InflectorAggregateInterface $inflectors = new InflectorAggregate(),
     ) {
         $this->definitions->setContainer($this);
         $this->providers->setContainer($this);

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -24,21 +24,6 @@ class Container implements DefinitionContainerInterface
     protected bool $defaultToShared = false;
 
     /**
-     * @var \Cake\Container\Definition\DefinitionAggregateInterface
-     */
-    protected DefinitionAggregateInterface $definitions;
-
-    /**
-     * @var \Cake\Container\ServiceProvider\ServiceProviderAggregateInterface
-     */
-    protected ServiceProviderAggregateInterface $providers;
-
-    /**
-     * @var \Cake\Container\Inflector\InflectorAggregateInterface
-     */
-    protected InflectorAggregateInterface $inflectors;
-
-    /**
      * @var array<\Psr\Container\ContainerInterface>
      */
     protected array $delegates = [];
@@ -49,14 +34,10 @@ class Container implements DefinitionContainerInterface
      * @param \Cake\Container\Inflector\InflectorAggregateInterface|null $inflectors
      */
     public function __construct(
-        ?DefinitionAggregateInterface $definitions = null,
-        ?ServiceProviderAggregateInterface $providers = null,
-        ?InflectorAggregateInterface $inflectors = null,
+        protected ?DefinitionAggregateInterface $definitions = new DefinitionAggregate(),
+        protected ?ServiceProviderAggregateInterface $providers = new ServiceProviderAggregate(),
+        protected ?InflectorAggregateInterface $inflectors = new InflectorAggregate(),
     ) {
-        $this->definitions = $definitions ?? new DefinitionAggregate();
-        $this->providers = $providers ?? new ServiceProviderAggregate();
-        $this->inflectors = $inflectors ?? new InflectorAggregate();
-
         $this->definitions->setContainer($this);
         $this->providers->setContainer($this);
         $this->inflectors->setContainer($this);
@@ -69,9 +50,9 @@ class Container implements DefinitionContainerInterface
      */
     public function add(string $id, $concrete = null): DefinitionInterface
     {
-        $concrete = $concrete ?? $id;
+        $concrete ??= $id;
 
-        if ($this->defaultToShared === true) {
+        if ($this->defaultToShared) {
             return $this->addShared($id, $concrete);
         }
 
@@ -83,7 +64,7 @@ class Container implements DefinitionContainerInterface
      */
     public function addShared(string $id, $concrete = null): DefinitionInterface
     {
-        $concrete = $concrete ?? $id;
+        $concrete ??= $id;
 
         return $this->definitions->addShared($id, $concrete);
     }
@@ -305,13 +286,13 @@ class Container implements DefinitionContainerInterface
     protected function resolve(mixed $id, bool $new = false, array $args = []): mixed
     {
         if ($this->definitions->has($id)) {
-            $resolved = $new === true ? $this->definitions->resolveNew($id) : $this->definitions->resolve($id);
+            $resolved = $new ? $this->definitions->resolveNew($id) : $this->definitions->resolve($id);
 
             return $this->inflectors->inflect($resolved);
         }
 
         if ($this->definitions->hasTag($id)) {
-            $arrayOf = $new === true
+            $arrayOf = $new
                 ? $this->definitions->resolveTaggedNew($id)
                 : $this->definitions->resolveTagged($id);
 

--- a/src/Container/ContainerAwareTrait.php
+++ b/src/Container/ContainerAwareTrait.php
@@ -27,7 +27,7 @@ trait ContainerAwareTrait
         throw new BadMethodCallException(sprintf(
             'Attempt to use (%s) while not implementing (%s)',
             ContainerAwareTrait::class,
-            ContainerAwareInterface::class
+            ContainerAwareInterface::class,
         ));
     }
 

--- a/src/Container/Definition/Definition.php
+++ b/src/Container/Definition/Definition.php
@@ -64,7 +64,7 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
     {
         $id = static::normaliseAlias($id);
 
-        $concrete = $concrete ?? $id;
+        $concrete ??= $id;
         $this->alias = $id;
         $this->concrete = $concrete;
     }

--- a/src/Container/Definition/Definition.php
+++ b/src/Container/Definition/Definition.php
@@ -8,9 +8,7 @@ use Cake\Container\Argument\ArgumentResolverInterface;
 use Cake\Container\Argument\ArgumentResolverTrait;
 use Cake\Container\Argument\LiteralArgumentInterface;
 use Cake\Container\ContainerAwareTrait;
-use Cake\Container\DefinitionContainerInterface;
 use Cake\Container\Exception\ContainerException;
-use Psr\Container\ContainerInterface;
 use ReflectionClass;
 
 class Definition implements ArgumentResolverInterface, DefinitionInterface
@@ -243,7 +241,12 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
             $container = null;
         }
 
-        if (is_string($concrete) && $concrete !== $this->alias && $container !== null && $container->hasDefinition($concrete)) {
+        if (
+            is_string($concrete)
+            && $concrete !== $this->alias
+            && $container !== null
+            && $container->hasDefinition($concrete)
+        ) {
             $this->recursiveCheck[] = $concrete;
             $concrete = $container->get($concrete);
             $this->resolved = $concrete;

--- a/src/Container/Definition/Definition.php
+++ b/src/Container/Definition/Definition.php
@@ -8,6 +8,7 @@ use Cake\Container\Argument\ArgumentResolverInterface;
 use Cake\Container\Argument\ArgumentResolverTrait;
 use Cake\Container\Argument\LiteralArgumentInterface;
 use Cake\Container\ContainerAwareTrait;
+use Cake\Container\DefinitionContainerInterface;
 use Cake\Container\Exception\ContainerException;
 use Psr\Container\ContainerInterface;
 use ReflectionClass;
@@ -233,18 +234,29 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
             $concrete = $concrete->getValue();
         }
 
+        // Check if the container has a registered definition for this concrete class
+        // before attempting to instantiate it directly. This ensures interface -> concrete
+        // bindings respect existing definitions for the concrete class (fixes #275, #278).
+        try {
+            $container = $this->getContainer();
+        } catch (ContainerException) {
+            $container = null;
+        }
+
+        if (is_string($concrete) && $concrete !== $this->alias && $container !== null && $container->hasDefinition($concrete)) {
+            $this->recursiveCheck[] = $concrete;
+            $concrete = $container->get($concrete);
+            $this->resolved = $concrete;
+
+            return $concrete;
+        }
+
         if (is_string($concrete) && class_exists($concrete)) {
             $concrete = $this->resolveClass($concrete);
         }
 
         if (is_object($concrete)) {
             $concrete = $this->invokeMethods($concrete);
-        }
-
-        try {
-            $container = $this->getContainer();
-        } catch (ContainerException $e) {
-            $container = null;
         }
 
         // stop recursive resolving
@@ -256,7 +268,7 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
 
         // if we still have a string, try to pull it from the container
         // this allows for `alias -> alias -> ... -> concrete
-        if (is_string($concrete) && $container instanceof ContainerInterface && $container->has($concrete)) {
+        if (is_string($concrete) && $container !== null && $container->has($concrete)) {
             $this->recursiveCheck[] = $concrete;
             $concrete = $container->get($concrete);
         }
@@ -278,28 +290,12 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
     }
 
     /**
-     * @param string $concrete
+     * @param class-string $concrete
      * @return object
      * @throws \ReflectionException
      */
     protected function resolveClass(string $concrete): object
     {
-//        $reflector = new ReflectionClass($concrete);
-//        $construct = $reflector->getConstructor();
-//        $params = $construct->getParameters();
-//        if (count($params) !== count($this->arguments)) {
-//            // This indicates, that certain arguments need to be auto wired
-//            $tmpArgs = $this->arguments;
-//            $this->arguments = [];
-//            foreach($params as $param) {
-//                if (!array_key_exists($param->getName(), $tmpArgs)) {
-//                    $this->addArgument($param->getType()->getName(), $param->getName());
-//                } else {
-//                    $this->addArgument($tmpArgs[$param->getName()], $param->getName());
-//                }
-//            }
-//        }
-
         $resolved = $this->resolveArguments($this->arguments);
         $reflection = new ReflectionClass($concrete);
 
@@ -314,6 +310,7 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
     {
         foreach ($this->methods as $method) {
             $args = $this->resolveArguments($method['arguments']);
+            /** @var callable $callable */
             $callable = [$instance, $method['method']];
             call_user_func_array($callable, $args);
         }

--- a/src/Container/DefinitionContainerInterface.php
+++ b/src/Container/DefinitionContainerInterface.php
@@ -43,6 +43,17 @@ interface DefinitionContainerInterface extends ContainerInterface
     public function getNew(mixed $id): mixed;
 
     /**
+     * Check if the container has a registered definition for the given id.
+     *
+     * Unlike `has()`, this only checks explicit definitions, not service providers
+     * or delegate containers.
+     *
+     * @param string $id
+     * @return bool
+     */
+    public function hasDefinition(string $id): bool;
+
+    /**
      * @param string $type
      * @param callable|null $callback
      * @return \Cake\Container\Inflector\InflectorInterface

--- a/src/Container/Inflector/Inflector.php
+++ b/src/Container/Inflector/Inflector.php
@@ -109,6 +109,7 @@ class Inflector implements ArgumentResolverInterface, InflectorInterface
 
         foreach ($this->methods as $method => $args) {
             $args = $this->resolveArguments($args);
+            /** @var callable $callable */
             $callable = [$object, $method];
             call_user_func_array($callable, $args);
         }

--- a/src/Container/ReflectionContainer.php
+++ b/src/Container/ReflectionContainer.php
@@ -41,7 +41,7 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
     public function get(string $id, array $args = [])
     {
         // Only use cache when no custom args are provided
-        if ($this->cacheResolutions === true && $args === [] && array_key_exists($id, $this->cache)) {
+        if ($this->cacheResolutions && $args === [] && array_key_exists($id, $this->cache)) {
             return $this->cache[$id];
         }
 
@@ -66,7 +66,7 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
             : $reflector->newInstanceArgs($this->reflectArguments($construct, $args));
 
         // Only cache when no custom args are provided
-        if ($this->cacheResolutions === true && $args === []) {
+        if ($this->cacheResolutions && $args === []) {
             $this->cache[$id] = $resolution;
         }
 
@@ -130,7 +130,7 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
                 // if we have a definition container, try that first, otherwise, reflect
                 try {
                     $callable[0] = $this->getContainer()->get($callable[0]);
-                } catch (ContainerException $e) {
+                } catch (ContainerException) {
                     $callable[0] = $this->get($callable[0]);
                 }
             }

--- a/src/Container/ReflectionContainer.php
+++ b/src/Container/ReflectionContainer.php
@@ -40,22 +40,24 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
      */
     public function get(string $id, array $args = [])
     {
-        if ($this->cacheResolutions === true && array_key_exists($id, $this->cache)) {
+        // Only use cache when no custom args are provided
+        if ($this->cacheResolutions === true && $args === [] && array_key_exists($id, $this->cache)) {
             return $this->cache[$id];
         }
 
         if (!$this->has($id)) {
             throw new NotFoundException(
-                sprintf('Alias (%s) is not an existing class and therefore cannot be resolved', $id)
+                sprintf('Alias (%s) is not an existing class and therefore cannot be resolved', $id),
             );
         }
 
+        /** @var class-string $id */
         $reflector = new ReflectionClass($id);
         $construct = $reflector->getConstructor();
 
         if ($construct && !$construct->isPublic()) {
             throw new NotFoundException(
-                sprintf('Alias (%s) has a non-public constructor and therefore cannot be instantiated', $id)
+                sprintf('Alias (%s) has a non-public constructor and therefore cannot be instantiated', $id),
             );
         }
 
@@ -63,7 +65,8 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
             ? new $id()
             : $reflector->newInstanceArgs($this->reflectArguments($construct, $args));
 
-        if ($this->cacheResolutions === true) {
+        // Only cache when no custom args are provided
+        if ($this->cacheResolutions === true && $args === []) {
             $this->cache[$id] = $resolution;
         }
 
@@ -76,6 +79,36 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
     public function has($id): bool
     {
         return class_exists($id);
+    }
+
+    /**
+     * Get a new instance, bypassing the cache.
+     *
+     * @param string $id
+     * @param array<string, mixed> $args
+     * @return mixed
+     */
+    public function getNew(string $id, array $args = []): mixed
+    {
+        if (!$this->has($id)) {
+            throw new NotFoundException(
+                sprintf('Alias (%s) is not an existing class and therefore cannot be resolved', $id),
+            );
+        }
+
+        /** @var class-string $id */
+        $reflector = new ReflectionClass($id);
+        $construct = $reflector->getConstructor();
+
+        if ($construct && !$construct->isPublic()) {
+            throw new NotFoundException(
+                sprintf('Alias (%s) has a non-public constructor and therefore cannot be instantiated', $id),
+            );
+        }
+
+        return $construct === null
+            ? new $id()
+            : $reflector->newInstanceArgs($this->reflectArguments($construct, $args));
     }
 
     /**
@@ -125,7 +158,7 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
 
         throw new NotFoundException(sprintf(
             'Callable (%s) is not a valid callable',
-            $callable
+            $callable,
         ));
     }
 }

--- a/src/Container/ServiceProvider/ServiceProviderAggregate.php
+++ b/src/Container/ServiceProvider/ServiceProviderAggregate.php
@@ -70,7 +70,7 @@ class ServiceProviderAggregate implements ServiceProviderAggregateInterface
     {
         if ($this->provides($service) === false) {
             throw new ContainerException(
-                sprintf('(%s) is not provided by a service provider', $service)
+                sprintf('(%s) is not provided by a service provider', $service),
             );
         }
 

--- a/src/Container/composer.json
+++ b/src/Container/composer.json
@@ -28,10 +28,10 @@
         "issues": "https://github.com/cakephp/cakephp/issues",
         "forum": "https://stackoverflow.com/tags/cakephp",
         "irc": "irc://irc.freenode.org/cakephp",
-        "source": "https://github.com/cakephp/console"
+        "source": "https://github.com/cakephp/container"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "psr/container": "^1.1 || ^2.0"
     },
     "provide": {

--- a/tests/TestCase/Container/Argument/TypedArgumentTest.php
+++ b/tests/TestCase/Container/Argument/TypedArgumentTest.php
@@ -15,7 +15,7 @@ class TypedArgumentTest extends TestCase
         $arguments = [
             Literal\ArrayArgument::class => [],
             Literal\BooleanArgument::class => true,
-            Literal\CallableArgument::class => function () {
+            Literal\CallableArgument::class => function (): void {
             },
             Literal\FloatArgument::class => 1.23,
             Literal\IntegerArgument::class => 1,

--- a/tests/TestCase/Container/Asset/Baz.php
+++ b/tests/TestCase/Container/Asset/Baz.php
@@ -5,7 +5,10 @@ namespace Cake\Test\TestCase\Container\Asset;
 
 class Baz
 {
+    public ?BarInterface $bar;
+
     public function __construct(?BarInterface $bar = null)
     {
+        $this->bar = $bar;
     }
 }

--- a/tests/TestCase/Container/Asset/FooCallable.php
+++ b/tests/TestCase/Container/Asset/FooCallable.php
@@ -5,7 +5,7 @@ namespace Cake\Test\TestCase\Container\Asset;
 
 class FooCallable
 {
-    public function __invoke(Bar $bar)
+    public function __invoke(Bar $bar): Foo
     {
         return new Foo($bar);
     }

--- a/tests/TestCase/Container/ContainerTest.php
+++ b/tests/TestCase/Container/ContainerTest.php
@@ -276,10 +276,11 @@ class ContainerTest extends TestCase
     public function testNonExistentClassCausesException(): void
     {
         $container = new Container();
-        $container->add(NonExistent::class);
+        $nonExistent = 'Cake\Test\TestCase\Container\NonExistent';
+        $container->add($nonExistent);
 
-        self::assertTrue($container->has(NonExistent::class));
-        self::assertSame(NonExistent::class, $container->get(NonExistent::class));
+        self::assertTrue($container->has($nonExistent));
+        self::assertSame($nonExistent, $container->get($nonExistent));
     }
 
     /**

--- a/tests/TestCase/Container/ContainerTest.php
+++ b/tests/TestCase/Container/ContainerTest.php
@@ -11,6 +11,7 @@ use Cake\Container\Exception\NotFoundException;
 use Cake\Container\ReflectionContainer;
 use Cake\Container\ServiceProvider\AbstractServiceProvider;
 use Cake\Test\TestCase\Container\Asset\Bar;
+use Cake\Test\TestCase\Container\Asset\BarInterface;
 use Cake\Test\TestCase\Container\Asset\Foo;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/TestCase/Container/ContainerTest.php
+++ b/tests/TestCase/Container/ContainerTest.php
@@ -281,15 +281,72 @@ class ContainerTest extends TestCase
         self::assertSame(NonExistent::class, $container->get(NonExistent::class));
     }
 
-//    public function testContainerResolvesWithNamedArgument(): void
-//    {
-//        $container = new Container();
-//        $container->add(Foo::class)
-//            ->addArgument('something', 'myString');
-//        self::assertTrue($container->has(Foo::class));
-//        $foo = $container->get(Foo::class);
-//        self::assertInstanceOf(Foo::class, $foo);
-//        self::assertInstanceOf(Bar::class, $foo->bar);
-//        self::assertSame('something', $foo->myString);
-//    }
+    /**
+     * Test that named arguments work when all required arguments are provided.
+     *
+     * Note: Partial autowiring (where some args are named and others are auto-wired)
+     * is not yet supported in Definition. For that use case, use Container::make().
+     */
+    public function testContainerResolvesWithNamedArgument(): void
+    {
+        $container = new Container();
+        $container->add(Foo::class)
+            ->addArgument(Bar::class, 'bar')
+            ->addArgument('something', 'myString');
+        self::assertTrue($container->has(Foo::class));
+        $foo = $container->get(Foo::class);
+        self::assertInstanceOf(Foo::class, $foo);
+        self::assertInstanceOf(Bar::class, $foo->bar);
+        self::assertSame('something', $foo->myString);
+    }
+
+    public function testContainerMakeWithArgs(): void
+    {
+        $container = new Container();
+        $foo = $container->make(Foo::class, ['myString' => 'hello world']);
+        self::assertInstanceOf(Foo::class, $foo);
+        self::assertInstanceOf(Bar::class, $foo->bar);
+        self::assertSame('hello world', $foo->myString);
+    }
+
+    public function testContainerMakeAlwaysReturnsNewInstance(): void
+    {
+        $container = new Container();
+        $fooOne = $container->make(Foo::class);
+        $fooTwo = $container->make(Foo::class);
+        self::assertNotSame($fooOne, $fooTwo);
+    }
+
+    public function testInterfaceToImplementationUsesExistingDefinition(): void
+    {
+        $container = new Container();
+        // Register Bar with specific configuration
+        $container->addShared(Bar::class);
+
+        // Map interface to the concrete class
+        $container->add(BarInterface::class, Bar::class);
+
+        // Get via interface should use the existing Bar definition
+        $barFromInterface = $container->get(BarInterface::class);
+        $barDirect = $container->get(Bar::class);
+
+        self::assertInstanceOf(Bar::class, $barFromInterface);
+        // Should be the same instance because Bar is shared
+        self::assertSame($barDirect, $barFromInterface);
+    }
+
+    public function testHasDefinitionOnlyChecksExplicitDefinitions(): void
+    {
+        $container = new Container();
+        $container->add(Foo::class);
+
+        // hasDefinition should return true for explicitly added definitions
+        self::assertTrue($container->hasDefinition(Foo::class));
+
+        // hasDefinition should return false for autowirable classes not explicitly added
+        self::assertFalse($container->hasDefinition(Bar::class));
+
+        // but has() should return true because autowiring can resolve it
+        self::assertTrue($container->has(Bar::class));
+    }
 }

--- a/tests/TestCase/Container/Definition/DefinitionAggregateTest.php
+++ b/tests/TestCase/Container/Definition/DefinitionAggregateTest.php
@@ -22,7 +22,7 @@ class DefinitionAggregateTest extends TestCase
             ->expects(self::once())
             ->method('setAlias')
             ->with(self::equalTo('alias'))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $aggregate = (new DefinitionAggregate())->setContainer($container);
         $definition = $aggregate->add('alias', $definition);
@@ -79,7 +79,7 @@ class DefinitionAggregateTest extends TestCase
             ->expects(self::once())
             ->method('setAlias')
             ->with(self::equalTo('alias1'))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition2
             ->expects(self::once())
@@ -90,24 +90,24 @@ class DefinitionAggregateTest extends TestCase
             ->expects(self::once())
             ->method('setContainer')
             ->with(self::equalTo($container))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition2
             ->expects(self::once())
             ->method('setShared')
             ->with(self::equalTo(true))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition2
             ->expects(self::once())
             ->method('setAlias')
             ->with(self::equalTo('alias2'))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition2
             ->expects(self::once())
             ->method('resolve')
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $aggregate->setContainer($container);
 
@@ -128,7 +128,7 @@ class DefinitionAggregateTest extends TestCase
             ->expects(self::once())
             ->method('setContainer')
             ->with(self::equalTo($container))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition1
             ->expects(self::exactly(2))
@@ -145,7 +145,7 @@ class DefinitionAggregateTest extends TestCase
             ->expects(self::once())
             ->method('setContainer')
             ->with(self::equalTo($container))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition2
             ->expects(self::once())
@@ -184,7 +184,7 @@ class DefinitionAggregateTest extends TestCase
             ->expects(self::once())
             ->method('setAlias')
             ->with(self::equalTo('alias1'))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition2
             ->expects(self::once())
@@ -195,13 +195,13 @@ class DefinitionAggregateTest extends TestCase
             ->expects(self::once())
             ->method('setShared')
             ->with(self::equalTo(true))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition2
             ->expects(self::once())
             ->method('setAlias')
             ->with(self::equalTo('alias2'))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $aggregate->setContainer($container);
 

--- a/tests/TestCase/Container/Definition/DefinitionTest.php
+++ b/tests/TestCase/Container/Definition/DefinitionTest.php
@@ -151,7 +151,7 @@ class DefinitionTest extends TestCase
 
     public function testDefinitionCanSetConcrete(): void
     {
-        $definition = new Definition('class', null);
+        $definition = new Definition('class');
         $concrete = new Literal\StringArgument(Foo::class);
         $definition->setConcrete($concrete);
         self::assertSame($concrete, $definition->getConcrete());

--- a/tests/TestCase/Container/Inflector/InflectorTest.php
+++ b/tests/TestCase/Container/Inflector/InflectorTest.php
@@ -24,7 +24,6 @@ class InflectorTest extends TestCase
         ]);
 
         $methods = (new ReflectionClass($inflector))->getProperty('methods');
-        $methods->setAccessible(true);
 
         self::assertSame($methods->getValue($inflector), [
             'method1' => ['arg1'],
@@ -46,7 +45,6 @@ class InflectorTest extends TestCase
         ]);
 
         $properties = (new ReflectionClass($inflector))->getProperty('properties');
-        $properties->setAccessible(true);
 
         self::assertSame($properties->getValue($inflector), [
             'property1' => 'value',
@@ -135,7 +133,7 @@ class InflectorTest extends TestCase
         $bar = new class {
         };
 
-        $inflector = new Inflector('Type', function ($object) use ($bar) {
+        $inflector = new Inflector('Type', function ($object) use ($bar): void {
             $object->setBar($bar);
         });
 

--- a/tests/TestCase/Container/ReflectionContainerTest.php
+++ b/tests/TestCase/Container/ReflectionContainerTest.php
@@ -158,7 +158,7 @@ class ReflectionContainerTest extends TestCase
     {
         $container = new ReflectionContainer();
         $foo = new Foo();
-        $container->call([$foo, 'setBar']);
+        $container->call($foo->setBar(...));
         self::assertInstanceOf(Foo::class, $foo);
         self::assertInstanceOf(Bar::class, $foo->bar);
     }

--- a/tests/TestCase/Container/ServiceProvider/ServiceProviderAggregateTest.php
+++ b/tests/TestCase/Container/ServiceProvider/ServiceProviderAggregateTest.php
@@ -84,7 +84,7 @@ class ServiceProviderAggregateTest extends TestCase
         // was only aggregated and booted once
         self::assertSame(
             [$provider],
-            iterator_to_array($aggregate->getIterator())
+            iterator_to_array($aggregate->getIterator()),
         );
 
         self::assertSame(1, $provider->booted);


### PR DESCRIPTION
## Summary

This PR builds on top of #18090 to fix the following issues:

### Upstream Issues Fixed
- **league/container#275 / #278**: Interface-to-implementation binding now respects existing definitions. When binding `Interface -> ConcreteClass`, if `ConcreteClass` has an existing registered definition with specific configuration, that definition is now used instead of being bypassed.
- **league/container#277**: Added `Container::make()` method to allow passing constructor arguments during autowiring:
  ```php
  $container->make(MyService::class, ['configValue' => 'foo']);
  ```

### New API
- `Container::make(string $id, array $args = [])` - Resolve with specific constructor arguments (always returns new instance)
- `Container::hasDefinition(string $id)` - Check if an explicit definition exists (not just autowirable)
- `ReflectionContainer::getNew(string $id, array $args = [])` - Bypass cache when resolving

### CI Fixes
- Fixed PHPCS issues (trailing commas in multi-line function calls)
- Fixed PHPStan type errors with callable and class-string annotations
- Fixed PHPUnit 12 compatibility (`self::returnSelf()` → `willReturnSelf()`)