### PR TITLE
Remove underscore prefix from local variables in tests

### DIFF
--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -312,14 +312,14 @@ class RouterTest extends TestCase
         $this->assertSame('/users/logout', $result);
 
         Router::reload();
-        $_back = Configure::read('App.fullBaseUrl');
+        $back = Configure::read('App.fullBaseUrl');
         Configure::write('App.fullBaseUrl', '/');
 
         $request = new ServerRequest();
         Router::setRequest($request);
         $result = Router::normalize('users/login');
         $this->assertSame('/users/login', $result);
-        Configure::write('App.fullBaseUrl', $_back);
+        Configure::write('App.fullBaseUrl', $back);
 
         Router::reload();
         $request = new ServerRequest(['base' => 'beer']);

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -45,7 +45,7 @@ class SecurityTest extends TestCase
      */
     public function testHash(): void
     {
-        $_hashType = Security::$hashType;
+        $originalHashType = Security::$hashType;
 
         $key = 'someKey';
         $hash = 'someHash';
@@ -79,7 +79,7 @@ class SecurityTest extends TestCase
         $this->assertSame(64, strlen(Security::hash($key, 'sha256', false)));
         $this->assertSame(64, strlen(Security::hash($key, 'sha256', true)));
 
-        Security::setHash($_hashType);
+        Security::setHash($originalHashType);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Rename `$_hashType` to `$originalHashType` in SecurityTest to avoid conflict with test variables
- Rename `$_back` to `$back` in RouterTest

Follows PSR naming conventions by removing underscore prefix from local variables.