### PR TITLE
Add PHPUnit 13 support and remove deprecated any() matcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "mikey179/vfsstream": "^1.6.12",
         "mockery/mockery": "^1.6",
         "paragonie/csp-builder": "^2.3 || ^3.0",
-        "phpunit/phpunit": "^11.5.3 || ^12.1.3"
+        "phpunit/phpunit": "^11.5.3 || ^12.1.3 || ^13.0"
     },
     "suggest": {
         "ext-curl": "To enable more efficient network calls in Http\\Client.",

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -183,8 +183,7 @@ class SqliteTest extends TestCase
             ->onlyMethods(['createPdo'])
             ->getMock();
 
-        $driver->expects($this->any())
-            ->method('createPdo')
+        $driver->method('createPdo')
             ->willReturn($mock);
 
         $this->assertEquals($expected, $driver->schemaValue($input));

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -336,8 +336,7 @@ class SqlserverTest extends TestCase
             ->onlyMethods(['createPdo', 'getPdo', 'version', 'enabled'])
             ->setConstructorArgs([[]])
             ->getMock();
-        $driver->expects($this->any())
-            ->method('version')
+        $driver->method('version')
             ->willReturn('8');
         $driver->method('enabled')
             ->willReturn(true);
@@ -479,8 +478,7 @@ class SqlserverTest extends TestCase
             ->onlyMethods(['connect', 'getPdo', 'version', 'enabled'])
             ->setConstructorArgs([[]])
             ->getMock();
-        $driver->expects($this->any())
-            ->method('version')
+        $driver->method('version')
             ->willReturn('8');
         $driver->method('enabled')
             ->willReturn(true);
@@ -510,8 +508,7 @@ class SqlserverTest extends TestCase
             ->onlyMethods(['connect', 'getPdo', 'version', 'enabled'])
             ->setConstructorArgs([[]])
             ->getMock();
-        $driver->expects($this->any())
-            ->method('version')
+        $driver->method('version')
             ->willReturn('8');
         $driver->method('enabled')
             ->willReturn(true);

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -132,8 +132,7 @@ class DriverTest extends TestCase
             ->with($value, PDO::PARAM_STR)
             ->willReturn('string');
 
-        $this->driver->expects($this->any())
-            ->method('createPdo')
+        $this->driver->method('createPdo')
             ->willReturn($connection);
 
         $this->driver->schemaValue($value);
@@ -154,8 +153,7 @@ class DriverTest extends TestCase
             ->method('lastInsertId')
             ->willReturn('all-the-bears');
 
-        $this->driver->expects($this->any())
-            ->method('createPdo')
+        $this->driver->method('createPdo')
             ->willReturn($connection);
 
         $this->assertSame('all-the-bears', $this->driver->lastInsertId());
@@ -178,8 +176,7 @@ class DriverTest extends TestCase
             ->method('query')
             ->willReturn(new PDOStatement());
 
-        $this->driver->expects($this->any())
-            ->method('createPdo')
+        $this->driver->method('createPdo')
             ->willReturn($connection);
 
         $this->driver->connect();
@@ -310,12 +307,11 @@ class DriverTest extends TestCase
             ->setConstructorArgs([$inner, $this->driver])
             ->onlyMethods(['queryString','rowCount','execute'])
             ->getMock();
-        $statement->expects($this->any())->method('queryString')->willReturn('SELECT bar FROM foo');
+        $statement->method('queryString')->willReturn('SELECT bar FROM foo');
         $statement->method('rowCount')->willReturn(3);
         $statement->method('execute')->willReturn(true);
 
-        $this->driver->expects($this->any())
-            ->method('prepare')
+        $this->driver->method('prepare')
             ->willReturn($statement);
         $this->driver->setLogger(new QueryLogger(['connection' => 'test']));
 
@@ -339,11 +335,10 @@ class DriverTest extends TestCase
             ->getMock();
         $statement->method('rowCount')->willReturn(3);
         $statement->method('execute')->willReturn(true);
-        $statement->expects($this->any())->method('queryString')->willReturn('SELECT bar FROM foo WHERE a=:a AND b=:b');
+        $statement->method('queryString')->willReturn('SELECT bar FROM foo WHERE a=:a AND b=:b');
 
         $this->driver->setLogger(new QueryLogger(['connection' => 'test']));
-        $this->driver->expects($this->any())
-            ->method('prepare')
+        $this->driver->method('prepare')
             ->willReturn($statement);
 
         $this->driver->execute(
@@ -371,13 +366,12 @@ class DriverTest extends TestCase
             ->setConstructorArgs([$inner, $this->driver])
             ->onlyMethods(['queryString','rowCount','execute'])
             ->getMock();
-        $statement->expects($this->any())->method('queryString')->willReturn('SELECT bar FROM foo');
+        $statement->method('queryString')->willReturn('SELECT bar FROM foo');
         $statement->method('rowCount')->willReturn(0);
         $statement->method('execute')->will($this->throwException(new PDOException()));
 
         $this->driver->setLogger(new QueryLogger(['connection' => 'test']));
-        $this->driver->expects($this->any())
-            ->method('prepare')
+        $this->driver->method('prepare')
             ->willReturn($statement);
 
         try {
@@ -420,15 +414,12 @@ class DriverTest extends TestCase
             ->onlyMethods(['beginTransaction', 'commit', 'rollback', 'inTransaction'])
             ->getMock();
         $pdo
-            ->expects($this->any())
             ->method('beginTransaction')
             ->willReturn(true);
         $pdo
-            ->expects($this->any())
             ->method('commit')
             ->willReturn(true);
         $pdo
-            ->expects($this->any())
             ->method('rollBack')
             ->willReturn(true);
         $pdo->expects($this->exactly(5))
@@ -446,8 +437,7 @@ class DriverTest extends TestCase
             ->onlyMethods(['getPdo'])
             ->getMock();
 
-        $driver->expects($this->any())
-            ->method('getPdo')
+        $driver->method('getPdo')
             ->willReturn($pdo);
 
         $driver->beginTransaction();
@@ -491,12 +481,11 @@ class DriverTest extends TestCase
             ->setConstructorArgs([$inner, $this->driver])
             ->onlyMethods(['queryString','rowCount','execute'])
             ->getMock();
-        $statement->expects($this->any())->method('queryString')->willReturn('SELECT bar FROM foo');
+        $statement->method('queryString')->willReturn('SELECT bar FROM foo');
         $statement->method('rowCount')->willReturn(3);
         $statement->method('execute')->willReturn(true);
 
-        $this->driver->expects($this->any())
-            ->method('prepare')
+        $this->driver->method('prepare')
             ->willReturn($statement);
         $this->driver->setLogger(new QueryLogger(['connection' => 'test']));
 

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -1688,7 +1688,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = (new TableSchema('posts'))
@@ -1737,7 +1737,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = (new TableSchema('posts'))
@@ -1819,7 +1819,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = (new TableSchema('posts'))->addColumn('id', [
@@ -1881,12 +1881,10 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())
-            ->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $this->pdo
-            ->expects($this->any())
             ->method('getAttribute')
             ->willReturn('5.7.0');
 
@@ -1928,7 +1926,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
         $table = (new TableSchema('schema_articles'))->addColumn('id', [
             'type' => 'integer',
@@ -1948,7 +1946,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = (new TableSchema('articles_tags'))
@@ -2012,7 +2010,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = new TableSchema('articles');
@@ -2030,7 +2028,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = new TableSchema('articles');
@@ -2089,8 +2087,7 @@ SQL;
             ->onlyMethods(['quote', 'getAttribute', 'quoteIdentifier'])
             ->disableOriginalConstructor()
             ->getMock();
-        $this->pdo->expects($this->any())
-            ->method('quote')
+        $this->pdo->method('quote')
             ->willReturnCallback(function ($value) {
                 return "'{$value}'";
             });
@@ -2099,12 +2096,10 @@ SQL;
             ->onlyMethods(['createPdo', 'version'])
             ->getMock();
 
-        $driver->expects($this->any())
-            ->method('createPdo')
+        $driver->method('createPdo')
             ->willReturn($this->pdo);
 
-        $driver->expects($this->any())
-            ->method('version')
+        $driver->method('version')
             ->willReturn($version);
 
         $driver->connect();

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -1604,7 +1604,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = (new TableSchema('posts'))
@@ -1653,7 +1653,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = (new TableSchema('posts'))
@@ -1702,7 +1702,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = (new TableSchema('schema_articles'))->addColumn('id', [
@@ -1769,7 +1769,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = (new TableSchema('ref_table'))
@@ -1812,8 +1812,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())
-            ->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = (new TableSchema('schema_articles'))->addColumn('title', [
@@ -1833,7 +1832,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
         $table = (new TableSchema('schema_articles'))->addColumn('id', [
             'type' => 'integer',
@@ -1853,7 +1852,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = (new TableSchema('articles_tags'))
@@ -1917,7 +1916,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = new TableSchema('schema_articles');
@@ -1935,7 +1934,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = new TableSchema('schema_articles');
@@ -2029,8 +2028,7 @@ SQL;
             ->onlyMethods(['quote', 'exec'])
             ->disableOriginalConstructor()
             ->getMock();
-        $mock->expects($this->any())
-            ->method('quote')
+        $mock->method('quote')
             ->willReturnCallback(function ($value) {
                 return "'{$value}'";
             });
@@ -2040,12 +2038,10 @@ SQL;
             ->onlyMethods(['createPdo', 'version'])
             ->getMock();
 
-        $driver->expects($this->any())
-            ->method('createPdo')
+        $driver->method('createPdo')
             ->willReturn($mock);
 
-        $driver->expects($this->any())
-            ->method('version')
+        $driver->method('version')
             ->willReturnCallback(function () {
                 return '10.0.0';
             });

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -1252,7 +1252,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = new TableSchema('posts');
@@ -1270,7 +1270,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = new TableSchema('posts');
@@ -1475,7 +1475,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = (new TableSchema('articles'))->addColumn('id', [
@@ -1525,7 +1525,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
         $table = (new TableSchema('schema_articles'))->addColumn('id', [
             'type' => 'integer',
@@ -1545,7 +1545,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = (new TableSchema('articles_tags'))
@@ -1611,7 +1611,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = new TableSchema('articles');
@@ -1629,7 +1629,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $statement = $this->getMockBuilder('\PDOStatement')
@@ -1660,7 +1660,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $statement = $this->getMockBuilder('\PDOStatement')
@@ -1692,8 +1692,7 @@ SQL;
             ->onlyMethods(['quote', 'prepare'])
             ->disableOriginalConstructor()
             ->getMock();
-        $this->pdo->expects($this->any())
-            ->method('quote')
+        $this->pdo->method('quote')
             ->willReturnCallback(function ($value) {
                 return '"' . $value . '"';
             });
@@ -1702,8 +1701,7 @@ SQL;
             ->onlyMethods(['createPdo'])
             ->getMock();
 
-        $driver->expects($this->any())
-            ->method('createPdo')
+        $driver->method('createPdo')
             ->willReturn($this->pdo);
 
         $driver->connect();

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -1112,7 +1112,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = (new TableSchema('posts'))
@@ -1161,7 +1161,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = (new TableSchema('posts'))
@@ -1250,7 +1250,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = (new TableSchema('schema_articles'))->addColumn('id', [
@@ -1324,7 +1324,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = new TableSchema('schema_articles');
@@ -1342,7 +1342,7 @@ SQL;
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $connection->expects($this->any())->method('getWriteDriver')
+        $connection->method('getWriteDriver')
             ->willReturn($driver);
 
         $table = new TableSchema('schema_articles');
@@ -1413,8 +1413,7 @@ SQL;
             ->onlyMethods(['quote'])
             ->disableOriginalConstructor()
             ->getMock();
-        $mock->expects($this->any())
-            ->method('quote')
+        $mock->method('quote')
             ->willReturnCallback(function ($value) {
                 return "'{$value}'";
             });
@@ -1423,8 +1422,7 @@ SQL;
             ->onlyMethods(['createPdo'])
             ->getMock();
 
-        $driver->expects($this->any())
-            ->method('createPdo')
+        $driver->method('createPdo')
             ->willReturn($mock);
 
         $driver->connect();

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -626,8 +626,7 @@ class ClientTest extends TestCase
         $mock = $this->getMockBuilder(Stream::class)
             ->onlyMethods(['send'])
             ->getMock();
-        $mock->expects($this->any())
-            ->method('send')
+        $mock->method('send')
             ->with($this->callback(function ($request) use ($data) {
                 $this->assertSame($data, '' . $request->getBody());
                 $this->assertSame('application/x-www-form-urlencoded', $request->getHeaderLine('content-type'));

--- a/tests/TestCase/Http/ResponseEmitterTest.php
+++ b/tests/TestCase/Http/ResponseEmitterTest.php
@@ -50,8 +50,7 @@ class ResponseEmitterTest extends TestCase
             ->onlyMethods(['setCookie'])
             ->getMock();
 
-        $this->emitter->expects($this->any())
-            ->method('setCookie')
+        $this->emitter->method('setCookie')
             ->willReturnCallback(function ($cookie) {
                 if (is_string($cookie)) {
                     $cookie = Cookie::createFromHeaderString($cookie, ['path' => '']);

--- a/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
+++ b/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
@@ -67,7 +67,7 @@ class TableGetWithCustomFinderTest extends TestCase
 
         $table->expects($this->once())->method('selectQuery')
             ->willReturn($query);
-        $table->expects($this->any())->method('findCustom')
+        $table->method('findCustom')
             ->willReturn($query);
 
         $entity = new Entity();

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1291,8 +1291,7 @@ class TableTest extends TestCase
             ->willReturn($query);
 
         $options = ['fields' => ['a', 'b']];
-        $query->expects($this->any())
-            ->method('select')
+        $query->method('select')
             ->willReturnSelf();
 
         $query->expects($this->once())->method('getOptions')
@@ -2618,7 +2617,7 @@ class TableTest extends TestCase
 
         $connection->expects($this->once())->method('begin');
         $connection->expects($this->once())->method('commit');
-        $connection->expects($this->any())->method('inTransaction')->willReturn(true);
+        $connection->method('inTransaction')->willReturn(true);
         $data = new Entity([
             'username' => 'superuser',
             'created' => new DateTime('2013-10-10 00:00'),
@@ -2648,7 +2647,7 @@ class TableTest extends TestCase
             ->onlyMethods(['execute', 'addDefaultTypes'])
             ->setConstructorArgs([$table])
             ->getMock();
-        $table->expects($this->any())->method('getConnection')
+        $table->method('getConnection')
             ->willReturn($connection);
 
         $table->expects($this->once())->method('insertQuery')
@@ -2688,7 +2687,7 @@ class TableTest extends TestCase
             ->setConstructorArgs([$table])
             ->getMock();
 
-        $table->expects($this->any())->method('getConnection')
+        $table->method('getConnection')
             ->willReturn($connection);
 
         $table->expects($this->once())->method('insertQuery')
@@ -3456,8 +3455,7 @@ class TableTest extends TestCase
         $entity = new Entity(['id' => 1, 'name' => 'mark']);
 
         $mock = $this->getMockBuilder(EventManager::class)->getMock();
-        $mock->expects($this->any())
-            ->method('dispatch')
+        $mock->method('dispatch')
             ->willReturnCallback(function (EventInterface $event) {
                 $event->stopPropagation();
 
@@ -3478,8 +3476,7 @@ class TableTest extends TestCase
         $entity = new Entity(['id' => 1, 'name' => 'mark']);
 
         $mock = $this->getMockBuilder(EventManager::class)->getMock();
-        $mock->expects($this->any())
-            ->method('dispatch')
+        $mock->method('dispatch')
             ->willReturnCallback(function (EventInterface $event) {
                 $event->stopPropagation();
                 $event->setResult('got stopped');


### PR DESCRIPTION
## Summary
- Allow PHPUnit 13 in composer.json (`^11.5.3 || ^12.1.3 || ^13.0`)
- Remove deprecated `any()` matcher usage (68 occurrences across 12 test files)

The `any()` matcher is deprecated in PHPUnit 12 and removed in PHPUnit 13. The replacement is to use simple stubs without `expects()` - calling `$mock->method('foo')->willReturn('bar')` instead of `$mock->expects($this->any())->method('foo')->willReturn('bar')`.

### Files updated:
- `composer.json`
- `tests/TestCase/Database/DriverTest.php`
- `tests/TestCase/Database/Driver/SqliteTest.php`
- `tests/TestCase/Database/Driver/SqlserverTest.php`
- `tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php`
- `tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php`
- `tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php`
- `tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php`
- `tests/TestCase/ORM/TableTest.php`
- `tests/TestCase/ORM/TableGetWithCustomFinderTest.php`
- `tests/TestCase/Http/ResponseEmitterTest.php`
- `tests/TestCase/Http/ClientTest.php`