### PR TITLE
Fix setError() to handle dotted field paths for application rules

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -1180,6 +1180,13 @@ trait EntityTrait
             $errors = [$errors];
         }
 
+        // Handle dotted field paths by creating nested error structure
+        if (str_contains($field, '.')) {
+            $nested = Hash::insert([], $field, $errors);
+
+            return $this->setErrors($nested, $overwrite);
+        }
+
         return $this->setErrors([$field => $errors], $overwrite);
     }
 

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1241,6 +1241,47 @@ class EntityTest extends TestCase
     }
 
     /**
+     * Tests that setError with dotted paths creates nested structure
+     */
+    public function testSetErrorDottedPath(): void
+    {
+        $entity = new Entity();
+        $entity->setError('patients._ids', ['dummyRule' => 'Error message']);
+
+        // Should create nested structure that can be retrieved with dotted path
+        $expected = ['dummyRule' => 'Error message'];
+        $this->assertEquals($expected, $entity->getError('patients._ids'));
+
+        // Should also work with getErrors()
+        $expected = [
+            'patients' => [
+                '_ids' => ['dummyRule' => 'Error message'],
+            ],
+        ];
+        $this->assertEquals($expected, $entity->getErrors());
+
+        // Test deeper nesting
+        $entity = new Entity();
+        $entity->setError('foo.bar.baz', 'deep error');
+
+        $this->assertEquals(['deep error'], $entity->getError('foo.bar.baz'));
+        $expected = [
+            'foo' => [
+                'bar' => [
+                    'baz' => ['deep error'],
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $entity->getErrors());
+
+        // Test with string error message
+        $entity = new Entity();
+        $entity->setError('field.subfield', 'simple message');
+
+        $this->assertEquals(['simple message'], $entity->getError('field.subfield'));
+    }
+
+    /**
      * Tests reading errors from nested validator
      */
     public function testGetErrorNested(): void


### PR DESCRIPTION
## Summary

- Fixes `EntityTrait::setError()` to properly handle dotted field paths (e.g., `patients._ids`)
- When `errorField` contains dots, creates a nested error structure using `Hash::insert()` instead of storing with a literal key
- This allows `FormHelper::error()` and `EntityContext::error()` to correctly retrieve the error message

## Root Cause

When an application rule sets `errorField => 'patients._ids'`, the error was stored as:
```php
$_errors['patients._ids'] = ['rule' => 'message'];
```

But `getError()` via `_nestedErrors()` uses `Hash::get()` which expects:
```php
$_errors['patients']['_ids'] = ['rule' => 'message'];
```

## The Fix

In `EntityTrait::setError()`, detect dotted paths and normalize them using `Hash::insert()`:
```php
if (str_contains($field, '.')) {
    $nested = Hash::insert([], $field, $errors);
    return $this->setErrors($nested, $overwrite);
}
```

Fixes #19274