### PR TITLE
fix MySQL DEFAULT_GENERATED bug in schema reflection

### DIFF
--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Schema;
 
+use Cake\Database\Driver\Mysql;
 use Cake\Database\DriverFeatureEnum;
 use Cake\Database\Exception\DatabaseException;
 use PDOException;
@@ -144,11 +145,15 @@ class MysqlSchemaDialect extends SchemaDialect
                 'comment' => $row['Comment'],
                 'length' => null,
             ];
-            $extra = $row['Extra'] ?? '';
+            $extra = trim($row['Extra'] ?? '');
             if ($extra === 'auto_increment') {
                 $field['autoIncrement'] = true;
             }
-            if ($extra === 'on update CURRENT_TIMESTAMP' || $extra === 'on update current_timestamp()') {
+            // Depending on the MySQL Version the extra column can contain/start with DEFAULT_GENERATED as well
+            if (
+                str_ends_with($extra, 'on update CURRENT_TIMESTAMP') ||
+                str_ends_with($extra, 'on update current_timestamp()')
+            ) {
                 $field['onUpdate'] = 'CURRENT_TIMESTAMP';
             }
 
@@ -225,6 +230,14 @@ class MysqlSchemaDialect extends SchemaDialect
                 "\\1'\\3')",
                 $default,
             );
+        }
+
+        if (
+            $this->_driver instanceof Mysql &&
+            $this->_driver->isMariaDb() &&
+            $default === 'current_timestamp()'
+        ) {
+            return 'CURRENT_TIMESTAMP';
         }
 
         return $default;

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -369,7 +369,7 @@ SQL;
                 config JSON,
                 created DATETIME,
                 created_with_precision DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3),
-                updated DATETIME ON UPDATE CURRENT_TIMESTAMP,
+                updated DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                 KEY `author_idx` (`author_id`),
                 CONSTRAINT `length_idx` UNIQUE KEY(`title`(4)),
                 FOREIGN KEY `author_idx` (`author_id`) REFERENCES `schema_authors`(`id`) ON UPDATE CASCADE ON DELETE RESTRICT,
@@ -541,10 +541,10 @@ SQL;
             'updated' => [
                 'type' => 'datetime',
                 'null' => true,
-                'default' => null,
+                'default' => 'CURRENT_TIMESTAMP',
                 'length' => null,
                 'precision' => null,
-                'comment' => null,
+                'comment' => '',
                 'onUpdate' => 'CURRENT_TIMESTAMP',
             ],
         ];


### PR DESCRIPTION
Refs: https://github.com/cakephp/migrations/pull/1026

This is something that gets automatically added by MySQL 8+ when a datetime column has a `DEFAULT_VALUE` definition like `CURRENT_TIMESTAMP`

and therefore adjusts the `EXTRA` column for schema reflection like so

```
mysql> SHOW FULL COLUMNS FROM table1;
+---------+--------------+-----------+------+-----+-------------------+-----------------------------------------------+---------------------------------+---------+
| Field   | Type         | Collation | Null | Key | Default           | Extra                                         | Privileges                      | Comment |
+---------+--------------+-----------+------+-----+-------------------+-----------------------------------------------+---------------------------------+---------+
| id      | int unsigned | NULL      | NO   | PRI | NULL              | auto_increment                                | select,insert,update,references |         |
| created | datetime     | NULL      | NO   |     | CURRENT_TIMESTAMP | DEFAULT_GENERATED                             | select,insert,update,references |         |
| updated | datetime     | NULL      | NO   |     | CURRENT_TIMESTAMP | DEFAULT_GENERATED on update CURRENT_TIMESTAMP | select,insert,update,references |         |
+---------+--------------+-----------+------+-----+-------------------+-----------------------------------------------+---------------------------------+---------+
```

This means a direct comparisson for the `onUpdate` string will not suffice, therefore I adjusted it to check the end of it.

I think this will always be at the end of the extra definiton, otherwise we can change it to a `str_contains()` as well of course.