### PR TITLE
Add collation support for uuid columns in MySQL

### DIFF
--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -834,6 +834,7 @@ SQL;
             TableSchemaInterface::TYPE_TEXT,
             TableSchemaInterface::TYPE_CHAR,
             TableSchemaInterface::TYPE_STRING,
+            TableSchemaInterface::TYPE_UUID,
         ];
         if (in_array($column['type'], $hasCollate, true) && isset($column['collate']) && $column['collate'] !== '') {
             $out .= ' COLLATE ' . $column['collate'];

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -144,6 +144,9 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         'text' => [
             'collate' => null,
         ],
+        'uuid' => [
+            'collate' => null,
+        ],
         'tinyinteger' => [
             'unsigned' => null,
             'autoIncrement' => null,

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -1168,6 +1168,11 @@ SQL;
             ],
             [
                 'id',
+                ['type' => 'uuid', 'collate' => 'ascii_general_ci'],
+                '`id` CHAR(36) COLLATE ascii_general_ci',
+            ],
+            [
+                'id',
                 ['type' => 'nativeuuid'],
                 '`id` UUID',
             ],


### PR DESCRIPTION
## Summary

- Adds `TYPE_UUID` to the `$hasCollate` array in `MysqlSchemaDialect::columnDefinitionSql()`
- This enables collation support for uuid columns which generate `CHAR(36)` SQL

The uuid type was missing from the `$hasCollate` array, causing column collation settings to be silently ignored. Since uuid columns are represented as `CHAR(36)` in MySQL, they should support collation just like other character types (text, char, string).

This is the proper fix for the issue reported in cakephp/migrations#1020. A workaround has also been proposed in cakephp/migrations#1025.