### PR TITLE
Add CTE strategy for eager loading HasMany/BelongsToMany associations

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -65,6 +65,13 @@ abstract class Association
     public const STRATEGY_SELECT = 'select';
 
     /**
+     * Strategy name to use a CTE for fetching associated records
+     *
+     * @var string
+     */
+    public const STRATEGY_CTE = 'cte';
+
+    /**
      * Association type for one to one associations.
      *
      * @var string

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -130,6 +130,7 @@ class BelongsToMany extends Association
     protected array $_validStrategies = [
         self::STRATEGY_SELECT,
         self::STRATEGY_SUBQUERY,
+        self::STRATEGY_CTE,
     ];
 
     /**

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -69,6 +69,7 @@ class HasMany extends Association
     protected array $_validStrategies = [
         self::STRATEGY_SELECT,
         self::STRATEGY_SUBQUERY,
+        self::STRATEGY_CTE,
     ];
 
     /**

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\ORM\Association\Loader;
 
 use Cake\Database\Exception\DatabaseException;
+use Cake\Database\Expression\CommonTableExpression;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\ExpressionInterface;
@@ -61,7 +62,7 @@ class SelectLoader
     protected array|string $foreignKey;
 
     /**
-     * The strategy to use for loading, either select or subquery
+     * The strategy to use for loading: select, subquery, or cte
      *
      * @var string
      */
@@ -192,6 +193,9 @@ class SelectLoader
         if ($useSubquery) {
             $filter = $this->_buildSubquery($selectQuery);
             $fetchQuery = $this->_addFilteringJoin($fetchQuery, $key, $filter);
+        } elseif ($options['strategy'] === Association::STRATEGY_CTE) {
+            $cteQuery = $this->_buildSubquery($selectQuery);
+            $fetchQuery = $this->_addFilteringCTE($fetchQuery, $key, $cteQuery);
         } else {
             $fetchQuery = $this->_addFilteringCondition($fetchQuery, $key, $filter);
         }
@@ -336,6 +340,83 @@ class SelectLoader
         }
 
         return $query->andWhere($conditions);
+    }
+
+    /**
+     * Appends any conditions required to load the relevant set of records in the
+     * target table query using a Common Table Expression (CTE).
+     *
+     * This strategy is beneficial for large result sets as it:
+     * - Avoids packet size limits from large WHERE IN clauses
+     * - Reduces PHP memory usage by keeping IDs in the database
+     * - Allows the database to optimize the join more effectively
+     *
+     * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array> $query Target table's query
+     * @param array<string>|string $key The fields that should be used for filtering
+     * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array> $cteQuery The CTE query for filtering
+     * @return \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array>
+     */
+    protected function _addFilteringCTE(SelectQuery $query, array|string $key, SelectQuery $cteQuery): SelectQuery
+    {
+        $cteName = '_cte_' . $this->sourceAlias;
+
+        // Preprocess CTE select fields to use IdentifierExpressions (prevents auto-aliasing)
+        // This is similar to what _addFilteringJoin does for subqueries
+        $filter = [];
+        foreach ($cteQuery->clause('select') as $aliasedField => $field) {
+            if (is_int($aliasedField)) {
+                $filter[] = new IdentifierExpression($field);
+            } else {
+                $filter[$aliasedField] = $field;
+            }
+        }
+        $cteQuery->select($filter, true);
+
+        // Build CTE with the source query
+        $cte = new CommonTableExpression($cteName, $cteQuery);
+        $query->with($cte);
+
+        // Build join conditions between target table and CTE
+        $keys = (array)$key;
+        $conditions = $query->expr()->setConjunction('AND');
+
+        foreach ($keys as $i => $keyField) {
+            // Get the corresponding CTE field - same approach as subquery
+            $cteField = $filter[$i] ?? $filter[0];
+            $cteFieldName = $this->_extractFieldName($cteField);
+
+            $conditions->add(
+                $query->expr()->eq(
+                    new IdentifierExpression($keyField),
+                    new IdentifierExpression($cteName . '.' . $cteFieldName),
+                ),
+            );
+        }
+
+        return $query->innerJoin($cteName, $conditions);
+    }
+
+    /**
+     * Extract the field name from a qualified or aliased field reference.
+     *
+     * @param \Cake\Database\ExpressionInterface|string $field The field reference
+     * @return string The extracted field name
+     */
+    protected function _extractFieldName(ExpressionInterface|string $field): string
+    {
+        if ($field instanceof IdentifierExpression) {
+            $field = $field->getIdentifier();
+        } elseif ($field instanceof ExpressionInterface) {
+            // For complex expressions, use a temporary binder to get SQL representation
+            $binder = new ValueBinder();
+
+            return $field->sql($binder);
+        }
+
+        // Handle "Table.field" format
+        $parts = explode('.', (string)$field);
+
+        return end($parts);
     }
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\ORM\Association;
 
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
+use Cake\Database\DriverFeatureEnum;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
@@ -26,6 +27,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\I18n\DateTime;
 use Cake\Log\Log;
