### PR TITLE
Make FormHelper::enumOptions() public.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1393,7 +1393,7 @@ class FormHelper extends Helper
      * @param class-string<\BackedEnum> $enumClass Enum class name.
      * @return array<int|string, string>
      */
-    protected function enumOptions(string $enumClass): array
+    public function enumOptions(string $enumClass): array
     {
         assert(is_subclass_of($enumClass, BackedEnum::class));
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3941,6 +3941,37 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * Test enumOptions() returns correct value => label mapping for backed enums.
+     */
+    public function testEnumOptions(): void
+    {
+        // Basic backed enum without EnumLabelInterface - labels from humanized case names
+        $result = $this->Form->enumOptions(ArticleStatus::class);
+        $expected = [
+            'Y' => 'Published',
+            'N' => 'Unpublished',
+        ];
+        $this->assertSame($expected, $result);
+
+        // Enum implementing EnumLabelInterface - labels from label() method
+        $result = $this->Form->enumOptions(ArticleStatusLabelInterface::class);
+        $expected = [
+            'Y' => 'Is Published',
+            'N' => 'Is Unpublished',
+        ];
+        $this->assertSame($expected, $result);
+
+        // Integer-backed enum implementing EnumLabelInterface
+        $result = $this->Form->enumOptions(Priority::class);
+        $expected = [
+            1 => 'Is Low',
+            2 => 'Is Medium',
+            3 => 'Is High',
+        ];
+        $this->assertSame($expected, $result);
+    }
+
+    /**
      * testControlWithNonStandardPrimaryKeyMakesHidden method
      *
      * Test that control() and a non standard primary key makes a hidden input by default.


### PR DESCRIPTION
This allows generating select options when the form is created without context.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
