### PR TITLE
Stabilize Plugin Commands under CLI OPcache

### DIFF
--- a/tests/TestCase/Command/PluginConfigFileTrait.php
+++ b/tests/TestCase/Command/PluginConfigFileTrait.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP :  Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP Project
+ * @since         5.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Command;
+
+trait PluginConfigFileTrait
+{
+    protected function invalidatePhpFileCache(string $path): void
+    {
+        clearstatcache(true, $path);
+        if (function_exists('opcache_invalidate')) {
+            opcache_invalidate($path, true);
+        }
+    }
+
+    protected function writePhpFile(string $path, string $contents): void
+    {
+        file_put_contents($path, $contents);
+        $this->invalidatePhpFileCache($path);
+    }
+
+    protected function deletePhpFile(string $path): void
+    {
+        $this->invalidatePhpFileCache($path);
+        unlink($path);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function includePhpConfig(string $path): array
+    {
+        $this->invalidatePhpFileCache($path);
+        $config = include $path;
+        assert(is_array($config));
+
+        return $config;
+    }
+}

--- a/tests/TestCase/Command/PluginListCommandTest.php
+++ b/tests/TestCase/Command/PluginListCommandTest.php
@@ -26,6 +26,7 @@ use Cake\TestSuite\TestCase;
 class PluginListCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
+    use PluginConfigFileTrait;
 
     protected string $pluginsListPath;
 
@@ -43,7 +44,7 @@ class PluginListCommandTest extends TestCase
         $this->setAppNamespace();
         $this->pluginsListPath = ROOT . DS . 'cakephp-plugins.php';
         if (file_exists($this->pluginsListPath)) {
-            unlink($this->pluginsListPath);
+            $this->deletePhpFile($this->pluginsListPath);
         }
         $this->pluginsConfigPath = CONFIG . 'plugins.php';
         if (file_exists($this->pluginsConfigPath)) {
@@ -55,20 +56,10 @@ class PluginListCommandTest extends TestCase
     {
         parent::tearDown();
         if (file_exists($this->pluginsListPath)) {
-            unlink($this->pluginsListPath);
-            $this->invalidatePhpFileCache($this->pluginsListPath);
+            $this->deletePhpFile($this->pluginsListPath);
         }
         if (file_exists($this->pluginsConfigPath)) {
-            file_put_contents($this->pluginsConfigPath, $this->originalPluginsConfigContent);
-            $this->invalidatePhpFileCache($this->pluginsConfigPath);
-        }
-    }
-
-    protected function invalidatePhpFileCache($path): void
-    {
-        clearstatcache(true, $path);
-        if (function_exists('opcache_invalidate')) {
-            opcache_invalidate($path, true);
+            $this->writePhpFile($this->pluginsConfigPath, $this->originalPluginsConfigContent);
         }
     }
 
@@ -97,7 +88,7 @@ return [
     ]
 ];
 PHP;
-        file_put_contents($this->pluginsListPath, $file);
+        $this->writePhpFile($this->pluginsListPath, $file);
 
         $this->exec('plugin list');
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
@@ -115,7 +106,7 @@ PHP;
 declare(strict_types=1);
 return [];
 PHP;
-        file_put_contents($this->pluginsListPath, $file);
+        $this->writePhpFile($this->pluginsListPath, $file);
 
         $this->exec('plugin list');
         $this->assertExitCode(CommandInterface::CODE_ERROR);
@@ -137,7 +128,7 @@ return [
     ]
 ];
 PHP;
-        file_put_contents($this->pluginsListPath, $file);
+        $this->writePhpFile($this->pluginsListPath, $file);
 
         $config = <<<PHP
 <?php
@@ -147,7 +138,7 @@ return [
     'OtherPlugin' => ['onlyDebug' => true, 'onlyCli' => true, 'optional' => true]
 ];
 PHP;
-        file_put_contents($this->pluginsConfigPath, $config);
+        $this->writePhpFile($this->pluginsConfigPath, $config);
 
         $this->deprecated(function (): void {
             $this->exec('plugin list');
@@ -172,7 +163,7 @@ return [
     ]
 ];
 PHP;
-        file_put_contents($this->pluginsListPath, $file);
+        $this->writePhpFile($this->pluginsListPath, $file);
 
         $config = <<<PHP
 <?php
@@ -181,7 +172,7 @@ return [
     'Unknown'
 ];
 PHP;
-        file_put_contents($this->pluginsConfigPath, $config);
+        $this->writePhpFile($this->pluginsConfigPath, $config);
 
         $this->expectException(MissingPluginException::class);
         $this->expectExceptionMessage('Plugin `Unknown` could not be found.');
@@ -204,7 +195,7 @@ return [
     ]
 ];
 PHP;
-        file_put_contents($this->pluginsListPath, $file);
+        $this->writePhpFile($this->pluginsListPath, $file);
 
         $config = <<<PHP
 <?php
@@ -214,7 +205,7 @@ return [
     'CodeSniffer'
 ];
 PHP;
