### PR TITLE
Cast float column attributes to int for PHP 8.4 compatibility

### DIFF
--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -378,6 +378,15 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             }
             $attrs[$key] = $value;
         }
+
+        // Cast numeric values that may come as floats from database drivers.
+        // PHP 8.4 is stricter about implicit float-to-int conversions.
+        foreach (['length', 'precision', 'srid'] as $key) {
+            if (isset($attrs[$key])) {
+                $attrs[$key] = (int)$attrs[$key];
+            }
+        }
+
         $column = new Column(...$attrs);
 
         $this->_columns[$name] = $column;

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -381,6 +381,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
 
         // Cast numeric values that may come as floats from database drivers.
         // PHP 8.4 is stricter about implicit float-to-int conversions.
+        // Known to affect SQLite on Windows x86.
         foreach (['length', 'precision', 'srid'] as $key) {
             if (isset($attrs[$key])) {
                 $attrs[$key] = (int)$attrs[$key];

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -758,6 +758,27 @@ class TableSchemaTest extends TestCase
     }
 
     /**
+     * Test that float values for length and precision are cast to int.
+     *
+     * Some database drivers return numeric metadata as floats (e.g., SQLite).
+     * PHP 8.4 is stricter about implicit float-to-int conversions, so we need
+     * to explicitly cast these values.
+     */
+    public function testAddColumnWithFloatLengthAndPrecision(): void
+    {
+        $table = new TableSchema('articles');
+        $table->addColumn('amount', [
+            'type' => 'decimal',
+            'length' => 10.0,
+            'precision' => 2.0,
+        ]);
+
+        $column = $table->column('amount');
+        $this->assertSame(10, $column->getLength());
+        $this->assertSame(2, $column->getPrecision());
+    }
+
+    /**
      * Assertion for comparing a regex pattern against a query having its identifiers
      * quoted. It accepts queries quoted with the characters `<` and `>`. If the third
      * parameter is set to true, it will alter the pattern to both accept quoted and


### PR DESCRIPTION
## Summary

- Cast `length`, `precision`, and `srid` column attributes to int in `TableSchema::addColumn()`
- Fixes PHP 8.4 TypeError when database drivers return numeric metadata as floats

## Problem

On PHP 8.4 with DebugKit (which uses SQLite), users encounter:

```
Cake\Database\Schema\Column::__construct(): Argument #5 ($length) must be of type ?int, float given
```

Some database drivers return numeric schema metadata as floats (e.g., `255.0` instead of `255`). PHP 8.4 is stricter about implicit float-to-int conversions, causing the Column constructor to fail.

## Solution

Explicitly cast `length`, `precision`, and `srid` to int before constructing the Column object.

Refs: https://discourse.cakephp.org/t/issue-tableschema/12808/