### PR TITLE
Console UX improvements for help output and third-party integration

### DIFF
--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -33,7 +33,7 @@ use SimpleXMLElement;
 /**
  * Print out command list
  */
-class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
+class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface, CommandHiddenInterface
 {
     /**
      * The command collection to get help on.
@@ -43,11 +43,29 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
     protected CommandCollection $commands;
 
     /**
+     * The header line rendered above command listings.
+     *
+     * @var string|null
+     */
+    protected ?string $headerLine = null;
+
+    /**
      * @inheritDoc
      */
     public function setCommandCollection(CommandCollection $commands): void
     {
         $this->commands = $commands;
+    }
+
+    /**
+     * Set the header line rendered above command listings.
+     *
+     * @param string $headerLine Header text including optional console markup.
+     * @return void
+     */
+    public function setHeaderLine(string $headerLine): void
+    {
+        $this->headerLine = $headerLine;
     }
 
     /**
@@ -143,10 +161,12 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
         }
         sort($commandList);
 
+        $headerLine = $this->getHeaderLine();
+        if ($headerLine !== '') {
+            $io->out($headerLine, 2);
+        }
+
         if ($verbose) {
-            $version = Configure::version();
-            $debug = Configure::read('debug') ? 'true' : 'false';
-            $io->out("<info>CakePHP:</info> {$version} (debug: {$debug})", 2);
             $this->outputPaths($io);
             $this->outputGrouped($io, $invert);
         } else {
@@ -162,6 +182,27 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
         } else {
             $io->out('', 2);
         }
+    }
+
+    /**
+     * Get the help output header line.
+     *
+     * @return string
+     */
+    protected function getHeaderLine(): string
+    {
+        if ($this->headerLine !== null) {
+            return $this->headerLine;
+        }
+
+        $version = Configure::version();
+        if ($version === 'unknown') {
+            return '';
+        }
+
+        $debug = Configure::read('debug') ? 'true' : 'false';
+
+        return "<info>CakePHP:</info> {$version} (debug: {$debug})";
     }
 
     /**
@@ -212,7 +253,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
             $io->out("<info>{$prefix}</info>:");
             sort($names);
             foreach ($names as $data) {
-                $io->out(' - ' . $data['name']);
+                $io->out(' - <comment>' . $data['name'] . '</comment>');
                 if ($data['description']) {
                     $io->info(str_pad(" \u{2514}", 13, "\u{2500}") . ' ' . $data['description']);
                 }
@@ -263,7 +304,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
         foreach ($commands as $data) {
             $maxNameLength = max($maxNameLength, strlen($data['name']));
         }
-        $nameColumnWidth = $maxNameLength + 3;
+        $nameColumnWidth = max($maxNameLength + 5, 17);
 
         // Output single commands under "Available Commands:" header
         $isFirst = true;
@@ -272,7 +313,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
             foreach ($singleCommands as $prefix => $cmd) {
                 $description = $cmd['description'];
                 $padding = str_repeat(' ', $nameColumnWidth - 2 - strlen($prefix));
-                $linePrefix = '  <info>' . $prefix . '</info>' . $padding;
+                $linePrefix = '  <comment>' . $prefix . '</comment>' . $padding;
 
                 if ($description !== '') {
                     $description = strtok($description, "\n");
@@ -296,7 +337,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
                 $description = $cmd['description'];
 
                 $padding = str_repeat(' ', $nameColumnWidth - 2 - strlen($fullName));
-                $linePrefix = '  <info>' . $fullName . '</info>' . $padding;
+                $linePrefix = '  <comment>' . $fullName . '</comment>' . $padding;
 
                 if ($description !== '') {
                     $description = strtok($description, "\n");

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -21,6 +21,7 @@ use Cake\Console\Command\HelpCommand;
 use Cake\Console\Exception\MissingOptionException;
 use Cake\Console\Exception\StopException;
 use Cake\Core\ConsoleApplicationInterface;
+use Cake\Core\ConsoleHelpHeaderProviderInterface;
 use Cake\Core\ContainerApplicationInterface;
 use Cake\Core\EventAwareApplicationInterface;
 use Cake\Core\PluginApplicationInterface;
@@ -262,6 +263,10 @@ class CommandRunner implements EventDispatcherInterface
             $instance = $this->createCommand($instance);
         }
 
+        if ($instance instanceof HelpCommand && $this->app instanceof ConsoleHelpHeaderProviderInterface) {
+            $instance->setHeaderLine($this->app->getConsoleHelpHeader());
+        }
+
         $instance->setName("{$this->root} {$name}");
 
         if ($instance instanceof CommandCollectionAwareInterface) {
@@ -320,7 +325,6 @@ class CommandRunner implements EventDispatcherInterface
     protected function resolveName(CommandCollection $commands, ConsoleIo $io, ?string $name): string
     {
         if (!$name) {
-            $io->error('No command provided. Choose one of the available commands.', 2);
             $name = 'help';
         }
         $name = $this->aliases[$name] ?? $name;

--- a/src/Core/ConsoleHelpHeaderProviderInterface.php
+++ b/src/Core/ConsoleHelpHeaderProviderInterface.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright 2005-2011, Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Core;
+
+/**
+ * Provides a custom header line for console help output.
+ */
+interface ConsoleHelpHeaderProviderInterface
+{
+    /**
+     * Get the header line to render at the top of console help output.
+     *
+     * @return string
+     */
+    public function getConsoleHelpHeader(): string;
+}

--- a/src/Core/ConsoleHelpHeaderProviderInterface.php
+++ b/src/Core/ConsoleHelpHeaderProviderInterface.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         5.3.0
+ * @since         5.4.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Core;

--- a/tests/TestCase/Command/CompletionCommandTest.php
+++ b/tests/TestCase/Command/CompletionCommandTest.php
@@ -80,7 +80,6 @@ class CompletionCommandTest extends TestCase
             'unique',
             'welcome',
             'cache',
-            'help',
             'i18n',
             'plugin',
             'routes',

--- a/tests/TestCase/Console/Command/HelpCommandTest.php
+++ b/tests/TestCase/Console/Command/HelpCommandTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Console\Command;
 
 use Cake\Console\CommandInterface;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -71,8 +72,25 @@ class HelpCommandTest extends TestCase
         $this->assertOutputContains('<comment>cache clear</comment>', 'cache subcommand listed');
         $this->assertOutputContains('Clear all data in a single cache engine', 'inline description shown');
         $this->assertOutputNotContains('<info>app</info>:', 'no plugin group headers in compact mode');
-        $this->assertOutputNotContains('<info>help</info>', 'help command should be hidden');
+        $this->assertOutputNotContains('<comment>help</comment>', 'help command should be hidden');
         $this->assertOutputContains('To run a command', 'more info present');
+    }
+
+    /**
+     * Test that the default header is omitted when Cake version is unknown.
+     */
+    public function testMainCompactOmitsHeaderWhenVersionUnknown(): void
+    {
+        $version = Configure::read('Cake.version');
+        Configure::write('Cake.version', 'unknown');
+
+        try {
+            $this->exec('help');
+            $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+            $this->assertOutputNotContains('<info>CakePHP:</info>', 'header should be omitted when version is unknown');
+        } finally {
+            Configure::write('Cake.version', $version);
+        }
     }
 
     /**

--- a/tests/TestCase/Console/Command/HelpCommandTest.php
+++ b/tests/TestCase/Console/Command/HelpCommandTest.php
@@ -53,6 +53,7 @@ class HelpCommandTest extends TestCase
     {
         $this->exec('help -v');
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+        $this->assertOutputContains('<info>CakePHP:</info>', 'header should appear in verbose mode');
         $this->assertCommandListVerbose();
     }
 
@@ -63,12 +64,14 @@ class HelpCommandTest extends TestCase
     {
         $this->exec('help');
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+        $this->assertOutputContains('<info>CakePHP:</info>', 'header should appear in compact mode');
         $this->assertOutputContains('<info>Available Commands:</info>', 'single commands header');
         $this->assertOutputContains('<info>routes:</info>', 'routes group header');
         $this->assertOutputContains('<info>cache:</info>', 'cache group header');
-        $this->assertOutputContains('clear', 'cache subcommand listed');
+        $this->assertOutputContains('<comment>cache clear</comment>', 'cache subcommand listed');
         $this->assertOutputContains('Clear all data in a single cache engine', 'inline description shown');
         $this->assertOutputNotContains('<info>app</info>:', 'no plugin group headers in compact mode');
+        $this->assertOutputNotContains('<info>help</info>', 'help command should be hidden');
         $this->assertOutputContains('To run a command', 'more info present');
     }
 
@@ -78,7 +81,7 @@ class HelpCommandTest extends TestCase
     protected function assertCommandListVerbose(): void
     {
         $this->assertOutputContains('<info>test_plugin</info>', 'plugin header should appear');
-        $this->assertOutputContains('- sample', 'plugin command should appear');
+        $this->assertOutputContains('<comment>sample</comment>', 'plugin command should appear');
         $this->assertOutputNotContains(
             '- test_plugin.sample',
             'only short alias for plugin command.',
@@ -88,18 +91,18 @@ class HelpCommandTest extends TestCase
             'Abstract command classes should not appear.',
         );
         $this->assertOutputContains('<info>app</info>', 'app header should appear');
-        $this->assertOutputContains('- sample', 'app shell');
+        $this->assertOutputContains('<comment>sample</comment>', 'app shell');
         $this->assertOutputContains('<info>cakephp</info>', 'cakephp header should appear');
-        $this->assertOutputContains('- routes', 'core shell');
-        $this->assertOutputContains('- sample', 'short plugin name');
-        $this->assertOutputContains('- abort', 'command object');
+        $this->assertOutputContains('<comment>routes</comment>', 'core shell');
+        $this->assertOutputContains('<comment>sample</comment>', 'short plugin name');
+        $this->assertOutputContains('<comment>abort</comment>', 'command object');
         $this->assertOutputContains('To run a command', 'more info present');
         $this->assertOutputContains('To get help', 'more info present');
         $this->assertOutputContains('This is a demo command', 'command description missing');
         $this->assertOutputContains('<info>custom_group</info>');
-        $this->assertOutputContains('- grouped');
+        $this->assertOutputContains('<comment>grouped</comment>');
         $this->assertOutputNotContains(
-            '- hidden',
+            '<comment>hidden</comment>',
             'Hidden commands should not appear in help output.',
         );
     }
@@ -112,8 +115,8 @@ class HelpCommandTest extends TestCase
         $this->exec('help cache');
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('<info>cache:</info>');
-        $this->assertOutputContains('cache clear');
-        $this->assertOutputContains('cache list');
+        $this->assertOutputContains('<comment>cache clear</comment>');
+        $this->assertOutputContains('<comment>cache list</comment>');
         $this->assertOutputNotContains('routes');
         $this->assertOutputNotContains('sample');
     }
@@ -126,9 +129,9 @@ class HelpCommandTest extends TestCase
         $this->exec('help cache -v');
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('Available Commands');
-        $this->assertOutputContains('- cache clear');
+        $this->assertOutputContains('<comment>cache clear</comment>');
         $this->assertOutputContains('Clear all data in a single cache engine');
-        $this->assertOutputNotContains('- routes');
+        $this->assertOutputNotContains('<comment>routes</comment>');
     }
 
     /**
@@ -149,6 +152,7 @@ class HelpCommandTest extends TestCase
 
         $find = '<shell name="test_plugin.sample" call_as="test_plugin.sample" provider="TestPlugin\Command\SampleCommand" help="test_plugin.sample -h"';
         $this->assertOutputContains($find);
+        $this->assertOutputNotContains('<shell name="help"', 'help command should be hidden in XML output');
 
         $this->assertOutputNotContains(
             'HiddenCommand',

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -25,6 +25,7 @@ use Cake\Console\CommandRunner;
 use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Core\Configure;
+use Cake\Core\ConsoleHelpHeaderProviderInterface;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerInterface;
 use Cake\Http\BaseApplication;
@@ -196,9 +197,35 @@ class CommandRunnerTest extends TestCase
 
         $this->assertSame(0, $result, 'help output is success.');
         $messages = implode("\n", $output->messages());
-        $this->assertStringContainsString('No command provided. Choose one of the available commands', $messages);
+        $this->assertStringNotContainsString('No command provided. Choose one of the available commands', $messages);
         $this->assertStringContainsString('<info>i18n:</info>', $messages);
         $this->assertStringContainsString('Available Commands:', $messages);
+    }
+
+    /**
+     * Test that apps can provide a custom help header.
+     */
+    public function testRunNoCommandWithCustomHeaderProvider(): void
+    {
+        $app = new class ($this->config) extends BaseApplication implements ConsoleHelpHeaderProviderInterface {
+            public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+            {
+                return $middlewareQueue;
+            }
+
+            public function getConsoleHelpHeader(): string
+            {
+                return '<info>Acme CLI:</info> 1.2.3';
+            }
+        };
+
+        $output = new StubConsoleOutput();
+        $runner = new CommandRunner($app);
+        $result = $runner->run(['cake'], $this->getMockIo($output));
+
+        $this->assertSame(0, $result, 'help output is success.');
+        $messages = implode("\n", $output->messages());
+        $this->assertStringContainsString('<info>Acme CLI:</info> 1.2.3', $messages);
     }
 
     /**

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -207,7 +207,8 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunNoCommandWithCustomHeaderProvider(): void
     {
-        $app = new class ($this->config) extends BaseApplication implements ConsoleHelpHeaderProviderInterface {
+        $app = new class ($this->config) extends BaseApplication implements ConsoleHelpHeaderProviderInterface
+        {
             public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
             {
                 return $middlewareQueue;


### PR DESCRIPTION
This PR improves Console help UX and makes behavior more suitable when the package is embedded in non-CakePHP applications.

### Why this matters for third-party usage
These changes are particularly useful for third-party implementations because help output should reflect the host app, not assume CakePHP context. Without this, users can see misleading framework/version branding and noisier command discovery flow.

### What changed
- Running with no command now doesn't show the  “no command provided” error line. (this was really BAD UX in my book)
- `help` is now hidden from command listings via `CommandHiddenInterface`.
  - Reason: when users are already in help output, listing `help` adds noise and little value; help remains available via the `help` command.
- Added a pluggable header extension point so host apps can provide their own help header:
  - ConsoleHelpHeaderProviderInterface.php
  - wired through CommandRunner.php
- Default CakePHP header in HelpCommand.php now appears only in CakePHP context (known Cake version) and is shown in non verbose mode too. (good UX)
- Improved readability of compact command output in HelpCommand.php:
  - tuned spacing between command and description
  - visual distinction between group headers and command names

### Example: custom Console help header
Implement `ConsoleHelpHeaderProviderInterface` on the application class used by `CommandRunner`:

```php
<?php
declare(strict_types=1);

namespace App;

use Cake\Console\CommandCollection;
use Cake\Core\ConsoleApplicationInterface;
use Cake\Core\ConsoleHelpHeaderProviderInterface;

final class Application implements ConsoleApplicationInterface, ConsoleHelpHeaderProviderInterface
{
    public function bootstrap(): void
    {
        // bootstrap logic
    }

    public function console(CommandCollection $commands): CommandCollection
    {
        return $commands;
    }

    public function getConsoleHelpHeader(): string
    {
        return '<info>Foo Commander:</info> 1.4.0 (env: prod)';
    }
}
```

When this interface is implemented, the custom header is shown in help output instead of the default CakePHP header.

### Examples in a Cake context

<img width="2248" height="1958" alt="image" src="https://github.com/user-attachments/assets/f4b8e66b-bae9-4455-abc5-6a5b95b4d90e" />

<img width="2248" height="1958" alt="image" src="https://github.com/user-attachments/assets/5e2e3be7-45d7-4f5e-9e0a-834d78d63972" />

### Examples in a Custom app context

#### BEFORE:
<img width="1412" height="626" alt="image" src="https://github.com/user-attachments/assets/2e8133ff-7c67-4990-85ca-ff86cd197a77" />

#### AFTER:
<img width="1636" height="920" alt="image" src="https://github.com/user-attachments/assets/d01cefb5-442a-4716-ae6e-db83e90269e9" />
