### PR TITLE
Make template `TRepo` covariant in `LocatorInterface`.

### DIFF
--- a/src/Datasource/Locator/AbstractLocator.php
+++ b/src/Datasource/Locator/AbstractLocator.php
@@ -22,7 +22,7 @@ use Cake\Datasource\RepositoryInterface;
 /**
  * Provides an abstract registry/factory for repository objects.
  *
- * @template TRepo of \Cake\Datasource\RepositoryInterface
+ * @template-covariant TRepo of \Cake\Datasource\RepositoryInterface
  * @implements \Cake\Datasource\Locator\LocatorInterface<TRepo>
  */
 abstract class AbstractLocator implements LocatorInterface

--- a/src/Datasource/Locator/LocatorInterface.php
+++ b/src/Datasource/Locator/LocatorInterface.php
@@ -21,7 +21,7 @@ use Cake\Datasource\RepositoryInterface;
 /**
  * Registries for repository objects should implement this interface.
  *
- * @template TRepo of \Cake\Datasource\RepositoryInterface
+ * @template-covariant TRepo of \Cake\Datasource\RepositoryInterface
  */
 interface LocatorInterface
 {


### PR DESCRIPTION
This resolves `argument.type` error by phpstan for calls like:

`FactoryLocator::add('Table', (new TableLocator())->allowFallbackClass(false));`

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
