### PR TITLE
more underscore cleanup

### DIFF
--- a/src/TestSuite/StringCompareTrait.php
+++ b/src/TestSuite/StringCompareTrait.php
@@ -21,7 +21,7 @@ use function Cake\Core\env;
 /**
  * Compare a string to the contents of a file
  *
- * Implementing objects are expected to modify the `$_compareBasePath` property
+ * Implementing objects are expected to modify the `$compareBasePath` property
  * before use.
  */
 trait StringCompareTrait

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -264,7 +264,7 @@ class StringTemplate
     /**
      * Returns a space-delimited string with items of the $options array. If a key
      * of $options array happens to be one of those listed
-     * in `StringTemplate::$_compactAttributes` and its value is one of:
+     * in `StringTemplate::$compactAttributes` and its value is one of:
      *
      * - '1' (string)
      * - 1 (integer)

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -340,7 +340,7 @@ class View implements EventDispatcherInterface
      * @param \Cake\Http\ServerRequest|null $request Request instance.
      * @param \Cake\Http\Response|null $response Response instance.
      * @param \Cake\Event\EventManagerInterface|null $eventManager Event manager instance.
-     * @param array<string, mixed> $viewOptions View options. See {@link View::$_passedVars} for list of
+     * @param array<string, mixed> $viewOptions View options. See {@link View::$passedVars} for list of
      *   options which get set as class properties.
      */
     public function __construct(


### PR DESCRIPTION
Thanks to @dereuromark for doing the last 2 packages in https://github.com/cakephp/cakephp/pull/19250

I tested the current state of `6.x` via this regex in the `src` directory

```
\$_(?!(GET|POST|FILES|COOKIE|SESSION|REQUEST|SERVER|ENV|GLOBALS)\b).*
```

 and now only the chronos related `_toStringFormat` changes are open 🥳 