### PR TITLE
Hydrate $args and $io as BaseCommand properties

### DIFF
--- a/src/Command/PluginAssetsCopyCommand.php
+++ b/src/Command/PluginAssetsCopyCommand.php
@@ -55,9 +55,6 @@ class PluginAssetsCopyCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
-        $this->io = $io;
-        $this->args = $args;
-
         $name = $args->getArgument('name');
         $overwrite = (bool)$args->getOption('overwrite');
         $this->_process($this->_list($name), true, $overwrite);

--- a/src/Command/PluginAssetsRemoveCommand.php
+++ b/src/Command/PluginAssetsRemoveCommand.php
@@ -54,9 +54,6 @@ class PluginAssetsRemoveCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
-        $this->io = $io;
-        $this->args = $args;
-
         $name = $args->getArgument('name');
         $plugins = $this->_list($name);
 

--- a/src/Command/PluginAssetsSymlinkCommand.php
+++ b/src/Command/PluginAssetsSymlinkCommand.php
@@ -56,9 +56,6 @@ class PluginAssetsSymlinkCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
-        $this->io = $io;
-        $this->args = $args;
-
         $name = $args->getArgument('name');
         $overwrite = (bool)$args->getOption('overwrite');
         $relative = (bool)$args->getOption('relative');

--- a/src/Command/PluginAssetsTrait.php
+++ b/src/Command/PluginAssetsTrait.php
@@ -16,8 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Command;
 
