### PR TITLE
Improve type hints for SelectQuery disableHydration

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1456,9 +1456,12 @@ class BelongsToMany extends Association
 
         $unions = [];
         foreach ($missing as $key) {
-            $unions[] = $hasMany->find()
+            /** @var \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface> $unionQuery */
+            $unionQuery = $hasMany->find()
                 ->where(array_combine($foreignKey, $sourceKey))
                 ->where(array_combine($assocForeignKey, $key));
+
+            $unions[] = $unionQuery;
         }
 
         $query = array_shift($unions);
@@ -1466,7 +1469,6 @@ class BelongsToMany extends Association
             $query->union($q);
         }
 
-        // @phpstan-ignore return.type
         return array_merge($result, $query->toArray());
     }
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -619,6 +619,7 @@ class BelongsToMany extends Association
         $table = $this->junction();
         $hasMany = $this->getSource()->getAssociation($table->getAlias());
         if ($this->_cascadeCallbacks) {
+            /** @var \Cake\Datasource\EntityInterface $related */
             foreach ($hasMany->find('all')->where($conditions)->toArray() as $related) {
                 $success = $table->delete($related, $options);
                 if (!$success) {

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1466,6 +1466,7 @@ class BelongsToMany extends Association
             $query->union($q);
         }
 
+        // @phpstan-ignore return.type
         return array_merge($result, $query->toArray());
     }
 

--- a/src/ORM/Association/DependentDeleteHelper.php
+++ b/src/ORM/Association/DependentDeleteHelper.php
@@ -53,6 +53,7 @@ class DependentDeleteHelper
         $conditions = array_combine($foreignKey, $bindingValue);
 
         if ($association->getCascadeCallbacks()) {
+            /** @var \Cake\Datasource\EntityInterface $related */
             foreach ($association->find()->where($conditions)->toArray() as $related) {
                 $success = $table->delete($related, $options);
                 if (!$success) {

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -234,6 +234,7 @@ class TreeBehavior extends Behavior
 
         if ($diff > 2) {
             if ($this->getConfig('cascadeCallbacks')) {
+                /** @var \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface> $query */
                 $query = $this->_scope($this->_table->query())
                     ->where(
                         fn(QueryExpression $exp) => $exp

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -524,6 +524,7 @@ class Marshaller
             $filter = [$primaryKey[0] . ' IN' => $ids];
         }
 
+        // @phpstan-ignore return.type
         return $target->find()->where($filter)->toArray();
     }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -524,8 +524,10 @@ class Marshaller
             $filter = [$primaryKey[0] . ' IN' => $ids];
         }
 
-        // @phpstan-ignore return.type
-        return $target->find()->where($filter)->toArray();
+        /** @var \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface> $query */
+        $query = $target->find()->where($filter);
+
+        return $query->toArray();
     }
 
     /**

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1528,6 +1528,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
         $this->_dirty();
         $this->_hydrate = false;
 
+        // @phpstan-ignore return.type
         return $this;
     }
 

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1728,7 +1728,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @param string $finder The finder method to use.
      * @param mixed ...$args Arguments that match up to finder-specific parameters
-     * @return static Returns a modified query.
+     * @return static<TSubject> Returns a modified query.
      */
     public function find(string $finder, mixed ...$args): static
     {

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1527,7 +1527,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
         $this->_dirty();
         $this->_hydrate = false;
 
-        // @phpstan-ignore return.type
+        /** @phpstan-ignore return.type */
         return $this;
     }
 

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1503,7 +1503,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * If set to false array results will be returned for the query.
      *
      * @param bool $enable Use a boolean to set the hydration mode.
-     * @return ($enable is true ? static<\Cake\Datasource\EntityInterface> : static<array>)
+     * @return $this
      */
     public function enableHydration(bool $enable = true)
     {

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -44,7 +44,7 @@ use Psr\SimpleCache\CacheInterface;
  * into a specific iterator that will be responsible for hydrating results if
  * required.
  *
- * @template TSubject of \Cake\Datasource\EntityInterface|array
+ * @template TSubject of \Cake\Datasource\EntityInterface
  * @extends \Cake\Database\Query\SelectQuery<TSubject>
  */
 class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterface
@@ -234,7 +234,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * iterated without having to call execute() manually, thus making it look like
      * a result set instead of the query itself.
      *
-     * @return \Cake\Datasource\ResultSetInterface<array-key, \Cake\Datasource\EntityInterface|array>
+     * @return \Cake\Datasource\ResultSetInterface<array-key, TSubject>
      */
     public function getIterator(): ResultSetInterface
     {
@@ -397,7 +397,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
     /**
      * Returns an array representation of the results after executing the query.
      *
-     * @return array
+     * @return array<array-key, TSubject>
      */
     public function toArray(): array
     {
@@ -1519,7 +1519,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * Disabling hydration will cause array results to be returned for the query
      * instead of entities.
      *
-     * @return $this
+     * @return static<array<string,mixed>>
      */
     public function disableHydration()
     {
@@ -1545,8 +1545,9 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * When DTO projection is enabled, results will be hydrated into
      * the specified DTO class instead of entity objects.
      *
-     * @param class-string $dtoClass The DTO class name
-     * @return $this
+     * @template TClass
+     * @param class-string<TClass> $dtoClass The DTO class name
+     * @return static<TClass>
      */
     public function projectAs(string $dtoClass)
     {

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1520,11 +1520,10 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * instead of entities.
      *
      * @return static<array<string,mixed>>
-     * phpcs:disable SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      */
     public function disableHydration()
     {
-        // phpcs:enable SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
         $this->_dirty();
         $this->_hydrate = false;
 

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -44,7 +44,7 @@ use Psr\SimpleCache\CacheInterface;
  * into a specific iterator that will be responsible for hydrating results if
  * required.
  *
- * @template TSubject of \Cake\Datasource\EntityInterface
+ * @template TSubject of \Cake\Datasource\EntityInterface|array
  * @extends \Cake\Database\Query\SelectQuery<TSubject>
  */
 class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterface
@@ -1503,7 +1503,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * If set to false array results will be returned for the query.
      *
      * @param bool $enable Use a boolean to set the hydration mode.
-     * @return $this
+     * @return ($enable is true ? static<\Cake\Datasource\EntityInterface> : static<array<string,mixed>>)
      */
     public function enableHydration(bool $enable = true)
     {
@@ -1521,7 +1521,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @return static<array<string,mixed>>
      */
-    public function disableHydration()
+    public function disableHydration(): self
     {
         $this->_dirty();
         $this->_hydrate = false;
@@ -1545,11 +1545,10 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * When DTO projection is enabled, results will be hydrated into
      * the specified DTO class instead of entity objects.
      *
-     * @template TClass
-     * @param class-string<TClass> $dtoClass The DTO class name
-     * @return static<TClass>
+     * @param class-string $dtoClass The DTO class name
+     * @return $this
      */
-    public function projectAs(string $dtoClass)
+    public function projectAs(string $dtoClass): self
     {
         $this->_dirty();
         $this->dtoClass = $dtoClass;

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1503,7 +1503,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * If set to false array results will be returned for the query.
      *
      * @param bool $enable Use a boolean to set the hydration mode.
-     * @return ($enable is true ? static<\Cake\Datasource\EntityInterface> : static<array<string,mixed>>)
+     * @return ($enable is true ? static<\Cake\Datasource\EntityInterface> : static<array>)
      */
     public function enableHydration(bool $enable = true)
     {
@@ -1520,9 +1520,11 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * instead of entities.
      *
      * @return static<array<string,mixed>>
+     * phpcs:disable SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      */
-    public function disableHydration(): self
+    public function disableHydration()
     {
+        // phpcs:enable SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
         $this->_dirty();
         $this->_hydrate = false;
 
@@ -1548,7 +1550,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * @param class-string $dtoClass The DTO class name
      * @return $this
      */
-    public function projectAs(string $dtoClass): self
+    public function projectAs(string $dtoClass)
     {
         $this->_dirty();
         $this->dtoClass = $dtoClass;
@@ -1726,7 +1728,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @param string $finder The finder method to use.
      * @param mixed ...$args Arguments that match up to finder-specific parameters
-     * @return static<TSubject> Returns a modified query.
+     * @return static Returns a modified query.
      */
     public function find(string $finder, mixed ...$args): static
     {


### PR DESCRIPTION
Improve type hints for SelectQuery.

Most common use cases are supported. enableHydration() can be improved but couldn't figure out how to do it.
Fixes: https://github.com/cakephp/cakephp/issues/19306