### PR TITLE
Add TYPE_VARBINARY for proper binary type distinction

### DIFF
--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -198,7 +198,12 @@ class MysqlSchemaDialect extends SchemaDialect
                 $type,
                 array_merge(
                     TableSchema::GEOSPATIAL_TYPES,
-                    [TableSchema::TYPE_BINARY, TableSchema::TYPE_JSON, TableSchema::TYPE_TEXT],
+                    [
+                        TableSchema::TYPE_BINARY,
+                        TableSchema::TYPE_VARBINARY,
+                        TableSchema::TYPE_JSON,
+                        TableSchema::TYPE_TEXT,
+                    ],
                 ),
             )
         ) {
@@ -381,16 +386,14 @@ class MysqlSchemaDialect extends SchemaDialect
         if ($col === 'uuid') {
             return ['type' => TableSchemaInterface::TYPE_NATIVE_UUID, 'length' => null];
         }
-        if (str_contains($col, 'blob') || in_array($col, ['binary', 'varbinary'])) {
+        if (str_contains($col, 'blob') || $col === 'binary') {
             $lengthName = substr($col, 0, -4);
             $length = TableSchema::$columnLengths[$lengthName] ?? $length;
 
-            $result = ['type' => TableSchemaInterface::TYPE_BINARY, 'length' => $length];
-            if ($col === 'binary') {
-                $result['fixed'] = true;
-            }
-
-            return $result;
+            return ['type' => TableSchemaInterface::TYPE_BINARY, 'length' => $length];
+        }
+        if ($col === 'varbinary') {
+            return ['type' => TableSchemaInterface::TYPE_VARBINARY, 'length' => $length];
         }
         if (str_contains($col, 'float') || str_contains($col, 'double')) {
             return [
@@ -579,6 +582,7 @@ SQL;
             'text' => true,
             'char' => true,
             'binary' => true,
+            'varbinary' => true,
         ];
         if (isset($typeMap[$column['type']])) {
             $out .= $typeMap[$column['type']];
@@ -618,11 +622,10 @@ SQL;
                         break;
                     }
 
-                    if (!empty($column['fixed'])) {
-                        $out .= ' BINARY';
-                    } else {
-                        $out .= ' VARBINARY';
-                    }
+                    $out .= ' BINARY';
+                    break;
+                case TableSchemaInterface::TYPE_VARBINARY:
+                    $out .= ' VARBINARY';
                     break;
             }
         }
@@ -633,6 +636,7 @@ SQL;
             TableSchemaInterface::TYPE_TINYINTEGER,
             TableSchemaInterface::TYPE_STRING,
             TableSchemaInterface::TYPE_BINARY,
+            TableSchemaInterface::TYPE_VARBINARY,
             TableSchemaInterface::TYPE_BIT,
         ];
         if (!isset($typeMap[$column['type']]) && !isset($specialMap[$column['type']])) {
@@ -712,7 +716,12 @@ SQL;
 
         $defaultExpressionTypes = array_merge(
             TableSchemaInterface::GEOSPATIAL_TYPES,
-            [TableSchemaInterface::TYPE_BINARY, TableSchemaInterface::TYPE_TEXT, TableSchemaInterface::TYPE_JSON],
+            [
+                TableSchemaInterface::TYPE_BINARY,
+                TableSchemaInterface::TYPE_VARBINARY,
+                TableSchemaInterface::TYPE_TEXT,
+                TableSchemaInterface::TYPE_JSON,
+            ],
         );
         if (in_array($column['type'], $defaultExpressionTypes) && isset($column['default'])) {
             // Geospatial, blob and text types need to be wrapped in () to create an expression.

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -592,6 +592,7 @@ class PostgresSchemaDialect extends SchemaDialect
             TableSchemaInterface::TYPE_INTEGER => ' INT',
             TableSchemaInterface::TYPE_BIGINTEGER => ' BIGINT',
             TableSchemaInterface::TYPE_BINARY => ' BYTEA',
+            TableSchemaInterface::TYPE_VARBINARY => ' BYTEA',
             TableSchemaInterface::TYPE_BINARY_UUID => ' UUID',
             TableSchemaInterface::TYPE_BOOLEAN => ' BOOLEAN',
             TableSchemaInterface::TYPE_FLOAT => ' FLOAT',

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -125,8 +125,11 @@ class SqliteSchemaDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_STRING, 'length' => $length];
         }
 