-use Cake\Console\Arguments;
-use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Utility\Filesystem;
@@ -31,20 +29,6 @@ use InvalidArgumentException;
  */
 trait PluginAssetsTrait
 {
-    /**
-     * Arguments
-     *
-     * @var \Cake\Console\Arguments
-     */
-    protected Arguments $args;
-
-    /**
-     * Console IO
-     *
-     * @var \Cake\Console\ConsoleIo
-     */
-    protected ConsoleIo $io;
-
     /**
      * Get list of plugins to process. Plugins without a webroot directory are skipped.
      *

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -62,6 +62,10 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
      */
     protected string $name = 'cake unknown';
 
+    protected Arguments $args;
+
+    protected ConsoleIo $io;
+
     protected ?CommandFactoryInterface $factory = null;
 
     /**
@@ -243,6 +247,9 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
 
             return static::CODE_ERROR;
         }
+        $this->args = $args;
+        $this->io = $io;
+
         $this->setOutputLevel($args, $io);
 
         if ($args->getOption('help')) {

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -175,8 +175,9 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
      * Hook method invoked by CakePHP when a command is about to be executed.
      *
      * Override this method and implement expensive/important setup steps that
-     * should not run on every command run. This method will be called *before*
-     * the options and arguments are validated and processed.
+     * should not run on every command run. This method will be called *after*
+     * the options and arguments are validated and processed, so `$this->args`
+     * and `$this->io` are both available.
      *
      * @return void
      */
@@ -232,7 +233,7 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
      */
     public function run(array $argv, ConsoleIo $io): ?int
     {
-        $this->initialize();
+        $this->io = $io;
 
         $parser = $this->getOptionParser();
         try {
@@ -248,9 +249,9 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
             return static::CODE_ERROR;
         }
         $this->args = $args;
-        $this->io = $io;
 
         $this->setOutputLevel($args, $io);
+        $this->initialize();
 
         if ($args->getOption('help')) {
             $this->displayHelp($parser, $args, $io);

--- a/tests/TestCase/Console/BaseCommandTest.php
+++ b/tests/TestCase/Console/BaseCommandTest.php
@@ -1,0 +1,158 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Console;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Console\TestSuite\StubConsoleOutput;
+use Cake\TestSuite\TestCase;
+use Mockery;
+
+/**
+ * Test that BaseCommand hydrates $args and $io properties.
+ */
+class BaseCommandTest extends TestCase
+{
+    /**
+     * Test that $this->args is available inside execute()
+     */
+    public function testRunHydratesArgs(): void
+    {
+        $command = new class extends Command {
+            public ?Arguments $capturedArgs = null;
+
+            public function execute(Arguments $args, ConsoleIo $io): int
+            {
+                $this->capturedArgs = $this->args;
+
+                return static::CODE_SUCCESS;
+            }
+        };
+        $command->setName('cake test');
+        $output = new StubConsoleOutput();
+        $io = Mockery::mock(ConsoleIo::class, [$output, $output, null, null])->makePartial();
+
+        $command->run([], $io);
+
+        $this->assertInstanceOf(Arguments::class, $command->capturedArgs);
+    }
+
+    /**
+     * Test that $this->io is available inside execute()
+     */
+    public function testRunHydratesIo(): void
+    {
+        $command = new class extends Command {
+            public ?ConsoleIo $capturedIo = null;
+
+            public function execute(Arguments $args, ConsoleIo $io): int
+            {
+                $this->capturedIo = $this->io;
+
+                return static::CODE_SUCCESS;
+            }
+        };
+        $command->setName('cake test');
+        $output = new StubConsoleOutput();
+        $io = Mockery::mock(ConsoleIo::class, [$output, $output, null, null])->makePartial();
+
+        $command->run([], $io);
+
+        $this->assertSame($io, $command->capturedIo);
+    }
+
+    /**
+     * Test that $this->args matches the Arguments passed to execute()
+     */
+    public function testRunHydratedArgsMatchExecuteArgs(): void
+    {
+        $command = new class extends Command {
+            public bool $argsMatch = false;
+
+            public function execute(Arguments $args, ConsoleIo $io): int
+            {
+                $this->argsMatch = ($this->args === $args);
+
+                return static::CODE_SUCCESS;
+            }
+        };
+        $command->setName('cake test');
+        $output = new StubConsoleOutput();
+        $io = Mockery::mock(ConsoleIo::class, [$output, $output, null, null])->makePartial();
+
+        $command->run([], $io);
+
+        $this->assertTrue($command->argsMatch);
+    }
+
+    /**
+     * Test that $this->args and $this->io are hydrated before execute(),
+     * so traits/parent classes can rely on them without manual assignment.
+     */
+    public function testRunHydratesPropertiesBeforeExecute(): void
+    {
+        $command = new class extends Command {
+            public bool $propsAvailable = false;
+
+            public function execute(Arguments $args, ConsoleIo $io): int
+            {
+                $this->propsAvailable = isset($this->args) && isset($this->io);
+
+                return static::CODE_SUCCESS;
+            }
+        };
+        $command->setName('cake test');
+        $output = new StubConsoleOutput();
+        $io = Mockery::mock(ConsoleIo::class, [$output, $output, null, null])->makePartial();
+
+        $command->run([], $io);
+
+        $this->assertTrue($command->propsAvailable);
+    }
+
+    /**
+     * Test that hydrated args contain the parsed arguments from the command line.
+     */
+    public function testRunHydratedArgsContainParsedValues(): void
+    {
+        $command = new class extends Command {
+            public ?string $capturedName = null;
+
+            protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+            {
+                $parser->addArgument('name', ['required' => true]);
+
+                return $parser;
+            }
+
+            public function execute(Arguments $args, ConsoleIo $io): int
+            {
+                $this->capturedName = $this->args->getArgument('name');
+
+                return static::CODE_SUCCESS;
+            }
+        };
+        $command->setName('cake test');
+        $output = new StubConsoleOutput();
+        $io = Mockery::mock(ConsoleIo::class, [$output, $output, null, null])->makePartial();
+
+        $command->run(['Alice'], $io);
+
+        $this->assertSame('Alice', $command->capturedName);
+    }
+}

--- a/tests/TestCase/Console/BaseCommandTest.php
+++ b/tests/TestCase/Console/BaseCommandTest.php
@@ -126,6 +126,60 @@ class BaseCommandTest extends TestCase
     }
 
     /**
+     * Test that $this->io is accessible in initialize()
+     */
+    public function testInitializeCanAccessIo(): void
+    {
+        $command = new class extends Command {
+            public bool $ioAccessible = false;
+
+            public function initialize(): void
+            {
+                $this->ioAccessible = isset($this->io);
+            }
+
+            public function execute(Arguments $args, ConsoleIo $io): int
+            {
+                return static::CODE_SUCCESS;
+            }
+        };
+        $command->setName('cake test');
+        $output = new StubConsoleOutput();
+        $io = Mockery::mock(ConsoleIo::class, [$output, $output, null, null])->makePartial();
+
+        $command->run([], $io);
+
+        $this->assertTrue($command->ioAccessible);
+    }
+
+    /**
+     * Test that $this->args is accessible in initialize()
+     */
+    public function testInitializeCanAccessArgs(): void
+    {
+        $command = new class extends Command {
+            public bool $argsAccessible = false;
+
+            public function initialize(): void
+            {
+                $this->argsAccessible = isset($this->args);
+            }
+
+            public function execute(Arguments $args, ConsoleIo $io): int
+            {
+                return static::CODE_SUCCESS;
+            }
+        };
+        $command->setName('cake test');
+        $output = new StubConsoleOutput();
+        $io = Mockery::mock(ConsoleIo::class, [$output, $output, null, null])->makePartial();
+
+        $command->run([], $io);
+
+        $this->assertTrue($command->argsAccessible);
+    }
+
+    /**
      * Test that hydrated args contain the parsed arguments from the command line.
      */
     public function testRunHydratedArgsContainParsedValues(): void


### PR DESCRIPTION
## Summary

- Adds `protected Arguments $args` and `protected ConsoleIo $io` properties to `BaseCommand`, hydrated in `run()` before `execute()` is called
- Removes redundant property declarations from `PluginAssetsTrait` and manual assignments from the three PluginAssets commands
- Enables any method in a command to access `$this->args` and `$this->io` without threading them through as parameters

## Test plan

- [x] `tests/TestCase/Console/CommandTest.php` passes (24 tests)
- [x] `tests/TestCase/Command/PluginAssetsCommandsTest.php` passes (15 tests)
- [x] Full `tests/TestCase/Console/` and `tests/TestCase/Command/` suites pass (493 tests, 1 pre-existing unrelated failure in `ConsoleInputTest`)