+use Cake\ORM\Association;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Association\HasMany;
@@ -198,8 +200,133 @@ class BelongsToManyTest extends TestCase
         $assoc->setStrategy(BelongsToMany::STRATEGY_SUBQUERY);
         $this->assertFalse($assoc->requiresKeys());
 
+        $assoc->setStrategy(Association::STRATEGY_CTE);
+        $this->assertFalse($assoc->requiresKeys());
+
         $assoc->setStrategy(BelongsToMany::STRATEGY_SELECT);
         $this->assertTrue($assoc->requiresKeys());
+    }
+
+    /**
+     * Test the CTE strategy correctly loads associated records through junction table.
+     *
+     * CTE strategy is beneficial for large result sets as it:
+     * - Avoids packet size limits from large WHERE IN clauses
+     * - Reduces PHP memory usage by keeping IDs in the database
+     * - Allows the database to optimize the join more effectively
+     */
+    public function testCTEStrategy(): void
+    {
+        $this->skipIf(
+            !ConnectionManager::get('test')->getDriver()->supports(DriverFeatureEnum::CTE),
+            'Database does not support CTEs',
+        );
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->belongsToMany('Tags');
+        $articles->Tags->setStrategy(Association::STRATEGY_CTE);
+
+        $result = $articles->get(1, ...['contain' => 'Tags']);
+
+        $this->assertNotEmpty($result->tags);
+        $this->assertCount(2, $result->tags);
+        $tagIds = array_column($result->tags, 'id');
+        sort($tagIds);
+        $this->assertSame([1, 2], $tagIds);
+    }
+
+    /**
+     * Test CTE strategy with multiple parent records.
+     */
+    public function testCTEStrategyMultipleParents(): void
+    {
+        $this->skipIf(
+            !ConnectionManager::get('test')->getDriver()->supports(DriverFeatureEnum::CTE),
+            'Database does not support CTEs',
+        );
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->belongsToMany('Tags');
+        $articles->Tags->setStrategy(Association::STRATEGY_CTE);
+
+        $result = $articles->find()
+            ->contain('Tags')
+            ->orderBy(['Articles.id' => 'ASC'])
+            ->toArray();
+
+        // Article 1 has 2 tags (tag1, tag2)
+        $this->assertCount(2, $result[0]->tags);
+        // Article 2 has 2 tags (tag1, tag3)
+        $this->assertCount(2, $result[1]->tags);
+        // Article 3 has 0 tags
+        $this->assertEmpty($result[2]->tags);
+    }
+
+    /**
+     * Test CTE strategy with limit on parent query.
+     */
+    public function testCTEStrategyWithLimit(): void
+    {
+        $this->skipIf(
+            !ConnectionManager::get('test')->getDriver()->supports(DriverFeatureEnum::CTE),
+            'Database does not support CTEs',
+        );
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->belongsToMany('Tags');
+        $articles->Tags->setStrategy(Association::STRATEGY_CTE);
+
+        $result = $articles->find()
+            ->contain('Tags')
+            ->limit(2)
+            ->toArray();
+
+        $this->assertCount(2, $result);
+    }
+
+    /**
+     * Test CTE strategy with conditions on parent query.
+     */
+    public function testCTEStrategyWithConditions(): void
+    {
+        $this->skipIf(
+            !ConnectionManager::get('test')->getDriver()->supports(DriverFeatureEnum::CTE),
+            'Database does not support CTEs',
+        );
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->belongsToMany('Tags');
+        $articles->Tags->setStrategy(Association::STRATEGY_CTE);
+
+        $result = $articles->find()
+            ->contain('Tags')
+            ->where(['Articles.title LIKE' => 'First%'])
+            ->toArray();
+
+        $this->assertCount(1, $result);
+        $this->assertCount(2, $result[0]->tags);
+    }
+
+    /**
+     * Test CTE strategy with conditions on the association through junction table.
+     */
+    public function testCTEStrategyWithJunctionConditions(): void
+    {
+        $this->skipIf(
+            !ConnectionManager::get('test')->getDriver()->supports(DriverFeatureEnum::CTE),
+            'Database does not support CTEs',
+        );
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->belongsToMany('Tags', [
+            'through' => 'SpecialTags',
+            'conditions' => ['SpecialTags.highlighted' => true],
+        ]);
+        $articles->Tags->setStrategy(Association::STRATEGY_CTE);
+
+        $result = $articles->find()
+            ->contain('Tags')
+            ->where(['Articles.id' => 2])
+            ->first();
+
+        // Article 2 has highlighted special_tag for tag1
+        $this->assertCount(1, $result->tags);
+        $this->assertSame('tag1', $result->tags[0]->name);
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -829,6 +829,98 @@ class HasManyTest extends TestCase
     }
 
     /**
+     * Test the CTE strategy correctly loads associated records.
+     *
+     * CTE strategy is beneficial for large result sets as it:
+     * - Avoids packet size limits from large WHERE IN clauses
+     * - Reduces PHP memory usage by keeping IDs in the database
+     * - Allows the database to optimize the join more effectively
+     */
+    public function testCTEStrategy(): void
+    {
+        $Authors = $this->getTableLocator()->get('Authors');
+        $Authors->Articles->setStrategy(Association::STRATEGY_CTE);
+
+        $query = $Authors->find();
+        $result = $query
+            ->contain('Articles')
+            ->where(['Authors.id' => 1])
+            ->first();
+
+        $this->assertNotEmpty($result->articles);
+        $this->assertCount(2, $result->articles);
+        foreach ($result->articles as $article) {
+            $this->assertSame(1, $article->author_id);
+        }
+    }
+
+    /**
+     * Test CTE strategy with multiple parent records.
+     */
+    public function testCTEStrategyMultipleParents(): void
+    {
+        $Authors = $this->getTableLocator()->get('Authors');
+        $Authors->Articles->setStrategy(Association::STRATEGY_CTE);
+
+        $result = $Authors->find()
+            ->contain('Articles')
+            ->orderBy(['Authors.id' => 'ASC'])
+            ->toArray();
+
+        // Author 1 (mariano) has 2 articles
+        $this->assertCount(2, $result[0]->articles);
+        // Author 2 (nate) has 0 articles
+        $this->assertEmpty($result[1]->articles);
+        // Author 3 (larry) has 1 article
+        $this->assertCount(1, $result[2]->articles);
+        // Author 4 (garrett) has 0 articles
+        $this->assertEmpty($result[3]->articles);
+    }
+
+    /**
+     * Test CTE strategy with limit on parent query.
+     */
+    public function testCTEStrategyWithLimit(): void
+    {
+        $Authors = $this->getTableLocator()->get('Authors');
+        $Authors->Articles->setStrategy(Association::STRATEGY_CTE);
+
+        $result = $Authors->find()
+            ->contain('Articles')
+            ->limit(2)
+            ->toArray();
+
+        $this->assertCount(2, $result);
+    }
+
+    /**
+     * Test CTE strategy with conditions on parent query.
+     */
+    public function testCTEStrategyWithConditions(): void
+    {
+        $Authors = $this->getTableLocator()->get('Authors');
+        $Authors->Articles->setStrategy(Association::STRATEGY_CTE);
+
+        $result = $Authors->find()
+            ->contain('Articles')
+            ->where(['Authors.name LIKE' => 'mar%'])
+            ->toArray();
+
+        $this->assertCount(1, $result);
+        $this->assertCount(2, $result[0]->articles);
+    }
+
+    /**
+     * Test that CTE strategy does not require keys from the parent query.
+     */
+    public function testCTEStrategyDoesNotRequireKeys(): void
+    {
+        $assoc = new HasMany('Test');
+        $assoc->setStrategy(HasMany::STRATEGY_CTE);
+        $this->assertFalse($assoc->requiresKeys());
+    }
+
+    /**
      * Assertion method for order by clause contents.
      *
      * @param array $expected The expected join clause.

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\ORM\Association;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Driver\Sqlserver;
+use Cake\Database\DriverFeatureEnum;
 use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
@@ -838,6 +839,10 @@ class HasManyTest extends TestCase
      */
     public function testCTEStrategy(): void
     {
+        $this->skipIf(
+            !ConnectionManager::get('test')->getDriver()->supports(DriverFeatureEnum::CTE),
+            'Database does not support CTEs',
+        );
         $Authors = $this->getTableLocator()->get('Authors');
         $Authors->Articles->setStrategy(Association::STRATEGY_CTE);
 
@@ -859,6 +864,10 @@ class HasManyTest extends TestCase
      */
     public function testCTEStrategyMultipleParents(): void
     {
+        $this->skipIf(
+            !ConnectionManager::get('test')->getDriver()->supports(DriverFeatureEnum::CTE),
+            'Database does not support CTEs',
+        );
         $Authors = $this->getTableLocator()->get('Authors');
         $Authors->Articles->setStrategy(Association::STRATEGY_CTE);
 
@@ -882,6 +891,10 @@ class HasManyTest extends TestCase
      */
     public function testCTEStrategyWithLimit(): void
     {
+        $this->skipIf(
+            !ConnectionManager::get('test')->getDriver()->supports(DriverFeatureEnum::CTE),
+            'Database does not support CTEs',
+        );
         $Authors = $this->getTableLocator()->get('Authors');
         $Authors->Articles->setStrategy(Association::STRATEGY_CTE);
 
@@ -898,6 +911,10 @@ class HasManyTest extends TestCase
      */
     public function testCTEStrategyWithConditions(): void
     {
+        $this->skipIf(
+            !ConnectionManager::get('test')->getDriver()->supports(DriverFeatureEnum::CTE),
+            'Database does not support CTEs',
+        );
         $Authors = $this->getTableLocator()->get('Authors');
         $Authors->Articles->setStrategy(Association::STRATEGY_CTE);
 


### PR DESCRIPTION
## Summary

This PR adds a new `'cte'` strategy for eager loading HasMany and BelongsToMany associations that uses Common Table Expressions instead of `WHERE IN` clauses.

Refs #19107

## Problem

When eager loading with large result sets, the current `select` strategy generates queries like:

```sql
SELECT * FROM articles WHERE author_id IN (1, 2, 3, ... 50000);
```

This has several issues:
- **Packet size limits**: MySQL's `max_allowed_packet` (default 64MB) can be exceeded
- **Parsing overhead**: Database must parse thousands of literal values
- **Memory round-trip**: IDs fetched to PHP → converted to string → sent back to DB → parsed again

## Solution

The new CTE strategy generates:

```sql
WITH _cte_Authors AS (
    SELECT id FROM authors WHERE active = 1
)
SELECT articles.* 
FROM articles
INNER JOIN _cte_Authors ON articles.author_id = _cte_Authors.id;
```

## Performance Comparison (MySQL 8.0)

Benchmark comparing all three eager loading strategies with varying parent record counts:

| Parent Records | Strategy | Time (ms) | Memory (MB) |
|----------------|----------|-----------|-------------|
| 1,000          | select   | 21.88 | 3.33 |
|                | subquery | 14.79 | 0.00 |
|                | cte      | 17.20 | 0.00 |
| 5,000          | select   | 114.48 | 13.33 |
|                | subquery | 105.10 | 0.00 |
|                | cte      | 111.57 | 0.67 |
| 10,000         | select   | 277.05 | 16.67 |
|                | subquery | 234.85 | 0.00 |
|                | cte      | 233.17 | 0.67 |
| 25,000         | select   | 745.30 | 49.33 |
|                | subquery | 591.48 | 0.00 |
|                | cte      | 627.62 | 0.67 |

**Key findings:**
- Both `subquery` and `cte` are faster than `select` for large datasets
- `select` uses significantly more PHP memory (holds all IDs in array)
- At 10K+ records, `subquery` and `cte` perform similarly
- CTE advantage: avoids packet size limits that could hit both `select` and `subquery` with very large ID sets

## Usage

```php
// In Table class
$this->hasMany('Articles', ['strategy' => 'cte']);

// Or at query time
$authors = $this->Authors->find()
    ->contain(['Articles' => ['strategy' => 'cte']])
    ->where(['Authors.active' => true])
    ->all();
```

## When to Use

- Large result sets (1,000+ parent records)
- Complex parent query conditions
- Memory-constrained PHP environments
- High-frequency queries
- Scenarios where `max_allowed_packet` limits are a concern

## Compatibility

CTEs are supported in MySQL 8.0+, PostgreSQL, SQLite 3.8.3+, and SQL Server. CakePHP 5.x already requires modern DB versions with CTE support.