-        if (in_array($col, ['blob', 'clob', 'binary', 'varbinary'])) {
+        if (in_array($col, ['blob', 'clob', 'binary'])) {
             return ['type' => TableSchemaInterface::TYPE_BINARY, 'length' => $length];
+        }
+        if ($col === 'varbinary') {
+            return ['type' => TableSchemaInterface::TYPE_VARBINARY, 'length' => $length];
         }
 
         $datetimeTypes = [
@@ -631,6 +634,7 @@ class SqliteSchemaDialect extends SchemaDialect
         $typeMap = [
             TableSchemaInterface::TYPE_BINARY_UUID => ' BINARY(16)',
             TableSchemaInterface::TYPE_BINARY => ' BLOB',
+            TableSchemaInterface::TYPE_VARBINARY => ' BLOB',
             TableSchemaInterface::TYPE_UUID => ' CHAR(36)',
             TableSchemaInterface::TYPE_CHAR => ' CHAR',
             TableSchemaInterface::TYPE_STRING => ' VARCHAR',

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -584,14 +584,16 @@ class SqlserverSchemaDialect extends SchemaDialect
         }
 
         if ($column['type'] === TableSchemaInterface::TYPE_BINARY) {
+            // SQL Server BINARY only supports lengths up to 8000, use VARBINARY for MAX
             if (
                 !isset($column['length'])
                 || in_array($column['length'], [TableSchema::LENGTH_MEDIUM, TableSchema::LENGTH_LONG], true)
             ) {
                 $column['length'] = 'MAX';
+                $out .= ' VARBINARY';
+            } else {
+                $out .= ' BINARY';
             }
-
-            $out .= ' BINARY';
             $foundType = true;
         }
         if ($column['type'] === TableSchemaInterface::TYPE_VARBINARY) {

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -194,13 +194,21 @@ class SqlserverSchemaDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_TEXT, 'length' => null];
         }
 
-        if ($col === 'image' || str_contains($col, 'binary')) {
+        if ($col === 'image' || $col === 'binary') {
             // -1 is the value for MAX which we treat as a 'long' binary
             if ($length === -1) {
                 $length = TableSchema::LENGTH_LONG;
             }
 
             return ['type' => TableSchemaInterface::TYPE_BINARY, 'length' => $length];
+        }
+        if ($col === 'varbinary') {
+            // -1 is the value for MAX which we treat as a 'long' binary
+            if ($length === -1) {
+                $length = TableSchema::LENGTH_LONG;
+            }
+
+            return ['type' => TableSchemaInterface::TYPE_VARBINARY, 'length' => $length];
         }
 
         if ($col === 'uniqueidentifier') {
@@ -550,6 +558,7 @@ class SqlserverSchemaDialect extends SchemaDialect
             TableSchemaInterface::TYPE_CHAR,
             TableSchemaInterface::TYPE_STRING,
             TableSchemaInterface::TYPE_BINARY,
+            TableSchemaInterface::TYPE_VARBINARY,
         ];
         $autoIncrementTypes = [
             TableSchemaInterface::TYPE_TINYINTEGER,
@@ -582,11 +591,18 @@ class SqlserverSchemaDialect extends SchemaDialect
                 $column['length'] = 'MAX';
             }
 
-            if ($column['length'] === 1) {
-                $out .= ' BINARY';
-            } else {
-                $out .= ' VARBINARY';
+            $out .= ' BINARY';
+            $foundType = true;
+        }
+        if ($column['type'] === TableSchemaInterface::TYPE_VARBINARY) {
+            if (
+                !isset($column['length'])
+                || in_array($column['length'], [TableSchema::LENGTH_MEDIUM, TableSchema::LENGTH_LONG], true)
+            ) {
+                $column['length'] = 'MAX';
             }
+
+            $out .= ' VARBINARY';
             $foundType = true;
         }
 

--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -24,11 +24,18 @@ use Cake\Datasource\SchemaInterface;
 interface TableSchemaInterface extends SchemaInterface
 {
     /**
-     * Binary column type
+     * Binary column type (fixed-length)
      *
      * @var string
      */
     public const string TYPE_BINARY = 'binary';
+
+    /**
+     * Variable-length binary column type
+     *
+     * @var string
+     */
+    public const string TYPE_VARBINARY = 'varbinary';
 
     /**
      * Binary UUID column type

--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -33,6 +33,7 @@ class TypeFactory
         'biginteger' => Type\IntegerType::class,
         'binary' => Type\BinaryType::class,
         'binaryuuid' => Type\BinaryUuidType::class,
+        'varbinary' => Type\BinaryType::class,
         'boolean' => Type\BoolType::class,
         'char' => Type\StringType::class,
         'cidr' => Type\StringType::class,

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -157,15 +157,15 @@ class MysqlSchemaDialectTest extends TestCase
             ],
             [
                 'BINARY(1)',
-                ['type' => 'binary', 'length' => 1, 'fixed' => true],
+                ['type' => 'binary', 'length' => 1],
             ],
             [
                 'BINARY(20)',
-                ['type' => 'binary', 'length' => 20, 'fixed' => true],
+                ['type' => 'binary', 'length' => 20],
             ],
             [
                 'VARBINARY(20)',
-                ['type' => 'binary', 'length' => 20],
+                ['type' => 'varbinary', 'length' => 20],
             ],
             [
                 'TEXT',
@@ -1321,18 +1321,28 @@ SQL;
             [
                 'bytes',
                 ['type' => 'binary', 'length' => 5],
-                '`bytes` VARBINARY(5)',
+                '`bytes` BINARY(5)',
             ],
             [
                 'bit',
                 ['type' => 'binary', 'length' => 1],
-                '`bit` VARBINARY(1)',
+                '`bit` BINARY(1)',
             ],
-            // Fixed binary (BINARY vs VARBINARY)
             [
                 'hash',
-                ['type' => 'binary', 'length' => 20, 'fixed' => true],
+                ['type' => 'binary', 'length' => 20],
                 '`hash` BINARY(20)',
+            ],
+            // Variable-length binary (VARBINARY)
+            [
+                'data',
+                ['type' => 'varbinary', 'length' => 20],
+                '`data` VARBINARY(20)',
+            ],
+            [
+                'bytes',
+                ['type' => 'varbinary', 'length' => 5],
+                '`bytes` VARBINARY(5)',
             ],
             // Integers
             [

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -750,11 +750,11 @@ SQL;
                 ['type' => 'float', 'length' => 11, 'precision' => 3],
                 '[value] FLOAT(3)',
             ],
-            // Binary (fixed-length)
+            // Binary (fixed-length, but MAX lengths fall back to VARBINARY)
             [
                 'img',
                 ['type' => 'binary', 'length' => null],
-                '[img] BINARY(MAX)',
+                '[img] VARBINARY(MAX)',
             ],
             [
                 'img',
@@ -764,12 +764,12 @@ SQL;
             [
                 'img',
                 ['type' => 'binary', 'length' => TableSchema::LENGTH_MEDIUM],
-                '[img] BINARY(MAX)',
+                '[img] VARBINARY(MAX)',
             ],
             [
                 'img',
                 ['type' => 'binary', 'length' => TableSchema::LENGTH_LONG],
-                '[img] BINARY(MAX)',
+                '[img] VARBINARY(MAX)',
             ],
             [
                 'bytes',

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -209,11 +209,11 @@ SQL;
             ],
             [
                 'VARBINARY(30)',
-                ['type' => 'binary', 'length' => 30],
+                ['type' => 'varbinary', 'length' => 30],
             ],
             [
                 'VARBINARY(MAX)',
-                ['type' => 'binary', 'length' => TableSchema::LENGTH_LONG],
+                ['type' => 'varbinary', 'length' => TableSchema::LENGTH_LONG],
             ],
             // Geospatial types
             [
@@ -750,36 +750,52 @@ SQL;
                 ['type' => 'float', 'length' => 11, 'precision' => 3],
                 '[value] FLOAT(3)',
             ],
-            // Binary
+            // Binary (fixed-length)
             [
                 'img',
                 ['type' => 'binary', 'length' => null],
-                '[img] VARBINARY(MAX)',
+                '[img] BINARY(MAX)',
             ],
             [
                 'img',
                 ['type' => 'binary', 'length' => TableSchema::LENGTH_TINY],
-                sprintf('[img] VARBINARY(%s)', TableSchema::LENGTH_TINY),
+                sprintf('[img] BINARY(%s)', TableSchema::LENGTH_TINY),
             ],
             [
                 'img',
                 ['type' => 'binary', 'length' => TableSchema::LENGTH_MEDIUM],
-                '[img] VARBINARY(MAX)',
+                '[img] BINARY(MAX)',
             ],
             [
                 'img',
                 ['type' => 'binary', 'length' => TableSchema::LENGTH_LONG],
-                '[img] VARBINARY(MAX)',
+                '[img] BINARY(MAX)',
             ],
             [
                 'bytes',
                 ['type' => 'binary', 'length' => 5],
-                '[bytes] VARBINARY(5)',
+                '[bytes] BINARY(5)',
             ],
             [
                 'bytes',
                 ['type' => 'binary', 'length' => 1],
                 '[bytes] BINARY(1)',
+            ],
+            // Varbinary (variable-length)
+            [
+                'data',
+                ['type' => 'varbinary', 'length' => null],
+                '[data] VARBINARY(MAX)',
+            ],
+            [
+                'data',
+                ['type' => 'varbinary', 'length' => 20],
+                '[data] VARBINARY(20)',
+            ],
+            [
+                'data',
+                ['type' => 'varbinary', 'length' => TableSchema::LENGTH_LONG],
+                '[data] VARBINARY(MAX)',
             ],
             // Boolean
             [


### PR DESCRIPTION
## Summary

This is a BC-breaking alternative to #19207 that adds a proper `TYPE_VARBINARY` constant instead of using a `fixed` attribute on the binary type.

- `binary` type now always generates `BINARY` (fixed-length)
- New `varbinary` type generates `VARBINARY` (variable-length)
- SQLite/PostgreSQL map both to `BLOB`/`BYTEA` respectively (no distinction in those databases)

| CakePHP Type | MySQL | SQLite | SQL Server | PostgreSQL |
|-------------|-------|--------|------------|------------|
| binary | BINARY | BLOB | BINARY | BYTEA |
| varbinary | VARBINARY | BLOB | VARBINARY | BYTEA |

This mirrors the existing pattern for string types where `char` → `CHAR` and `string` → `VARCHAR`.