### PR TITLE
Stabilize TimestampBehavior insert test timing in CI

### DIFF
--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -404,25 +404,31 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testSaveTriggersInsert(): void
     {
-        $table = $this->getTableLocator()->get('users');
-        $table->addBehavior('Timestamp', [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'updated' => 'always',
+        $now = new DateTime('2026-01-01 12:00:00');
+        DateTime::setTestNow($now);
+
+        try {
+            $table = $this->getTableLocator()->get('users');
+            $table->addBehavior('Timestamp', [
+                'events' => [
+                    'Model.beforeSave' => [
+                        'created' => 'new',
+                        'updated' => 'always',
+                    ],
                 ],
-            ],
-        ]);
+            ]);
 
-        $entity = new Entity(['username' => 'timestamp test']);
-        $return = $table->save($entity);
-        $this->assertSame($entity, $return, 'The returned object is expected to be the same entity object');
+            $entity = new Entity(['username' => 'timestamp test']);
+            $return = $table->save($entity);
+            $this->assertSame($entity, $return, 'The returned object is expected to be the same entity object');
 
-        $row = $table->find('all')->where(['id' => $entity->id])->first();
+            $row = $table->find('all')->where(['id' => $entity->id])->first();
 
-        $now = DateTime::now();
-        $this->assertSame($now->toDateTimeString(), $row->created->toDateTimeString());
-        $this->assertSame($now->toDateTimeString(), $row->updated->toDateTimeString());
+            $this->assertSame($now->toDateTimeString(), $row->created->toDateTimeString());
+            $this->assertSame($now->toDateTimeString(), $row->updated->toDateTimeString());
+        } finally {
+            DateTime::setTestNow();
+        }
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -404,6 +404,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testSaveTriggersInsert(): void
     {
+        $previousTestNow = DateTime::getTestNow();
         $now = new DateTime('2026-01-01 12:00:00');
         DateTime::setTestNow($now);
 
@@ -427,7 +428,7 @@ class TimestampBehaviorTest extends TestCase
             $this->assertSame($now->toDateTimeString(), $row->created->toDateTimeString());
             $this->assertSame($now->toDateTimeString(), $row->updated->toDateTimeString());
         } finally {
-            DateTime::setTestNow();
+            DateTime::setTestNow($previousTestNow);
         }
     }
 


### PR DESCRIPTION
This PR fixes a flaky assertion in `TimestampBehaviorTest` that could fail in CI due to 1-second timing drift.

### What changed
- Updated TimestampBehaviorTest.php (`testSaveTriggersInsert`):
  - Freeze current time with `DateTime::setTestNow(...)` before save.
  - Assert `created` and `updated` against that fixed timestamp.
  - Reset test time in `finally` with `DateTime::setTestNow()`.

### Why
The previous test compared DB timestamps to `DateTime::now()` after saving, which can cross a second boundary on slower CI runners and fail intermittently. This makes the test deterministic.