### PR TITLE
Improve Security::encrypt key strength

### DIFF
--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Utility;
 
+use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use Cake\Utility\Crypto\OpenSsl;
 use InvalidArgumentException;
@@ -201,12 +202,13 @@ class Security
         self::_checkKey($key, 'encrypt()');
 
         $hmacSalt ??= static::getSalt();
+
         // Generate the encryption and hmac key.
-        $key = mb_substr(hash('sha256', $key . $hmacSalt), 0, 32, '8bit');
+        [$encryptionKey, $hmacKey] = static::_makeEncryptionKeys($key, $hmacSalt);
 
         $crypto = static::engine();
-        $ciphertext = $crypto->encrypt($plain, $key);
-        $hmac = hash_hmac('sha256', $ciphertext, $key);
+        $ciphertext = $crypto->encrypt($plain, $encryptionKey);
+        $hmac = hash_hmac('sha256', $ciphertext, $hmacKey);
 
         return $hmac . $ciphertext;
     }
@@ -229,6 +231,31 @@ class Security
     }
 
     /**
+     * Generate a key for encryption.
+     *
+     * Encapsulates the two key generation implementations we support.
+     * Raw keys are more secure as they are twice as long.
+     *
+     * @param string $key The bare key to use.
+     * @param string $hmacSalt The hmac salt to use.
+     * @return array{string, string} A list of $encryption, $authentication keys for encryption purposes.
+     */
+    protected static function _makeEncryptionKeys(string $key, string $hmacSalt): array
+    {
+        if (Configure::read('Security.encryptWithRawKey') === true) {
+            $encryption = hash_hkdf('sha256', $key, 32, 'encryption', $hmacSalt);
+            $authentication = hash_hkdf('sha256', $key, 32, 'authentication', $hmacSalt);
+
+            return [$encryption, $authentication];
+        }
+
+        $hashKey = mb_substr(hash('sha256', $key . $hmacSalt), 0, 32, '8bit');
+
+        // The old implementation both keys were the same.
+        return [$hashKey, $hashKey];
+    }
+
+    /**
      * Decrypt a value using AES-256.
      *
      * @param string $cipher The ciphertext to decrypt.
@@ -247,21 +274,21 @@ class Security
         $hmacSalt ??= static::getSalt();
 
         // Generate the encryption and hmac key.
-        $key = mb_substr(hash('sha256', $key . $hmacSalt), 0, 32, '8bit');
+        [$encryptionKey, $hmacKey] = static::_makeEncryptionKeys($key, $hmacSalt);
 
         // Split out hmac for comparison
         $macSize = 64;
         $hmac = mb_substr($cipher, 0, $macSize, '8bit');
         $cipher = mb_substr($cipher, $macSize, null, '8bit');
 
-        $compareHmac = hash_hmac('sha256', $cipher, $key);
+        $compareHmac = hash_hmac('sha256', $cipher, $hmacKey);
         if (!static::constantEquals($hmac, $compareHmac)) {
             return null;
         }
 
         $crypto = static::engine();
 
-        return $crypto->decrypt($cipher, $key);
+        return $crypto->decrypt($cipher, $encryptionKey);
     }
 
     /**

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -231,14 +231,18 @@ class Security
     }
 
     /**
-     * Generate a key for encryption.
+     * Generate a key pair of encryption and authentication tokens.
      *
      * Encapsulates the two key generation implementations we support.
-     * Raw keys are more secure as they are twice as long.
+     * The previous implementation has a keyspace reduction weakness.
+     *
+     * It is recommended to enable `Security.encryptWithRawKey` in new applications,
+     * to take advantage of longer keys that are longer and have derived encryption
+     * and authentication keys.
      *
      * @param string $key The bare key to use.
      * @param string $hmacSalt The hmac salt to use.
-     * @return array{string, string} A list of $encryption, $authentication keys for encryption purposes.
+     * @return array{string, string} A list of $encryption, $authentication keys intended for encrypt() and decrypt().
      */
     protected static function _makeEncryptionKeys(string $key, string $hmacSalt): array
     {

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Utility;
 
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Crypto\OpenSsl;
 use Cake\Utility\Security;
@@ -104,6 +105,33 @@ class SecurityTest extends TestCase
         $this->assertNotEquals($txt, $result, 'Should be encrypted.');
         $this->assertNotEquals($result, Security::encrypt($txt, $key), 'Each result is unique.');
         $this->assertSame($txt, Security::decrypt($result, $key));
+    }
+
+    /**
+     * Test encrypt/decrypt with raw key feature.
+     *
+     * Raw keys give results that are more quantum resistant.
+     */
+    public function testEncryptDecryptRawKey(): void
+    {
+        Configure::write('Security.encryptWithRawKey', true);
+
+        $txt = 'The quick brown fox';
+        $key = 'This key is longer than 32 bytes long.';
+        $result = Security::encrypt($txt, $key);
+        $this->assertNotEquals($txt, $result, 'Should be encrypted.');
+        $this->assertNotEquals($result, Security::encrypt($txt, $key), 'Each result is unique.');
+        $this->assertSame($txt, Security::decrypt($result, $key));
+
+        Configure::write('Security.encryptWithRawKey', false);
+
+        $oldKeyResult = Security::encrypt($txt, $key);
+        $this->assertNotEquals($txt, $oldKeyResult, 'Should be encrypted.');
+        $this->assertSame($txt, Security::decrypt($oldKeyResult, $key));
+        $this->assertNull(
+            Security::decrypt($result, $key),
+            'value encrypted with new key cannot be decrypted with old',
+        );
     }
 
     /**


### PR DESCRIPTION
Thank you to 'Pigeondrops' who contacted us through the security mailing list about a weakness in the `Security::encrypt()` key handling.

> This is likely a low severity since AES-128-CBC is still not fully
> deprecated (the reference will make sense later in this report I know in
> code AES-256-CBC is being used). But Post-quantum guidance (due to
> grover's algorithm
> https://postquantum.com/post-quantum/grovers-algorithm/) and generally
> in financial sector, CNSA 2.0 is moving away from AES-128-cbc.

The problem with the current implementation is that the keys are converted to a hexadecimal string and then truncated. Because each byte requires 2 characters in hexadecimal representation this halves the entropy in the key. With the `Security.encryptWithRawKey` configure value is enabled, encrypted values will use a full 32 bytes, and furthermore will use key derivation with separate encryption and authentication keys.
