### PR TITLE
Fix plugin fixtures not finding their table

### DIFF
--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Core\Exception\CakeException;
+use Cake\Core\Plugin;
 use Cake\Database\Connection;
 use Cake\Database\Schema\SqlGeneratorInterface;
 use Cake\Database\Schema\TableSchema;
@@ -164,7 +165,7 @@ class TestFixture implements FixtureInterface
         // Detect plugin namespace pattern: {Plugin}\Test\Fixture\...
         // and prepend plugin name to alias for proper table resolution
         $plugin = strstr(static::class, '\\Test\\Fixture\\', before_needle: true);
-        if ($plugin) {
+        if ($plugin && Plugin::isLoaded($plugin)) {
             return $plugin . '.' . $alias;
         }
 

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -164,8 +164,8 @@ class TestFixture implements FixtureInterface
 
         // Detect plugin namespace pattern: {Plugin}\Test\Fixture\...
         // and prepend plugin name to alias for proper table resolution
-        if (preg_match('/^([^\\\\]+)\\\\Test\\\\Fixture\\\\/', static::class, $nsMatches)) {
-            $plugin = $nsMatches[1];
+        if (str_contains(static::class, '\\Test\\Fixture\\')) {
+            $plugin = explode('\\', static::class)[0];
             if (Plugin::isLoaded($plugin)) {
                 return $plugin . '.' . $alias;
             }

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Core\Exception\CakeException;
+use Cake\Core\Plugin;
 use Cake\Database\Connection;
 use Cake\Database\Schema\SqlGeneratorInterface;
 use Cake\Database\Schema\TableSchema;
@@ -60,7 +61,8 @@ class TestFixture implements FixtureInterface
      *
      * If both table and tableAlias are empty, the alias will be inflected
      * from the class name using tableize() then camelize() to respect
-     * custom Inflector rules.
+     * custom Inflector rules. For plugin fixtures, the plugin name is
+     * automatically prepended (e.g., `MyPlugin.Articles`).
      *
      * @var string
      */
@@ -147,6 +149,9 @@ class TestFixture implements FixtureInterface
      * Uses tableize() then camelize() to respect custom Inflector rules
      * like uninflected words.
      *
+     * For plugin fixtures (namespace pattern `{Plugin}\Test\Fixture\`),
+     * the plugin name is automatically prepended to the alias.
+     *
      * @return string
      */
     protected function _aliasFromClass(): string
@@ -155,7 +160,18 @@ class TestFixture implements FixtureInterface
         preg_match('/^(.*)Fixture$/', $class, $matches);
         $name = $matches[1] ?? $class;
 
-        return Inflector::camelize(Inflector::tableize($name));
+        $alias = Inflector::camelize(Inflector::tableize($name));
+
+        // Detect plugin namespace pattern: {Plugin}\Test\Fixture\...
+        // and prepend plugin name to alias for proper table resolution
+        if (preg_match('/^([^\\\\]+)\\\\Test\\\\Fixture\\\\/', static::class, $nsMatches)) {
+            $plugin = $nsMatches[1];
+            if (Plugin::isLoaded($plugin)) {
+                return $plugin . '.' . $alias;
+            }
+        }
+
+        return $alias;
     }
 
     /**

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -164,11 +164,9 @@ class TestFixture implements FixtureInterface
 
         // Detect plugin namespace pattern: {Plugin}\Test\Fixture\...
         // and prepend plugin name to alias for proper table resolution
-        if (str_contains(static::class, '\\Test\\Fixture\\')) {
-            $plugin = explode('\\', static::class)[0];
-            if (Plugin::isLoaded($plugin)) {
-                return $plugin . '.' . $alias;
-            }
+        $plugin = strstr(static::class, '\\Test\\Fixture\\', before_needle: true) ?: null;
+        if ($plugin && Plugin::isLoaded($plugin)) {
+            return $plugin . '.' . $alias;
         }
 
         return $alias;

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Core\Exception\CakeException;
-use Cake\Core\Plugin;
 use Cake\Database\Connection;
 use Cake\Database\Schema\SqlGeneratorInterface;
 use Cake\Database\Schema\TableSchema;
@@ -164,8 +163,8 @@ class TestFixture implements FixtureInterface
 
         // Detect plugin namespace pattern: {Plugin}\Test\Fixture\...
         // and prepend plugin name to alias for proper table resolution
-        $plugin = strstr(static::class, '\\Test\\Fixture\\', before_needle: true) ?: null;
-        if ($plugin && Plugin::isLoaded($plugin)) {
+        $plugin = strstr(static::class, '\\Test\\Fixture\\', before_needle: true);
+        if ($plugin) {
             return $plugin . '.' . $alias;
         }
 

--- a/tests/TestCase/TestSuite/Fixture/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TestFixtureTest.php
@@ -21,9 +21,23 @@ use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\TestFixture;
 use Cake\TestSuite\TestCase;
+use TestPlugin\Test\Fixture\TestableArticlesFixture;
 
 class TestFixtureTest extends TestCase
 {
+    /**
+     * Test that plugin fixtures automatically get their plugin prefix in the alias.
+     */
+    public function testAliasFromClassWithPlugin(): void
+    {
+        $this->loadPlugins(['TestPlugin']);
+
+        // Plugin fixture class should automatically get plugin prefix in alias
+        $pluginFixture = new TestableArticlesFixture();
+        $this->assertSame('TestPlugin.TestableArticles', $pluginFixture->getAliasFromClass());
+        $this->assertSame('TestPlugin.TestableArticles', $pluginFixture->tableAlias);
+    }
+
     public function testStrictFields(): void
     {
         $fixture = new class extends TestFixture {

--- a/tests/test_app/Plugin/TestPlugin/tests/Fixture/TestableArticlesFixture.php
+++ b/tests/test_app/Plugin/TestPlugin/tests/Fixture/TestableArticlesFixture.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestPlugin\Test\Fixture;
+
+use Cake\Database\Schema\TableSchema;
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Test fixture for verifying plugin alias detection.
+ */
+class TestableArticlesFixture extends TestFixture
+{
+    /**
+     * Skip schema reflection for testing purposes.
+     */
+    protected function _schemaFromReflection(): void
+    {
+        $this->_schema = new TableSchema('articles', []);
+    }
+
+    /**
+     * Expose the protected _aliasFromClass method for testing.
+     */
+    public function getAliasFromClass(): string
+    {
+        return $this->_aliasFromClass();
+    }
+}


### PR DESCRIPTION
## Summary

- Plugin fixtures in namespaces like `MyPlugin\Test\Fixture\ArticlesFixture` now automatically get the plugin prefix in their table alias (e.g., `MyPlugin.Articles`)
- This allows them to properly resolve their Table class when `allowFallbackClass(false)` is enabled
- The fix detects the `{Plugin}\Test\Fixture\` namespace pattern and uses `Plugin::isLoaded()` to verify the namespace corresponds to an actual loaded plugin

Fixes #19304