### PR TITLE
replace PHPUnit mocks with mockery mocks

### DIFF
--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -5,9 +5,10 @@ namespace Cake\Test\TestCase\Cache\Engine;
 
 use Cake\Cache\Cache;
 use Cake\Cache\Engine\RedisEngine;
-use Cake\Log\Engine\ArrayLog;
 use Cake\Log\Log;
+use Cake\TestSuite\LogTestTrait;
 use Cake\TestSuite\TestCase;
+use Mockery;
 use RedisCluster;
 use ReflectionClass;
 
@@ -16,6 +17,8 @@ use ReflectionClass;
  */
 class RedisClusterEngineTest extends TestCase
 {
+    use LogTestTrait;
+
     private false|string|null $skipTest = null;
 
     /**
@@ -157,26 +160,12 @@ class RedisClusterEngineTest extends TestCase
      */
     public function testConnectNamedClusterWithoutNodes(): void
     {
-        // Mock logger
-        $logger = $this->getMockBuilder(ArrayLog::class)
-            ->onlyMethods(['log'])
-            ->getMock();
-
-        $logger->expects($this->once())
-            ->method('log')
-            ->with(
-                $this->equalTo('error'),
-                $this->stringContains('RedisEngine requires one or more nodes in cluster mode'),
-                $this->anything(),
-            );
-
-        Log::reset();
-        Log::setConfig('default', ['className' => $logger]);
-
+        $this->setupLog('error');
         $this->assertFalse((new RedisEngine())->init([
             'className' => 'Redis',
             'clusterName' => 'mycluster',
         ]));
+        $this->assertLogMessageContains('error', 'RedisEngine requires one or more nodes in cluster mode');
     }
 
     /**
@@ -200,35 +189,20 @@ class RedisClusterEngineTest extends TestCase
             }
         };
 
-        // Use a stubbed RedisCluster to avoid triggering constructor logic
-        $redisMock = $this->createStub(RedisCluster::class);
+        // Use a Mockery mock for RedisCluster to avoid triggering constructor logic
+        $redisMock = Mockery::mock(RedisCluster::class);
 
         // Set $_Redis manually using Reflection
         $reflection = new ReflectionClass($mock);
         $property = $reflection->getProperty('_Redis');
         $property->setValue($mock, $redisMock);
 
-        // Mock logger
-        $logger = $this->getMockBuilder(ArrayLog::class)
-            ->onlyMethods(['log'])
-            ->getMock();
-
-        $logger->expects($this->once())
-            ->method('log')
-            ->with(
-                $this->equalTo('error'),
-                $this->stringContains('RedisClusterEngine could not connect. Got error: Mocked cluster failure'),
-                $this->anything(),
-            );
-
-        Log::reset();
-        Log::setConfig('default', ['className' => $logger]);
-
+        $this->setupLog('error');
         $result = $mock->init([
             'nodes' => ['127.0.0.1:7000'],
             'persistent' => true,
         ]);
-
+        $this->assertLogMessageContains('error', 'RedisClusterEngine could not connect. Got error: Mocked cluster failure');
         $this->assertFalse($result);
     }
 
@@ -239,13 +213,13 @@ class RedisClusterEngineTest extends TestCase
      */
     public function testConnectRedisClusterWithTlsConfig(): void
     {
-        $mock = $this->getMockBuilder(RedisEngine::class)
-            ->onlyMethods(['connectRedisCluster'])
-            ->getMock();
+        $mock = Mockery::mock(RedisEngine::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
 
-        $mock->expects($this->once())
-            ->method('connectRedisCluster')
-            ->willReturn(true);
+        $mock->shouldReceive('connectRedisCluster')
+            ->once()
+            ->andReturn(true);
 
         $config = [
             'nodes' => $this->redisClusterNodes(),

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -214,10 +214,10 @@ class RedisClusterEngineTest extends TestCase
     public function testConnectRedisClusterWithTlsConfig(): void
     {
         $mock = Mockery::mock(RedisEngine::class)
-            ->shouldAllowMockingProtectedMethods()
             ->makePartial();
 
-        $mock->shouldReceive('connectRedisCluster')
+        $mock->shouldAllowMockingProtectedMethods()
+            ->shouldReceive('connectRedisCluster')
             ->once()
             ->andReturn(true);
 

--- a/tests/TestCase/Command/SchemaCacheCommandsTest.php
+++ b/tests/TestCase/Command/SchemaCacheCommandsTest.php
@@ -22,12 +22,11 @@ use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Database\Schema\CachedCollection;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Mockery;
 
 /**
  * SchemaCacheCommands test.
  */
-#[AllowMockObjectsWithoutExpectations]
 class SchemaCacheCommandsTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
@@ -45,7 +44,7 @@ class SchemaCacheCommandsTest extends TestCase
     protected $connection;
 
     /**
-     * @var \Cake\Cache\Engine\NullEngine|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Cake\Cache\Engine\NullEngine|\Mockery\MockInterface
      */
     protected $cache;
 
@@ -57,9 +56,9 @@ class SchemaCacheCommandsTest extends TestCase
         parent::setUp();
         $this->setAppNamespace();
 
-        $this->cache = $this->getMockBuilder(NullEngine::class)
-            ->onlyMethods(['set', 'get', 'delete'])
-            ->getMock();
+        $this->cache = Mockery::mock(NullEngine::class)->makePartial();
+
+        Cache::drop('orm_cache');
         Cache::setConfig('orm_cache', $this->cache);
 
         $this->connection = ConnectionManager::get('test');
@@ -75,7 +74,6 @@ class SchemaCacheCommandsTest extends TestCase
         parent::tearDown();
 
         unset($this->connection);
-        Cache::drop('orm_cache');
     }
 
     /**
@@ -107,9 +105,9 @@ class SchemaCacheCommandsTest extends TestCase
      */
     public function testBuildNoArgs(): void
     {
-        $this->cache->expects($this->atLeastOnce())
-            ->method('set')
-            ->willReturn(true);
+        $this->cache->shouldReceive('set')
+            ->atLeast()->once()
+            ->andReturn(true);
 
         $this->exec('schema_cache build --connection test');
         $this->assertExitSuccess();
@@ -120,13 +118,12 @@ class SchemaCacheCommandsTest extends TestCase
      */
     public function testBuildNamedModel(): void
     {
-        $this->cache->expects($this->once())
-            ->method('set')
-            ->with('test_articles')
-            ->willReturn(true);
-        $this->cache->expects($this->never())
-            ->method('delete')
-            ->willReturn(false);
+        $this->cache->shouldReceive('set')
+            ->once()
+            ->withSomeOfArgs('test_articles')
+            ->andReturn(true);
+        $this->cache->shouldReceive('delete')
+            ->never();
 
         $this->exec('schema_cache build --connection test articles');
         $this->assertExitSuccess();
@@ -137,15 +134,14 @@ class SchemaCacheCommandsTest extends TestCase
      */
     public function testBuildOverwritesExistingData(): void
     {
-        $this->cache->expects($this->once())
-            ->method('set')
-            ->with('test_articles')
-            ->willReturn(true);
-        $this->cache->expects($this->never())
-            ->method('get');
-        $this->cache->expects($this->never())
-            ->method('delete')
-            ->willReturn(false);
+        $this->cache->shouldReceive('set')
+            ->once()
+            ->withSomeOfArgs('test_articles')
+            ->andReturn(true);
+        $this->cache->shouldReceive('get')
+            ->never();
+        $this->cache->shouldReceive('delete')
+            ->never();
 
         $this->exec('schema_cache build --connection test articles');
         $this->assertExitSuccess();
@@ -174,9 +170,9 @@ class SchemaCacheCommandsTest extends TestCase
      */
     public function testClearNoArgs(): void
     {
-        $this->cache->expects($this->atLeastOnce())
-            ->method('delete')
-            ->willReturn(true);
+        $this->cache->shouldReceive('delete')
+            ->atLeast()->once()
+            ->andReturn(true);
 
         $this->exec('schema_cache clear --connection test');
         $this->assertExitSuccess();
@@ -187,13 +183,12 @@ class SchemaCacheCommandsTest extends TestCase
      */
     public function testClearNamedModel(): void
     {
-        $this->cache->expects($this->never())
-            ->method('set')
-            ->willReturn(true);
-        $this->cache->expects($this->once())
-            ->method('delete')
+        $this->cache->shouldReceive('set')
+            ->never();
+        $this->cache->shouldReceive('delete')
+            ->once()
             ->with('test_articles')
-            ->willReturn(false);
+            ->andReturn(false);
 
         $this->exec('schema_cache clear --connection test articles');
         $this->assertExitSuccess();

--- a/tests/TestCase/Console/ConsoleInputArgumentTest.php
+++ b/tests/TestCase/Console/ConsoleInputArgumentTest.php
@@ -27,11 +27,6 @@ use SimpleXMLElement;
  */
 class ConsoleInputArgumentTest extends TestCase
 {
-    /**
-     * @var \Cake\Console\ConsoleInputArgument|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $input;
-
     public static function dataProperties(): array
     {
         return [

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -45,9 +45,10 @@ class MysqlTest extends TestCase
      */
     public function testConnectionConfigDefault(): void
     {
-        $driver = $this->getMockBuilder(Mysql::class)
-            ->onlyMethods(['createPdo'])
-            ->getMock();
+        $driver = Mockery::mock(Mysql::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct();
         $dsn = 'mysql:host=localhost;port=3306;dbname=cake;charset=utf8mb4';
         $expected = [
             'persistent' => true,
@@ -70,8 +71,10 @@ class MysqlTest extends TestCase
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
         ];
 
-        $driver->expects($this->once())->method('createPdo')
-            ->with($dsn, $expected);
+        $driver->shouldReceive('createPdo')
+            ->with($dsn, $expected)
+            ->once()
+            ->andReturn(Mockery::mock(PDO::class));
 
         $driver->connect();
     }
@@ -99,10 +102,10 @@ class MysqlTest extends TestCase
             ],
             'log' => false,
         ];
-        $driver = $this->getMockBuilder(Mysql::class)
-            ->onlyMethods(['createPdo'])
-            ->setConstructorArgs([$config])
-            ->getMock();
+        $driver = Mockery::mock(Mysql::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct($config);
         $dsn = 'mysql:host=foo;port=3440;dbname=bar';
         $expected = $config;
         $expected['init'][] = "SET time_zone = 'Antarctica'";
@@ -118,9 +121,10 @@ class MysqlTest extends TestCase
         $connection->shouldReceive('exec')->with('this too')->once();
         $connection->shouldReceive('exec')->with("SET time_zone = 'Antarctica'")->once();
 
-        $driver->expects($this->once())->method('createPdo')
+        $driver->shouldReceive('createPdo')
             ->with($dsn, $expected)
-            ->willReturn($connection);
+            ->once()
+            ->andReturn($connection);
         $driver->connect();
     }
 
@@ -173,24 +177,20 @@ class MysqlTest extends TestCase
     #[DataProvider('versionStringProvider')]
     public function testVersion($dbVersion, $expectedVersion): void
     {
-        /** @var \PHPUnit\Framework\MockObject\MockObject&\PDO $connection */
-        $connection = $this->getMockBuilder(PDO::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getAttribute'])
-            ->getMock();
-        $connection->expects($this->once())
-            ->method('getAttribute')
+        $connection = Mockery::mock(PDO::class);
+        $connection->shouldReceive('getAttribute')
             ->with(PDO::ATTR_SERVER_VERSION)
-            ->willReturn($dbVersion);
+            ->once()
+            ->andReturn($dbVersion);
 
-        /** @var \PHPUnit\Framework\MockObject\MockObject&\Cake\Database\Driver\Mysql $driver */
-        $driver = $this->getMockBuilder(Mysql::class)
-            ->onlyMethods(['createPdo'])
-            ->getMock();
+        $driver = Mockery::mock(Mysql::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct();
 
-        $driver->expects($this->once())
-            ->method('createPdo')
-            ->willReturn($connection);
+        $driver->shouldReceive('createPdo')
+            ->once()
+            ->andReturn($connection);
 
         $result = $driver->version();
         $this->assertSame($expectedVersion, $result);

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -24,12 +24,10 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Mockery;
 use PDO;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * Tests Postgres driver
  */
-#[AllowMockObjectsWithoutExpectations]
 class PostgresTest extends TestCase
 {
     /**
@@ -37,9 +35,10 @@ class PostgresTest extends TestCase
      */
     public function testConnectionConfigDefault(): void
     {
-        $driver = $this->getMockBuilder(Postgres::class)
-            ->onlyMethods(['createPdo'])
-            ->getMock();
+        $driver = Mockery::mock(Postgres::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct();
         $dsn = 'pgsql:host=localhost;port=5432;dbname=cake';
         $expected = [
             'persistent' => true,
@@ -76,9 +75,10 @@ class PostgresTest extends TestCase
         $connection->shouldReceive('exec')->with('SET NAMES utf8')->once();
         $connection->shouldReceive('exec')->with('SET search_path TO public')->once();
 
-        $driver->expects($this->once())->method('createPdo')
+        $driver->shouldReceive('createPdo')
             ->with($dsn, $expected)
-            ->willReturn($connection);
+            ->once()
+            ->andReturn($connection);
 
         $driver->connect();
     }
@@ -107,10 +107,10 @@ class PostgresTest extends TestCase
             'ssl' => true,
             'ssl_mode' => 'verify-ca',
         ];
-        $driver = $this->getMockBuilder(Postgres::class)
-            ->onlyMethods(['createPdo'])
-            ->setConstructorArgs([$config])
-            ->getMock();
+        $driver = Mockery::mock(Postgres::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct($config);
         $dsn = 'pgsql:host=foo;port=3440;dbname=bar;sslmode=verify-ca;sslkey=/path/to/key;sslcert=/path/to/crt;sslrootcert=/path/to/ca';
 
         $expected = $config;
@@ -132,9 +132,10 @@ class PostgresTest extends TestCase
         $connection->shouldReceive('exec')->with('this too')->once();
         $connection->shouldReceive('exec')->with('SET timezone = Antarctica')->once();
 
-        $driver->expects($this->once())->method('createPdo')
+        $driver->shouldReceive('createPdo')
             ->with($dsn, $expected)
-            ->willReturn($connection);
+            ->once()
+            ->andReturn($connection);
 
         $driver->connect();
     }
@@ -144,11 +145,13 @@ class PostgresTest extends TestCase
      */
     public function testInsertReturning(): void
     {
-        $driver = $this->getMockBuilder(Postgres::class)
-            ->onlyMethods(['createPdo', 'getPdo', 'connect', 'enabled'])
-            ->setConstructorArgs([[]])
-            ->getMock();
-        $driver->method('enabled')->willReturn(true);
+        $driver = Mockery::mock(Postgres::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct([]);
+        $driver->shouldReceive('enabled')->andReturn(true);
+        $driver->shouldReceive('connect')->andReturnNull();
+        $driver->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
         $connection = new Connection(['driver' => $driver, 'log' => false]);
 
         $query = $connection->insertQuery('articles', ['id' => 1, 'title' => 'foo']);
@@ -164,12 +167,14 @@ class PostgresTest extends TestCase
      */
     public function testHavingReplacesAlias(): void
     {
-        $driver = $this->getMockBuilder(Postgres::class)
-            ->onlyMethods(['connect', 'getPdo', 'version', 'enabled'])
-            ->setConstructorArgs([[]])
-            ->getMock();
-        $driver->method('enabled')
-            ->willReturn(true);
+        $driver = Mockery::mock(Postgres::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct([]);
+        $driver->shouldReceive('enabled')->andReturn(true);
+        $driver->shouldReceive('connect')->andReturnNull();
+        $driver->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
+        $driver->shouldReceive('version')->andReturn('16.0');
 
         $connection = new Connection(['driver' => $driver, 'log' => false]);
 
@@ -192,12 +197,14 @@ class PostgresTest extends TestCase
      */
     public function testHavingWhenNoAliasIsUsed(): void
     {
-        $driver = $this->getMockBuilder(Postgres::class)
-            ->onlyMethods(['connect', 'getPdo', 'version', 'enabled'])
-            ->setConstructorArgs([[]])
-            ->getMock();
-        $driver->method('enabled')
-            ->willReturn(true);
+        $driver = Mockery::mock(Postgres::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct([]);
+        $driver->shouldReceive('enabled')->andReturn(true);
+        $driver->shouldReceive('connect')->andReturnNull();
+        $driver->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
+        $driver->shouldReceive('version')->andReturn('16.0');
 
         $connection = new Connection(['driver' => $driver, 'log' => false]);
 

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -24,13 +24,11 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Mockery;
 use PDO;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Sqlite driver
  */
-#[AllowMockObjectsWithoutExpectations]
 class SqliteTest extends TestCase
 {
     protected function tearDown(): void
@@ -45,9 +43,10 @@ class SqliteTest extends TestCase
      */
     public function testConnectionConfigDefault(): void
     {
-        $driver = $this->getMockBuilder(Sqlite::class)
-            ->onlyMethods(['createPdo'])
-            ->getMock();
+        $driver = Mockery::mock(Sqlite::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct();
         $dsn = 'sqlite::memory:';
         $expected = [
             'persistent' => false,
@@ -68,8 +67,10 @@ class SqliteTest extends TestCase
             PDO::ATTR_EMULATE_PREPARES => false,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
         ];
-        $driver->expects($this->once())->method('createPdo')
-            ->with($dsn, $expected);
+        $driver->shouldReceive('createPdo')
+            ->with($dsn, $expected)
+            ->once()
+            ->andReturn(Mockery::mock(PDO::class));
         $driver->connect();
     }
 
@@ -87,10 +88,10 @@ class SqliteTest extends TestCase
             'init' => ['Execute this', 'this too'],
             'mask' => 0666,
         ];
-        $driver = $this->getMockBuilder(Sqlite::class)
-            ->onlyMethods(['createPdo'])
-            ->setConstructorArgs([$config])
-            ->getMock();
+        $driver = Mockery::mock(Sqlite::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct($config);
         $dsn = 'sqlite:bar.db';
 
         $expected = $config;
@@ -105,9 +106,10 @@ class SqliteTest extends TestCase
         $connection->shouldReceive('exec')->with('Execute this')->once();
         $connection->shouldReceive('exec')->with('this too')->once();
 
-        $driver->expects($this->once())->method('createPdo')
+        $driver->shouldReceive('createPdo')
             ->with($dsn, $expected)
-            ->willReturn($connection);
+            ->once()
+            ->andReturn($connection);
 
         $driver->connect();
     }
@@ -179,12 +181,13 @@ class SqliteTest extends TestCase
                 return '"' . $value . '"';
             });
 
-        $driver = $this->getMockBuilder(Sqlite::class)
-            ->onlyMethods(['createPdo'])
-            ->getMock();
+        $driver = Mockery::mock(Sqlite::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct();
 
-        $driver->method('createPdo')
-            ->willReturn($mock);
+        $driver->shouldReceive('createPdo')
+            ->andReturn($mock);
 
         $this->assertEquals($expected, $driver->schemaValue($input));
     }

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -252,7 +252,7 @@ class SqlserverTest extends TestCase
             ->shouldAllowMockingProtectedMethods();
         $driver->__construct();
 
-        $pdo = Mockery::mock(PDO::class);
+        $pdo = Mockery::mock(PDO::class)->makePartial();
 
         $statement = Mockery::mock(PDOStatement::class);
         $connection = new Connection(['driver' => $driver, 'log' => false]);
@@ -271,6 +271,11 @@ class SqlserverTest extends TestCase
         $pdo->shouldReceive('prepare')
             ->with('', [])
             ->andReturn($statement)
+            ->once();
+
+        $pdo->shouldReceive('getAttribute')
+            ->with(PDO::ATTR_SERVER_VERSION)
+            ->andReturn('12')
             ->once();
 
         $query = new SelectQuery($connection);

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -29,13 +29,11 @@ use InvalidArgumentException;
 use Mockery;
 use PDO;
 use PDOStatement;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Sqlserver driver
  */
-#[AllowMockObjectsWithoutExpectations]
 class SqlserverTest extends TestCase
 {
     /**
@@ -120,17 +118,19 @@ class SqlserverTest extends TestCase
     public function testDnsString($constructorArgs, $dnsString): void
     {
         $this->skipIf($this->missingExtension, 'pdo_sqlsrv is not installed.');
-        $driver = $this->getMockBuilder(Sqlserver::class)
-            ->onlyMethods(['createPdo'])
-            ->setConstructorArgs([$constructorArgs])
-            ->getMock();
+        $driver = Mockery::mock(Sqlserver::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct($constructorArgs);
 
-        $driver->method('createPdo')
-            ->with($this->callback(function ($dns) use ($dnsString) {
+        $driver->shouldReceive('createPdo')
+            ->withArgs(function ($dns) use ($dnsString) {
                 $this->assertSame($dns, $dnsString);
 
                 return true;
-            }));
+            })
+            ->once()
+            ->andReturn(Mockery::mock(PDO::class));
 
         $driver->connect();
     }
@@ -151,10 +151,10 @@ class SqlserverTest extends TestCase
             'init' => ['Execute this', 'this too'],
             'settings' => ['config1' => 'value1', 'config2' => 'value2'],
         ];
-        $driver = $this->getMockBuilder(Sqlserver::class)
-            ->onlyMethods(['createPdo', 'getPdo'])
-            ->setConstructorArgs([$config])
-            ->getMock();
+        $driver = Mockery::mock(Sqlserver::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct($config);
         $dsn = 'sqlsrv:Server=foo;Database=bar;MultipleActiveResultSets=false';
 
         $expected = $config;
@@ -185,9 +185,10 @@ class SqlserverTest extends TestCase
         $connection->shouldReceive('exec')->with('SET config1 value1')->once();
         $connection->shouldReceive('exec')->with('SET config2 value2')->once();
 
-        $driver->expects($this->once())->method('createPdo')
+        $driver->shouldReceive('createPdo')
             ->with($dsn, $expected)
-            ->willReturn($connection);
+            ->once()
+            ->andReturn($connection);
 
         $driver->connect();
     }
@@ -246,22 +247,18 @@ class SqlserverTest extends TestCase
     {
         $this->skipIf($this->missingExtension, 'pdo_sqlsrv is not installed.');
 
-        $driver = $this->getMockBuilder(Sqlserver::class)
-            ->onlyMethods(['getPdo'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $driver = Mockery::mock(Sqlserver::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct();
 
         $pdo = Mockery::mock(PDO::class);
 
-        $statement = $this->getMockBuilder(PDOStatement::class)
-            ->getMock();
+        $statement = Mockery::mock(PDOStatement::class);
+        $connection = new Connection(['driver' => $driver, 'log' => false]);
 
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $driver->method('getPdo')
-            ->willReturn($pdo);
+        $driver->shouldReceive('getPdo')
+            ->andReturn($pdo);
 
         $pdo->shouldReceive('prepare')
             ->with('', [
@@ -288,14 +285,14 @@ class SqlserverTest extends TestCase
      */
     public function testSelectLimitVersion12(): void
     {
-        $driver = $this->getMockBuilder(Sqlserver::class)
-            ->onlyMethods(['createPdo', 'getPdo', 'version', 'enabled'])
-            ->setConstructorArgs([[]])
-            ->getMock();
-        $driver->method('version')
-            ->willReturn('12');
-        $driver->method('enabled')
-            ->willReturn(true);
+        $driver = Mockery::mock(Sqlserver::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct([]);
+        $driver->shouldReceive('version')->andReturn('12');
+        $driver->shouldReceive('enabled')->andReturn(true);
+        $driver->shouldReceive('connect')->andReturnNull();
+        $driver->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
 
         $connection = new Connection(['driver' => $driver, 'log' => false]);
 
@@ -332,14 +329,14 @@ class SqlserverTest extends TestCase
      */
     public function testSelectLimitOldServer(): void
     {
-        $driver = $this->getMockBuilder(Sqlserver::class)
-            ->onlyMethods(['createPdo', 'getPdo', 'version', 'enabled'])
-            ->setConstructorArgs([[]])
-            ->getMock();
-        $driver->method('version')
-            ->willReturn('8');
-        $driver->method('enabled')
-            ->willReturn(true);
+        $driver = Mockery::mock(Sqlserver::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct([]);
+        $driver->shouldReceive('version')->andReturn('8');
+        $driver->shouldReceive('enabled')->andReturn(true);
+        $driver->shouldReceive('connect')->andReturnNull();
+        $driver->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
 
         $connection = new Connection(['driver' => $driver, 'log' => false]);
 
@@ -454,12 +451,13 @@ class SqlserverTest extends TestCase
      */
     public function testInsertUsesOutput(): void
     {
-        $driver = $this->getMockBuilder(Sqlserver::class)
-            ->onlyMethods(['createPdo', 'getPdo', 'enabled'])
-            ->setConstructorArgs([[]])
-            ->getMock();
-        $driver->method('enabled')
-            ->willReturn(true);
+        $driver = Mockery::mock(Sqlserver::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct([]);
+        $driver->shouldReceive('enabled')->andReturn(true);
+        $driver->shouldReceive('connect')->andReturnNull();
+        $driver->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
         $connection = new Connection(['driver' => $driver, 'log' => false]);
         $query = new InsertQuery($connection);
         $query->insert(['title'])
@@ -474,14 +472,14 @@ class SqlserverTest extends TestCase
      */
     public function testHavingReplacesAlias(): void
     {
-        $driver = $this->getMockBuilder(Sqlserver::class)
-            ->onlyMethods(['connect', 'getPdo', 'version', 'enabled'])
-            ->setConstructorArgs([[]])
-            ->getMock();
-        $driver->method('version')
-            ->willReturn('8');
-        $driver->method('enabled')
-            ->willReturn(true);
+        $driver = Mockery::mock(Sqlserver::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct([]);
+        $driver->shouldReceive('version')->andReturn('8');
+        $driver->shouldReceive('enabled')->andReturn(true);
+        $driver->shouldReceive('connect')->andReturnNull();
+        $driver->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
 
         $connection = new Connection(['driver' => $driver, 'log' => false]);
 
@@ -504,14 +502,14 @@ class SqlserverTest extends TestCase
      */
     public function testHavingWhenNoAliasIsUsed(): void
     {
-        $driver = $this->getMockBuilder(Sqlserver::class)
-            ->onlyMethods(['connect', 'getPdo', 'version', 'enabled'])
-            ->setConstructorArgs([[]])
-            ->getMock();
-        $driver->method('version')
-            ->willReturn('8');
-        $driver->method('enabled')
-            ->willReturn(true);
+        $driver = Mockery::mock(Sqlserver::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct([]);
+        $driver->shouldReceive('version')->andReturn('8');
+        $driver->shouldReceive('enabled')->andReturn(true);
+        $driver->shouldReceive('connect')->andReturnNull();
+        $driver->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
 
         $connection = new Connection(['driver' => $driver, 'log' => false]);
 

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -33,6 +33,7 @@ use Exception;
 use Mockery;
 use PDO;
 use PDOException;
+use PDOStatement;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Database\Driver\RetryDriver;
 use TestApp\Database\Driver\StubDriver;
@@ -160,7 +161,7 @@ class DriverTest extends TestCase
         $connection = Mockery::mock(PDO::class);
         $connection->shouldReceive('query')
             ->once()
-            ->andReturn(Mockery::mock(\PDOStatement::class));
+            ->andReturn(Mockery::mock(PDOStatement::class));
 
         $this->driver->shouldReceive('createPdo')
             ->once()

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -23,17 +23,16 @@ use Cake\Database\Log\QueryLogger;
 use Cake\Database\Query;
 use Cake\Database\QueryCompiler;
 use Cake\Database\Schema\TableSchema;
-use Cake\Database\Statement\Statement;
+use Cake\Database\StatementInterface;
 use Cake\Database\ValueBinder;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use DateTime;
 use Exception;
+use Mockery;
 use PDO;
 use PDOException;
-use PDOStatement;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Database\Driver\RetryDriver;
 use TestApp\Database\Driver\StubDriver;
@@ -41,11 +40,10 @@ use TestApp\Database\Driver\StubDriver;
 /**
  * Tests Driver class
  */
-#[AllowMockObjectsWithoutExpectations]
 class DriverTest extends TestCase
 {
     /**
-     * @var \TestApp\Database\Driver\StubDriver|\PHPUnit\Framework\MockObject\MockObject
+     * @var \TestApp\Database\Driver\StubDriver
      */
     protected $driver;
 
@@ -61,9 +59,10 @@ class DriverTest extends TestCase
             'scopes' => ['queriesLog'],
         ]);
 
-        $this->driver = $this->getMockBuilder(StubDriver::class)
-            ->onlyMethods(['createPdo', 'prepare'])
-            ->getMock();
+        $this->driver = Mockery::mock(StubDriver::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $this->driver->__construct();
     }
 
     protected function tearDown(): void
@@ -121,19 +120,15 @@ class DriverTest extends TestCase
     {
         $value = 'string';
 
-        $connection = $this->getMockBuilder(PDO::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['quote'])
-            ->getMock();
-
-        $connection
-            ->expects($this->once())
-            ->method('quote')
+        $connection = Mockery::mock(PDO::class);
+        $connection->shouldReceive('quote')
             ->with($value, PDO::PARAM_STR)
-            ->willReturn('string');
+            ->once()
+            ->andReturn('string');
 
-        $this->driver->method('createPdo')
-            ->willReturn($connection);
+        $this->driver->shouldReceive('createPdo')
+            ->once()
+            ->andReturn($connection);
 
         $this->driver->schemaValue($value);
     }
@@ -143,18 +138,14 @@ class DriverTest extends TestCase
      */
     public function testLastInsertId(): void
     {
-        $connection = $this->getMockBuilder(PDO::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['lastInsertId'])
-            ->getMock();
+        $connection = Mockery::mock(PDO::class);
+        $connection->shouldReceive('lastInsertId')
+            ->once()
+            ->andReturn('all-the-bears');
 
-        $connection
-            ->expects($this->once())
-            ->method('lastInsertId')
-            ->willReturn('all-the-bears');
-
-        $this->driver->method('createPdo')
-            ->willReturn($connection);
+        $this->driver->shouldReceive('createPdo')
+            ->once()
+            ->andReturn($connection);
 
         $this->assertSame('all-the-bears', $this->driver->lastInsertId());
     }
@@ -166,18 +157,14 @@ class DriverTest extends TestCase
     {
         $this->assertFalse($this->driver->isConnected());
 
-        $connection = $this->getMockBuilder(PDO::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['query'])
-            ->getMock();
+        $connection = Mockery::mock(PDO::class);
+        $connection->shouldReceive('query')
+            ->once()
+            ->andReturn(Mockery::mock(\PDOStatement::class));
 
-        $connection
-            ->expects($this->once())
-            ->method('query')
-            ->willReturn(new PDOStatement());
-
-        $this->driver->method('createPdo')
-            ->willReturn($connection);
+        $this->driver->shouldReceive('createPdo')
+            ->once()
+            ->andReturn($connection);
 
         $this->driver->connect();
 
@@ -203,33 +190,25 @@ class DriverTest extends TestCase
      */
     public function testCompileQuery(): void
     {
-        $compiler = $this->getMockBuilder(QueryCompiler::class)
-            ->onlyMethods(['compile'])
-            ->getMock();
+        $compiler = Mockery::mock(QueryCompiler::class);
+        $compiler->shouldReceive('compile')
+            ->once()
+            ->andReturn('1');
 
-        $compiler
-            ->expects($this->once())
-            ->method('compile')
-            ->willReturn('1');
+        $driver = Mockery::mock(StubDriver::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct();
+        $driver->shouldReceive('newCompiler')
+            ->once()
+            ->andReturn($compiler);
 
-        $driver = $this->getMockBuilder(StubDriver::class)
-            ->onlyMethods(['newCompiler', 'transformQuery'])
-            ->getMock();
+        $query = Mockery::mock(Query::class)->shouldIgnoreMissing();
+        $query->shouldReceive('type')->andReturn('select');
 
-        $driver
-            ->expects($this->once())
-            ->method('newCompiler')
-            ->willReturn($compiler);
-
-        $query = $this->getMockBuilder(Query::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $query->method('type')->willReturn('select');
-
-        $driver
-            ->expects($this->once())
-            ->method('transformQuery')
-            ->willReturn($query);
+        $driver->shouldReceive('transformQuery')
+            ->once()
+            ->andReturn($query);
 
         $result = $driver->compileQuery($query, new ValueBinder());
 
@@ -301,18 +280,15 @@ class DriverTest extends TestCase
      */
     public function testExecuteNoParams(): void
     {
-        $inner = $this->getMockBuilder(PDOStatement::class)->getMock();
+        $statement = Mockery::mock(StatementInterface::class);
+        $statement->shouldReceive('queryString')->andReturn('SELECT bar FROM foo');
+        $statement->shouldReceive('rowCount')->andReturn(3);
+        $statement->shouldReceive('execute')->andReturn(true);
+        $statement->shouldReceive('getBoundParams')->andReturn([]);
 
-        $statement = $this->getMockBuilder(Statement::class)
-            ->setConstructorArgs([$inner, $this->driver])
-            ->onlyMethods(['queryString','rowCount','execute'])
-            ->getMock();
-        $statement->method('queryString')->willReturn('SELECT bar FROM foo');
-        $statement->method('rowCount')->willReturn(3);
-        $statement->method('execute')->willReturn(true);
-
-        $this->driver->method('prepare')
-            ->willReturn($statement);
+        $this->driver->shouldReceive('prepare')
+            ->once()
+            ->andReturn($statement);
         $this->driver->setLogger(new QueryLogger(['connection' => 'test']));
 
         $this->driver->execute('SELECT bar FROM foo');
@@ -327,19 +303,28 @@ class DriverTest extends TestCase
      */
     public function testExecuteWithBinding(): void
     {
-        $inner = $this->getMockBuilder(PDOStatement::class)->getMock();
-
-        $statement = $this->getMockBuilder(Statement::class)
-            ->setConstructorArgs([$inner, $this->driver])
-            ->onlyMethods(['queryString','rowCount','execute'])
-            ->getMock();
-        $statement->method('rowCount')->willReturn(3);
-        $statement->method('execute')->willReturn(true);
-        $statement->method('queryString')->willReturn('SELECT bar FROM foo WHERE a=:a AND b=:b');
+        $boundParams = [];
+        $statement = Mockery::mock(StatementInterface::class);
+        $statement->shouldReceive('rowCount')->andReturn(3);
+        $statement->shouldReceive('execute')->andReturn(true);
+        $statement->shouldReceive('queryString')->andReturn('SELECT bar FROM foo WHERE a=:a AND b=:b');
+        $statement->shouldReceive('bind')
+            ->once()
+            ->andReturnUsing(function (array $params, array $types) use (&$boundParams): void {
+                $boundParams = [
+                    'a' => (string)$params['a'],
+                    'b' => $params['b']->format('Y-m-d'),
+                ];
+            });
+        $statement->shouldReceive('getBoundParams')
+            ->andReturnUsing(function () use (&$boundParams): array {
+                return $boundParams;
+            });
 
         $this->driver->setLogger(new QueryLogger(['connection' => 'test']));
-        $this->driver->method('prepare')
-            ->willReturn($statement);
+        $this->driver->shouldReceive('prepare')
+            ->once()
+            ->andReturn($statement);
 
         $this->driver->execute(
             'SELECT bar FROM foo WHERE a=:a AND b=:b',
@@ -360,19 +345,16 @@ class DriverTest extends TestCase
      */
     public function testExecuteWithError(): void
     {
-        $inner = $this->getMockBuilder(PDOStatement::class)->getMock();
-
-        $statement = $this->getMockBuilder(Statement::class)
-            ->setConstructorArgs([$inner, $this->driver])
-            ->onlyMethods(['queryString','rowCount','execute'])
-            ->getMock();
-        $statement->method('queryString')->willReturn('SELECT bar FROM foo');
-        $statement->method('rowCount')->willReturn(0);
-        $statement->method('execute')->will($this->throwException(new PDOException()));
+        $statement = Mockery::mock(StatementInterface::class);
+        $statement->shouldReceive('queryString')->andReturn('SELECT bar FROM foo');
+        $statement->shouldReceive('rowCount')->andReturn(0);
+        $statement->shouldReceive('execute')->andThrow(new PDOException());
+        $statement->shouldReceive('getBoundParams')->andReturn([]);
 
         $this->driver->setLogger(new QueryLogger(['connection' => 'test']));
-        $this->driver->method('prepare')
-            ->willReturn($statement);
+        $this->driver->shouldReceive('prepare')
+            ->once()
+            ->andReturn($statement);
 
         try {
             $this->driver->execute('SELECT foo FROM bar');
@@ -386,15 +368,16 @@ class DriverTest extends TestCase
 
     public function testGetLoggerDefault(): void
     {
-        $driver = $this->getMockBuilder(StubDriver::class)
-            ->onlyMethods(['createPdo', 'prepare'])
-            ->getMock();
+        $driver = Mockery::mock(StubDriver::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct();
         $this->assertNull($driver->getLogger());
 
-        $driver = $this->getMockBuilder(StubDriver::class)
-            ->setConstructorArgs([['log' => true]])
-            ->onlyMethods(['createPdo'])
-            ->getMock();
+        $driver = Mockery::mock(StubDriver::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct(['log' => true]);
 
         $logger = $driver->getLogger();
         $this->assertInstanceOf(QueryLogger::class, $logger);
@@ -409,36 +392,20 @@ class DriverTest extends TestCase
 
     public function testLogTransaction(): void
     {
-        $pdo = $this->getMockBuilder(PDO::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['beginTransaction', 'commit', 'rollback', 'inTransaction'])
-            ->getMock();
-        $pdo
-            ->method('beginTransaction')
-            ->willReturn(true);
-        $pdo
-            ->method('commit')
-            ->willReturn(true);
-        $pdo
-            ->method('rollBack')
-            ->willReturn(true);
-        $pdo->expects($this->exactly(5))
-            ->method('inTransaction')
-            ->willReturn(
-                false,
-                true,
-                true,
-                false,
-                true,
-            );
+        $pdo = Mockery::mock(PDO::class);
+        $pdo->shouldReceive('beginTransaction')->andReturn(true);
+        $pdo->shouldReceive('commit')->andReturn(true);
+        $pdo->shouldReceive('rollBack')->andReturn(true);
+        $pdo->shouldReceive('inTransaction')
+            ->times(5)
+            ->andReturn(false, true, true, false, true);
 
-        $driver = $this->getMockBuilder(StubDriver::class)
-            ->setConstructorArgs([['log' => true]])
-            ->onlyMethods(['getPdo'])
-            ->getMock();
-
-        $driver->method('getPdo')
-            ->willReturn($pdo);
+        $driver = Mockery::mock(StubDriver::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct(['log' => true]);
+        $driver->shouldReceive('getPdo')
+            ->andReturn($pdo);
 
         $driver->beginTransaction();
         $driver->beginTransaction(); //This one will not be logged
@@ -475,18 +442,15 @@ class DriverTest extends TestCase
      */
     public function testDisableQueryLogging(): void
     {
-        $inner = $this->getMockBuilder(PDOStatement::class)->getMock();
+        $statement = Mockery::mock(StatementInterface::class);
+        $statement->shouldReceive('queryString')->andReturn('SELECT bar FROM foo');
+        $statement->shouldReceive('rowCount')->andReturn(3);
+        $statement->shouldReceive('execute')->andReturn(true);
+        $statement->shouldReceive('getBoundParams')->andReturn([]);
 
-        $statement = $this->getMockBuilder(Statement::class)
-            ->setConstructorArgs([$inner, $this->driver])
-            ->onlyMethods(['queryString','rowCount','execute'])
-            ->getMock();
-        $statement->method('queryString')->willReturn('SELECT bar FROM foo');
-        $statement->method('rowCount')->willReturn(3);
-        $statement->method('execute')->willReturn(true);
-
-        $this->driver->method('prepare')
-            ->willReturn($statement);
+        $this->driver->shouldReceive('prepare')
+            ->twice()
+            ->andReturn($statement);
         $this->driver->setLogger(new QueryLogger(['connection' => 'test']));
 
         $this->driver->execute('SELECT bar FROM foo');

--- a/tests/TestCase/Database/Query/UpdateQueryTest.php
+++ b/tests/TestCase/Database/Query/UpdateQueryTest.php
@@ -26,19 +26,17 @@ use Cake\Database\Expression\QueryExpression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query\SelectQuery;
 use Cake\Database\Query\UpdateQuery;
-use Cake\Database\Statement\Statement;
+use Cake\Database\StatementInterface;
 use Cake\Database\ValueBinder;
 use Cake\Datasource\ConnectionManager;
 use Cake\Test\TestCase\Database\QueryAssertsTrait;
 use Cake\TestSuite\TestCase;
 use DateTime;
-use PDOStatement;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Mockery;
 
 /**
  * Tests UpdateQuery class
  */
-#[AllowMockObjectsWithoutExpectations]
 class UpdateQueryTest extends TestCase
 {
     use QueryAssertsTrait;
@@ -376,28 +374,20 @@ class UpdateQueryTest extends TestCase
      */
     public function testRowCountAndClose(): void
     {
-        $inner = $this->getMockBuilder(PDOStatement::class)->getMock();
+        $statementMock = Mockery::mock(StatementInterface::class);
+        $statementMock->shouldReceive('rowCount')
+            ->once()
+            ->andReturn(500);
+        $statementMock->shouldReceive('closeCursor')
+            ->once();
 
-        $statementMock = $this->getMockBuilder(Statement::class)
-            ->setConstructorArgs([$inner, $this->connection->getDriver()])
-            ->onlyMethods(['rowCount', 'closeCursor'])
-            ->getMock();
-
-        $statementMock->expects($this->once())
-            ->method('rowCount')
-            ->willReturn(500);
-
-        $statementMock->expects($this->once())
-            ->method('closeCursor');
-
-        $queryMock = $this->getMockBuilder(UpdateQuery::class)
-            ->onlyMethods(['execute'])
-            ->setConstructorArgs([$this->connection])
-            ->getMock();
-
-        $queryMock->expects($this->once())
-            ->method('execute')
-            ->willReturn($statementMock);
+        $queryMock = Mockery::mock(UpdateQuery::class)
+            ->makePartial()
+            ->shouldIgnoreMissing();
+        $queryMock->__construct($this->connection);
+        $queryMock->shouldReceive('execute')
+            ->once()
+            ->andReturn($statementMock);
 
         $rowCount = $queryMock->update('authors')
             ->set('name', 'mark')

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -30,14 +30,13 @@ use Cake\Database\Schema\UniqueKey;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Exception;
+use Mockery;
 use PDO;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test case for MySQL Schema Dialect.
  */
-#[AllowMockObjectsWithoutExpectations]
 class MysqlSchemaDialectTest extends TestCase
 {
     protected PDO $pdo;
@@ -1685,11 +1684,9 @@ SQL;
     public function testAddConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
@@ -1734,11 +1731,9 @@ SQL;
     public function testDropConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
@@ -1816,11 +1811,9 @@ SQL;
     public function testCreateSql(): void
     {
         $driver = $this->_getMockedDriver('5.6.0');
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = (new TableSchema('posts'))->addColumn('id', [
                 'type' => 'integer',
@@ -1878,15 +1871,12 @@ SQL;
     public function testCreateSqlJson(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
-        $this->pdo
-            ->method('getAttribute')
-            ->willReturn('5.7.0');
+        $this->pdo->shouldReceive('getAttribute')
+            ->andReturn('5.7.0');
 
         $table = (new TableSchema('posts'))->addColumn('id', [
                 'type' => 'integer',
@@ -1923,11 +1913,9 @@ SQL;
     public function testCreateTemporary(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
         $table = (new TableSchema('schema_articles'))->addColumn('id', [
             'type' => 'integer',
             'null' => false,
@@ -1943,11 +1931,9 @@ SQL;
     public function testCreateSqlCompositeIntegerKey(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = (new TableSchema('articles_tags'))
             ->addColumn('article_id', [
@@ -2007,11 +1993,9 @@ SQL;
     public function testDropSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = new TableSchema('articles');
         $result = $table->dropSql($connection);
@@ -2025,11 +2009,9 @@ SQL;
     public function testTruncateSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = new TableSchema('articles');
         $result = $table->truncateSql($connection);
@@ -2042,9 +2024,8 @@ SQL;
      */
     public function testConstructConnectsDriver(): void
     {
-        $driver = $this->getMockBuilder(Driver::class)->getMock();
-        $driver->expects($this->once())
-            ->method('connect');
+        $driver = Mockery::mock(Driver::class)->shouldIgnoreMissing();
+        $driver->shouldReceive('connect')->once();
         new MysqlSchemaDialect($driver);
     }
 
@@ -2083,24 +2064,22 @@ SQL;
     {
         $this->_needsConnection();
 
-        $this->pdo = $this->getMockBuilder(PDOMocked::class)
-            ->onlyMethods(['quote', 'getAttribute', 'quoteIdentifier'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->pdo->method('quote')
-            ->willReturnCallback(function ($value) {
+        $this->pdo = Mockery::mock(PDOMocked::class);
+        $this->pdo->shouldReceive('quote')
+            ->andReturnUsing(function ($value) {
                 return "'{$value}'";
             });
 
-        $driver = $this->getMockBuilder(Mysql::class)
-            ->onlyMethods(['createPdo', 'version'])
-            ->getMock();
+        $driver = Mockery::mock(Mysql::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct();
 
-        $driver->method('createPdo')
-            ->willReturn($this->pdo);
+        $driver->shouldReceive('createPdo')
+            ->andReturn($this->pdo);
 
-        $driver->method('version')
-            ->willReturn($version);
+        $driver->shouldReceive('version')
+            ->andReturn($version);
 
         $driver->connect();
 

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -2010,6 +2010,9 @@ SQL;
             ->andReturnUsing(function ($value) {
                 return "'{$value}'";
             });
+        $mock->shouldReceive('exec')
+            ->zeroOrMoreTimes()
+            ->andReturn(0);
 
         $driver = Mockery::mock(Postgres::class)
             ->makePartial()

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -29,14 +29,13 @@ use Cake\Database\Schema\UniqueKey;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Exception;
+use Mockery;
 use PDO;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Postgres schema test case.
  */
-#[AllowMockObjectsWithoutExpectations]
 class PostgresSchemaDialectTest extends TestCase
 {
     /**
@@ -1601,11 +1600,9 @@ SQL;
     public function testAddConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
@@ -1650,11 +1647,9 @@ SQL;
     public function testDropConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
@@ -1699,11 +1694,9 @@ SQL;
     public function testCreateSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = (new TableSchema('schema_articles'))->addColumn('id', [
                 'type' => 'integer',
@@ -1766,11 +1759,9 @@ SQL;
     public function testCreateSqlGeospacialTypes(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = (new TableSchema('ref_table'))
             ->addColumn('geometry', [
@@ -1809,11 +1800,9 @@ SQL;
     public function testCreateInSchema(): void
     {
         $driver = $this->_getMockedDriver(['schema' => 'notpublic']);
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = (new TableSchema('schema_articles'))->addColumn('title', [
             'type' => 'string',
@@ -1829,11 +1818,9 @@ SQL;
     public function testCreateTemporary(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
         $table = (new TableSchema('schema_articles'))->addColumn('id', [
             'type' => 'integer',
             'null' => false,
@@ -1849,11 +1836,9 @@ SQL;
     public function testCreateSqlCompositeIntegerKey(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = (new TableSchema('articles_tags'))
             ->addColumn('article_id', [
@@ -1913,11 +1898,9 @@ SQL;
     public function testDropSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = new TableSchema('schema_articles');
         $result = $table->dropSql($connection);
@@ -1931,11 +1914,9 @@ SQL;
     public function testTruncateSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = new TableSchema('schema_articles');
         $table->addColumn('id', 'integer')
@@ -2024,25 +2005,22 @@ SQL;
     {
         $this->_needsConnection();
 
-        $mock = $this->getMockBuilder(PDO::class)
-            ->onlyMethods(['quote', 'exec'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $mock->method('quote')
-            ->willReturnCallback(function ($value) {
+        $mock = Mockery::mock(PDO::class);
+        $mock->shouldReceive('quote')
+            ->andReturnUsing(function ($value) {
                 return "'{$value}'";
             });
 
-        $driver = $this->getMockBuilder(Postgres::class)
-            ->setConstructorArgs([$config])
-            ->onlyMethods(['createPdo', 'version'])
-            ->getMock();
+        $driver = Mockery::mock(Postgres::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct($config);
 
-        $driver->method('createPdo')
-            ->willReturn($mock);
+        $driver->shouldReceive('createPdo')
+            ->andReturn($mock);
 
-        $driver->method('version')
-            ->willReturnCallback(function () {
+        $driver->shouldReceive('version')
+            ->andReturnUsing(function () {
                 return '10.0.0';
             });
 

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -28,14 +28,14 @@ use Cake\Database\Schema\SqliteSchemaDialect;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
+use Mockery;
 use PDO;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PDOStatement;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test case for Sqlite Schema Dialect.
  */
-#[AllowMockObjectsWithoutExpectations]
 class SqliteSchemaDialectTest extends TestCase
 {
     protected PDO $pdo;
@@ -1249,11 +1249,9 @@ SQL;
     public function testAddConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = new TableSchema('posts');
 
@@ -1267,11 +1265,9 @@ SQL;
     public function testDropConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = new TableSchema('posts');
         $result = $table->dropConstraintSql($connection);
@@ -1472,11 +1468,9 @@ SQL;
     public function testCreateSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = (new TableSchema('articles'))->addColumn('id', [
                 'type' => 'integer',
@@ -1522,11 +1516,9 @@ SQL;
     public function testCreateTemporary(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
         $table = (new TableSchema('schema_articles'))->addColumn('id', [
             'type' => 'integer',
             'null' => false,
@@ -1542,11 +1534,9 @@ SQL;
     public function testCreateSqlCompositeIntegerKey(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = (new TableSchema('articles_tags'))
             ->addColumn('article_id', [
@@ -1608,11 +1598,9 @@ SQL;
     public function testDropSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = new TableSchema('articles');
         $result = $table->dropSql($connection);
@@ -1626,23 +1614,19 @@ SQL;
     public function testTruncateSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
-        $statement = $this->getMockBuilder('\PDOStatement')
-            ->onlyMethods(['execute', 'rowCount', 'closeCursor', 'fetch'])
-            ->getMock();
-        $this->pdo->expects($this->once())
-            ->method('prepare')
+        $statement = Mockery::mock(PDOStatement::class);
+        $this->pdo->shouldReceive('prepare')
             ->with('SELECT 1 FROM sqlite_master WHERE name = "sqlite_sequence"')
-            ->willReturn($statement);
-        $statement->expects($this->once())
-            ->method('fetch')
-            ->willReturn(['1']);
-        $statement->method('execute')->willReturn(true);
+            ->once()
+            ->andReturn($statement);
+        $statement->shouldReceive('fetch')
+            ->once()
+            ->andReturn(['1']);
+        $statement->shouldReceive('execute')->andReturn(true);
 
         $table = new TableSchema('articles');
         $result = $table->truncateSql($connection);
@@ -1657,23 +1641,19 @@ SQL;
     public function testTruncateSqlNoSequences(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
-        $statement = $this->getMockBuilder('\PDOStatement')
-            ->onlyMethods(['execute', 'rowCount', 'closeCursor', 'fetch'])
-            ->getMock();
-        $this->pdo->expects($this->once())
-            ->method('prepare')
+        $statement = Mockery::mock(PDOStatement::class);
+        $this->pdo->shouldReceive('prepare')
             ->with('SELECT 1 FROM sqlite_master WHERE name = "sqlite_sequence"')
-            ->willReturn($statement);
-        $statement->expects($this->once())
-            ->method('fetch')
-            ->willReturn(false);
-        $statement->method('execute')->willReturn(true);
+            ->once()
+            ->andReturn($statement);
+        $statement->shouldReceive('fetch')
+            ->once()
+            ->andReturn(false);
+        $statement->shouldReceive('execute')->andReturn(true);
 
         $table = new TableSchema('articles');
         $result = $table->truncateSql($connection);
@@ -1688,21 +1668,19 @@ SQL;
     {
         $this->_needsConnection();
 
-        $this->pdo = $this->getMockBuilder(PDO::class)
-            ->onlyMethods(['quote', 'prepare'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->pdo->method('quote')
-            ->willReturnCallback(function ($value) {
+        $this->pdo = Mockery::mock(PDO::class);
+        $this->pdo->shouldReceive('quote')
+            ->andReturnUsing(function ($value) {
                 return '"' . $value . '"';
             });
 
-        $driver = $this->getMockBuilder(Sqlite::class)
-            ->onlyMethods(['createPdo'])
-            ->getMock();
+        $driver = Mockery::mock(Sqlite::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct();
 
-        $driver->method('createPdo')
-            ->willReturn($this->pdo);
+        $driver->shouldReceive('createPdo')
+            ->andReturn($this->pdo);
 
         $driver->connect();
 

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -26,14 +26,13 @@ use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
+use Mockery;
 use PDO;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * SQL Server schema test case.
  */
-#[AllowMockObjectsWithoutExpectations]
 class SqlserverSchemaDialectTest extends TestCase
 {
     /**
@@ -1109,11 +1108,9 @@ SQL;
     public function testAddConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
@@ -1158,11 +1155,9 @@ SQL;
     public function testDropConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
@@ -1247,11 +1242,9 @@ SQL;
     public function testCreateSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = (new TableSchema('schema_articles'))->addColumn('id', [
                 'type' => 'integer',
@@ -1321,11 +1314,9 @@ SQL;
     public function testDropSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = new TableSchema('schema_articles');
         $result = $table->dropSql($connection);
@@ -1339,11 +1330,9 @@ SQL;
     public function testTruncateSql(): void
     {
         $driver = $this->_getMockedDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->method('getWriteDriver')
-            ->willReturn($driver);
+        $connection = Mockery::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getWriteDriver')
+            ->andReturn($driver);
 
         $table = new TableSchema('schema_articles');
         $table->addColumn('id', 'integer')
@@ -1409,21 +1398,19 @@ SQL;
     {
         $this->_needsConnection();
 
-        $mock = $this->getMockBuilder(PDO::class)
-            ->onlyMethods(['quote'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $mock->method('quote')
-            ->willReturnCallback(function ($value) {
+        $mock = Mockery::mock(PDO::class);
+        $mock->shouldReceive('quote')
+            ->andReturnUsing(function ($value) {
                 return "'{$value}'";
             });
 
-        $driver = $this->getMockBuilder(Sqlserver::class)
-            ->onlyMethods(['createPdo'])
-            ->getMock();
+        $driver = Mockery::mock(Sqlserver::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct();
 
-        $driver->method('createPdo')
-            ->willReturn($mock);
+        $driver->shouldReceive('createPdo')
+            ->andReturn($mock);
 
         $driver->connect();
 

--- a/tests/TestCase/Database/SchemaCacheTest.php
+++ b/tests/TestCase/Database/SchemaCacheTest.php
@@ -53,6 +53,7 @@ class SchemaCacheTest extends TestCase
     {
         parent::setUp();
 
+        Cache::drop('orm_cache');
         Cache::setConfig('orm_cache', ['className' => 'Array']);
         $this->cache = Cache::pool('orm_cache');
 
@@ -69,7 +70,6 @@ class SchemaCacheTest extends TestCase
         parent::tearDown();
 
         unset($this->connection);
-        Cache::drop('orm_cache');
     }
 
     /**

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -24,6 +24,7 @@ use Cake\Datasource\Paging\NumericPaginator;
 use Cake\Datasource\RepositoryInterface;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\ResultSet;
+use Mockery;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Table\PaginatorPostsTable;
@@ -115,8 +116,8 @@ trait PaginatorTestTrait
             ->method('selectQuery')
             ->willReturn($query);
 
-        $query->expects($this->once())
-            ->method('applyOptions')
+        $query->shouldReceive('applyOptions')
+            ->once()
             ->with([
                 'limit' => 10,
                 'order' => ['PaginatorPosts.id' => 'ASC'],
@@ -190,8 +191,8 @@ trait PaginatorTestTrait
             ->method('selectQuery')
             ->willReturn($query);
 
-        $query->expects($this->once())
-            ->method('applyOptions')
+        $query->shouldReceive('applyOptions')
+            ->once()
             ->with([
                 'limit' => 10,
                 'page' => 1,
@@ -220,8 +221,8 @@ trait PaginatorTestTrait
             ->method('selectQuery')
             ->willReturn($query);
 
-        $query->expects($this->once())
-            ->method('applyOptions')
+        $query->shouldReceive('applyOptions')
+            ->once()
             ->with([
                 'limit' => 20,
                 'page' => 1,
@@ -252,8 +253,8 @@ trait PaginatorTestTrait
             ->method('selectQuery')
             ->willReturn($query);
 
-        $query->expects($this->once())
-            ->method('applyOptions')
+        $query->shouldReceive('applyOptions')
+            ->once()
             ->with([
                 'limit' => 10,
                 'page' => 1,
@@ -610,7 +611,8 @@ trait PaginatorTestTrait
             ->method('selectQuery')
             ->willReturn($query);
 
-        $query->expects($this->once())->method('applyOptions')
+        $query->shouldReceive('applyOptions')
+            ->once()
             ->with([
                 'limit' => 20,
                 'page' => 1,
@@ -656,7 +658,8 @@ trait PaginatorTestTrait
             ->method('selectQuery')
             ->willReturn($query);
 
-        $query->expects($this->once())->method('applyOptions')
+        $query->shouldReceive('applyOptions')
+            ->once()
             ->with([
                 'limit' => 20,
                 'page' => 1,
@@ -689,7 +692,8 @@ trait PaginatorTestTrait
             ->method('selectQuery')
             ->willReturn($query);
 
-        $query->expects($this->once())->method('applyOptions')
+        $query->shouldReceive('applyOptions')
+            ->once()
             ->with([
                 'limit' => 20,
                 'page' => 1,
@@ -731,7 +735,8 @@ trait PaginatorTestTrait
             ->method('selectQuery')
             ->willReturn($query);
 
-        $query->expects($this->once())->method('applyOptions')
+        $query->shouldReceive('applyOptions')
+            ->once()
             ->with([
                 'limit' => 20,
                 'page' => 1,
@@ -853,10 +858,9 @@ trait PaginatorTestTrait
      */
     public function testValidateAllowedSortNotInSchema(): void
     {
-        $model = $this->getMockRepository();
-        $model->method('getAlias')->willReturn('model');
-        $model->expects($this->once())->method('hasField')
-            ->willReturn(false);
+        $model = Mockery::mock(RepositoryInterface::class);
+        $model->shouldReceive('getAlias')->andReturn('model');
+        $model->shouldReceive('hasField')->andReturn(false);
 
         $options = [
             'sort' => 'score',
@@ -897,25 +901,14 @@ trait PaginatorTestTrait
     }
 
     /**
-     * @return \Cake\Datasource\RepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getMockRepository()
-    {
-        $model = $this->getMockBuilder(RepositoryInterface::class)
-            ->getMock();
-
-        return $model;
-    }
-
-    /**
      * @param string $modelAlias Model alias to use.
-     * @return \Cake\Datasource\RepositoryInterface|\PHPUnit\Framework\MockObject\Stub
+     * @return \Cake\Datasource\RepositoryInterface
      */
     protected function mockAliasHasFieldModel($modelAlias = 'model')
     {
-        $model = $this->createStub(RepositoryInterface::class);
-        $model->method('getAlias')->willReturn($modelAlias);
-        $model->method('hasField')->willReturn(true);
+        $model = Mockery::mock(RepositoryInterface::class);
+        $model->shouldReceive('getAlias')->andReturn($modelAlias);
+        $model->shouldReceive('hasField')->andReturn(true);
 
         return $model;
     }
@@ -1149,8 +1142,8 @@ trait PaginatorTestTrait
         $table = $this->_getMockPosts(['find']);
         $query = $this->_getMockFindQuery($table);
         $table->expects($this->never())->method('find');
-        $query->expects($this->once())
-            ->method('applyOptions')
+        $query->shouldReceive('applyOptions')
+            ->once()
             ->with([
                 'limit' => 10,
                 'order' => ['PaginatorPosts.id' => 'ASC'],
@@ -1197,8 +1190,8 @@ trait PaginatorTestTrait
         $query = $this->_getMockFindQuery($table);
         $query->limit(2);
         $table->expects($this->never())->method('find');
-        $query->expects($this->once())
-            ->method('applyOptions')
+        $query->shouldReceive('applyOptions')
+            ->once()
             ->with([
                 'limit' => 5,
                 'order' => ['PaginatorPosts.id' => 'ASC'],
@@ -1235,21 +1228,19 @@ trait PaginatorTestTrait
     /**
      * Helper method for mocking queries.
      *
-     * @param string|null $table
-     * @return \Cake\ORM\Query\SelectQuery|\PHPUnit\Framework\MockObject\MockObject
+     * @param RepositoryInterface|null $table
+     * @return \Cake\ORM\Query\SelectQuery|\Mockery\MockInterface
+     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     protected function _getMockFindQuery($table = null)
     {
-        /** @var \Cake\ORM\Query\SelectQuery|\PHPUnit\Framework\MockObject\MockObject $query */
-        $query = $this->getMockBuilder(SelectQuery::class)
-            ->onlyMethods(['all', 'count', 'applyOptions'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $query = Mockery::mock(SelectQuery::class)
+            ->makePartial();
 
         $results = $this->createStub(ResultSet::class);
 
-        $query->method('count')->willReturn(2);
-        $query->method('all')->willReturn($results);
+        $query->shouldReceive('count')->andReturn(2);
+        $query->shouldReceive('all')->andReturn($results);
 
         if ($table) {
             $query->setRepository($table);

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -22,26 +22,26 @@ use Cake\Http\Client\Request;
 use Cake\Http\Client\Response;
 use Cake\TestSuite\TestCase;
 use Exception;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Mockery;
 use TestApp\Http\Client\Adapter\CakeStreamWrapper;
 
 /**
  * HTTP stream adapter test.
  */
-#[AllowMockObjectsWithoutExpectations]
 class StreamTest extends TestCase
 {
     /**
-     * @var \Cake\Http\Client\Adapter\Stream|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Cake\Http\Client\Adapter\Stream
      */
     protected $stream;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->stream = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['_send'])
-            ->getMock();
+        $this->stream = Mockery::mock(Stream::class)->makePartial();
+        $this->stream
+            ->shouldAllowMockingProtectedMethods()
+            ->shouldReceive('_send');
         stream_wrapper_unregister('http');
         stream_wrapper_register('http', CakeStreamWrapper::class);
     }

--- a/tests/TestCase/Http/Client/Auth/DigestTest.php
+++ b/tests/TestCase/Http/Client/Auth/DigestTest.php
@@ -21,6 +21,7 @@ use Cake\Http\Client\Request;
 use Cake\Http\Client\Response;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
@@ -29,7 +30,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 class DigestTest extends TestCase
 {
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Cake\Http\Client
+     * @var \Cake\Http\Client
      */
     protected $client;
 
@@ -64,13 +65,16 @@ class DigestTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\Cake\Http\Client
+     * @return \Cake\Http\Client
      */
     protected function getClientMock()
     {
-        return $this->getMockBuilder(Client::class)
-            ->onlyMethods(['send'])
-            ->getMock();
+        $client = Mockery::mock(Client::class)
+            ->makePartial()
+            ->shouldIgnoreMissing();
+        $client->__construct();
+
+        return $client;
     }
 
     /**
@@ -83,9 +87,9 @@ class DigestTest extends TestCase
         ];
 
         $response = new Response($headers, '');
-        $this->client->expects($this->once())
-            ->method('send')
-            ->willReturn($response);
+        $this->client->shouldReceive('send')
+            ->once()
+            ->andReturn($response);
 
         $auth = ['username' => 'admin', 'password' => '1234'];
         $request = new Request('http://example.com/some/path', Request::METHOD_GET);
@@ -111,9 +115,9 @@ class DigestTest extends TestCase
         ];
 
         $response = new Response($headers, '');
-        $this->client->expects($this->once())
-            ->method('send')
-            ->willReturn($response);
+        $this->client->shouldReceive('send')
+            ->once()
+            ->andReturn($response);
         $auth = ['username' => 'admin', 'password' => '1234'];
         $request = new Request('http://example.com/some/path', Request::METHOD_GET);
         $request = $this->auth->authentication($request, $auth);
@@ -134,9 +138,9 @@ class DigestTest extends TestCase
         ];
 
         $response = new Response($headers, '');
-        $this->client->expects($this->once())
-            ->method('send')
-            ->willReturn($response);
+        $this->client->shouldReceive('send')
+            ->once()
+            ->andReturn($response);
 
         $auth = ['username' => 'admin', 'password' => '1234'];
         $request = new Request('http://example.com/some/path', Request::METHOD_GET);
@@ -157,9 +161,9 @@ class DigestTest extends TestCase
         ];
 
         $response = new Response($headers, '');
-        $this->client->expects($this->once())
-            ->method('send')
-            ->willReturn($response);
+        $this->client->shouldReceive('send')
+            ->once()
+            ->andReturn($response);
 
         $auth = ['username' => 'admin', 'password' => '1234'];
         $request = new Request('http://example.com/some/path', Request::METHOD_GET);
@@ -178,9 +182,9 @@ class DigestTest extends TestCase
         ];
 
         $response = new Response($headers, '');
-        $this->client->expects($this->once())
-            ->method('send')
-            ->willReturn($response);
+        $this->client->shouldReceive('send')
+            ->once()
+            ->andReturn($response);
 
         $auth = ['username' => 'admin', 'password' => '1234'];
         $request = new Request('http://example.com/some/path', Request::METHOD_GET);
@@ -336,9 +340,9 @@ class DigestTest extends TestCase
     public function testAlgorithms($message, $headers, $method, $data, $expected): void
     {
         $response = new Response($headers, '');
-        $this->client->expects($this->once())
-            ->method('send')
-            ->willReturn($response);
+        $this->client->shouldReceive('send')
+            ->once()
+            ->andReturn($response);
         $auth = ['username' => 'admin', 'password' => '1234'];
         $request = new Request('http://example.com/some/path', $method, [], $data);
         $request = $this->auth->authentication($request, $auth);
@@ -354,9 +358,9 @@ class DigestTest extends TestCase
         ];
 
         $response = new Response($headers, '');
-        $this->client->expects($this->once())
-            ->method('send')
-            ->willReturn($response);
+        $this->client->shouldReceive('send')
+            ->once()
+            ->andReturn($response);
 
         $auth = ['username' => 'admin', 'password' => '1234'];
         $request = new Request('http://example.com/some/path', Request::METHOD_GET);

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -28,13 +28,11 @@ use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Laminas\Diactoros\Request as LaminasRequest;
 use Mockery;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * HTTP client test.
  */
-#[AllowMockObjectsWithoutExpectations]
 class ClientTest extends TestCase
 {
     protected function tearDown(): void
@@ -232,12 +230,10 @@ class ClientTest extends TestCase
             'split' => 'value',
         ];
 
-        $mock = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
-        $mock->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function ($request) use ($headers) {
+        $mock = Mockery::mock(Stream::class);
+        $mock->shouldReceive('send')
+            ->once()
+            ->withArgs(function ($request) use ($headers) {
                 $this->assertInstanceOf(Request::class, $request);
                 $this->assertSame(Request::METHOD_GET, $request->getMethod());
                 $this->assertSame('2', $request->getProtocolVersion());
@@ -247,8 +243,8 @@ class ClientTest extends TestCase
                 $this->assertSame($headers['Connection'], $request->getHeaderLine('connection'));
 
                 return true;
-            }))
-            ->willReturn([$response]);
+            })
+            ->andReturn([$response]);
 
         $http = new Client(['adapter' => $mock, 'protocolVersion' => '2']);
         $result = $http->get('http://cakephp.org/test.html', [], [
@@ -265,12 +261,10 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
-        $mock->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function ($request) {
+        $mock = Mockery::mock(Stream::class);
+        $mock->shouldReceive('send')
+            ->once()
+            ->withArgs(function ($request) {
                 $this->assertSame(Request::METHOD_GET, $request->getMethod());
                 $this->assertEmpty($request->getHeaderLine('Content-Type'), 'Should have no content-type set');
                 $this->assertSame(
@@ -279,8 +273,8 @@ class ClientTest extends TestCase
                 );
 
                 return true;
-            }))
-            ->willReturn([$response]);
+            })
+            ->andReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -297,12 +291,10 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
-        $mock->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function ($request) {
+        $mock = Mockery::mock(Stream::class);
+        $mock->shouldReceive('send')
+            ->once()
+            ->withArgs(function ($request) {
                 $this->assertSame(Request::METHOD_GET, $request->getMethod());
                 $this->assertSame(
                     'http://cakephp.org/search?q=hi%20there&Category%5Bid%5D%5B0%5D=2&Category%5Bid%5D%5B1%5D=3',
@@ -310,8 +302,8 @@ class ClientTest extends TestCase
                 );
 
                 return true;
-            }))
-            ->willReturn([$response]);
+            })
+            ->andReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -331,20 +323,18 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
-        $mock->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function ($request) {
+        $mock = Mockery::mock(Stream::class);
+        $mock->shouldReceive('send')
+            ->once()
+            ->withArgs(function ($request) {
                 $this->assertSame(
                     'http://cakephp.org/search?q=hi+there&Category%5Bid%5D%5B0%5D=2&Category%5Bid%5D%5B1%5D=3',
                     $request->getUri() . '',
                 );
 
                 return true;
-            }))
-            ->willReturn([$response]);
+            })
+            ->andReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -366,19 +356,17 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
-        $mock->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function ($request) {
+        $mock = Mockery::mock(Stream::class);
+        $mock->shouldReceive('send')
+            ->once()
+            ->withArgs(function ($request) {
                 $this->assertSame(Request::METHOD_GET, $request->getMethod());
                 $this->assertSame('http://cakephp.org/search', '' . $request->getUri());
                 $this->assertSame('some data', '' . $request->getBody());
 
                 return true;
-            }))
-            ->willReturn([$response]);
+            })
+            ->andReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -396,11 +384,8 @@ class ClientTest extends TestCase
     public function testInvalidAuthenticationType(): void
     {
         $this->expectException(CakeException::class);
-        $mock = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
-        $mock->expects($this->never())
-            ->method('send');
+        $mock = Mockery::mock(Stream::class);
+        $mock->shouldReceive('send')->never();
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -418,24 +403,22 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
+        $mock = Mockery::mock(Stream::class);
         $headers = [
             'Authorization' => 'Basic ' . base64_encode('mark:secret'),
             'Proxy-Authorization' => 'Basic ' . base64_encode('mark:pass'),
         ];
-        $mock->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function ($request) use ($headers) {
+        $mock->shouldReceive('send')
+            ->once()
+            ->withArgs(function ($request) use ($headers) {
                 $this->assertSame(Request::METHOD_GET, $request->getMethod());
                 $this->assertSame('http://cakephp.org/', '' . $request->getUri());
                 $this->assertSame($headers['Authorization'], $request->getHeaderLine('Authorization'));
                 $this->assertSame($headers['Proxy-Authorization'], $request->getHeaderLine('Proxy-Authorization'));
 
                 return true;
-            }))
-            ->willReturn([$response]);
+            })
+            ->andReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -474,19 +457,17 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
-        $mock->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function ($request) use ($method) {
+        $mock = Mockery::mock(Stream::class);
+        $mock->shouldReceive('send')
+            ->once()
+            ->withArgs(function ($request) use ($method) {
                 $this->assertInstanceOf(Request::class, $request);
                 $this->assertEquals($method, $request->getMethod());
                 $this->assertSame('http://cakephp.org/projects/add', '' . $request->getUri());
 
                 return true;
-            }))
-            ->willReturn([$response]);
+            })
+            ->andReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -524,19 +505,17 @@ class ClientTest extends TestCase
             'Accept' => $mime,
         ];
 
-        $mock = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
-        $mock->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function ($request) use ($headers) {
+        $mock = Mockery::mock(Stream::class);
+        $mock->shouldReceive('send')
+            ->once()
+            ->withArgs(function ($request) use ($headers) {
                 $this->assertSame(Request::METHOD_POST, $request->getMethod());
                 $this->assertEquals($headers['Content-Type'], $request->getHeaderLine('Content-Type'));
                 $this->assertEquals($headers['Accept'], $request->getHeaderLine('Accept'));
 
                 return true;
-            }))
-            ->willReturn([$response]);
+            })
+            ->andReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -552,19 +531,17 @@ class ClientTest extends TestCase
             'Content-Type' => 'application/octet-stream',
         ];
 
-        $mock = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
-        $mock->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function ($request) use ($headers) {
+        $mock = Mockery::mock(Stream::class);
+        $mock->shouldReceive('send')
+            ->once()
+            ->withArgs(function ($request) use ($headers) {
                 $this->assertSame(Request::METHOD_POST, $request->getMethod());
                 $this->assertEquals($headers['Content-Type'], $request->getHeaderLine('Content-Type'));
                 $this->assertEquals('', (string)$request->getBody());
 
                 return true;
-            }))
-            ->willReturn([$response]);
+            })
+            ->andReturn([$response]);
 
         $http = new Client([
             'adapter' => $mock,
@@ -587,19 +564,17 @@ class ClientTest extends TestCase
             'Content-Type' => 'application/octet-stream',
         ];
 
-        $mock = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
-        $mock->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function ($request) use ($headers) {
+        $mock = Mockery::mock(Stream::class);
+        $mock->shouldReceive('send')
+            ->once()
+            ->withArgs(function ($request) use ($headers) {
                 $this->assertSame(Request::METHOD_POST, $request->getMethod());
                 $this->assertEquals($headers['Content-Type'], $request->getHeaderLine('Content-Type'));
                 $this->assertEquals('0', (string)$request->getBody());
 
                 return true;
-            }))
-            ->willReturn([$response]);
+            })
+            ->andReturn([$response]);
 
         $http = new Client([
             'adapter' => $mock,
@@ -623,17 +598,16 @@ class ClientTest extends TestCase
         $response = new Response();
         $data = 'some=value&more=data';
 
-        $mock = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
-        $mock->method('send')
-            ->with($this->callback(function ($request) use ($data) {
+        $mock = Mockery::mock(Stream::class);
+        $mock->shouldReceive('send')
+            ->times(3)
+            ->withArgs(function ($request) use ($data) {
                 $this->assertSame($data, '' . $request->getBody());
                 $this->assertSame('application/x-www-form-urlencoded', $request->getHeaderLine('content-type'));
 
                 return true;
-            }))
-            ->willReturn([$response]);
+            })
+            ->andReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -650,11 +624,8 @@ class ClientTest extends TestCase
     public function testExceptionOnUnknownType(): void
     {
         $this->expectException(CakeException::class);
-        $mock = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
-        $mock->expects($this->never())
-            ->method('send');
+        $mock = Mockery::mock(Stream::class);
+        $mock->shouldReceive('send')->never();
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -668,9 +639,7 @@ class ClientTest extends TestCase
      */
     public function testCookieStorage(): void
     {
-        $adapter = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
+        $adapter = Mockery::mock(Stream::class);
 
         $headers = [
             'HTTP/1.0 200 Ok',
@@ -678,9 +647,9 @@ class ClientTest extends TestCase
             'Set-Cookie: expiring=now; Expires=Wed, 09-Jun-1999 10:18:14 GMT',
         ];
         $response = new Response($headers, '');
-        $adapter->expects($this->once())
-            ->method('send')
-            ->willReturn([$response]);
+        $adapter->shouldReceive('send')
+            ->once()
+            ->andReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -760,19 +729,17 @@ class ClientTest extends TestCase
     {
         $response = new Response();
 
-        $mock = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
-        $mock->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function ($request) {
+        $mock = Mockery::mock(Stream::class);
+        $mock->shouldReceive('send')
+            ->once()
+            ->withArgs(function ($request) {
                 $this->assertInstanceOf(Request::class, $request);
                 $this->assertSame(Request::METHOD_HEAD, $request->getMethod());
                 $this->assertSame('http://cakephp.org/search?q=hi%20there', '' . $request->getUri());
 
                 return true;
-            }))
-            ->willReturn([$response]);
+            })
+            ->andReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -868,12 +835,10 @@ class ClientTest extends TestCase
             'Content-Type' => 'application/x-www-form-urlencoded',
         ];
 
-        $mock = $this->getMockBuilder(Stream::class)
-            ->onlyMethods(['send'])
-            ->getMock();
-        $mock->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function ($request) use ($headers) {
+        $mock = Mockery::mock(Stream::class);
+        $mock->shouldReceive('send')
+            ->once()
+            ->withArgs(function ($request) use ($headers) {
                 $this->assertInstanceOf(LaminasRequest::class, $request);
                 $this->assertSame(Request::METHOD_GET, $request->getMethod());
                 $this->assertSame('http://cakephp.org/test.html', $request->getUri() . '');
@@ -881,8 +846,8 @@ class ClientTest extends TestCase
                 $this->assertSame($headers['Connection'], $request->getHeaderLine('connection'));
 
                 return true;
-            }))
-            ->willReturn([$response]);
+            })
+            ->andReturn([$response]);
 
         $http = new Client(['adapter' => $mock]);
         $request = new LaminasRequest(

--- a/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
@@ -22,14 +22,12 @@ use Cake\Http\Middleware\RateLimitMiddleware;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Psr\Http\Server\RequestHandlerInterface;
 use stdClass;
 
 /**
  * RateLimitMiddleware test case
  */
-#[AllowMockObjectsWithoutExpectations]
 class RateLimitMiddlewareTest extends TestCase
 {
     /**

--- a/tests/TestCase/Http/ResponseEmitterTest.php
+++ b/tests/TestCase/Http/ResponseEmitterTest.php
@@ -21,14 +21,13 @@ use Cake\Http\Cookie\Cookie;
 use Cake\Http\Response;
 use Cake\Http\ResponseEmitter;
 use Cake\TestSuite\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Mockery;
 
 require_once __DIR__ . '/server_mocks.php';
 
 /**
  * Response emitter test.
  */
-#[AllowMockObjectsWithoutExpectations]
 class ResponseEmitterTest extends TestCase
 {
     /**
@@ -45,13 +44,16 @@ class ResponseEmitterTest extends TestCase
 
         $GLOBALS['mockedHeadersSent'] = false;
         $GLOBALS['mockedHeaders'] = [];
+        $GLOBALS['mockedCookies'] = [];
 
-        $this->emitter = $this->getMockBuilder(ResponseEmitter::class)
-            ->onlyMethods(['setCookie'])
-            ->getMock();
+        $this->emitter = Mockery::mock(ResponseEmitter::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $this->emitter->__construct();
 
-        $this->emitter->method('setCookie')
-            ->willReturnCallback(function ($cookie) {
+        $this->emitter->shouldReceive('setCookie')
+            ->zeroOrMoreTimes()
+            ->andReturnUsing(function ($cookie) {
                 if (is_string($cookie)) {
                     $cookie = Cookie::createFromHeaderString($cookie, ['path' => '']);
                 }

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -28,7 +28,7 @@ use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use Laminas\Diactoros\Uri;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
@@ -36,7 +36,6 @@ use Psr\Http\Message\UriInterface;
 /**
  * ServerRequest Test
  */
-#[AllowMockObjectsWithoutExpectations]
 class ServerRequestTest extends TestCase
 {
     /**
@@ -1429,7 +1428,7 @@ class ServerRequestTest extends TestCase
         $request = new ServerRequest([
             'input' => 'key=val&some=data',
         ]);
-        $body = $this->getMockBuilder(StreamInterface::class)->getMock();
+        $body = Mockery::mock(StreamInterface::class);
         $new = $request->withBody($body);
         $this->assertNotSame($new, $request);
         $this->assertNotSame($body, $request->getBody());
@@ -1458,7 +1457,7 @@ class ServerRequestTest extends TestCase
             ],
             'url' => 'articles/view/3',
         ]);
-        $uri = $this->getMockBuilder(UriInterface::class)->getMock();
+        $uri = Mockery::mock(UriInterface::class)->shouldIgnoreMissing();
         $new = $request->withUri($uri);
         $this->assertNotSame($new, $request);
         $this->assertNotSame($uri, $request->getUri());

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -189,10 +189,9 @@ class ServerTest extends TestCase
      */
     public function testRunClosesSessionIfServerRequestUsed(): void
     {
-        $sessionMock = $this->createMock(Session::class);
-
-        $sessionMock->expects($this->once())
-            ->method('close');
+        $sessionMock = Mockery::mock(Session::class);
+        $sessionMock->shouldReceive('close')
+            ->once();
 
         $app = new MiddlewareApplication($this->config);
         $server = new Server($app);
@@ -248,9 +247,9 @@ class ServerTest extends TestCase
             ->withHeader('X-First', 'first')
             ->withHeader('X-Second', 'second');
 
-        $emitter = $this->getMockBuilder(ResponseEmitter::class)->getMock();
-        $emitter->expects($this->once())
-            ->method('emit')
+        $emitter = Mockery::mock(ResponseEmitter::class);
+        $emitter->shouldReceive('emit')
+            ->once()
             ->with($final);
 
         $server->emit($final, $emitter);

--- a/tests/TestCase/I18n/TranslatorRegistryTest.php
+++ b/tests/TestCase/I18n/TranslatorRegistryTest.php
@@ -24,10 +24,8 @@ use Cake\I18n\PackageLocator;
 use Cake\I18n\Translator;
 use Cake\I18n\TranslatorRegistry;
 use Cake\TestSuite\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use TestApp\Cache\Engine\TestAppCacheEngine;
 
-#[AllowMockObjectsWithoutExpectations]
 class TranslatorRegistryTest extends TestCase
 {
     /**
@@ -35,36 +33,31 @@ class TranslatorRegistryTest extends TestCase
      */
     public function testGetNullPackageInitializationFromCache(): void
     {
-        $packageLocator = $this->getMockBuilder(PackageLocator::class)->getMock();
-        $package = $this->getMockBuilder(Package::class)->getMock();
-        $formatter = $this->getMockBuilder(SprintfFormatter::class)->getMock();
-        $formatterLocator = $this->getMockBuilder(FormatterLocator::class)->getMock();
-        $cacheEngineNullPackage = $this->getMockBuilder(TestAppCacheEngine::class)->getMock();
-        $translatorNullPackage = $this->getMockBuilder(Translator::class)->disableOriginalConstructor()->getMock();
+        $package = new Package('default');
+        $packageLocator = new PackageLocator([
+            'default' => [
+                'en_CA' => $package,
+            ],
+        ]);
+        $formatterLocator = new FormatterLocator([
+            'default' => SprintfFormatter::class,
+        ]);
 
-        $translatorNonNullPackage = $this->getMockBuilder(Translator::class)->disableOriginalConstructor()->getMock();
-        $translatorNonNullPackage
-            ->method('getPackage')
-            ->willReturn($package);
+        $cachedTranslator = new Translator('en_CA', $package, new SprintfFormatter());
+        $cacheEngineNullPackage = new class ($cachedTranslator) extends TestAppCacheEngine {
+            public function __construct(protected Translator $translator)
+            {
+            }
 
-        $formatterLocator
-            ->method('get')
-            ->willReturn($formatter);
-
-        $package
-            ->method('getFormatter')
-            ->willReturn('basic');
-
-        $packageLocator->method('get')
-            ->willReturn($package);
-
-        $cacheEngineNullPackage
-            ->method('get')
-            ->willReturn($translatorNullPackage);
+            public function get($key, $default = null): mixed
+            {
+                return $this->translator;
+            }
+        };
 
         $registry = new TranslatorRegistry($packageLocator, $formatterLocator, 'en_CA');
         $registry->setCacher($cacheEngineNullPackage);
 
-        $this->assertNotNull($registry->get('default')->getPackage());
+        $this->assertSame($package, $registry->get('default')->getPackage());
     }
 }

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -19,6 +19,7 @@ use Cake\Console\ConsoleOutput;
 use Cake\Log\Engine\ConsoleLog;
 use Cake\Log\Formatter\JsonFormatter;
 use Cake\TestSuite\TestCase;
+use Mockery;
 
 /**
  * ConsoleLogTest class
@@ -30,12 +31,14 @@ class ConsoleLogTest extends TestCase
      */
     public function testConsoleOutputlogs(): void
     {
-        $output = $this->getMockBuilder(ConsoleOutput::class)->getMock();
+        $output = Mockery::mock(ConsoleOutput::class);
 
-        $message = ' Error: oh noes</error>';
-        $output->expects($this->once())
-            ->method('write')
-            ->with($this->stringContains($message));
+        $message = ' error: oh noes</error>';
+        $output->shouldReceive('write')
+            ->with(Mockery::on(static function ($content) use ($message): bool {
+                return is_string($content) && str_contains($content, $message);
+            }))
+            ->once();
 
         $log = new ConsoleLog([
             'stream' => $output,
@@ -64,11 +67,11 @@ class ConsoleLogTest extends TestCase
      */
     public function testDefaultOutputAs(): void
     {
-        $output = $this->getMockBuilder(ConsoleOutput::class)->getMock();
+        $output = Mockery::mock(ConsoleOutput::class);
 
-        $output->expects($this->once())
-            ->method('setOutputAs')
-            ->with(ConsoleOutput::RAW);
+        $output->shouldReceive('setOutputAs')
+            ->with(ConsoleOutput::RAW)
+            ->once();
 
         $log = new ConsoleLog([
             'stream' => $output,

--- a/tests/TestCase/Log/Engine/SyslogLogTest.php
+++ b/tests/TestCase/Log/Engine/SyslogLogTest.php
@@ -31,22 +31,26 @@ class SyslogLogTest extends TestCase
      */
     public function testOpenLog(): void
     {
-        /** @var \Cake\Log\Engine\SyslogLog|\PHPUnit\Framework\MockObject\MockObject $log */
-        $log = $this->getMockBuilder(SyslogLog::class)
-            ->onlyMethods(['_open', '_write'])
-            ->getMock();
-        $log->expects($this->once())->method('_open')->with('', LOG_ODELAY, LOG_USER);
+        $log = Mockery::mock(SyslogLog::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods()
+            ->shouldIgnoreMissing();
+        $log->__construct();
+        $log->shouldReceive('_open')->once()->with('', LOG_ODELAY, LOG_USER);
         $log->log('debug', 'message');
 
-        $log = $this->getMockBuilder(SyslogLog::class)
-            ->onlyMethods(['_open', '_write'])
-            ->getMock();
+        $log = Mockery::mock(SyslogLog::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods()
+            ->shouldIgnoreMissing();
+        $log->__construct();
         $log->setConfig([
             'prefix' => 'thing',
             'flag' => LOG_NDELAY,
             'facility' => LOG_MAIL,
         ]);
-        $log->expects($this->once())->method('_open')
+        $log->shouldReceive('_open')
+            ->once()
             ->with('thing', LOG_NDELAY, LOG_MAIL);
         $log->log('debug', 'message');
     }
@@ -57,11 +61,12 @@ class SyslogLogTest extends TestCase
     #[DataProvider('typesProvider')]
     public function testWriteOneLine(string $type, int $expected): void
     {
-        /** @var \Cake\Log\Engine\SyslogLog|\PHPUnit\Framework\MockObject\MockObject $log */
-        $log = $this->getMockBuilder(SyslogLog::class)
-            ->onlyMethods(['_open', '_write'])
-            ->getMock();
-        $log->expects($this->once())->method('_write')->with($expected, $type . ': Foo');
+        $log = Mockery::mock(SyslogLog::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods()
+            ->shouldIgnoreMissing();
+        $log->__construct();
+        $log->shouldReceive('_write')->once()->with($expected, $type . ': Foo');
         $log->log($type, 'Foo');
     }
 

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -782,13 +782,10 @@ class SmtpTransportTest extends TestCase
     {
         $this->SmtpTransport->setConfig(['keepAlive' => true]);
 
-        /** @var \Cake\Mailer\Message $message */
-        $message = $this->getMockBuilder(Message::class)
-            ->onlyMethods(['getBody'])
-            ->getMock();
+        $message = Mockery::mock(Message::class)->makePartial();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
         $message->setTo('cake@cakephp.org', 'CakePHP');
-        $message->expects($this->exactly(2))->method('getBody')->willReturn(['First Line']);
+        $message->shouldReceive('getBody')->twice()->andReturn(['First Line']);
 
         $this->socket->shouldNotReceive('disconnect');
 
@@ -847,13 +844,10 @@ class SmtpTransportTest extends TestCase
      */
     public function testSendDefaults(): void
     {
-        /** @var \Cake\Mailer\Message $message */
-        $message = $this->getMockBuilder(Message::class)
-            ->onlyMethods(['getBody'])
-            ->getMock();
+        $message = Mockery::mock(Message::class)->makePartial();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
         $message->setTo('cake@cakephp.org', 'CakePHP');
-        $message->expects($this->once())->method('getBody')->willReturn(['First Line']);
+        $message->shouldReceive('getBody')->once()->andReturn(['First Line']);
 
         $this->socket->shouldReceive('connect')->andReturnTrue()->once();
 
@@ -893,13 +887,10 @@ class SmtpTransportTest extends TestCase
      */
     public function testSendMessageTooBigOnWindows(): void
     {
-        /** @var \Cake\Mailer\Message $message */
-        $message = $this->getMockBuilder(Message::class)
-            ->onlyMethods(['getBody'])
-            ->getMock();
+        $message = Mockery::mock(Message::class)->makePartial();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
         $message->setTo('cake@cakephp.org', 'CakePHP');
-        $message->expects($this->once())->method('getBody')->willReturn(['First Line']);
+        $message->shouldReceive('getBody')->once()->andReturn(['First Line']);
 
         $this->socket->shouldReceive('connect')->andReturnTrue()->once();
 

--- a/tests/TestCase/ORM/Association/BelongsToManySaveAssociatedOnlyEntitiesAppendTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManySaveAssociatedOnlyEntitiesAppendTest.php
@@ -21,21 +21,20 @@ use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Mockery;
 
 /**
  * Tests BelongsToManySaveAssociatedOnlyEntitiesAppendTest class
  */
-#[AllowMockObjectsWithoutExpectations]
 class BelongsToManySaveAssociatedOnlyEntitiesAppendTest extends TestCase
 {
     /**
-     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Cake\ORM\Table
      */
     protected $tag;
 
     /**
-     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Cake\ORM\Table
      */
     protected $article;
 
@@ -45,27 +44,21 @@ class BelongsToManySaveAssociatedOnlyEntitiesAppendTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->tag = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['find', 'delete'])
-            ->setConstructorArgs([['alias' => 'Tags', 'table' => 'tags']])
-            ->getMock();
+        $this->tag = new Table(['alias' => 'Tags', 'table' => 'tags']);
         $this->tag->setSchema([
-            'id' => ['type' => 'integer'],
-            'name' => ['type' => 'string'],
-            '_constraints' => [
-                'primary' => ['type' => 'primary', 'columns' => ['id']],
-            ],
+        'id' => ['type' => 'integer'],
+        'name' => ['type' => 'string'],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+        ],
         ]);
-        $this->article = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['find', 'delete'])
-            ->setConstructorArgs([['alias' => 'Articles', 'table' => 'articles']])
-            ->getMock();
+        $this->article = new Table(['alias' => 'Articles', 'table' => 'articles']);
         $this->article->setSchema([
-            'id' => ['type' => 'integer'],
-            'name' => ['type' => 'string'],
-            '_constraints' => [
-                'primary' => ['type' => 'primary', 'columns' => ['id']],
-            ],
+        'id' => ['type' => 'integer'],
+        'name' => ['type' => 'string'],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+        ],
         ]);
     }
 
@@ -75,9 +68,9 @@ class BelongsToManySaveAssociatedOnlyEntitiesAppendTest extends TestCase
     public function testSaveAssociatedOnlyEntitiesAppend(): void
     {
         $connection = ConnectionManager::get('test');
-        $table = $this->getMockBuilder(MockedTable::class)
-            ->setConstructorArgs([['table' => 'tags', 'connection' => $connection]])
-            ->getMock();
+        /** @var \Cake\Test\TestCase\ORM\Association\MockedTable&\Mockery\MockInterface $table */
+        $table = Mockery::mock(new MockedTable(['table' => 'tags', 'connection' => $connection]))
+            ->makePartial();
         $table->setPrimaryKey('id');
 
         $config = [
@@ -95,8 +88,7 @@ class BelongsToManySaveAssociatedOnlyEntitiesAppendTest extends TestCase
             ],
         ]);
 
-        $table->expects($this->never())
-            ->method('saveAssociated');
+        $table->shouldReceive('saveAssociated')->never();
 
         $association = new BelongsToMany('Tags', $config);
         $association->saveAssociated($entity);

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM\Association;
 
 use Cake\Database\Connection;
-use Cake\Database\Driver;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\OrderClauseExpression;
@@ -38,7 +37,7 @@ use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Entity\ArticlesTag;
 use function Cake\Collection\collection;
@@ -46,7 +45,6 @@ use function Cake\Collection\collection;
 /**
  * Tests BelongsToMany class
  */
-#[AllowMockObjectsWithoutExpectations]
 class BelongsToManyTest extends TestCase
 {
     /**
@@ -68,12 +66,12 @@ class BelongsToManyTest extends TestCase
     ];
 
     /**
-     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Cake\ORM\Table
      */
     protected $tag;
 
     /**
-     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Cake\ORM\Table
      */
     protected $article;
 
@@ -83,10 +81,7 @@ class BelongsToManyTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->tag = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['find', 'delete'])
-            ->setConstructorArgs([['alias' => 'Tags', 'table' => 'tags']])
-            ->getMock();
+        $this->tag = new Table(['alias' => 'Tags', 'table' => 'tags']);
         $this->tag->setSchema([
             'id' => ['type' => 'integer'],
             'name' => ['type' => 'string'],
@@ -94,10 +89,7 @@ class BelongsToManyTest extends TestCase
                 'primary' => ['type' => 'primary', 'columns' => ['id']],
             ],
         ]);
-        $this->article = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['find', 'delete'])
-            ->setConstructorArgs([['alias' => 'Articles', 'table' => 'articles']])
-            ->getMock();
+        $this->article = new Table(['alias' => 'Articles', 'table' => 'articles']);
         $this->article->setSchema([
             'id' => ['type' => 'integer'],
             'name' => ['type' => 'string'],
@@ -280,23 +272,17 @@ class BelongsToManyTest extends TestCase
      */
     public function testJunctionConnection(): void
     {
-        $driver = $this->getMockBuilder(Driver::class)->getMock();
-        $driver->expects($this->once())
-            ->method('enabled')
-            ->willReturn(true);
-
-        $mock = $this->getMockBuilder(Connection::class)
-            ->setConstructorArgs([['name' => 'other_source', 'driver' => $driver]])
-            ->getMock();
-        ConnectionManager::setConfig('other_source', $mock);
-        $this->article->setConnection(ConnectionManager::get('other_source'));
+        $config = ConnectionManager::getConfig('test');
+        ConnectionManager::setConfig('other_source', $config);
+        $otherConnection = ConnectionManager::get('other_source');
+        $this->article->setConnection($otherConnection);
 
         $assoc = new BelongsToMany('Test', [
             'sourceTable' => $this->article,
             'targetTable' => $this->tag,
         ]);
         $junction = $assoc->junction();
-        $this->assertSame($mock, $junction->getConnection());
+        $this->assertSame($otherConnection, $junction->getConnection());
         ConnectionManager::drop('other_source');
     }
 
@@ -435,9 +421,9 @@ class BelongsToManyTest extends TestCase
      */
     public function testCascadeDelete(): void
     {
-        $articleTag = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['deleteAll'])
-            ->getMock();
+        /** @var \Cake\ORM\Table&\Mockery\MockInterface $articleTag */
+        $articleTag = Mockery::mock(new Table(['alias' => 'ArticlesTags', 'table' => 'articles_tags']))
+            ->makePartial();
         $config = [
             'sourceTable' => $this->article,
             'targetTable' => $this->tag,
@@ -449,8 +435,8 @@ class BelongsToManyTest extends TestCase
             ->getAssociation($articleTag->getAlias())
             ->setConditions(['click_count' => 3]);
 
-        $articleTag->expects($this->once())
-            ->method('deleteAll')
+        $articleTag->shouldReceive('deleteAll')
+            ->once()
             ->with([
                 'click_count' => 3,
                 'article_id' => 1,
@@ -465,9 +451,9 @@ class BelongsToManyTest extends TestCase
      */
     public function testCascadeDeleteDependent(): void
     {
-        $articleTag = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['delete', 'deleteAll'])
-            ->getMock();
+        /** @var \Cake\ORM\Table&\Mockery\MockInterface $articleTag */
+        $articleTag = Mockery::mock(new Table(['alias' => 'ArticlesTags', 'table' => 'articles_tags']))
+            ->makePartial();
         $config = [
             'sourceTable' => $this->article,
             'targetTable' => $this->tag,
@@ -480,10 +466,8 @@ class BelongsToManyTest extends TestCase
             ->getAssociation($articleTag->getAlias())
             ->setConditions(['click_count' => 3]);
 
-        $articleTag->expects($this->never())
-            ->method('deleteAll');
-        $articleTag->expects($this->never())
-            ->method('delete');
+        $articleTag->shouldReceive('deleteAll')->never();
+        $articleTag->shouldReceive('delete')->never();
 
         $entity = new Entity(['id' => 1, 'name' => 'PHP']);
         $association->cascadeDelete($entity);
@@ -655,10 +639,9 @@ class BelongsToManyTest extends TestCase
     public function testLinkSuccessWithMocks(): void
     {
         $connection = ConnectionManager::get('test');
-        $joint = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['save', 'getPrimaryKey'])
-            ->setConstructorArgs([['alias' => 'ArticlesTags', 'connection' => $connection]])
-            ->getMock();
+        /** @var \Cake\ORM\Table&\Mockery\MockInterface $joint */
+        $joint = Mockery::mock(new Table(['alias' => 'ArticlesTags', 'connection' => $connection]))
+            ->makePartial();
 
         $config = [
             'sourceTable' => $this->article,
@@ -673,12 +656,12 @@ class BelongsToManyTest extends TestCase
         $tags = [new Entity(['id' => 2], $opts), new Entity(['id' => 3], $opts)];
         $saveOptions = ['foo' => 'bar'];
 
-        $joint->method('getPrimaryKey')
-            ->willReturn(['article_id', 'tag_id']);
+        $joint->shouldReceive('getPrimaryKey')
+            ->andReturn(['article_id', 'tag_id']);
 
-        $joint->expects($this->exactly(2))
-            ->method('save')
-            ->willReturnOnConsecutiveCalls($entity, $entity);
+        $joint->shouldReceive('save')
+            ->twice()
+            ->andReturn($entity, $entity);
 
         $this->assertTrue($assoc->link($entity, $tags, $saveOptions));
         $this->assertSame($entity->test, $tags);
@@ -690,11 +673,9 @@ class BelongsToManyTest extends TestCase
     public function testLinkSetSourceToJunctionEntities(): void
     {
         $connection = ConnectionManager::get('test');
-        /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $joint */
-        $joint = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['save', 'getPrimaryKey'])
-            ->setConstructorArgs([['alias' => 'ArticlesTags', 'connection' => $connection]])
-            ->getMock();
+        /** @var \Cake\ORM\Table&\Mockery\MockInterface $joint */
+        $joint = Mockery::mock(new Table(['alias' => 'ArticlesTags', 'connection' => $connection]))
+            ->makePartial();
         $joint->setRegistryAlias('Plugin.ArticlesTags');
 
         $config = [
@@ -708,12 +689,12 @@ class BelongsToManyTest extends TestCase
         $entity = new Entity(['id' => 1], $opts);
         $tags = [new Entity(['id' => 2], $opts)];
 
-        $joint->method('getPrimaryKey')
-            ->willReturn(['article_id', 'tag_id']);
+        $joint->shouldReceive('getPrimaryKey')
+            ->andReturn(['article_id', 'tag_id']);
 
-        $joint->expects($this->once())
-            ->method('save')
-            ->willReturnCallback(function (EntityInterface $e) {
+        $joint->shouldReceive('save')
+            ->once()
+            ->andReturnUsing(function (EntityInterface $e) {
                 $this->assertSame('Plugin.ArticlesTags', $e->getSource());
 
                 return $e;
@@ -822,10 +803,9 @@ class BelongsToManyTest extends TestCase
     public function testUnlinkFailure(): void
     {
         $connection = ConnectionManager::get('test');
-        $joint = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['deleteMany'])
-            ->setConstructorArgs([['alias' => 'SpecialTags', 'table' => 'special_tags', 'connection' => $connection]])
-            ->getMock();
+        /** @var \Cake\ORM\Table&\Mockery\MockInterface $joint */
+        $joint = Mockery::mock(new Table(['alias' => 'SpecialTags', 'table' => 'special_tags', 'connection' => $connection]))
+            ->makePartial();
 
         $articles = $this->getTableLocator()->get('Articles');
 
@@ -836,9 +816,9 @@ class BelongsToManyTest extends TestCase
         $entity = $articles->get(2, contain: ['Tags']);
         $this->assertCount(1, $entity->tags);
 
-        $joint->expects($this->once())
-            ->method('deleteMany')
-            ->willReturn(false);
+        $joint->shouldReceive('deleteMany')
+            ->once()
+            ->andReturn(false);
 
         $this->assertFalse($assoc->unlink($entity, $entity->tags));
         $this->assertCount(1, $entity->tags);
@@ -1235,25 +1215,19 @@ class BelongsToManyTest extends TestCase
     #[DataProvider('emptyProvider')]
     public function testSaveAssociatedEmptySetSuccess($value): void
     {
-        /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockBuilder $table */
-        $table = $this->getMockBuilder(Table::class)
-            ->getMock();
+        $table = new Table(['alias' => 'Articles', 'table' => 'articles']);
         $table->setSchema([]);
-        /** @var \Cake\ORM\Association\BelongsToMany|\PHPUnit\Framework\MockObject\MockObject $assoc */
-        $assoc = $this->getMockBuilder(BelongsToMany::class)
-            ->onlyMethods(['_saveTarget', 'replaceLinks'])
-            ->setConstructorArgs(['tags', ['sourceTable' => $table]])
-            ->getMock();
+        $assoc = Mockery::mock(BelongsToMany::class, ['tags', ['sourceTable' => $table]])
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
         $entity = new Entity([
             'id' => 1,
             'tags' => $value,
         ], ['markNew' => true]);
 
         $assoc->setSaveStrategy(BelongsToMany::SAVE_REPLACE);
-        $assoc->expects($this->never())
-            ->method('replaceLinks');
-        $assoc->expects($this->never())
-            ->method('_saveTarget');
+        $assoc->shouldReceive('replaceLinks')->never();
+        $assoc->shouldReceive('_saveTarget')->never();
         $this->assertSame($entity, $assoc->saveAssociated($entity));
     }
 
@@ -1265,28 +1239,22 @@ class BelongsToManyTest extends TestCase
     #[DataProvider('emptyProvider')]
     public function testSaveAssociatedEmptySetUpdateSuccess($value): void
     {
-        /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockBuilder $table */
-        $table = $this->getMockBuilder(Table::class)
-            ->getMock();
+        $table = new Table(['alias' => 'Articles', 'table' => 'articles']);
         $table->setSchema([]);
-        /** @var \Cake\ORM\Association\BelongsToMany|\PHPUnit\Framework\MockObject\MockObject $assoc */
-        $assoc = $this->getMockBuilder(BelongsToMany::class)
-            ->onlyMethods(['_saveTarget', 'replaceLinks'])
-            ->setConstructorArgs(['tags', ['sourceTable' => $table]])
-            ->getMock();
+        $assoc = Mockery::mock(BelongsToMany::class, ['tags', ['sourceTable' => $table]])
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
         $entity = new Entity([
             'id' => 1,
             'tags' => $value,
         ], ['markNew' => false]);
 
         $assoc->setSaveStrategy(BelongsToMany::SAVE_REPLACE);
-        $assoc->expects($this->once())
-            ->method('replaceLinks')
-            ->with($entity, [])
-            ->willReturn(true);
+        $assoc->shouldReceive('replaceLinks')
+            ->once()
+            ->andReturn(true);
 
-        $assoc->expects($this->never())
-            ->method('_saveTarget');
+        $assoc->shouldReceive('_saveTarget')->never();
 
         $this->assertSame($entity, $assoc->saveAssociated($entity));
     }
@@ -1296,14 +1264,10 @@ class BelongsToManyTest extends TestCase
      */
     public function testSaveAssociatedWithReplace(): void
     {
-        /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
-        $table = $this->getMockBuilder(Table::class)
-            ->getMock();
+        $table = new Table(['alias' => 'Articles', 'table' => 'articles']);
         $table->setSchema([]);
-        $assoc = $this->getMockBuilder(BelongsToMany::class)
-            ->onlyMethods(['replaceLinks'])
-            ->setConstructorArgs(['tags', ['sourceTable' => $table]])
-            ->getMock();
+        $assoc = Mockery::mock(BelongsToMany::class, ['tags', ['sourceTable' => $table]])
+            ->makePartial();
         $entity = new Entity([
             'id' => 1,
             'tags' => [
@@ -1313,9 +1277,10 @@ class BelongsToManyTest extends TestCase
 
         $options = ['foo' => 'bar'];
         $assoc->setSaveStrategy(BelongsToMany::SAVE_REPLACE);
-        $assoc->expects($this->once())->method('replaceLinks')
+        $assoc->shouldReceive('replaceLinks')
+            ->once()
             ->with($entity, $entity->tags, $options)
-            ->willReturn(true);
+            ->andReturn(true);
         $this->assertSame($entity, $assoc->saveAssociated($entity, $options));
     }
 
@@ -1324,14 +1289,10 @@ class BelongsToManyTest extends TestCase
      */
     public function testSaveAssociatedWithReplaceReturnFalse(): void
     {
-        /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
-        $table = $this->getMockBuilder(Table::class)
-            ->getMock();
+        $table = new Table(['alias' => 'Articles', 'table' => 'articles']);
         $table->setSchema([]);
-        $assoc = $this->getMockBuilder(BelongsToMany::class)
-            ->onlyMethods(['replaceLinks'])
-            ->setConstructorArgs(['tags', ['sourceTable' => $table]])
-            ->getMock();
+        $assoc = Mockery::mock(BelongsToMany::class, ['tags', ['sourceTable' => $table]])
+            ->makePartial();
         $entity = new Entity([
             'id' => 1,
             'tags' => [
@@ -1341,9 +1302,10 @@ class BelongsToManyTest extends TestCase
 
         $options = ['foo' => 'bar'];
         $assoc->setSaveStrategy(BelongsToMany::SAVE_REPLACE);
-        $assoc->expects($this->once())->method('replaceLinks')
+        $assoc->shouldReceive('replaceLinks')
+            ->once()
             ->with($entity, $entity->tags, $options)
-            ->willReturn(false);
+            ->andReturn(false);
         $this->assertFalse($assoc->saveAssociated($entity, $options));
     }
 
@@ -1439,12 +1401,9 @@ class BelongsToManyTest extends TestCase
      */
     public function testPropertyNoPlugin(): void
     {
-        $mock = $this->getMockBuilder(Table::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $config = [
             'sourceTable' => $this->article,
-            'targetTable' => $mock,
+            'targetTable' => $this->tag,
         ];
         $association = new BelongsToMany('Contacts.Tags', $config);
         $this->assertSame('tags', $association->getProperty());

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -29,12 +29,10 @@ use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Mockery;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * Tests BelongsTo class
  */
-#[AllowMockObjectsWithoutExpectations]
 class BelongsToTest extends TestCase
 {
     /**
@@ -45,12 +43,12 @@ class BelongsToTest extends TestCase
     protected array $fixtures = ['core.Articles', 'core.Authors', 'core.Comments'];
 
     /**
-     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Cake\ORM\Table
      */
     protected $company;
 
     /**
-     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Cake\ORM\Table
      */
     protected $client;
 
@@ -296,17 +294,14 @@ class BelongsToTest extends TestCase
      */
     public function testCascadeDelete(): void
     {
-        $mock = $this->getMockBuilder(Table::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        /** @var \Cake\ORM\Table&\Mockery\MockInterface $mock */
+        $mock = Mockery::mock(Table::class)->shouldIgnoreMissing();
         $config = [
             'sourceTable' => $this->client,
             'targetTable' => $mock,
         ];
-        $mock->expects($this->never())
-            ->method('find');
-        $mock->expects($this->never())
-            ->method('delete');
+        $mock->shouldReceive('find')->never();
+        $mock->shouldReceive('delete')->never();
 
         $association = new BelongsTo('Companies', $config);
         $entity = new Entity(['company_name' => 'CakePHP', 'id' => 1]);
@@ -353,12 +348,9 @@ class BelongsToTest extends TestCase
      */
     public function testPropertyNoPlugin(): void
     {
-        $mock = $this->getMockBuilder(Table::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $config = [
             'sourceTable' => $this->client,
-            'targetTable' => $mock,
+            'targetTable' => $this->company,
         ];
         $association = new BelongsTo('Contacts.Companies', $config);
         $this->assertSame('company', $association->getProperty());

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -23,26 +23,27 @@ use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
+use Cake\Database\ExpressionInterface;
 use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\ResultSetInterface;
 use Cake\Log\Log;
 use Cake\ORM\Association;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Entity;
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\ResultSet;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use Closure;
 use InvalidArgumentException;
 use Mockery;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function Cake\I18n\__;
 
 /**
  * Tests HasMany class
  */
-#[AllowMockObjectsWithoutExpectations]
 class HasManyTest extends TestCase
 {
     /**
@@ -60,12 +61,12 @@ class HasManyTest extends TestCase
     ];
 
     /**
-     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Cake\ORM\Table
      */
     protected $author;
 
     /**
-     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Cake\ORM\Table&\Mockery\MockInterface
      */
     protected $article;
 
@@ -97,10 +98,11 @@ class HasManyTest extends TestCase
             ],
         ]);
         $connection = ConnectionManager::get('test');
-        $this->article = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['find', 'deleteAll', 'delete'])
-            ->setConstructorArgs([['alias' => 'Articles', 'table' => 'articles', 'connection' => $connection]])
-            ->getMock();
+        $this->article = Mockery::mock(new Table([
+            'alias' => 'Articles',
+            'table' => 'articles',
+            'connection' => $connection,
+        ]))->makePartial()->shouldIgnoreMissing();
         $this->article->setSchema([
             'id' => ['type' => 'integer'],
             'title' => ['type' => 'string'],
@@ -263,9 +265,8 @@ class HasManyTest extends TestCase
         ];
         $association = new HasMany('Articles', $config);
         $query = $this->article->selectQuery();
-        $this->article->method('find')
-            ->with('all')
-            ->willReturn($query);
+        $this->article->shouldReceive('find')
+            ->andReturn($query);
         $keys = [1, 2, 3, 4];
 
         $callable = $association->eagerLoader(compact('keys', 'query'));
@@ -306,9 +307,8 @@ class HasManyTest extends TestCase
         $keys = [1, 2, 3, 4];
 
         $query = $this->article->selectQuery();
-        $this->article->method('find')
-            ->with('all')
-            ->willReturn($query);
+        $association->shouldReceive('find')
+            ->andReturn($query);
 
         $association->eagerLoader(compact('keys', 'query'));
 
@@ -341,11 +341,10 @@ class HasManyTest extends TestCase
 
         /** @var \Cake\ORM\Query\SelectQuery $query */
         $query = $this->article->query();
-        $query->addDefaultTypes($this->article->Comments->getSource());
+        $query->addDefaultTypes($this->article);
 
-        $this->article->method('find')
-            ->with('all')
-            ->willReturn($query);
+        $this->article->shouldReceive('find')
+            ->andReturn($query);
 
         $association->eagerLoader([
             'conditions' => ['Articles.id !=' => 3],
@@ -398,10 +397,10 @@ class HasManyTest extends TestCase
 
         // Setup the mock to track what happens
         $queriesReturned = [];
-        $this->article->expects($this->once())
-            ->method('find')
+        $this->article->shouldReceive('find')
+            ->once()
             ->with('all')
-            ->willReturnCallback(function () use (&$queriesReturned) {
+            ->andReturnUsing(function () use (&$queriesReturned) {
                 // Preserve the current auto-quoting state (might be affected by other tests)
                 $query = $this->article->selectQuery();
                 $query->enableAutoFields(false);
@@ -461,9 +460,9 @@ class HasManyTest extends TestCase
 
         /** @var \Cake\ORM\Query\SelectQuery $query */
         $query = $this->article->query();
-        $this->article->method('find')
+        $this->article->shouldReceive('find')
             ->with('all')
-            ->willReturn($query);
+            ->andReturn($query);
 
         $queryBuilder = function ($query) {
             return $query->select(['author_id'])->join('comments')->where(['comments.id' => 1]);
@@ -510,34 +509,50 @@ class HasManyTest extends TestCase
         $this->author->setPrimaryKey(['id', 'site_id']);
         $association = new HasMany('Articles', $config);
         $keys = [[1, 10], [2, 20], [3, 30], [4, 40]];
-        $query = $this->getMockBuilder(Query::class)
-            ->onlyMethods(['all', 'andWhere', 'getRepository'])
-            ->setConstructorArgs([$this->article])
-            ->getMock();
-        $query->method('getRepository')
-            ->willReturn($this->article);
-        $this->article->method('find')
-            ->with('all')
-            ->willReturn($query);
-
         $results = new ResultSet([
             ['id' => 1, 'title' => 'article 1', 'author_id' => 2, 'site_id' => 10],
             ['id' => 2, 'title' => 'article 2', 'author_id' => 1, 'site_id' => 20],
         ]);
-        $query->method('all')
-            ->willReturn($results);
-
         $tuple = new TupleComparison(
             ['Articles.author_id', 'Articles.site_id'],
             $keys,
             ['integer'],
             'IN',
         );
-        $query->expects($this->once())->method('andWhere')
-            ->with($tuple)
-            ->willReturnSelf();
+        $query = new class ($this->article, $results, $tuple) extends SelectQuery {
+            public bool $andWhereCalled = false;
+
+            public function __construct(
+                Table $table,
+                protected ResultSet $resultSet,
+                protected TupleComparison $expectedTuple,
+            ) {
+                parent::__construct($table);
+            }
+
+            public function andWhere(
+                ExpressionInterface|Closure|array|string|null $conditions = null,
+                array $types = [],
+                bool $overwrite = false,
+            ) {
+                if ($conditions == $this->expectedTuple) {
+                    $this->andWhereCalled = true;
+                }
+
+                return $this;
+            }
+
+            public function all(): ResultSetInterface
+            {
+                return $this->resultSet;
+            }
+        };
+        $this->article->shouldReceive('find')
+            ->with('all')
+            ->andReturn($query);
 
         $callable = $association->eagerLoader(compact('keys', 'query'));
+        $this->assertTrue($query->andWhereCalled);
         $row = ['Authors__id' => 2, 'Authors__site_id' => 10, 'username' => 'author 1'];
         $result = $callable($row);
         $row['Articles'] = [
@@ -738,12 +753,9 @@ class HasManyTest extends TestCase
      */
     public function testPropertyNoPlugin(): void
     {
-        $mock = $this->getMockBuilder(Table::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $config = [
             'sourceTable' => $this->author,
-            'targetTable' => $mock,
+            'targetTable' => $this->article,
         ];
         $association = new HasMany('Contacts.Addresses', $config);
         $this->assertSame('addresses', $association->getProperty());

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -28,12 +28,10 @@ use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Mockery;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 /**
  * Tests HasOne class
  */
-#[AllowMockObjectsWithoutExpectations]
 class HasOneTest extends TestCase
 {
     /**
@@ -44,12 +42,12 @@ class HasOneTest extends TestCase
     protected array $fixtures = ['core.Articles', 'core.Authors', 'core.NullableAuthors', 'core.Users', 'core.Profiles'];
 
     /**
-     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Cake\ORM\Table
      */
     protected $user;
 
     /**
-     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Cake\ORM\Table
      */
     protected $profile;
 
@@ -185,13 +183,10 @@ class HasOneTest extends TestCase
         $this->user->setPrimaryKey(['id', 'site_id']);
         $association = new HasOne('Profiles', $config);
 
-        $query = $this->getMockBuilder(Query::class)
-            ->onlyMethods(['join'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $query = new Query($this->user);
         $field1 = new IdentifierExpression('Profiles.user_id');
         $field2 = new IdentifierExpression('Profiles.user_site_id');
-        $query->expects($this->once())->method('join')->with([
+        $expected = [
             'Profiles' => [
                 'conditions' => new QueryExpression([
                     'Profiles.is_active' => true,
@@ -199,9 +194,11 @@ class HasOneTest extends TestCase
                 ], $selectTypeMap),
                 'type' => 'LEFT',
                 'table' => 'profiles',
+                'alias' => 'Profiles',
             ],
-        ]);
+        ];
         $association->attachTo($query);
+        $this->assertEquals($expected, $query->clause('join'));
     }
 
     /**
@@ -212,10 +209,7 @@ class HasOneTest extends TestCase
     {
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Cannot match provided foreignKey for `Profiles`, got `(user_id)` but expected foreign key for `(id, site_id)`');
-        $query = $this->getMockBuilder(Query::class)
-            ->onlyMethods(['join', 'select'])
-            ->setConstructorArgs([$this->user])
-            ->getMock();
+        $query = new Query($this->user);
         $config = [
             'sourceTable' => $this->user,
             'targetTable' => $this->profile,

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -27,13 +27,12 @@ use Cake\ORM\Locator\LocatorInterface;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * AssociationCollection test case.
  */
-#[AllowMockObjectsWithoutExpectations]
 class AssociationCollectionTest extends TestCase
 {
     /**
@@ -57,7 +56,7 @@ class AssociationCollectionTest extends TestCase
     {
         $this->assertSame($this->getTableLocator(), $this->associations->getTableLocator());
 
-        $tableLocator = $this->createMock(LocatorInterface::class);
+        $tableLocator = Mockery::mock(LocatorInterface::class);
         $associations = new AssociationCollection($tableLocator);
         $this->assertSame($tableLocator, $associations->getTableLocator());
     }
@@ -102,7 +101,7 @@ class AssociationCollectionTest extends TestCase
      */
     public function testLoadCustomLocator(): void
     {
-        $locator = $this->createMock(LocatorInterface::class);
+        $locator = Mockery::mock(LocatorInterface::class);
         $this->associations->load(BelongsTo::class, 'Users', [
             'tableLocator' => $locator,
         ]);
@@ -132,8 +131,7 @@ class AssociationCollectionTest extends TestCase
      */
     public function testGetByProperty(): void
     {
-        $table = $this->getMockBuilder(Table::class)
-            ->getMock();
+        $table = new Table(['alias' => 'Clients', 'table' => 'clients']);
         $table->setSchema([]);
         $belongsTo = new BelongsTo('Users', [
             'sourceTable' => $table,
@@ -220,27 +218,23 @@ class AssociationCollectionTest extends TestCase
      */
     public function testCascadeDelete(): void
     {
-        $mockOne = $this->getMockBuilder(BelongsTo::class)
-            ->setConstructorArgs([''])
-            ->getMock();
-        $mockTwo = $this->getMockBuilder(HasMany::class)
-            ->setConstructorArgs([''])
-            ->getMock();
+        $mockOne = Mockery::mock(new BelongsTo(''))->makePartial();
+        $mockTwo = Mockery::mock(new HasMany(''))->makePartial();
 
         $entity = new Entity();
         $options = ['option' => 'value'];
         $this->associations->add('One', $mockOne);
         $this->associations->add('Two', $mockTwo);
 
-        $mockOne->expects($this->once())
-            ->method('cascadeDelete')
+        $mockOne->shouldReceive('cascadeDelete')
+            ->once()
             ->with($entity, $options)
-            ->willReturn(true);
+            ->andReturn(true);
 
-        $mockTwo->expects($this->once())
-            ->method('cascadeDelete')
+        $mockTwo->shouldReceive('cascadeDelete')
+            ->once()
             ->with($entity, $options)
-            ->willReturn(true);
+            ->andReturn(true);
 
         $result = $this->associations->cascadeDelete($entity, $options);
         $this->assertTrue($result);
@@ -251,21 +245,14 @@ class AssociationCollectionTest extends TestCase
      */
     public function testSaveParents(): void
     {
-        $table = $this->getMockBuilder(Table::class)
-            ->getMock();
+        $table = new Table(['alias' => 'Users', 'table' => 'users']);
         $table->setSchema([]);
-        $mockOne = $this->getMockBuilder(BelongsTo::class)
-            ->onlyMethods(['saveAssociated'])
-            ->setConstructorArgs(['Parent', [
-                'sourceTable' => $table,
-            ]])
-            ->getMock();
-        $mockTwo = $this->getMockBuilder(HasMany::class)
-            ->onlyMethods(['saveAssociated'])
-            ->setConstructorArgs(['Child', [
-                'sourceTable' => $table,
-            ]])
-            ->getMock();
+        $mockOne = Mockery::mock(new BelongsTo('Parent', [
+            'sourceTable' => $table,
+        ]))->makePartial();
+        $mockTwo = Mockery::mock(new HasMany('Child', [
+            'sourceTable' => $table,
+        ]))->makePartial();
 
         $this->associations->add('Parent', $mockOne);
         $this->associations->add('Child', $mockTwo);
@@ -276,13 +263,12 @@ class AssociationCollectionTest extends TestCase
 
         $options = ['option' => 'value'];
 
-        $mockOne->expects($this->once())
-            ->method('saveAssociated')
+        $mockOne->shouldReceive('saveAssociated')
+            ->once()
             ->with($entity, $options)
-            ->willReturn($entity);
+            ->andReturn($entity);
 
-        $mockTwo->expects($this->never())
-            ->method('saveAssociated');
+        $mockTwo->shouldReceive('saveAssociated')->never();
 
         $result = $this->associations->saveParents(
             $table,
@@ -298,21 +284,14 @@ class AssociationCollectionTest extends TestCase
      */
     public function testSaveParentsFiltered(): void
     {
-        $table = $this->getMockBuilder(Table::class)
-            ->getMock();
+        $table = new Table(['alias' => 'Users', 'table' => 'users']);
         $table->setSchema([]);
-        $mockOne = $this->getMockBuilder(BelongsTo::class)
-            ->onlyMethods(['saveAssociated'])
-            ->setConstructorArgs(['Parents', [
-                'sourceTable' => $table,
-            ]])
-            ->getMock();
-        $mockTwo = $this->getMockBuilder(BelongsTo::class)
-            ->onlyMethods(['saveAssociated'])
-            ->setConstructorArgs(['Categories', [
-                'sourceTable' => $table,
-            ]])
-            ->getMock();
+        $mockOne = Mockery::mock(new BelongsTo('Parents', [
+            'sourceTable' => $table,
+        ]))->makePartial();
+        $mockTwo = Mockery::mock(new BelongsTo('Categories', [
+            'sourceTable' => $table,
+        ]))->makePartial();
 
         $this->associations->add('Parents', $mockOne);
         $this->associations->add('Categories', $mockTwo);
@@ -323,13 +302,12 @@ class AssociationCollectionTest extends TestCase
 
         $options = ['atomic' => true];
 
-        $mockOne->expects($this->once())
-            ->method('saveAssociated')
+        $mockOne->shouldReceive('saveAssociated')
+            ->once()
             ->with($entity, ['atomic' => true, 'associated' => ['Others']])
-            ->willReturn($entity);
+            ->andReturn($entity);
 
-        $mockTwo->expects($this->never())
-            ->method('saveAssociated');
+        $mockTwo->shouldReceive('saveAssociated')->never();
 
         $result = $this->associations->saveParents(
             $table,
@@ -345,21 +323,14 @@ class AssociationCollectionTest extends TestCase
      */
     public function testSaveChildrenFiltered(): void
     {
-        $table = $this->getMockBuilder(Table::class)
-            ->getMock();
+        $table = new Table(['alias' => 'Users', 'table' => 'users']);
         $table->setSchema([]);
-        $mockOne = $this->getMockBuilder(HasMany::class)
-            ->onlyMethods(['saveAssociated'])
-            ->setConstructorArgs(['Comments', [
-                'sourceTable' => $table,
-            ]])
-            ->getMock();
-        $mockTwo = $this->getMockBuilder(HasOne::class)
-            ->onlyMethods(['saveAssociated'])
-            ->setConstructorArgs(['Profiles', [
-                'sourceTable' => $table,
-            ]])
-            ->getMock();
+        $mockOne = Mockery::mock(new HasMany('Comments', [
+            'sourceTable' => $table,
+        ]))->makePartial();
+        $mockTwo = Mockery::mock(new HasOne('Profiles', [
+            'sourceTable' => $table,
+        ]))->makePartial();
 
         $this->associations->add('Comments', $mockOne);
         $this->associations->add('Profiles', $mockTwo);
@@ -370,13 +341,12 @@ class AssociationCollectionTest extends TestCase
 
         $options = ['atomic' => true];
 
-        $mockOne->expects($this->once())
-            ->method('saveAssociated')
+        $mockOne->shouldReceive('saveAssociated')
+            ->once()
             ->with($entity, $options + ['associated' => ['Other']])
-            ->willReturn($entity);
+            ->andReturn($entity);
 
-        $mockTwo->expects($this->never())
-            ->method('saveAssociated');
+        $mockTwo->shouldReceive('saveAssociated')->never();
 
         $result = $this->associations->saveChildren(
             $table,
@@ -394,10 +364,7 @@ class AssociationCollectionTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot save `Profiles`, it is not associated to `Users`');
-        $table = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['save'])
-            ->setConstructorArgs([['alias' => 'Users']])
-            ->getMock();
+        $table = new Table(['alias' => 'Users', 'table' => 'users']);
 
         $entity = new Entity();
         $entity->set('profile', ['key' => 'value']);

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -23,7 +23,7 @@ use Cake\ORM\Locator\LocatorInterface;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Mockery;
 use TestApp\Model\Table\AuthorsTable;
 use TestApp\Model\Table\TestTable;
 use TestPlugin\Model\Table\CommentsTable;
@@ -31,7 +31,6 @@ use TestPlugin\Model\Table\CommentsTable;
 /**
  * Tests Association class
  */
-#[AllowMockObjectsWithoutExpectations]
 class AssociationTest extends TestCase
 {
     /**
@@ -40,7 +39,7 @@ class AssociationTest extends TestCase
     protected $source;
 
     /**
-     * @var \Cake\ORM\Association|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Cake\ORM\Association&\Mockery\MockInterface
      */
     protected $association;
 
@@ -59,13 +58,13 @@ class AssociationTest extends TestCase
             'sourceTable' => $this->source,
             'joinType' => 'INNER',
         ];
-        $this->association = $this->getMockBuilder(Association::class)
-            ->onlyMethods([
-                '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
-                'saveAssociated', 'eagerLoader', 'type', 'requiresKeys',
-            ])
-            ->setConstructorArgs(['Foo', $config])
-            ->getMock();
+        $this->association = Mockery::mock(
+            Association::class . '[_options,attachTo,_joinCondition,cascadeDelete,isOwningSide,saveAssociated,eagerLoader,type]',
+            ['Foo', $config],
+        )
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods()
+            ->shouldIgnoreMissing();
     }
 
     /**
@@ -75,7 +74,7 @@ class AssociationTest extends TestCase
     public function testOptionsIsCalled(): void
     {
         $options = ['foo' => 'bar'];
-        $this->association->expects($this->once())->method('_options')->with($options);
+        $this->association->shouldReceive('_options')->once()->with($options);
         $this->association->__construct('Name', $options);
     }
 
@@ -85,10 +84,16 @@ class AssociationTest extends TestCase
      */
     public function testSetttingClassNameFromAlias(): void
     {
-        $association = $this->getMockBuilder(Association::class)
-            ->onlyMethods(['type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'])
-            ->setConstructorArgs(['Foo'])
-            ->getMock();
+        /** @var \Cake\ORM\Association&\Mockery\MockInterface $association */
+        $association = Mockery::mock(
+            Association::class . '[type,eagerLoader,cascadeDelete,isOwningSide,saveAssociated]',
+            ['Foo'],
+        )
+            ->makePartial()
+            ->shouldIgnoreMissing();
+        $association->shouldReceive('type')
+            ->byDefault()
+            ->andReturn(Association::MANY_TO_ONE);
 
         $this->assertSame('Foo', $association->getClassName());
     }
@@ -157,13 +162,16 @@ class AssociationTest extends TestCase
         $config = [
             'className' => 'Test',
         ];
-        $this->association = $this->getMockBuilder(Association::class)
-            ->onlyMethods([
-                '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
-                'saveAssociated', 'eagerLoader', 'type', 'requiresKeys',
-            ])
-            ->setConstructorArgs(['Foo', $config])
-            ->getMock();
+        $this->association = Mockery::mock(
+            Association::class . '[_options,attachTo,_joinCondition,cascadeDelete,isOwningSide,saveAssociated,eagerLoader,type]',
+            ['Foo', $config],
+        )
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods()
+            ->shouldIgnoreMissing();
+        $this->association->shouldReceive('type')
+            ->byDefault()
+            ->andReturn(Association::MANY_TO_ONE);
 
         $this->assertSame('Test', $this->association->getClassName());
     }
@@ -179,13 +187,16 @@ class AssociationTest extends TestCase
         $config = [
             'className' => TestTable::class,
         ];
-        $this->association = $this->getMockBuilder(Association::class)
-            ->onlyMethods([
-                '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
-                'saveAssociated', 'eagerLoader', 'type', 'requiresKeys',
-            ])
-            ->setConstructorArgs(['Test', $config])
-            ->getMock();
+        $this->association = Mockery::mock(
+            Association::class . '[_options,attachTo,_joinCondition,cascadeDelete,isOwningSide,saveAssociated,eagerLoader,type]',
+            ['Test', $config],
+        )
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods()
+            ->shouldIgnoreMissing();
+        $this->association->shouldReceive('type')
+            ->byDefault()
+            ->andReturn(Association::MANY_TO_ONE);
         $this->association->setSource($this->getTableLocator()->get('Test'));
 
         $this->association->getTarget();
@@ -204,13 +215,16 @@ class AssociationTest extends TestCase
         $config = [
             'className' => $className,
         ];
-        $this->association = $this->getMockBuilder(Association::class)
-            ->onlyMethods([
-                '_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
-                'saveAssociated', 'eagerLoader', 'type', 'requiresKeys',
-            ])
-            ->setConstructorArgs(['Test', $config])
-            ->getMock();
+        $this->association = Mockery::mock(
+            Association::class . '[_options,attachTo,_joinCondition,cascadeDelete,isOwningSide,saveAssociated,eagerLoader,type]',
+            ['Test', $config],
+        )
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods()
+            ->shouldIgnoreMissing();
+        $this->association->shouldReceive('type')
+            ->byDefault()
+            ->andReturn(Association::MANY_TO_ONE);
 
         $target = $this->association->getTarget();
         $this->assertInstanceOf($className, $target);
@@ -242,9 +256,9 @@ class AssociationTest extends TestCase
     {
         $this->source->setPrimaryKey(['id', 'site_id']);
         $this->association
-            ->expects($this->once())
-            ->method('isOwningSide')
-            ->willReturn(true);
+            ->shouldReceive('isOwningSide')
+            ->once()
+            ->andReturn(true);
         $result = $this->association->getBindingKey();
         $this->assertEquals(['id', 'site_id'], $result);
     }
@@ -260,9 +274,9 @@ class AssociationTest extends TestCase
         $this->association->setTarget($target);
 
         $this->association
-            ->expects($this->once())
-            ->method('isOwningSide')
-            ->willReturn(false);
+            ->shouldReceive('isOwningSide')
+            ->once()
+            ->andReturn(false);
         $result = $this->association->getBindingKey();
         $this->assertEquals(['foo', 'site_id'], $result);
     }
@@ -324,13 +338,15 @@ class AssociationTest extends TestCase
             'joinType' => 'INNER',
         ];
 
-        $this->association = $this->getMockBuilder(Association::class)
-            ->onlyMethods([
-                'type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated',
-                'requiresKeys',
-            ])
-            ->setConstructorArgs(['ThisAssociationName', $config])
-            ->getMock();
+        $this->association = Mockery::mock(
+            Association::class . '[type,eagerLoader,cascadeDelete,isOwningSide,saveAssociated]',
+            ['ThisAssociationName', $config],
+        )
+            ->makePartial()
+            ->shouldIgnoreMissing();
+        $this->association->shouldReceive('type')
+            ->byDefault()
+            ->andReturn(Association::MANY_TO_ONE);
 
         $table = $this->association->getTarget();
         $this->assertInstanceOf(CommentsTable::class, $table);
@@ -442,13 +458,15 @@ class AssociationTest extends TestCase
             'joinType' => 'INNER',
             'finder' => 'published',
         ];
-        $assoc = $this->getMockBuilder(Association::class)
-            ->onlyMethods([
-                'type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated',
-                'requiresKeys',
-            ])
-            ->setConstructorArgs(['Foo', $config])
-            ->getMock();
+        $assoc = Mockery::mock(
+            Association::class . '[type,eagerLoader,cascadeDelete,isOwningSide,saveAssociated]',
+            ['Foo', $config],
+        )
+            ->makePartial()
+            ->shouldIgnoreMissing();
+        $assoc->shouldReceive('type')
+            ->byDefault()
+            ->andReturn(Association::MANY_TO_ONE);
         $this->assertSame('published', $assoc->getFinder());
     }
 
@@ -491,18 +509,20 @@ class AssociationTest extends TestCase
      */
     public function testLocatorInConstructor(): void
     {
-        $locator = $this->getMockBuilder(LocatorInterface::class)->getMock();
+        $locator = Mockery::mock(LocatorInterface::class);
         $config = [
             'className' => TestTable::class,
             'tableLocator' => $locator,
         ];
-        $assoc = $this->getMockBuilder(Association::class)
-            ->onlyMethods([
-                'type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated',
-                'requiresKeys',
-            ])
-            ->setConstructorArgs(['Foo', $config])
-            ->getMock();
+        $assoc = Mockery::mock(
+            Association::class . '[type,eagerLoader,cascadeDelete,isOwningSide,saveAssociated]',
+            ['Foo', $config],
+        )
+            ->makePartial()
+            ->shouldIgnoreMissing();
+        $assoc->shouldReceive('type')
+            ->byDefault()
+            ->andReturn(Association::MANY_TO_ONE);
         $this->assertEquals($locator, $assoc->getTableLocator());
     }
 }

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -416,9 +416,9 @@ class BehaviorRegistryTest extends TestCase
      */
     public function testSetTable(): void
     {
-        $table = $this->getMockBuilder(Table::class)->getMock();
-        $table->expects($this->once())->method('getEventManager');
+        $table = new Table(['table' => 'users']);
 
         $this->Behaviors->setTable($table);
+        $this->assertSame($table->getEventManager(), $this->Behaviors->getEventManager());
     }
 }

--- a/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
+++ b/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
@@ -6,6 +6,7 @@ namespace Cake\Test\TestCase\ORM;
 use Cake\Database\Driver;
 use Cake\Database\TypeFactory;
 use Cake\TestSuite\TestCase;
+use Mockery;
 use TestApp\Database\Type\ColumnSchemaAwareType;
 
 class ColumnSchemaAwareTypeIntegrationTest extends TestCase
@@ -59,16 +60,10 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
     {
         $table = $this->getTableLocator()->get('ColumnSchemaAwareTypeValues');
 
-        $type = $this
-            ->getMockBuilder(ColumnSchemaAwareType::class)
-            ->setConstructorArgs(['char'])
-            ->onlyMethods(['convertColumnDefinition'])
-            ->getMock();
-
-        $type
-            ->expects($this->once())
-            ->method('convertColumnDefinition')
-            ->willReturnCallback(function (array $definition, Driver $driver) {
+        $type = Mockery::mock(new ColumnSchemaAwareType('char'))->makePartial();
+        $type->shouldReceive('convertColumnDefinition')
+            ->once()
+            ->andReturnUsing(function (array $definition, Driver $driver) {
                 $this->assertEquals(
                     [
                         'length',

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -284,13 +284,13 @@ class EntityTest extends TestCase
      */
     public function testConstructorWithGuard(): void
     {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->onlyMethods(['patch'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $entity->expects($this->once())
-            ->method('patch')
-            ->with(['foo' => 'bar'], ['setter' => true, 'guard' => true, 'asOriginal' => true]);
+        $entity = Mockery::mock(Entity::class)->makePartial();
+
+        $entity
+            ->shouldReceive('patch')
+            ->with(['foo' => 'bar'], ['setter' => true, 'guard' => true, 'asOriginal' => true])
+            ->once();
+
         $entity->__construct(['foo' => 'bar'], ['guard' => true]);
     }
 
@@ -577,13 +577,11 @@ class EntityTest extends TestCase
      */
     public function testMagicUnset(): void
     {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->onlyMethods(['unset'])
-            ->getMock();
-        $entity->expects($this->once())
-            ->method('unset')
-            ->with('foo');
+        $entity = new Entity(['foo' => 'bar']);
+
         unset($entity->foo);
+
+        $this->assertFalse($entity->has('foo'));
     }
 
     /**
@@ -642,14 +640,11 @@ class EntityTest extends TestCase
      */
     public function testUnsetArrayAccess(): void
     {
-        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
-        $entity = $this->getMockBuilder(Entity::class)
-            ->onlyMethods(['unset'])
-            ->getMock();
-        $entity->expects($this->once())
-            ->method('unset')
-            ->with('foo');
+        $entity = new Entity(['foo' => 'bar']);
+
         unset($entity['foo']);
+
+        $this->assertFalse($entity->has('foo'));
     }
 
     /**
@@ -731,13 +726,10 @@ class EntityTest extends TestCase
      */
     public function testJsonSerializeRecursive(): void
     {
-        $phone = $this->getMockBuilder(Entity::class)
-            ->onlyMethods(['jsonSerialize'])
-            ->getMock();
-        $phone->expects($this->once())->method('jsonSerialize')->willReturn(['something']);
+        $phone = new Entity(['something' => true]);
         $data = ['name' => 'James', 'age' => 20, 'phone' => $phone];
         $entity = new Entity($data);
-        $expected = ['name' => 'James', 'age' => 20, 'phone' => ['something']];
+        $expected = ['name' => 'James', 'age' => 20, 'phone' => ['something' => true]];
         $this->assertEquals(json_encode($expected), json_encode($entity));
     }
 
@@ -984,19 +976,13 @@ class EntityTest extends TestCase
      */
     public function testConstructorWithClean(): void
     {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->onlyMethods(['clean'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $entity->expects($this->never())->method('clean');
-        $entity->__construct(['a' => 'b', 'c' => 'd']);
+        $entity = new Entity(['a' => 'b', 'c' => 'd']);
+        $this->assertTrue($entity->isDirty('a'));
+        $this->assertTrue($entity->isDirty('c'));
 
-        $entity = $this->getMockBuilder(Entity::class)
-            ->onlyMethods(['clean'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $entity->expects($this->once())->method('clean');
-        $entity->__construct(['a' => 'b', 'c' => 'd'], ['markClean' => true]);
+        $entity = new Entity(['a' => 'b', 'c' => 'd'], ['markClean' => true]);
+        $this->assertFalse($entity->isDirty('a'));
+        $this->assertFalse($entity->isDirty('c'));
     }
 
     /**
@@ -1004,19 +990,14 @@ class EntityTest extends TestCase
      */
     public function testConstructorWithMarkNew(): void
     {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->onlyMethods(['setNew', 'clean'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $entity->expects($this->never())->method('clean');
-        $entity->__construct(['a' => 'b', 'c' => 'd']);
+        $entity = new Entity(['a' => 'b', 'c' => 'd']);
+        $this->assertTrue($entity->isNew());
 
-        $entity = $this->getMockBuilder(Entity::class)
-            ->onlyMethods(['setNew'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $entity->expects($this->once())->method('setNew');
-        $entity->__construct(['a' => 'b', 'c' => 'd'], ['markNew' => true]);
+        $entity = new Entity(['a' => 'b', 'c' => 'd'], ['markNew' => false]);
+        $this->assertFalse($entity->isNew());
+
+        $entity = new Entity(['a' => 'b', 'c' => 'd'], ['markNew' => true]);
+        $this->assertTrue($entity->isNew());
     }
 
     /**

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -25,7 +25,6 @@ use Cake\ORM\Query\QueryFactory;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use ReflectionProperty;
 use TestApp\Infrastructure\Table\AddressesTable;
 use TestApp\Model\Entity\Article;
@@ -41,7 +40,6 @@ use TestPluginTwo\Model\Table\CommentsTable as PluginTwoCommentsTable;
 /**
  * Test case for TableLocator
  */
-#[AllowMockObjectsWithoutExpectations]
 class TableLocatorTest extends TestCase
 {
     /**

--- a/tests/TestCase/ORM/Query/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/Query/CompositeKeysTest.php
@@ -26,14 +26,12 @@ use Cake\ORM\Marshaller;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Entity\OpenArticleEntity;
 
 /**
  * Integration tests for table operations involving composite keys
  */
-#[AllowMockObjectsWithoutExpectations]
 class CompositeKeysTest extends TestCase
 {
     /**
@@ -556,10 +554,7 @@ class CompositeKeysTest extends TestCase
     public function testFindThreadedCompositeKeys(): void
     {
         $table = $this->getTableLocator()->get('SiteAuthors');
-        $query = $this->getMockBuilder(SelectQuery::class)
-            ->onlyMethods(['_addDefaultFields', 'execute'])
-            ->setConstructorArgs([$table])
-            ->getMock();
+        $query = new SelectQuery($table);
 
         $items = new ResultSetDecorator([
             ['id' => 1, 'name' => 'a', 'site_id' => 1, 'parent_id' => null],

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -43,7 +43,7 @@ use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\ResultSet;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 use TestApp\Model\Table\ArticlesTable;
@@ -53,7 +53,6 @@ use TestApp\Model\Table\TagsTable;
 /**
  * Tests SelectQuery class
  */
-#[AllowMockObjectsWithoutExpectations]
 class SelectQueryTest extends TestCase
 {
     /**
@@ -1867,11 +1866,7 @@ class SelectQueryTest extends TestCase
      */
     public function testClearContain(): void
     {
-        /** @var \Cake\ORM\Query\SelectQuery $query */
-        $query = $this->getMockBuilder(Query::class)
-            ->onlyMethods(['all'])
-            ->setConstructorArgs([$this->table])
-            ->getMock();
+        $query = new SelectQuery($this->table);
 
         $query->contain([
             'Articles',
@@ -1894,20 +1889,17 @@ class SelectQueryTest extends TestCase
      */
     public function testCacheReadIntegration(): void
     {
-        $query = $this->getMockBuilder(Query::class)
-            ->onlyMethods(['execute'])
-            ->setConstructorArgs([$this->table])
-            ->getMock();
+        $query = Mockery::mock(new Query($this->table))->makePartial();
         $resultSet = new ResultSet([]);
 
-        $query->expects($this->never())
-            ->method('execute');
+        $query->shouldReceive('execute')->never();
 
-        $cacher = $this->getMockBuilder(CacheEngine::class)->getMock();
-        $cacher->expects($this->once())
-            ->method('get')
+        $cacher = Mockery::mock(CacheEngine::class);
+        $cacher->shouldReceive('get')
             ->with('my_key')
-            ->willReturn($resultSet);
+            ->once()
+            ->andReturn($resultSet);
+        $cacher->shouldReceive('set')->never();
 
         $query->cache('my_key', $cacher)
             ->where(['id' => 1]);
@@ -1926,13 +1918,17 @@ class SelectQueryTest extends TestCase
 
         $query->select(['id', 'title']);
 
-        $cacher = $this->getMockBuilder(CacheEngine::class)->getMock();
-        $cacher->expects($this->once())
-            ->method('set')
-            ->with(
-                'my_key',
-                $this->isInstanceOf(ResultSetInterface::class),
-            );
+        $cacher = Mockery::mock(CacheEngine::class);
+        $cacher->shouldReceive('get')
+            ->with('my_key')
+            ->once()
+            ->andReturn(null);
+        $cacher->shouldReceive('set')
+            ->withArgs(function (string $key, mixed $value): bool {
+                return $key === 'my_key' && $value instanceof ResultSetInterface;
+            })
+            ->once()
+            ->andReturn(true);
 
         $query->cache('my_key', $cacher)
             ->where(['id' => 1]);
@@ -2379,14 +2375,12 @@ class SelectQueryTest extends TestCase
      */
     public function testCountCache(): void
     {
-        $query = $this->getMockBuilder(Query::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['_performCount'])
-            ->getMock();
-
-        $query->expects($this->once())
-            ->method('_performCount')
-            ->willReturn(1);
+        $query = Mockery::mock(Query::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $query->shouldReceive('_performCount')
+            ->once()
+            ->andReturn(1);
 
         $result = $query->count();
         $this->assertSame(1, $result, 'The result of the sql query should be returned');
@@ -2401,14 +2395,12 @@ class SelectQueryTest extends TestCase
      */
     public function testCountCacheDirty(): void
     {
-        $query = $this->getMockBuilder(Query::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['_performCount'])
-            ->getMock();
-
-        $query->expects($this->exactly(2))
-            ->method('_performCount')
-            ->willReturn(1, 2);
+        $query = Mockery::mock(Query::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $query->shouldReceive('_performCount')
+            ->twice()
+            ->andReturn(1, 2);
 
         $result = $query->count();
         $this->assertSame(1, $result, 'The result of the sql query should be returned');
@@ -2427,14 +2419,12 @@ class SelectQueryTest extends TestCase
      */
     public function testCountCacheClearedOnBind(): void
     {
-        $query = $this->getMockBuilder(SelectQuery::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['_performCount'])
-            ->getMock();
-
-        $query->expects($this->exactly(2))
-            ->method('_performCount')
-            ->willReturn(1, 2);
+        $query = Mockery::mock(SelectQuery::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $query->shouldReceive('_performCount')
+            ->twice()
+            ->andReturn(1, 2);
 
         $query->bind(':start', 'value1');
         $query->bind(':end', 'value2');

--- a/tests/TestCase/ORM/ResultSetFactoryTest.php
+++ b/tests/TestCase/ORM/ResultSetFactoryTest.php
@@ -26,7 +26,6 @@ use Cake\ORM\ResultSetFactory;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Mockery;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use TestApp\Dto\ArticleArrayDto;
 use TestApp\Dto\ArticleDto;
 use TestApp\Dto\AuthorArrayDto;
@@ -37,7 +36,6 @@ use TestApp\Dto\SimpleArticleDto;
 /**
  * ResultSetFactory test case.
  */
-#[AllowMockObjectsWithoutExpectations]
 class ResultSetFactoryTest extends TestCase
 {
     /**

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -149,16 +149,14 @@ class LinkConstraintTest extends TestCase
         $Articles = $this->getTableLocator()->get('Articles');
         $Articles->hasMany('Comments')->setForeignKey(['id', 'article_id']);
 
-        /** @var \Cake\ORM\Rule\LinkConstraint|\PHPUnit\Framework\MockObject\MockObject $ruleMock */
-        $ruleMock = $this
-            ->getMockBuilder(LinkConstraint::class)
-            ->setConstructorArgs(['Comments', LinkConstraint::STATUS_NOT_LINKED])
-            ->onlyMethods(['_aliasFields'])
-            ->getMock();
+        /** @var \Cake\ORM\Rule\LinkConstraint&\Mockery\MockInterface $ruleMock */
+        $ruleMock = Mockery::mock(LinkConstraint::class, ['Comments', LinkConstraint::STATUS_NOT_LINKED])
+            ->makePartial();
         $ruleMock
-            ->expects($this->once())
-            ->method('_aliasFields')
-            ->willReturn([]);
+            ->shouldAllowMockingProtectedMethods()
+            ->shouldReceive('_aliasFields')
+            ->once()
+            ->andReturn([]);
 
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete($ruleMock);

--- a/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
+++ b/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
@@ -17,9 +17,11 @@ namespace Cake\Test\TestCase\ORM;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Entity;
+use Cake\ORM\Query\QueryFactory;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class TableGetWithCustomFinderTest extends TestCase
@@ -48,37 +50,33 @@ class TableGetWithCustomFinderTest extends TestCase
     #[DataProvider('providerForTestGetWithCustomFinder')]
     public function testGetWithCustomFinder($options): void
     {
-        $table = $this->getMockBuilder(GetWithCustomFinderTable::class)
-            ->onlyMethods(['selectQuery', 'findCustom'])
-            ->setConstructorArgs([[
-                'connection' => $this->connection,
-                'schema' => [
-                    'id' => ['type' => 'integer'],
-                    'bar' => ['type' => 'integer'],
-                    '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['bar']]],
-                ],
-            ]])
-            ->getMock();
+        $queryFactory = Mockery::mock(QueryFactory::class);
+        $table = new GetWithCustomFinderTable([
+            'connection' => $this->connection,
+            'schema' => [
+                'id' => ['type' => 'integer'],
+                'bar' => ['type' => 'integer'],
+                '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['bar']]],
+            ],
+            'queryFactory' => $queryFactory,
+        ]);
 
-        $query = $this->getMockBuilder(SelectQuery::class)
-            ->onlyMethods(['addDefaultTypes', 'firstOrFail', 'where', 'cache', 'applyOptions'])
-            ->setConstructorArgs([$table])
-            ->getMock();
-
-        $table->expects($this->once())->method('selectQuery')
-            ->willReturn($query);
-        $table->method('findCustom')
-            ->willReturn($query);
+        $query = Mockery::mock(new SelectQuery($table))->makePartial();
+        $queryFactory->shouldReceive('select')->once()->with($table)->andReturn($query);
 
         $entity = new Entity();
-        $query->expects($this->once())->method('applyOptions')
-            ->with(['fields' => ['id']]);
-        $query->expects($this->once())->method('where')
+        $query->shouldReceive('applyOptions')
+            ->once()
+            ->with(['fields' => ['id']])
+            ->andReturnSelf();
+        $query->shouldReceive('where')
+            ->once()
             ->with([$table->getAlias() . '.bar' => 10])
-            ->willReturnSelf();
-        $query->expects($this->never())->method('cache');
-        $query->expects($this->once())->method('firstOrFail')
-            ->willReturn($entity);
+            ->andReturnSelf();
+        $query->shouldReceive('cache')->never();
+        $query->shouldReceive('firstOrFail')
+            ->once()
+            ->andReturn($entity);
 
         $result = $table->get(10, ...$options);
         $this->assertSame($entity, $result);

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -30,7 +30,6 @@ use Cake\Test\Fixture\FixturizedTestCase;
 use Cake\TestSuite\TestCase;
 use Exception;
 use PHPUnit\Framework\AssertionFailedError;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestStatus\Skipped;
 use PHPUnit\Framework\TestStatus\Success;
@@ -46,7 +45,6 @@ use function Cake\Core\deprecationWarning;
 /**
  * TestCaseTest
  */
-#[AllowMockObjectsWithoutExpectations]
 class TestCaseTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -31,14 +31,12 @@ use Cake\Test\Fixture\SpecialPkFixture;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Inflector;
 use Mockery;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use TestApp\Test\Fixture\FeaturedTagsFixture;
 use TestApp\Test\Fixture\LettersFixture;
 
 /**
  * Test case for TestFixture
  */
-#[AllowMockObjectsWithoutExpectations]
 class TestFixtureTest extends TestCase
 {
     /**


### PR DESCRIPTION
As PHPUnit Mocks have caused problems in the past this is a cleanup to either
- remove mocks as a whole when they are actually not needed or
- convert them to a Mockery based mock since its API seems to be more stable