### PR TITLE
Simplify makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,16 +167,6 @@ components: $(foreach component, $(COMPONENTS), component-$(component))
 components-tag: $(foreach component, $(COMPONENTS), tag-component-$(component))
 .PHONY: components-tag
 
-# Generate split components for the 'next_branch' if defined.
-components-next:
-	if [ "$(NEXT_BRANCH)" = '' ]; then \
-		echo "Cannot update component repos for next branch, NEXT_BRANCH is not set"; \
-		exit 0; \
-	fi;
-	make CURRENT_BRANCH=$(NEXT_BRANCH) components
-	make clean-components-branches
-.PHONY: components-next
-
 component-%:
 	git checkout $(CURRENT_BRANCH) > /dev/null
 	- (git remote add pkg-$* git@github.com:$(OWNER)/$*.git -f 2> /dev/null)
@@ -210,5 +200,5 @@ clean-component-%:
 .PHONY: components-clean
 
 # Top level alias for doing a release.
-release: guard-VERSION tag-release components-tag package publish components-next
+release: guard-VERSION tag-release components-tag package publish
 .PHONY: release


### PR DESCRIPTION
With the github workflow to update split packages in #19324 we don't need these make targets anymore.
 
