### PR TITLE
Fix sliding window rate limiter timing issue

### DIFF
--- a/src/Http/RateLimit/SlidingWindowRateLimiter.php
+++ b/src/Http/RateLimit/SlidingWindowRateLimiter.php
@@ -63,7 +63,7 @@ class SlidingWindowRateLimiter implements RateLimiterInterface
             ];
         } else {
             $weight = 1 - ($elapsed / $window);
-            $data['count'] = (int)($data['count'] * $weight);
+            $data['count'] = (int)ceil($data['count'] * $weight);
         }
 
         $allowed = $data['count'] + $cost <= $limit;


### PR DESCRIPTION
## Summary

- Fix integer truncation in `SlidingWindowRateLimiter` that caused flaky rate limit tests

The sliding window decay calculation used `(int)` truncation which caused the weighted count to prematurely drop to zero. With `limit=1` and even 1 second elapsed:

```php
$weight = 1 - (1/60) = 0.9833
$count = (int)(1 * 0.9833) = (int)(0.9833) = 0  // Rate limit bypassed!
```

Using `ceil()` ensures partial counts round up, maintaining the rate limit until the full decay period has passed.

This fixes the flaky `testIpIdentification` test failure: https://github.com/cakephp/cakephp/actions/runs/22170379947/job/64106794006