-        file_put_contents($this->pluginsConfigPath, $config);
+        $this->writePhpFile($this->pluginsConfigPath, $config);
 
         $path = ROOT . DS . 'tests' . DS . 'composer.lock';
         $this->deprecated(function () use ($path): void {

--- a/tests/TestCase/Command/PluginListCommandTest.php
+++ b/tests/TestCase/Command/PluginListCommandTest.php
@@ -56,9 +56,19 @@ class PluginListCommandTest extends TestCase
         parent::tearDown();
         if (file_exists($this->pluginsListPath)) {
             unlink($this->pluginsListPath);
+            $this->invalidatePhpFileCache($this->pluginsListPath);
         }
         if (file_exists($this->pluginsConfigPath)) {
             file_put_contents($this->pluginsConfigPath, $this->originalPluginsConfigContent);
+            $this->invalidatePhpFileCache($this->pluginsConfigPath);
+        }
+    }
+
+    protected function invalidatePhpFileCache($path): void
+    {
+        clearstatcache(true, $path);
+        if (function_exists('opcache_invalidate')) {
+            opcache_invalidate($path, true);
         }
     }
 

--- a/tests/TestCase/Command/PluginLoadCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadCommandTest.php
@@ -27,6 +27,7 @@ use Cake\TestSuite\TestCase;
 class PluginLoadCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
+    use PluginConfigFileTrait;
 
     /**
      * @var string
@@ -58,7 +59,7 @@ class PluginLoadCommandTest extends TestCase
     {
         parent::tearDown();
 
-        file_put_contents($this->configFile, $this->originalContent);
+        $this->writePhpFile($this->configFile, $this->originalContent);
     }
 
     /**
@@ -94,7 +95,7 @@ class PluginLoadCommandTest extends TestCase
         });
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
-        $config = include $this->configFile;
+        $config = $this->includePhpConfig($this->configFile);
         $this->assertTrue(isset($config['TestPlugin']));
         $this->assertTrue(isset($config['TestPluginTwo']));
         $this->assertTrue(isset($config['Company/TestPluginThree']));
@@ -114,7 +115,7 @@ class PluginLoadCommandTest extends TestCase
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         Plugin::getCollection()->remove('TestPluginFour');
 
-        $config = include $this->configFile;
+        $config = $this->includePhpConfig($this->configFile);
         $expected = [
             'onlyDebug' => true,
             'onlyCli' => true,
@@ -132,7 +133,7 @@ class PluginLoadCommandTest extends TestCase
         $this->assertExitCode(CommandInterface::CODE_ERROR);
         $this->assertErrorContains('Plugin `NopeNotThere` could not be found');
 
-        $config = include $this->configFile;
+        $config = $this->includePhpConfig($this->configFile);
         $this->assertFalse(isset($config['NopeNotThere']));
     }
 
@@ -143,7 +144,7 @@ class PluginLoadCommandTest extends TestCase
     {
         $this->exec('plugin load NopeNotThere --optional');
 
-        $config = include $this->configFile;
+        $config = $this->includePhpConfig($this->configFile);
         $this->assertTrue(isset($config['NopeNotThere']));
         $this->assertSame(['optional' => true], $config['NopeNotThere']);
     }

--- a/tests/TestCase/Command/PluginUnloadCommandTest.php
+++ b/tests/TestCase/Command/PluginUnloadCommandTest.php
@@ -27,6 +27,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 class PluginUnloadCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
+    use PluginConfigFileTrait;
 
     /**
      * @var string
@@ -59,7 +60,7 @@ class PluginUnloadCommandTest extends TestCase
         ];
         CONTENTS;
 
-        file_put_contents($this->configFile, $contents);
+        $this->writePhpFile($this->configFile, $contents);
 
         $this->setAppNamespace();
     }
@@ -72,7 +73,7 @@ class PluginUnloadCommandTest extends TestCase
         parent::tearDown();
 
         Plugin::getCollection()->clear();
-        file_put_contents($this->configFile, $this->originalContent);
+        $this->writePhpFile($this->configFile, $this->originalContent);
     }
 
     /**
@@ -103,7 +104,7 @@ class PluginUnloadCommandTest extends TestCase
 
     public function testUnloadNoConfigFile(): void
     {
-        unlink($this->configFile);
+        $this->deletePhpFile($this->configFile);
 
         $this->exec('plugin unload TestPlugin');
         $this->assertExitCode(CommandInterface::CODE_ERROR);


### PR DESCRIPTION
## Summary
This PR fixes intermittent command test failures under CLI OPcache by centralizing PHP config file mutation + cache invalidation in a shared test trait, and applying it consistently across plugin command tests.

## Changes
- Added shared trait: PluginConfigFileTrait.php
  - `invalidatePhpFileCache(string $path): void`
  - `writePhpFile(string $path, string $contents): void`
  - `deletePhpFile(string $path): void` (invalidate before unlink)
  - `includePhpConfig(string $path): array`
- Refactored tests to use the trait:
  - PluginListCommandTest.php
  - PluginLoadCommandTest.php
  - PluginUnloadCommandTest.php

## Why
These tests rewrite/delete PHP config files during execution. With CLI OPcache enabled, stale cached metadata/opcodes can cause nondeterministic failures. Centralized invalidation keeps behavior deterministic and removes duplication.

Command to reproduce

```bash
php -d opcache.enable_cli=1 ./vendor/bin/phpunit tests/TestCase/Command
```