### PR TITLE
re-add psalm v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
-      PHIVE_KEYS: 'CF1A108D0E7AE720,51C67305FFC2E5C0,12CE0F1D262429A5'
+      PHIVE_KEYS: 'CF1A108D0E7AE720,51C67305FFC2E5C0,12CE0F1D262429A5,99BF4D9A33D65E1E'
       PHPSTAN_TESTS: 1
 
     steps:
@@ -276,6 +276,10 @@ jobs:
       - name: Run phpstan
         if: always()
         run: tools/phpstan analyse --error-format=github
+
+      - name: Run Psalm
+        if: always()
+        run: tools/psalm --output-format=github
 
       - name: Setup phpcs cache
         if: always()
@@ -328,7 +332,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
-      PHIVE_KEYS: 'CF1A108D0E7AE720,51C67305FFC2E5C0,12CE0F1D262429A5'
+      PHIVE_KEYS: 'CF1A108D0E7AE720,51C67305FFC2E5C0,12CE0F1D262429A5,99BF4D9A33D65E1E'
 
     steps:
       - uses: actions/checkout@v6

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
   <phar name="phpstan" version="2.1.45" installed="2.1.45" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="7.0.0-beta19" installed="7.0.0-beta19" location="./tools/psalm" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -124,10 +124,14 @@
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
-        "stan": "tools/phpstan analyse",
+        "stan": [
+            "tools/phpstan analyse",
+            "tools/psalm"
+        ],
         "stan-tests": "tools/phpstan analyze -c tests/phpstan.neon",
         "stan-baseline": "tools/phpstan --generate-baseline",
         "stan-setup": "phive install",
+        "psalm-baseline": "tools/psalm --set-baseline=psalm-baseline.xml",
         "lowest": "validate-prefer-lowest",
         "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json",
         "rector-setup": "cp composer.json composer.backup && composer require --dev rector/rector:\"~2.3.1\" && mv composer.backup composer.json",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="7.0.0-beta15@90bb719c909380be79f7bb788751041f7bc8efb2">
+  <file src="src/Command/PluginLoadCommand.php">
+    <TaintedSSRF>
+      <code><![CDATA[$file]]></code>
+    </TaintedSSRF>
+  </file>
+  <file src="src/Controller/ComponentRegistry.php">
+    <OverriddenMethodAccess>
+      <code><![CDATA[protected function getContainer(): ContainerInterface]]></code>
+      <code><![CDATA[protected function getContainer(): ContainerInterface]]></code>
+      <code><![CDATA[protected function getMode(): int]]></code>
+    </OverriddenMethodAccess>
+  </file>
+  <file src="src/Core/InstanceConfigTrait.php">
+    <UnsupportedPropertyReferenceUsage>
+      <code><![CDATA[$update = &$this->_config]]></code>
+      <code><![CDATA[$update = &$this->_config]]></code>
+    </UnsupportedPropertyReferenceUsage>
+  </file>
+  <file src="src/Core/PluginConfig.php">
+    <TaintedSSRF>
+      <code><![CDATA[$jsonPath]]></code>
+    </TaintedSSRF>
+  </file>
+  <file src="src/Datasource/EntityTrait.php">
+    <UnsupportedPropertyReferenceUsage>
+      <code><![CDATA[$value = &$this->_fields[$field]]]></code>
+    </UnsupportedPropertyReferenceUsage>
+  </file>
+  <file src="src/TestSuite/TestCase.php">
+    <UndefinedVariable>
+      <code><![CDATA[$previousHandler]]></code>
+    </UndefinedVariable>
+  </file>
+</files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="7.0.0-beta15@90bb719c909380be79f7bb788751041f7bc8efb2">
+<files psalm-version="7.0.0-beta17@a7f96f911fc869c40c48ec977e21f01a8ca534bd">
   <file src="src/Command/PluginLoadCommand.php">
     <TaintedSSRF>
       <code><![CDATA[$file]]></code>
@@ -7,9 +7,26 @@
   </file>
   <file src="src/Controller/ComponentRegistry.php">
     <OverriddenMethodAccess>
-      <code><![CDATA[protected function getContainer(): ContainerInterface]]></code>
-      <code><![CDATA[protected function getContainer(): ContainerInterface]]></code>
-      <code><![CDATA[protected function getMode(): int]]></code>
+      <code><![CDATA[protected function getContainer(): ContainerInterface
+    {
+        if ($this->container === null) {
+            throw new CakeException('Container not set.');
+        }
+
+        return $this->container;
+    }]]></code>
+      <code><![CDATA[protected function getContainer(): ContainerInterface
+    {
+        if ($this->container === null) {
+            throw new CakeException('Container not set.');
+        }
+
+        return $this->container;
+    }]]></code>
+      <code><![CDATA[protected function getMode(): int
+    {
+        return ReflectionContainer::AUTO_WIRING;
+    }]]></code>
     </OverriddenMethodAccess>
   </file>
   <file src="src/Core/InstanceConfigTrait.php">

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="7"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    autoloader="tests/bootstrap.php"
+    findUnusedPsalmSuppress="true"
+    findUnusedCode="false"
+    errorBaseline="psalm-baseline.xml"
+>
+    <projectFiles>
+        <directory name="./src"/>
+        <ignoreFiles>
+            <directory name="./vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <MissingOverrideAttribute errorLevel="suppress"/>
+        <MissingPureAnnotation errorLevel="suppress"/>
+        <MissingAbstractPureAnnotation errorLevel="suppress"/>
+        <ImpureFunctionCall errorLevel="suppress"/>
+        <MissingInterfaceImmutableAnnotation errorLevel="suppress"/>
+        <MissingImmutableAnnotation errorLevel="suppress"/>
+        <MissingTemplateParam errorLevel="suppress"/>
+        <MissingFile errorLevel="suppress"/>
+        <UndefinedConstant errorLevel="suppress" />
+        <UndefinedClass errorLevel="suppress" />
+
+        <!-- All the taint -->
+        <TaintedCallable errorLevel="suppress"/>
+        <TaintedFile errorLevel="suppress"/>
+        <TaintedHtml errorLevel="suppress"/>
+    </issueHandlers>
+</psalm>


### PR DESCRIPTION
[Psalm v7](https://psalm.dev/articles/psalm-7-beta) has evolved quite a lot and [a stable public release seems to be around the corner](https://github.com/vimeo/psalm/releases/tag/7.0.0-beta15)

So this is the bare minimum to get level 7 working with a few custom ignores via baseline + a lot of generally ignored errors in the `psalm.xml`

Especially the taint stuff seems to be new/interesting.
[
We previously dropped Psalm v6](https://github.com/cakephp/cakephp/pull/18340) as it deviated from PHPStan more and more, caused more weird issues and was just a pain to maintain. But I think we can give Psalm v7 another try and maybe even get a few goodies out of it (like the taint and mutability-system)