### PR TITLE
add ability to add request data to DELETE requests in integration tests

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -455,11 +455,12 @@ trait IntegrationTestTrait
      * response.
      *
      * @param array|string $url The URL to request.
+     * @param array|string $data The data for the request.
      * @return void
      */
-    public function delete(array|string $url): void
+    public function delete(array|string $url, array|string $data = []): void
     {
-        $this->sendRequest($url, 'DELETE');
+        $this->sendRequest($url, 'DELETE', $data);
     }
 
     /**

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -490,6 +490,22 @@ class IntegrationTestTraitTest extends TestCase
     }
 
     /**
+     * Test that the PSR7 requests receive delete data
+     */
+    public function testDeleteDataFormUrlEncoded(): void
+    {
+        $this->configRequest([
+            'headers' => [
+                'Content-Type' => 'application/x-www-form-urlencoded',
+            ],
+        ]);
+        $this->delete('/request_action/delete_pass', ['title' => 'value']);
+        $this->assertResponseOk();
+        $data = json_decode('' . $this->response->getBody());
+        $this->assertSame('value', $data->title);
+    }
+
+    /**
      * Test that the uploaded files are passed correctly to the request
      */
     public function testUploadedFiles(): void

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -85,6 +85,16 @@ class RequestActionController extends AppController
     }
 
     /**
+     * delete pass, testing delete data passing
+     *
+     * @return \Cake\Http\Response
+     */
+    public function delete_pass()
+    {
+        return $this->response->withStringBody(json_encode($this->request->getData()));
+    }
+
+    /**
      * query pass, testing query passing
      *
      * @return \Cake\Http\Response


### PR DESCRIPTION
@maurobrandoni asked in Support chat why it was not possible to add request data in `DELETE` calls inside IntegrationTests.

Technically `DELETE` Requests do allow a request body to be present, so I adjusted the signature of that method to allow data to be passed down.

The question now is if we want to backport this to 5.next via a separate method as we can't do this change in 5.x since its not BC.