### PR TITLE
Use covariant generic type in FactoryLocator to fix variance issues

### DIFF
--- a/src/Datasource/FactoryLocator.php
+++ b/src/Datasource/FactoryLocator.php
@@ -27,7 +27,7 @@ class FactoryLocator
     /**
      * A list of model factory functions.
      *
-     * @var array<string, \Cake\Datasource\Locator\LocatorInterface<\Cake\Datasource\RepositoryInterface>>
+     * @var array<string, \Cake\Datasource\Locator\LocatorInterface<covariant \Cake\Datasource\RepositoryInterface>>
      */
     protected static array $_modelFactories = [];
 
@@ -35,7 +35,7 @@ class FactoryLocator
      * Register a locator to return repositories of a given type.
      *
      * @param string $type The name of the repository type the factory function is for.
-     * @param \Cake\Datasource\Locator\LocatorInterface<\Cake\Datasource\RepositoryInterface> $factory The factory function used to create instances.
+     * @param \Cake\Datasource\Locator\LocatorInterface<covariant \Cake\Datasource\RepositoryInterface> $factory The factory function used to create instances.
      * @return void
      */
     public static function add(string $type, LocatorInterface $factory): void
@@ -59,7 +59,7 @@ class FactoryLocator
      *
      * @param string $type The repository type to get the factory for.
      * @throws \InvalidArgumentException If the specified repository type has no factory.
-     * @return \Cake\Datasource\Locator\LocatorInterface<\Cake\Datasource\RepositoryInterface> The factory for the repository type.
+     * @return \Cake\Datasource\Locator\LocatorInterface<covariant \Cake\Datasource\RepositoryInterface> The factory for the repository type.
      */
     public static function get(string $type): LocatorInterface
     {

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -71,7 +71,6 @@ class TableRegistry
      */
     public static function setTableLocator(LocatorInterface $tableLocator): void
     {
-        // @phpstan-ignore argument.type (Table extends RepositoryInterface)
         FactoryLocator::add('Table', $tableLocator);
     }
 }

--- a/src/ORM/bootstrap.php
+++ b/src/ORM/bootstrap.php
@@ -18,5 +18,4 @@ declare(strict_types=1);
 use Cake\Datasource\FactoryLocator;
 use Cake\ORM\Locator\TableLocator;
 
-// @phpstan-ignore argument.type (Table extends RepositoryInterface)
 FactoryLocator::add('Table', new TableLocator());


### PR DESCRIPTION
Alternative to https://github.com/cakephp/cakephp/pull/19311

## Summary

- Use `covariant` modifier in FactoryLocator generic type annotations
- This allows downstream projects to call `FactoryLocator::add()` with `TableLocator` without needing `@phpstan-ignore argument.type` annotations
- Remove the now-unnecessary ignore comments from `bootstrap.php` and `TableRegistry.php`

The issue is that `TableLocator` implements `LocatorInterface<Table>`, but `FactoryLocator::add()` expected `LocatorInterface<RepositoryInterface>`. Since generics are invariant by default, this caused PHPStan to report type errors.

The `covariant` modifier tells PHPStan to accept any `LocatorInterface` with a subtype of `RepositoryInterface`.