### PR TITLE
6.x: encourage constructor property promotion

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\Config\RectorConfig;
+use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
 use Rector\Set\ValueObject\SetList;
 
 $cacheDir = getenv('RECTOR_CACHE_DIR') ?: sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'rector';
@@ -92,7 +93,6 @@ return RectorConfig::configure()
         \Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector::class,
         \Rector\Php73\Rector\String_\SensitiveHereNowDocRector::class,
         \Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector::class,
-        \Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector::class,
         \Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector::class,
         \Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class,
         \Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector::class,

--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -52,13 +52,6 @@ class MapReduce implements IteratorAggregate
     protected bool $executed = false;
 
     /**
-     * Holds the original data that needs to be processed
-     *
-     * @var iterable
-     */
-    protected iterable $data;
-
-    /**
      * A callable that will be executed for each record in the original data
      *
      * @var callable
@@ -115,9 +108,11 @@ class MapReduce implements IteratorAggregate
      * of the bucket that was created during the mapping phase and third one is an
      * instance of this class.
      */
-    public function __construct(iterable $data, callable $mapper, ?callable $reducer = null)
-    {
-        $this->data = $data;
+    public function __construct(
+        protected iterable $data,
+        callable $mapper,
+        ?callable $reducer = null,
+    ) {
         $this->mapper = $mapper;
         $this->reducer = $reducer;
     }

--- a/src/Collection/Iterator/TreePrinter.php
+++ b/src/Collection/Iterator/TreePrinter.php
@@ -57,13 +57,6 @@ class TreePrinter extends RecursiveIteratorIterator implements CollectionInterfa
     protected mixed $current = null;
 
     /**
-     * The string to use for prefixing the values according to their depth in the tree.
-     *
-     * @var string
-     */
-    protected string $spacer;
-
-    /**
      * Constructor
      *
      * @param \RecursiveIterator<mixed, mixed> $items The iterator to flatten.
@@ -80,13 +73,12 @@ class TreePrinter extends RecursiveIteratorIterator implements CollectionInterfa
         RecursiveIterator $items,
         callable|string $valuePath,
         callable|string $keyPath,
-        string $spacer,
+        protected string $spacer,
         int $mode = RecursiveIteratorIterator::SELF_FIRST,
     ) {
         parent::__construct($items, $mode);
         $this->value = $this->propertyExtractor($valuePath);
         $this->key = $this->propertyExtractor($keyPath);
-        $this->spacer = $spacer;
     }
 
     /**

--- a/src/Console/Arguments.php
+++ b/src/Console/Arguments.php
@@ -25,27 +25,6 @@ use Cake\Console\Exception\ConsoleException;
 class Arguments
 {
     /**
-     * Positional argument name map
-     *
-     * @var array<int, string>
-     */
-    protected array $argNames;
-
-    /**
-     * Positional arguments.
-     *
-     * @var array<int, array<string>|string>
-     */
-    protected array $args;
-
-    /**
-     * Named options
-     *
-     * @var array<string, array<string>|string|bool|null>
-     */
-    protected array $options;
-
-    /**
      * Constructor
      *
      * @param array<int, array<string>|string> $args Positional arguments
@@ -53,11 +32,11 @@ class Arguments
      * @param array<int, string> $argNames List of argument names. Order is expected to be
      *  the same as $args.
      */
-    public function __construct(array $args, array $options, array $argNames)
-    {
-        $this->args = $args;
-        $this->options = $options;
-        $this->argNames = $argNames;
+    public function __construct(
+        protected array $args,
+        protected array $options,
+        protected array $argNames,
+    ) {
     }
 
     /**

--- a/src/Console/CommandFactory.php
+++ b/src/Console/CommandFactory.php
@@ -25,18 +25,12 @@ use Cake\Core\ContainerInterface;
 class CommandFactory implements CommandFactoryInterface
 {
     /**
-     * @var \Cake\Core\ContainerInterface|null
-     */
-    protected ?ContainerInterface $container = null;
-
-    /**
      * Constructor
      *
      * @param \Cake\Core\ContainerInterface|null $container The container to use if available.
      */
-    public function __construct(?ContainerInterface $container = null)
+    public function __construct(protected ?ContainerInterface $container = null)
     {
-        $this->container = $container;
     }
 
     /**

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -46,27 +46,6 @@ class CommandRunner implements EventDispatcherInterface
     use EventDispatcherTrait;
 
     /**
-     * The application console commands are being run for.
-     *
-     * @var \Cake\Core\ConsoleApplicationInterface
-     */
-    protected ConsoleApplicationInterface $app;
-
-    /**
-     * The application console commands are being run for.
-     *
-     * @var \Cake\Console\CommandFactoryInterface|null
-     */
-    protected ?CommandFactoryInterface $factory = null;
-
-    /**
-     * The root command name. Defaults to `cake`.
-     *
-     * @var string
-     */
-    protected string $root;
-
-    /**
      * Alias mappings.
      *
      * @var array<string, string>
@@ -83,17 +62,14 @@ class CommandRunner implements EventDispatcherInterface
      * Constructor
      *
      * @param \Cake\Core\ConsoleApplicationInterface $app The application to run CLI commands for.
-     * @param string $root The root command name to be removed from argv.
+     * @param string $root The root command name to be removed from argv. Defaults to `cake`.
      * @param \Cake\Console\CommandFactoryInterface|null $factory Command factory instance.
      */
     public function __construct(
-        ConsoleApplicationInterface $app,
-        string $root = 'cake',
-        ?CommandFactoryInterface $factory = null,
+        protected ConsoleApplicationInterface $app,
+        protected string $root = 'cake',
+        protected ?CommandFactoryInterface $factory = null,
     ) {
-        $this->app = $app;
-        $this->root = $root;
-        $this->factory = $factory;
     }
 
     /**

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -28,48 +28,6 @@ use SimpleXMLElement;
 class ConsoleInputArgument
 {
     /**
-     * Name of the argument.
-     *
-     * @var string
-     */
-    protected string $name;
-
-    /**
-     * Help string
-     *
-     * @var string
-     */
-    protected string $help;
-
-    /**
-     * Is this option required?
-     *
-     * @var bool
-     */
-    protected bool $required;
-
-    /**
-     * An array of valid choices for this argument.
-     *
-     * @var array<string>
-     */
-    protected array $choices;
-
-    /**
-     * Default value for this argument.
-     *
-     * @var string|null
-     */
-    protected ?string $default = null;
-
-    /**
-     * The multiple separator.
-     *
-     * @var string|null
-     */
-    protected ?string $separator = null;
-
-    /**
      * Make a new Input Argument
      *
      * @param string $name The long name of the option.
@@ -81,20 +39,13 @@ class ConsoleInputArgument
      * @throws \Cake\Console\Exception\ConsoleException When the separator contains spaces.
      */
     public function __construct(
-        string $name,
-        string $help = '',
-        bool $required = false,
-        array $choices = [],
-        ?string $default = null,
-        ?string $separator = null,
+        protected string $name,
+        protected string $help = '',
+        protected bool $required = false,
+        protected array $choices = [],
+        protected ?string $default = null,
+        protected ?string $separator = null,
     ) {
-        $this->name = $name;
-        $this->help = $help;
-        $this->required = $required;
-        $this->choices = $choices;
-        $this->default = $default;
-        $this->separator = $separator;
-
         if ($this->separator !== null && str_contains($this->separator, ' ')) {
             throw new ConsoleException(
                 sprintf(

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -28,34 +28,6 @@ use SimpleXMLElement;
 class ConsoleInputOption
 {
     /**
-     * Name of the option
-     *
-     * @var string
-     */
-    protected string $name;
-
-    /**
-     * Short (1 character) alias for the option.
-     *
-     * @var string
-     */
-    protected string $short;
-
-    /**
-     * Help text for the option.
-     *
-     * @var string
-     */
-    protected string $help;
-
-    /**
-     * Is the option a boolean option. Boolean options do not consume a parameter.
-     *
-     * @var bool
-     */
-    protected bool $boolean;
-
-    /**
      * Default value for the option
      *
      * @var string|bool|null
@@ -63,47 +35,12 @@ class ConsoleInputOption
     protected string|bool|null $default = null;
 
     /**
-     * Can the option accept multiple value definition.
-     *
-     * @var bool
-     */
-    protected bool $multiple;
-
-    /**
-     * An array of choices for the option.
-     *
-     * @var array<string>
-     */
-    protected array $choices;
-
-    /**
-     * The prompt string
-     *
-     * @var string|null
-     */
-    protected ?string $prompt = null;
-
-    /**
-     * Is the option required.
-     *
-     * @var bool
-     */
-    protected bool $required;
-
-    /**
-     * The multiple separator.
-     *
-     * @var string|null
-     */
-    protected ?string $separator = null;
-
-    /**
      * Make a new Input Option
      *
      * @param string $name The long name of the option, or an array with all the properties.
-     * @param string $short The short alias for this option
+     * @param string $short The short (1 character) alias for this option
      * @param string $help The help text for this option
-     * @param bool $isBoolean Whether this option is a boolean option. Boolean options don't consume extra tokens
+     * @param bool $boolean Whether this option is a boolean option. Boolean options don't consume extra tokens
      * @param string|bool|null $default The default value for this option.
      * @param array<string> $choices Valid choices for this option.
      * @param bool $multiple Whether this option can accept multiple value definition.
@@ -112,28 +49,18 @@ class ConsoleInputOption
      * @throws \Cake\Console\Exception\ConsoleException
      */
     public function __construct(
-        string $name,
-        string $short = '',
-        string $help = '',
-        bool $isBoolean = false,
+        protected string $name,
+        protected string $short = '',
+        protected string $help = '',
+        protected bool $boolean = false,
         string|bool|null $default = null,
-        array $choices = [],
-        bool $multiple = false,
-        bool $required = false,
-        ?string $prompt = null,
-        ?string $separator = null,
+        protected array $choices = [],
+        protected bool $multiple = false,
+        protected bool $required = false,
+        protected ?string $prompt = null,
+        protected ?string $separator = null,
     ) {
-        $this->name = $name;
-        $this->short = $short;
-        $this->help = $help;
-        $this->boolean = $isBoolean;
-        $this->choices = $choices;
-        $this->multiple = $multiple;
-        $this->required = $required;
-        $this->prompt = $prompt;
-        $this->separator = $separator;
-
-        if ($isBoolean) {
+        if ($this->boolean) {
             $this->default = (bool)$default;
         } elseif ($default !== null) {
             $this->default = (string)$default;

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -407,7 +407,7 @@ class ConsoleOptionParser
             );
         }
         $this->options[$name] = $option;
-        asort($this->options);
+        ksort($this->options);
         if ($option->short()) {
             if (isset($this->shortOptions[$option->short()])) {
                 throw new LogicException(sprintf(
@@ -418,7 +418,7 @@ class ConsoleOptionParser
             }
 
             $this->shortOptions[$option->short()] = $name;
-            asort($this->shortOptions);
+            ksort($this->shortOptions);
         }
 
         return $this;

--- a/src/Console/Exception/MissingOptionException.php
+++ b/src/Console/Exception/MissingOptionException.php
@@ -23,20 +23,6 @@ use Throwable;
 class MissingOptionException extends ConsoleException
 {
     /**
-     * The requested thing that was not found.
-     *
-     * @var string
-     */
-    protected string $requested = '';
-
-    /**
-     * The valid suggestions.
-     *
-     * @var array<string>
-     */
-    protected array $suggestions = [];
-
-    /**
      * Constructor.
      *
      * @param string $message The string message.
@@ -47,13 +33,11 @@ class MissingOptionException extends ConsoleException
      */
     public function __construct(
         string $message,
-        string $requested = '',
-        array $suggestions = [],
+        protected string $requested = '',
+        protected array $suggestions = [],
         ?int $code = null,
         ?Throwable $previous = null,
     ) {
-        $this->suggestions = $suggestions;
-        $this->requested = $requested;
         parent::__construct($message, $code, $previous);
     }
 

--- a/src/Console/HelpFormatter.php
+++ b/src/Console/HelpFormatter.php
@@ -45,13 +45,6 @@ class HelpFormatter
     protected int $maxOptions = 6;
 
     /**
-     * Option parser.
-     *
-     * @var \Cake\Console\ConsoleOptionParser
-     */
-    protected ConsoleOptionParser $parser;
-
-    /**
      * Alias to display in the output.
      *
      * @var string
@@ -63,9 +56,8 @@ class HelpFormatter
      *
      * @param \Cake\Console\ConsoleOptionParser $parser The option parser help is being generated for.
      */
-    public function __construct(ConsoleOptionParser $parser)
+    public function __construct(protected ConsoleOptionParser $parser)
     {
-        $this->parser = $parser;
     }
 
     /**

--- a/src/Console/Helper.php
+++ b/src/Console/Helper.php
@@ -37,21 +37,15 @@ abstract class Helper
     protected array $defaultConfig = [];
 
     /**
-     * ConsoleIo instance.
-     *
-     * @var \Cake\Console\ConsoleIoInterface
-     */
-    protected ConsoleIoInterface $io;
-
-    /**
      * Constructor.
      *
      * @param \Cake\Console\ConsoleIoInterface $io The ConsoleIo instance to use.
      * @param array<string, mixed> $config The settings for this helper.
      */
-    public function __construct(ConsoleIoInterface $io, array $config = [])
-    {
-        $this->io = $io;
+    public function __construct(
+        protected ConsoleIoInterface $io,
+        array $config = [],
+    ) {
         $this->setConfig($config);
     }
 

--- a/src/Console/TestSuite/Constraint/ContentsBase.php
+++ b/src/Console/TestSuite/Constraint/ContentsBase.php
@@ -30,19 +30,13 @@ abstract class ContentsBase extends Constraint
     protected string $contents;
 
     /**
-     * @var string
-     */
-    protected string $output;
-
-    /**
      * Constructor
      *
      * @param array<string> $contents Contents
      * @param string $output Output type
      */
-    public function __construct(array $contents, string $output)
+    public function __construct(array $contents, protected string $output)
     {
         $this->contents = implode(PHP_EOL, $contents);
-        $this->output = $output;
     }
 }

--- a/src/Console/TestSuite/Constraint/ExitCode.php
+++ b/src/Console/TestSuite/Constraint/ExitCode.php
@@ -25,32 +25,14 @@ use PHPUnit\Framework\Constraint\Constraint;
 class ExitCode extends Constraint
 {
     /**
-     * @var int|null
-     */
-    private ?int $exitCode = null;
-
-    /**
-     * @var array
-     */
-    private array $out = [];
-
-    /**
-     * @var array
-     */
-    private array $err = [];
-
-    /**
      * Constructor
      *
      * @param int|null $exitCode Exit code
      * @param array $out stdout stream
      * @param array $err stderr stream
      */
-    public function __construct(?int $exitCode, array $out, array $err)
+    public function __construct(private ?int $exitCode, private array $out, private array $err)
     {
-        $this->exitCode = $exitCode;
-        $this->out = $out;
-        $this->err = $err;
     }
 
     /**

--- a/src/Console/TestSuite/StubConsoleInput.php
+++ b/src/Console/TestSuite/StubConsoleInput.php
@@ -27,13 +27,6 @@ use NumberFormatter;
 class StubConsoleInput extends ConsoleInput
 {
     /**
-     * Reply values for ask() and askChoice()
-     *
-     * @var array<string>
-     */
-    protected array $replies = [];
-
-    /**
      * Current message index
      *
      * @var int
@@ -43,13 +36,10 @@ class StubConsoleInput extends ConsoleInput
     /**
      * Constructor
      *
-     * @param array<string> $replies A list of replies for read()
+     * @param array<string> $replies Reply values for ask() and askChoice()
      */
-    public function __construct(array $replies)
+    public function __construct(protected array $replies)
     {
-        // Don't call parent on purpose as it opens php://stdin which doesn't
-        // always exist in RunInSeparateProcess tests.
-        $this->replies = $replies;
         $this->canReadline = false;
     }
 

--- a/src/Container/Argument/DefaultValueArgument.php
+++ b/src/Container/Argument/DefaultValueArgument.php
@@ -5,15 +5,12 @@ namespace Cake\Container\Argument;
 
 class DefaultValueArgument extends ResolvableArgument implements DefaultValueInterface
 {
-    protected mixed $defaultValue;
-
     /**
      * @param string $value
      * @param mixed|null $defaultValue
      */
-    public function __construct(string $value, mixed $defaultValue = null)
+    public function __construct(string $value, protected mixed $defaultValue = null)
     {
-        $this->defaultValue = $defaultValue;
         parent::__construct($value);
     }
 

--- a/src/Container/Argument/ResolvableArgument.php
+++ b/src/Container/Argument/ResolvableArgument.php
@@ -5,14 +5,11 @@ namespace Cake\Container\Argument;
 
 class ResolvableArgument implements ResolvableArgumentInterface
 {
-    protected string $value;
-
     /**
      * @param string $value
      */
-    public function __construct(string $value)
+    public function __construct(protected string $value)
     {
-        $this->value = $value;
     }
 
     /**

--- a/src/Container/Inflector/Inflector.php
+++ b/src/Container/Inflector/Inflector.php
@@ -13,11 +13,6 @@ class Inflector implements ArgumentResolverInterface, InflectorInterface
     use ContainerAwareTrait;
 
     /**
-     * @var string
-     */
-    protected string $type;
-
-    /**
      * @var callable|null
      */
     protected $callback;
@@ -36,9 +31,8 @@ class Inflector implements ArgumentResolverInterface, InflectorInterface
      * @param string $type
      * @param callable|null $callback
      */
-    public function __construct(string $type, ?callable $callback = null)
+    public function __construct(protected string $type, ?callable $callback = null)
     {
-        $this->type = $type;
         $this->callback = $callback;
     }
 

--- a/src/Container/ReflectionContainer.php
+++ b/src/Container/ReflectionContainer.php
@@ -18,11 +18,6 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
     use ContainerAwareTrait;
 
     /**
-     * @var bool
-     */
-    protected bool $cacheResolutions;
-
-    /**
      * @var array
      */
     protected array $cache = [];
@@ -30,9 +25,8 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
     /**
      * @param bool $cacheResolutions
      */
-    public function __construct(bool $cacheResolutions = false)
+    public function __construct(protected bool $cacheResolutions = false)
     {
-        $this->cacheResolutions = $cacheResolutions;
     }
 
     /**

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -64,13 +64,6 @@ class Component implements EventListenerInterface
     use LogTrait;
 
     /**
-     * Component registry class used to lazy load components.
-     *
-     * @var \Cake\Controller\ComponentRegistry<\Cake\Controller\Controller>
-     */
-    protected ComponentRegistry $registry;
-
-    /**
      * Other Components this component uses.
      *
      * @var array
@@ -100,14 +93,14 @@ class Component implements EventListenerInterface
      *  this component can use to lazy load its components.
      * @param array<string, mixed> $config Array of configuration settings.
      */
-    public function __construct(ComponentRegistry $registry, array $config = [])
-    {
-        $this->registry = $registry;
-
+    public function __construct(
+        protected ComponentRegistry $registry,
+        array $config = [],
+    ) {
         $this->setConfig($config);
 
         if ($this->components) {
-            $this->components = $registry->normalizeArray($this->components);
+            $this->components = $this->registry->normalizeArray($this->components);
         }
         $this->initialize($config);
     }

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -63,22 +63,16 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
     protected ?Controller $Controller = null;
 
     /**
-     * @var \Cake\Core\ContainerInterface|null
-     */
-    protected ?ContainerInterface $container = null;
-
-    /**
      * Constructor.
      *
      * @param \Cake\Controller\Controller|null $controller Controller instance.
      * @param \Cake\Core\ContainerInterface|null $container Container instance.
      */
-    public function __construct(?Controller $controller = null, ?ContainerInterface $container = null)
+    public function __construct(?Controller $controller = null, protected ?ContainerInterface $container = null)
     {
         if ($controller !== null) {
             $this->setController($controller);
         }
-        $this->container = $container;
     }
 
     /**

--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -45,11 +45,6 @@ use function Cake\Core\toInt;
 class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInterface
 {
     /**
-     * @var \Cake\Core\ContainerInterface
-     */
-    protected ContainerInterface $container;
-
-    /**
      * @var \Cake\Controller\Controller
      */
     protected Controller $controller;
@@ -59,9 +54,8 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
      *
      * @param \Cake\Core\ContainerInterface $container The container to build controllers with.
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(protected ContainerInterface $container)
     {
-        $this->container = $container;
     }
 
     /**

--- a/src/Core/Configure/Engine/IniConfig.php
+++ b/src/Core/Configure/Engine/IniConfig.php
@@ -66,24 +66,17 @@ class IniConfig implements ConfigEngineInterface
     protected string $extension = '.ini';
 
     /**
-     * The section to read, if null all sections will be read.
-     *
-     * @var string|null
-     */
-    protected ?string $section = null;
-
-    /**
      * Build and construct a new ini file parser. The parser can be used to read
      * ini files that are on the filesystem.
      *
      * @param string|null $path Path to load ini config files from. Defaults to CONFIG.
-     * @param string|null $section Only get one section, leave null to parse and fetch
-     *     all sections in the ini file.
+     * @param string|null $section The section to read, if null all sections will be read.
      */
-    public function __construct(?string $path = null, ?string $section = null)
-    {
+    public function __construct(
+        ?string $path = null,
+        protected ?string $section = null,
+    ) {
         $this->path = $path ?? CONFIG;
-        $this->section = $section;
     }
 
     /**

--- a/src/Core/Retry/CommandRetry.php
+++ b/src/Core/Retry/CommandRetry.php
@@ -28,18 +28,6 @@ use Exception;
 class CommandRetry
 {
     /**
-     * The strategy to follow should the executed action fail.
-     *
-     * @var \Cake\Core\Retry\RetryStrategyInterface
-     */
-    protected RetryStrategyInterface $strategy;
-
-    /**
-     * @var int
-     */
-    protected int $maxRetries;
-
-    /**
      * @var int
      */
     protected int $numRetries;
@@ -50,10 +38,10 @@ class CommandRetry
      * @param \Cake\Core\Retry\RetryStrategyInterface $strategy The strategy to follow should the action fail
      * @param int $maxRetries The maximum number of retry attempts allowed
      */
-    public function __construct(RetryStrategyInterface $strategy, int $maxRetries = 1)
-    {
-        $this->strategy = $strategy;
-        $this->maxRetries = $maxRetries;
+    public function __construct(
+        protected RetryStrategyInterface $strategy,
+        protected int $maxRetries = 1,
+    ) {
     }
 
     /**

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -45,13 +45,6 @@ use function Cake\Core\env;
 class Connection implements ConnectionInterface
 {
     /**
-     * Contains the configuration params for this connection.
-     *
-     * @var array<string, mixed>
-     */
-    protected array $config;
-
-    /**
      * @var \Cake\Database\Driver
      */
     protected Driver $readDriver;
@@ -119,14 +112,16 @@ class Connection implements ConnectionInterface
      *    If set to a string it will be used as the name of cache config to use.
      * - `cacheKeyPrefix` Custom prefix to use when generation cache keys. Defaults to connection name.
      *
-     * @param array<string, mixed> $config Configuration array.
+     * @param array<string, mixed> $config Contains the configuration params for this connection.
      * @throws \Cake\Database\Exception\MissingDriverException when the driver class cannot be found
      * @throws \Cake\Database\Exception\MissingExtensionException when the database extension is not enabled
      */
-    public function __construct(array $config)
+    public function __construct(protected array $config)
     {
-        $this->config = $config;
-        [self::ROLE_READ => $this->readDriver, self::ROLE_WRITE => $this->writeDriver] = $this->createDrivers($config);
+        [
+            self::ROLE_READ => $this->readDriver,
+            self::ROLE_WRITE => $this->writeDriver,
+        ] = $this->createDrivers($this->config);
     }
 
     /**

--- a/src/Database/Expression/CastExpression.php
+++ b/src/Database/Expression/CastExpression.php
@@ -33,20 +33,6 @@ class CastExpression implements ExpressionInterface, TypedResultInterface
     use TypedResultTrait;
 
     /**
-     * The value to be cast
-     *
-     * @var \Cake\Database\ExpressionInterface|string
-     */
-    protected ExpressionInterface|string $value;
-
-    /**
-     * The target SQL data type
-     *
-     * @var string
-     */
-    protected string $type;
-
-    /**
      * Constructor
      *
      * @param \Cake\Database\ExpressionInterface|string $value The value or expression to cast
@@ -54,12 +40,10 @@ class CastExpression implements ExpressionInterface, TypedResultInterface
      * @param string $returnType The abstract return type. Defaults to 'string'.
      */
     public function __construct(
-        ExpressionInterface|string $value,
-        string $type,
+        protected ExpressionInterface|string $value,
+        protected string $type,
         string $returnType = 'string',
     ) {
-        $this->value = $value;
-        $this->type = $type;
         $this->returnType = $returnType;
     }
 

--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -43,20 +43,6 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface, Typed
     protected mixed $value;
 
     /**
-     * The type to be used for casting the value to a database representation
-     *
-     * @var string|null
-     */
-    protected ?string $type = null;
-
-    /**
-     * The operator used for comparing field and value
-     *
-     * @var string
-     */
-    protected string $operator = '=';
-
-    /**
      * Whether the value in this expression is a traversable
      *
      * @var bool
@@ -76,19 +62,17 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface, Typed
      *
      * @param \Cake\Database\ExpressionInterface|string $field the field name to compare to a value
      * @param mixed $value The value to be used in comparison
-     * @param string|null $type the type name used to cast the value
+     * @param string|null $type the type name used to cast the value to a database representation
      * @param string $operator the operator used for comparing field and value
      */
     public function __construct(
         ExpressionInterface|string $field,
         mixed $value,
-        ?string $type = null,
-        string $operator = '=',
+        protected ?string $type = null,
+        protected string $operator = '=',
     ) {
-        $this->type = $type;
         $this->setField($field);
         $this->setValue($value);
-        $this->operator = $operator;
         $this->returnType = 'boolean';
     }
 

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -35,13 +35,6 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
     use TypedResultTrait;
 
     /**
-     * The name of the function to be constructed when generating the SQL string
-     *
-     * @var string
-     */
-    protected string $name;
-
-    /**
      * Constructor. Takes a name for the function to be invoked and a list of params
      * to be passed into the function. Optionally you can pass a list of types to
      * be used for each bound param.
@@ -59,16 +52,19 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
      *
      * Will produce `CONCAT(name, ' rules')`
      *
-     * @param string $name the name of the function to be constructed
+     * @param string $name the name of the function to be constructed when generating the SQL string
      * @param array $params list of arguments to be passed to the function
      * If associative the key would be used as argument when value is 'literal'
      * @param array<string, string>|array<string|null> $types Associative array of types to be associated with the
      * passed arguments
      * @param string $returnType The return type of this expression
      */
-    public function __construct(string $name, array $params = [], array $types = [], string $returnType = 'string')
-    {
-        $this->name = $name;
+    public function __construct(
+        protected string $name,
+        array $params = [],
+        array $types = [],
+        string $returnType = 'string',
+    ) {
         $this->returnType = $returnType;
         parent::__construct($params, $types, ',');
     }

--- a/src/Database/Expression/IdentifierExpression.php
+++ b/src/Database/Expression/IdentifierExpression.php
@@ -31,27 +31,15 @@ use Closure;
 class IdentifierExpression implements ExpressionInterface
 {
     /**
-     * Holds the identifier string
-     *
-     * @var string
-     */
-    protected string $identifier;
-
-    /**
-     * @var string|null
-     */
-    protected ?string $collation = null;
-
-    /**
      * Constructor
      *
      * @param string $identifier The identifier this expression represents
      * @param string|null $collation The identifier collation
      */
-    public function __construct(string $identifier, ?string $collation = null)
-    {
-        $this->identifier = $identifier;
-        $this->collation = $collation;
+    public function __construct(
+        protected string $identifier,
+        protected ?string $collation = null,
+    ) {
     }
 
     /**

--- a/src/Database/Expression/StringExpression.php
+++ b/src/Database/Expression/StringExpression.php
@@ -30,23 +30,11 @@ class StringExpression implements ExpressionInterface, TypedResultInterface
     use TypedResultTrait;
 
     /**
-     * @var string
-     */
-    protected string $string;
-
-    /**
-     * @var string
-     */
-    protected string $collation;
-
-    /**
      * @param string $string String value
      * @param string $collation String collation
      */
-    public function __construct(string $string, string $collation)
+    public function __construct(protected string $string, protected string $collation)
     {
-        $this->string = $string;
-        $this->collation = $collation;
     }
 
     /**

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -28,13 +28,6 @@ use InvalidArgumentException;
 class TupleComparison extends ComparisonExpression
 {
     /**
-     * The type to be used for casting the value to a database representation
-     *
-     * @var array<string|null>
-     */
-    protected array $types;
-
-    /**
      * Constructor
      *
      * @param \Cake\Database\ExpressionInterface|array|string $fields the fields to use to form a tuple
@@ -46,10 +39,9 @@ class TupleComparison extends ComparisonExpression
     public function __construct(
         ExpressionInterface|array|string $fields,
         ExpressionInterface|array $values,
-        array $types = [],
+        protected array $types = [],
         string $conjunction = '=',
     ) {
-        $this->types = $types;
         $this->setField($fields);
         $this->operator = $conjunction;
         $this->setValue($values);

--- a/src/Database/Expression/UnaryExpression.php
+++ b/src/Database/Expression/UnaryExpression.php
@@ -40,38 +40,17 @@ class UnaryExpression implements ExpressionInterface
     public const int POSTFIX = 1;
 
     /**
-     * The operator this unary expression represents
-     *
-     * @var string
-     */
-    protected string $operator;
-
-    /**
-     * Holds the value which the unary expression operates
-     *
-     * @var mixed
-     */
-    protected mixed $value;
-
-    /**
-     * Where to place the operator
-     *
-     * @var int
-     */
-    protected int $position;
-
-    /**
      * Constructor
      *
-     * @param string $operator The operator to used for the expression
-     * @param mixed $value the value to use as the operand for the expression
+     * @param string $operator The operator this unary expression represents
+     * @param mixed $value Holds the value which the unary expression operates
      * @param int $position either UnaryExpression::PREFIX or UnaryExpression::POSTFIX
      */
-    public function __construct(string $operator, mixed $value, int $position = self::PREFIX)
-    {
-        $this->operator = $operator;
-        $this->value = $value;
-        $this->position = $position;
+    public function __construct(
+        protected string $operator,
+        protected mixed $value,
+        protected int $position = self::PREFIX,
+    ) {
     }
 
     /**

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -44,13 +44,6 @@ class ValuesExpression implements ExpressionInterface
     protected array $values = [];
 
     /**
-     * List of columns to ensure are part of the insert.
-     *
-     * @var array
-     */
-    protected array $columns = [];
-
-    /**
      * The Query object to use as a values expression
      *
      * @var \Cake\Database\Query|null
@@ -71,9 +64,10 @@ class ValuesExpression implements ExpressionInterface
      * @param array $columns The list of columns that are going to be part of the values.
      * @param \Cake\Database\TypeMap $typeMap A dictionary of column -> type names
      */
-    public function __construct(array $columns, TypeMap $typeMap)
-    {
-        $this->columns = $columns;
+    public function __construct(
+        protected array $columns,
+        TypeMap $typeMap,
+    ) {
         $this->setTypeMap($typeMap);
     }
 

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -28,11 +28,6 @@ use Cake\Database\Type\OptionalConvertInterface;
 class FieldTypeConverter
 {
     /**
-     * @var \Cake\Database\Driver
-     */
-    protected Driver $driver;
-
-    /**
      * Maps type names to conversion settings.
      *
      * @var array
@@ -45,10 +40,8 @@ class FieldTypeConverter
      * @param \Cake\Database\TypeMap $typeMap Contains the types to use for converting results
      * @param \Cake\Database\Driver $driver The driver to use for the type conversion
      */
-    public function __construct(TypeMap $typeMap, Driver $driver)
+    public function __construct(TypeMap $typeMap, protected Driver $driver)
     {
-        $this->driver = $driver;
-
         $types = TypeFactory::buildAll();
         foreach ($typeMap->toArray() as $field => $typeName) {
             $type = $types[$typeName] ?? null;

--- a/src/Database/Retry/ErrorCodeWaitStrategy.php
+++ b/src/Database/Retry/ErrorCodeWaitStrategy.php
@@ -28,23 +28,11 @@ use PDOException;
 class ErrorCodeWaitStrategy implements RetryStrategyInterface
 {
     /**
-     * @var array<int>
-     */
-    protected array $errorCodes;
-
-    /**
-     * @var int
-     */
-    protected int $retryInterval;
-
-    /**
      * @param array<int> $errorCodes DB-specific error codes that allow retrying
      * @param int $retryInterval Seconds to wait before allowing next retry, 0 for no wait.
      */
-    public function __construct(array $errorCodes, int $retryInterval)
+    public function __construct(protected array $errorCodes, protected int $retryInterval)
     {
-        $this->errorCodes = $errorCodes;
-        $this->retryInterval = $retryInterval;
     }
 
     /**

--- a/src/Database/Retry/ReconnectStrategy.php
+++ b/src/Database/Retry/ReconnectStrategy.php
@@ -53,22 +53,14 @@ class ReconnectStrategy implements RetryStrategyInterface
     ];
 
     /**
-     * The connection to check for validity
-     *
-     * @var \Cake\Database\Connection
-     */
-    protected Connection $connection;
-
-    /**
      * Creates the ReconnectStrategy object by storing a reference to the
      * passed connection. This reference will be used to automatically
      * reconnect to the server in case of failure.
      *
-     * @param \Cake\Database\Connection $connection The connection to check
+     * @param \Cake\Database\Connection $connection The connection to check for validity
      */
-    public function __construct(Connection $connection)
+    public function __construct(protected Connection $connection)
     {
-        $this->connection = $connection;
     }
 
     /**

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -24,38 +24,17 @@ use Psr\SimpleCache\CacheInterface;
 class CachedCollection implements CollectionInterface
 {
     /**
-     * Cacher instance.
-     *
-     * @var \Psr\SimpleCache\CacheInterface
-     */
-    protected CacheInterface $cacher;
-
-    /**
-     * The decorated schema collection
-     *
-     * @var \Cake\Database\Schema\CollectionInterface
-     */
-    protected CollectionInterface $collection;
-
-    /**
-     * The cache key prefix
-     *
-     * @var string
-     */
-    protected string $prefix;
-
-    /**
      * Constructor.
      *
-     * @param \Cake\Database\Schema\CollectionInterface $collection The collection to wrap.
+     * @param \Cake\Database\Schema\CollectionInterface $collection The decorated schema collection to wrap.
      * @param string $prefix The cache key prefix to use. Typically the connection name.
      * @param \Psr\SimpleCache\CacheInterface $cacher Cacher instance.
      */
-    public function __construct(CollectionInterface $collection, string $prefix, CacheInterface $cacher)
-    {
-        $this->collection = $collection;
-        $this->prefix = $prefix;
-        $this->cacher = $cacher;
+    public function __construct(
+        protected CollectionInterface $collection,
+        protected string $prefix,
+        protected CacheInterface $cacher,
+    ) {
     }
 
     /**

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -29,13 +29,6 @@ use Cake\Database\Connection;
 class Collection implements CollectionInterface
 {
     /**
-     * Connection object
-     *
-     * @var \Cake\Database\Connection
-     */
-    protected Connection $connection;
-
-    /**
      * Schema dialect instance.
      *
      * @var \Cake\Database\Schema\SchemaDialect|null
@@ -47,9 +40,8 @@ class Collection implements CollectionInterface
      *
      * @param \Cake\Database\Connection $connection The connection instance.
      */
-    public function __construct(Connection $connection)
+    public function __construct(protected Connection $connection)
     {
-        $this->connection = $connection;
     }
 
     /**

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -131,13 +131,6 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     public const string ACTION_SET_DEFAULT = ForeignKey::SET_DEFAULT;
 
     /**
-     * The name of the table
-     *
-     * @var string
-     */
-    protected string $table;
-
-    /**
      * Columns in the table.
      *
      * @var array<string, \Cake\Database\Schema\Column>
@@ -340,9 +333,10 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      * @param string $table The table name.
      * @param array<string, array|string> $columns The list of columns for the schema.
      */
-    public function __construct(string $table, array $columns = [])
-    {
-        $this->table = $table;
+    public function __construct(
+        protected string $table,
+        array $columns = [],
+    ) {
         foreach ($columns as $field => $definition) {
             $this->addColumn($field, $definition);
         }

--- a/src/Database/Statement/Statement.php
+++ b/src/Database/Statement/Statement.php
@@ -37,11 +37,6 @@ class Statement implements StatementInterface
     ];
 
     /**
-     * @var \Cake\Database\Driver
-     */
-    protected Driver $driver;
-
-    /**
      * Cached bound parameters used for logging
      *
      * @var array<mixed>
@@ -55,10 +50,9 @@ class Statement implements StatementInterface
      */
     public function __construct(
         protected PDOStatement $statement,
-        Driver $driver,
+        protected Driver $driver,
         protected array $resultDecorators = [],
     ) {
-        $this->driver = $driver;
     }
 
     /**

--- a/src/Database/Type/BaseType.php
+++ b/src/Database/Type/BaseType.php
@@ -26,20 +26,12 @@ use PDO;
 abstract class BaseType implements TypeInterface
 {
     /**
-     * Identifier name for this type
-     *
-     * @var string|null
-     */
-    protected ?string $name = null;
-
-    /**
      * Constructor
      *
      * @param string|null $name The name identifying this type
      */
-    public function __construct(?string $name = null)
+    public function __construct(protected ?string $name = null)
     {
-        $this->name = $name;
     }
 
     /**

--- a/src/Database/Type/EnumType.php
+++ b/src/Database/Type/EnumType.php
@@ -43,29 +43,21 @@ class EnumType extends BaseType
     protected string $backingType;
 
     /**
-     * The enum classname which is associated to the type instance
-     *
-     * @var class-string<\BackedEnum>
-     */
-    protected string $enumClassName;
-
-    /**
      * @param string $name The name identifying this type
      * @param class-string<\BackedEnum> $enumClassName The associated enum class name
      */
     public function __construct(
         string $name,
-        string $enumClassName,
+        protected string $enumClassName,
     ) {
         parent::__construct($name);
-        $this->enumClassName = $enumClassName;
 
         try {
-            $reflectionEnum = new ReflectionEnum($enumClassName);
+            $reflectionEnum = new ReflectionEnum($this->enumClassName);
         } catch (ReflectionException $e) {
             throw new DatabaseException(sprintf(
                 'Unable to use `%s` for type `%s`. %s.',
-                $enumClassName,
+                $this->enumClassName,
                 $name,
                 $e->getMessage(),
             ));
@@ -74,7 +66,7 @@ class EnumType extends BaseType
         $namedType = $reflectionEnum->getBackingType();
         if ($namedType === null) {
             throw new DatabaseException(
-                sprintf('Unable to use enum `%s` for type `%s`, must be a backed enum.', $enumClassName, $name),
+                sprintf('Unable to use enum `%s` for type `%s`, must be a backed enum.', $this->enumClassName, $name),
             );
         }
 

--- a/src/Datasource/Paging/PaginatedResultSet.php
+++ b/src/Datasource/Paging/PaginatedResultSet.php
@@ -37,23 +37,14 @@ class PaginatedResultSet implements JsonSerializable, PaginatedInterface
     protected Traversable $results;
 
     /**
-     * Paging params.
-     *
-     * @var array
-     */
-    protected array $params = [];
-
-    /**
      * Constructor
      *
      * @param iterable<TKey, TValue> $results Resultset instance.
      * @param array $params Paging params.
      */
-    public function __construct(iterable $results, array $params)
+    public function __construct(iterable $results, protected array $params)
     {
         $this->results = is_array($results) ? new ArrayIterator($results) : $results;
-
-        $this->params = $params;
 
         if (!isset($this->params['count']) && is_countable($results)) {
             $this->params['count'] = count($results);

--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -33,29 +33,15 @@ use Traversable;
 class QueryCacher
 {
     /**
-     * The key or function to generate a key.
-     *
-     * @var \Closure|string
-     */
-    protected Closure|string $key;
-
-    /**
-     * Config for cache engine.
-     *
-     * @var \Psr\SimpleCache\CacheInterface|string
-     */
-    protected CacheInterface|string $config;
-
-    /**
      * Constructor.
      *
      * @param \Closure|string $key The key or function to generate a key.
      * @param \Psr\SimpleCache\CacheInterface|string $config The cache config name or cache engine instance.
      */
-    public function __construct(Closure|string $key, CacheInterface|string $config)
-    {
-        $this->key = $key;
-        $this->config = $config;
+    public function __construct(
+        protected Closure|string $key,
+        protected CacheInterface|string $config,
+    ) {
     }
 
     /**

--- a/src/Datasource/RuleInvoker.php
+++ b/src/Datasource/RuleInvoker.php
@@ -30,20 +30,6 @@ use Closure;
 class RuleInvoker
 {
     /**
-     * The rule name
-     *
-     * @var string|null
-     */
-    protected ?string $name = null;
-
-    /**
-     * Rule options
-     *
-     * @var array<string, mixed>
-     */
-    protected array $options = [];
-
-    /**
      * Rule callable
      *
      * @var callable
@@ -66,11 +52,12 @@ class RuleInvoker
      * @param string|null $name The name of the rule. Used in error messages.
      * @param array<string, mixed> $options The options for the rule. See above.
      */
-    public function __construct(callable $rule, ?string $name, array $options = [])
-    {
+    public function __construct(
+        callable $rule,
+        protected ?string $name,
+        protected array $options = [],
+    ) {
         $this->rule = $rule;
-        $this->name = $name;
-        $this->options = $options;
     }
 
     /**

--- a/src/Datasource/RulesChecker.php
+++ b/src/Datasource/RulesChecker.php
@@ -92,13 +92,6 @@ class RulesChecker
     protected array $deleteRules = [];
 
     /**
-     * List of options to pass to every callable rule
-     *
-     * @var array
-     */
-    protected array $options = [];
-
-    /**
      * Whether to use I18n functions for translating default error messages
      *
      * @var bool
@@ -110,9 +103,8 @@ class RulesChecker
      *
      * @param array<string, mixed> $options The options to pass to every rule
      */
-    public function __construct(array $options = [])
+    public function __construct(protected array $options = [])
     {
-        $this->options = $options;
         $this->useI18n = function_exists('\Cake\I18n\__d');
     }
 

--- a/src/Error/Debug/ArrayItemNode.php
+++ b/src/Error/Debug/ArrayItemNode.php
@@ -22,25 +22,13 @@ namespace Cake\Error\Debug;
 class ArrayItemNode implements NodeInterface
 {
     /**
-     * @var \Cake\Error\Debug\NodeInterface
-     */
-    private NodeInterface $key;
-
-    /**
-     * @var \Cake\Error\Debug\NodeInterface
-     */
-    private NodeInterface $value;
-
-    /**
      * Constructor
      *
      * @param \Cake\Error\Debug\NodeInterface $key The node for the item key
      * @param \Cake\Error\Debug\NodeInterface $value The node for the array value
      */
-    public function __construct(NodeInterface $key, NodeInterface $value)
+    public function __construct(private NodeInterface $key, private NodeInterface $value)
     {
-        $this->key = $key;
-        $this->value = $value;
     }
 
     /**

--- a/src/Error/Debug/ClassNode.php
+++ b/src/Error/Debug/ClassNode.php
@@ -22,16 +22,6 @@ namespace Cake\Error\Debug;
 class ClassNode implements NodeInterface
 {
     /**
-     * @var string
-     */
-    private string $class;
-
-    /**
-     * @var int
-     */
-    private int $id;
-
-    /**
      * @var array<\Cake\Error\Debug\PropertyNode>
      */
     private array $properties = [];
@@ -42,10 +32,8 @@ class ClassNode implements NodeInterface
      * @param string $class The class name
      * @param int $id The reference id of this object in the DumpContext
      */
-    public function __construct(string $class, int $id)
+    public function __construct(private string $class, private int $id)
     {
-        $this->class = $class;
-        $this->id = $id;
     }
 
     /**

--- a/src/Error/Debug/DebugContext.php
+++ b/src/Error/Debug/DebugContext.php
@@ -31,11 +31,6 @@ class DebugContext
     /**
      * @var int
      */
-    private int $maxDepth = 0;
-
-    /**
-     * @var int
-     */
     private int $depth = 0;
 
     /**
@@ -48,9 +43,8 @@ class DebugContext
      *
      * @param int $maxDepth The desired depth of dump output.
      */
-    public function __construct(int $maxDepth)
+    public function __construct(private int $maxDepth)
     {
-        $this->maxDepth = $maxDepth;
         $this->refs = new SplObjectStorage();
     }
 

--- a/src/Error/Debug/PropertyNode.php
+++ b/src/Error/Debug/PropertyNode.php
@@ -22,32 +22,14 @@ namespace Cake\Error\Debug;
 class PropertyNode implements NodeInterface
 {
     /**
-     * @var string
-     */
-    private string $name;
-
-    /**
-     * @var string|null
-     */
-    private ?string $visibility = null;
-
-    /**
-     * @var \Cake\Error\Debug\NodeInterface
-     */
-    private NodeInterface $value;
-
-    /**
      * Constructor
      *
      * @param string $name The property name
      * @param string|null $visibility The visibility of the property.
      * @param \Cake\Error\Debug\NodeInterface $value The property value node.
      */
-    public function __construct(string $name, ?string $visibility, NodeInterface $value)
+    public function __construct(private string $name, private ?string $visibility, private NodeInterface $value)
     {
-        $this->name = $name;
-        $this->visibility = $visibility;
-        $this->value = $value;
     }
 
     /**

--- a/src/Error/Debug/ReferenceNode.php
+++ b/src/Error/Debug/ReferenceNode.php
@@ -26,25 +26,13 @@ namespace Cake\Error\Debug;
 class ReferenceNode implements NodeInterface
 {
     /**
-     * @var string
-     */
-    private string $class;
-
-    /**
-     * @var int
-     */
-    private int $id;
-
-    /**
      * Constructor
      *
      * @param string $class The class name
      * @param int $id The id of the referenced class.
      */
-    public function __construct(string $class, int $id)
+    public function __construct(private string $class, private int $id)
     {
-        $this->class = $class;
-        $this->id = $id;
     }
 
     /**

--- a/src/Error/Debug/ScalarNode.php
+++ b/src/Error/Debug/ScalarNode.php
@@ -22,25 +22,13 @@ namespace Cake\Error\Debug;
 class ScalarNode implements NodeInterface
 {
     /**
-     * @var string
-     */
-    private string $type;
-
-    /**
-     * @var resource|string|float|int|bool|null
-     */
-    private $value;
-
-    /**
      * Constructor
      *
      * @param string $type The type of scalar value.
      * @param resource|string|float|int|bool|null $value The wrapped value.
      */
-    public function __construct(string $type, $value)
+    public function __construct(private string $type, private $value)
     {
-        $this->type = $type;
-        $this->value = $value;
     }
 
     /**

--- a/src/Error/Debug/SpecialNode.php
+++ b/src/Error/Debug/SpecialNode.php
@@ -22,18 +22,12 @@ namespace Cake\Error\Debug;
 class SpecialNode implements NodeInterface
 {
     /**
-     * @var string
-     */
-    private string $value;
-
-    /**
      * Constructor
      *
      * @param string $value The message/value to include in dump results.
      */
-    public function __construct(string $value)
+    public function __construct(private string $value)
     {
-        $this->value = $value;
     }
 
     /**

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -74,21 +74,14 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
     protected ?ExceptionTrap $exceptionTrap = null;
 
     /**
-     * @var \Cake\Routing\RoutingApplicationInterface|null
-     */
-    protected ?RoutingApplicationInterface $app = null;
-
-    /**
      * Constructor
      *
      * @param \Cake\Error\ExceptionTrap|array $config The error handler instance
      *  or config array.
      * @param \Cake\Routing\RoutingApplicationInterface|null $app Application instance.
      */
-    public function __construct(ExceptionTrap|array $config = [], ?RoutingApplicationInterface $app = null)
+    public function __construct(ExceptionTrap|array $config = [], protected ?RoutingApplicationInterface $app = null)
     {
-        $this->app = $app;
-
         if (Configure::read('debug')) {
             ini_set('zend.exception_ignore_args', '0');
         }

--- a/src/Error/PhpError.php
+++ b/src/Error/PhpError.php
@@ -22,33 +22,6 @@ namespace Cake\Error;
 class PhpError
 {
     /**
-     * @var int
-     */
-    private int $code;
-
-    /**
-     * @var string
-     */
-    private string $message;
-
-    /**
-     * @var string|null
-     */
-    private ?string $file;
-
-    /**
-     * @var int|null
-     */
-    private ?int $line;
-
-    /**
-     * Stack trace data. Each item should have a `reference`, `file` and `line` keys.
-     *
-     * @var array<array<string, int>>
-     */
-    private array $trace;
-
-    /**
      * @var array<int, string>
      */
     private array $levelMap = [
@@ -84,20 +57,15 @@ class PhpError
      * @param string $message The error message.
      * @param string|null $file The filename of the error.
      * @param int|null $line The line number for the error.
-     * @param array $trace The backtrace for the error.
+     * @param array $trace Stack trace data. Each item should have a `reference`, `file` and `line` keys.
      */
     public function __construct(
-        int $code,
-        string $message,
-        ?string $file = null,
-        ?int $line = null,
-        array $trace = [],
+        private int $code,
+        private string $message,
+        private ?string $file = null,
+        private ?int $line = null,
+        private array $trace = [],
     ) {
-        $this->code = $code;
-        $this->message = $message;
-        $this->file = $file;
-        $this->line = $line;
-        $this->trace = $trace;
     }
 
     /**

--- a/src/Error/Renderer/ConsoleExceptionRenderer.php
+++ b/src/Error/Renderer/ConsoleExceptionRenderer.php
@@ -33,11 +33,6 @@ use Throwable;
 class ConsoleExceptionRenderer implements ExceptionRendererInterface
 {
     /**
-     * @var \Throwable
-     */
-    private Throwable $error;
-
-    /**
      * @var \Cake\Console\ConsoleOutput
      */
     private ConsoleOutput $output;
@@ -54,9 +49,8 @@ class ConsoleExceptionRenderer implements ExceptionRendererInterface
      * @param \Psr\Http\Message\ServerRequestInterface|null $request Not used.
      * @param array $config Error handling configuration.
      */
-    public function __construct(Throwable $error, ?ServerRequestInterface $request, array $config)
+    public function __construct(private Throwable $error, ?ServerRequestInterface $request, array $config)
     {
-        $this->error = $error;
         $this->output = $config['stderr'] ?? new ConsoleOutput('php://stderr');
         $this->trace = $config['trace'] ?? true;
     }

--- a/src/Error/Renderer/TextExceptionRenderer.php
+++ b/src/Error/Renderer/TextExceptionRenderer.php
@@ -28,18 +28,12 @@ use Throwable;
 class TextExceptionRenderer implements ExceptionRendererInterface
 {
     /**
-     * @var \Throwable
-     */
-    protected Throwable $error;
-
-    /**
      * Constructor.
      *
      * @param \Throwable $error The error to render.
      */
-    public function __construct(Throwable $error)
+    public function __construct(protected Throwable $error)
     {
-        $this->error = $error;
     }
 
     /**

--- a/src/Error/Renderer/WebExceptionRenderer.php
+++ b/src/Error/Renderer/WebExceptionRenderer.php
@@ -64,13 +64,6 @@ use function Cake\I18n\__d;
 class WebExceptionRenderer implements ExceptionRendererInterface
 {
     /**
-     * The exception being handled.
-     *
-     * @var \Throwable
-     */
-    protected Throwable $error;
-
-    /**
      * Controller instance.
      *
      * @var \Cake\Controller\Controller
@@ -92,24 +85,16 @@ class WebExceptionRenderer implements ExceptionRendererInterface
     protected string $method = '';
 
     /**
-     * If set, this will be request used to create the controller that will render
-     * the error.
-     *
-     * @var \Cake\Http\ServerRequest|null
-     */
-    protected ?ServerRequest $request;
-
-    /**
      * Creates the controller to perform rendering on the error response.
      *
-     * @param \Throwable $exception Exception.
-     * @param \Cake\Http\ServerRequest|null $request The request if this is set it will be used
-     *   instead of creating a new one.
+     * @param \Throwable $error Exception.
+     * @param \Cake\Http\ServerRequest|null $request If set, this request will be
+     *   used to create the controller that will render the error.
      */
-    public function __construct(Throwable $exception, ?ServerRequest $request = null)
-    {
-        $this->error = $exception;
-        $this->request = $request;
+    public function __construct(
+        protected Throwable $error,
+        protected ?ServerRequest $request = null,
+    ) {
         $this->controller = $this->getController();
     }
 

--- a/src/Event/Decorator/AbstractDecorator.php
+++ b/src/Event/Decorator/AbstractDecorator.php
@@ -29,22 +29,14 @@ abstract class AbstractDecorator
     protected mixed $callable;
 
     /**
-     * Decorator options
-     *
-     * @var array
-     */
-    protected array $options = [];
-
-    /**
      * Constructor.
      *
      * @param callable $callable Callable.
      * @param array<string, mixed> $options Decorator options.
      */
-    public function __construct(callable $callable, array $options = [])
+    public function __construct(callable $callable, protected array $options = [])
     {
         $this->callable = $callable;
-        $this->options = $options;
     }
 
     /**

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -25,27 +25,6 @@ namespace Cake\Event;
 class Event implements EventInterface
 {
     /**
-     * Name of the event
-     *
-     * @var string
-     */
-    protected string $name;
-
-    /**
-     * The object this event applies to (usually the same object that generates the event)
-     *
-     * @var TSubject|null
-     */
-    protected ?object $subject = null;
-
-    /**
-     * Custom data for the method that receives the event
-     *
-     * @var array
-     */
-    protected array $data;
-
-    /**
      * Property used to retain the result value of the event listeners
      *
      * Use setResult() and getResult() to set and get the result.
@@ -78,11 +57,11 @@ class Event implements EventInterface
      *   with this event to it can be read by listeners.
      * @phpstan-param TSubject|null $subject
      */
-    public function __construct(string $name, ?object $subject = null, array $data = [])
-    {
-        $this->name = $name;
-        $this->subject = $subject;
-        $this->data = $data;
+    public function __construct(
+        protected string $name,
+        protected ?object $subject = null,
+        protected array $data = [],
+    ) {
     }
 
     /**

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -83,13 +83,6 @@ abstract class BaseApplication implements
     protected PluginCollection $plugins;
 
     /**
-     * Controller factory
-     *
-     * @var \Cake\Http\ControllerFactoryInterface<\Cake\Controller\Controller>|null
-     */
-    protected ?ControllerFactoryInterface $controllerFactory = null;
-
-    /**
      * Container
      *
      * @var \Cake\Core\ContainerInterface|null
@@ -106,12 +99,11 @@ abstract class BaseApplication implements
     public function __construct(
         string $configDir,
         ?EventManagerInterface $eventManager = null,
-        ?ControllerFactoryInterface $controllerFactory = null,
+        protected ?ControllerFactoryInterface $controllerFactory = null,
     ) {
         $this->configDir = rtrim($configDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         $this->plugins = new PluginCollection();
         $this->eventManager = $eventManager ?: EventManager::instance();
-        $this->controllerFactory = $controllerFactory;
         Plugin::setCollection($this->plugins);
     }
 

--- a/src/Http/Client/Auth/Digest.php
+++ b/src/Http/Client/Auth/Digest.php
@@ -56,12 +56,6 @@ class Digest
         self::ALGO_SHA_256_SESS => 'sha256',
         self::ALGO_SHA_512_256_SESS => 'sha512/256',
     ];
-    /**
-     * Instance of Cake\Http\Client
-     *
-     * @var \Cake\Http\Client
-     */
-    protected Client $client;
 
     /**
      * Algorithm
@@ -89,9 +83,8 @@ class Digest
      *
      * @param \Cake\Http\Client $client Http client object.
      */
-    public function __construct(Client $client)
+    public function __construct(protected Client $client)
     {
-        $this->client = $client;
     }
 
     /**

--- a/src/Http/Client/Exception/NetworkException.php
+++ b/src/Http/Client/Exception/NetworkException.php
@@ -30,20 +30,14 @@ use Throwable;
 class NetworkException extends RuntimeException implements NetworkExceptionInterface
 {
     /**
-     * @var \Psr\Http\Message\RequestInterface
-     */
-    protected RequestInterface $request;
-
-    /**
      * Constructor.
      *
      * @param string $message Exception message.
      * @param \Psr\Http\Message\RequestInterface $request Request instance.
      * @param \Throwable|null $previous Previous Exception
      */
-    public function __construct(string $message, RequestInterface $request, ?Throwable $previous = null)
+    public function __construct(string $message, protected RequestInterface $request, ?Throwable $previous = null)
     {
-        $this->request = $request;
         parent::__construct($message, 0, $previous);
     }
 

--- a/src/Http/Client/Exception/RequestException.php
+++ b/src/Http/Client/Exception/RequestException.php
@@ -31,20 +31,14 @@ use Throwable;
 class RequestException extends RuntimeException implements RequestExceptionInterface
 {
     /**
-     * @var \Psr\Http\Message\RequestInterface
-     */
-    protected RequestInterface $request;
-
-    /**
      * Constructor.
      *
      * @param string $message Exception message.
      * @param \Psr\Http\Message\RequestInterface $request Request instance.
      * @param \Throwable|null $previous Previous Exception
      */
-    public function __construct(string $message, RequestInterface $request, ?Throwable $previous = null)
+    public function __construct(string $message, protected RequestInterface $request, ?Throwable $previous = null)
     {
-        $this->request = $request;
         parent::__construct($message, 0, $previous);
     }
 

--- a/src/Http/CorsBuilder.php
+++ b/src/Http/CorsBuilder.php
@@ -33,27 +33,6 @@ use Psr\Http\Message\ResponseInterface;
 class CorsBuilder
 {
     /**
-     * The response object this builder is attached to.
-     *
-     * @var \Psr\Http\Message\ResponseInterface
-     */
-    protected ResponseInterface $response;
-
-    /**
-     * The request's Origin header value
-     *
-     * @var string
-     */
-    protected string $origin;
-
-    /**
-     * Whether the request was over SSL.
-     *
-     * @var bool
-     */
-    protected bool $isSsl;
-
-    /**
      * The headers that have been queued so far.
      *
      * @var array<string, mixed>
@@ -67,11 +46,11 @@ class CorsBuilder
      * @param string $origin The request's Origin header.
      * @param bool $isSsl Whether the request was over SSL.
      */
-    public function __construct(ResponseInterface $response, string $origin, bool $isSsl = false)
-    {
-        $this->origin = $origin;
-        $this->isSsl = $isSsl;
-        $this->response = $response;
+    public function __construct(
+        protected ResponseInterface $response,
+        protected string $origin,
+        protected bool $isSsl = false,
+    ) {
     }
 
     /**

--- a/src/Http/FlashMessage.php
+++ b/src/Http/FlashMessage.php
@@ -43,20 +43,14 @@ class FlashMessage
     ];
 
     /**
-     * @var \Cake\Http\Session
-     */
-    protected Session $session;
-
-    /**
      * Constructor
      *
      * @param \Cake\Http\Session $session Session instance.
      * @param array<string, mixed> $config Config array.
      * @see FlashMessage::set() For list of valid config keys.
      */
-    public function __construct(Session $session, array $config = [])
+    public function __construct(protected Session $session, array $config = [])
     {
-        $this->session = $session;
         $this->setConfig($config);
     }
 

--- a/src/Http/Link/Link.php
+++ b/src/Http/Link/Link.php
@@ -42,13 +42,6 @@ class Link implements EvolvableLinkInterface
     private array $rels;
 
     /**
-     * The link attributes.
-     *
-     * @var array<string, string|bool|int|float|array<string>>
-     */
-    private array $attributes;
-
-    /**
      * Constructor.
      *
      * @param string $href The link URI.
@@ -58,10 +51,9 @@ class Link implements EvolvableLinkInterface
     public function __construct(
         private string $href = '',
         string|array $rels = [],
-        array $attributes = [],
+        private array $attributes = [],
     ) {
         $this->rels = is_string($rels) ? [$rels] : $rels;
-        $this->attributes = $attributes;
     }
 
     /**

--- a/src/Http/Middleware/ClosureDecoratorMiddleware.php
+++ b/src/Http/Middleware/ClosureDecoratorMiddleware.php
@@ -39,20 +39,12 @@ use Psr\Http\Server\RequestHandlerInterface;
 class ClosureDecoratorMiddleware implements MiddlewareInterface
 {
     /**
-     * A Closure.
-     *
-     * @var \Closure
-     */
-    protected Closure $callable;
-
-    /**
      * Constructor
      *
      * @param \Closure $callable A closure.
      */
-    public function __construct(Closure $callable)
+    public function __construct(protected Closure $callable)
     {
-        $this->callable = $callable;
     }
 
     /**

--- a/src/Http/Middleware/EncryptedCookieMiddleware.php
+++ b/src/Http/Middleware/EncryptedCookieMiddleware.php
@@ -43,38 +43,17 @@ class EncryptedCookieMiddleware implements MiddlewareInterface
     use CookieCryptTrait;
 
     /**
-     * The list of cookies to encrypt/decrypt
-     *
-     * @var array<string>
-     */
-    protected array $cookieNames;
-
-    /**
-     * Encryption key to use.
-     *
-     * @var string
-     */
-    protected string $key;
-
-    /**
-     * Encryption type.
-     *
-     * @var string
-     */
-    protected string $cipherType;
-
-    /**
      * Constructor
      *
      * @param array<string> $cookieNames The list of cookie names that should have their values encrypted.
      * @param string $key The encryption key to use.
      * @param string $cipherType The cipher type to use. Defaults to 'aes'.
      */
-    public function __construct(array $cookieNames, string $key, string $cipherType = 'aes')
-    {
-        $this->cookieNames = $cookieNames;
-        $this->key = $key;
-        $this->cipherType = $cipherType;
+    public function __construct(
+        protected array $cookieNames,
+        protected string $key,
+        protected string $cipherType = 'aes',
+    ) {
     }
 
     /**

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -43,27 +43,15 @@ class MiddlewareQueue implements Countable, SeekableIterator
     protected int $position = 0;
 
     /**
-     * The queue of middlewares.
-     *
-     * @var array<int, mixed>
-     */
-    protected array $queue = [];
-
-    /**
-     * @var \Cake\Core\ContainerInterface|null
-     */
-    protected ?ContainerInterface $container;
-
-    /**
      * Constructor
      *
-     * @param array $middleware The list of middleware to append.
+     * @param array $queue The list of middleware to append.
      * @param \Cake\Core\ContainerInterface|null $container Container instance.
      */
-    public function __construct(array $middleware = [], ?ContainerInterface $container = null)
-    {
-        $this->container = $container;
-        $this->queue = $middleware;
+    public function __construct(
+        protected array $queue = [],
+        protected ?ContainerInterface $container = null,
+    ) {
     }
 
     /**

--- a/src/Http/RateLimit/FixedWindowRateLimiter.php
+++ b/src/Http/RateLimit/FixedWindowRateLimiter.php
@@ -24,20 +24,12 @@ use Psr\SimpleCache\CacheInterface;
 class FixedWindowRateLimiter implements RateLimiterInterface
 {
     /**
-     * Cache instance
-     *
-     * @var \Psr\SimpleCache\CacheInterface
-     */
-    protected CacheInterface $cache;
-
-    /**
      * Constructor
      *
      * @param \Psr\SimpleCache\CacheInterface $cache Cache instance
      */
-    public function __construct(CacheInterface $cache)
+    public function __construct(protected CacheInterface $cache)
     {
-        $this->cache = $cache;
     }
 
     /**

--- a/src/Http/RateLimit/SlidingWindowRateLimiter.php
+++ b/src/Http/RateLimit/SlidingWindowRateLimiter.php
@@ -24,20 +24,12 @@ use Psr\SimpleCache\CacheInterface;
 class SlidingWindowRateLimiter implements RateLimiterInterface
 {
     /**
-     * Cache instance
-     *
-     * @var \Psr\SimpleCache\CacheInterface
-     */
-    protected CacheInterface $cache;
-
-    /**
      * Constructor
      *
      * @param \Psr\SimpleCache\CacheInterface $cache Cache instance
      */
-    public function __construct(CacheInterface $cache)
+    public function __construct(protected CacheInterface $cache)
     {
-        $this->cache = $cache;
     }
 
     /**

--- a/src/Http/RateLimit/TokenBucketRateLimiter.php
+++ b/src/Http/RateLimit/TokenBucketRateLimiter.php
@@ -24,20 +24,12 @@ use Psr\SimpleCache\CacheInterface;
 class TokenBucketRateLimiter implements RateLimiterInterface
 {
     /**
-     * Cache instance
-     *
-     * @var \Psr\SimpleCache\CacheInterface
-     */
-    protected CacheInterface $cache;
-
-    /**
      * Constructor
      *
      * @param \Psr\SimpleCache\CacheInterface $cache Cache instance
      */
-    public function __construct(CacheInterface $cache)
+    public function __construct(protected CacheInterface $cache)
     {
-        $this->cache = $cache;
     }
 
     /**

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -32,20 +32,12 @@ use Psr\Link\LinkInterface;
 class ResponseEmitter
 {
     /**
-     * Maximum output buffering size for each iteration.
-     *
-     * @var int
-     */
-    protected int $maxBufferLength;
-
-    /**
      * Constructor
      *
      * @param int $maxBufferLength Maximum output buffering size for each iteration.
      */
-    public function __construct(int $maxBufferLength = 8192)
+    public function __construct(protected int $maxBufferLength = 8192)
     {
-        $this->maxBufferLength = $maxBufferLength;
     }
 
     /**

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -41,19 +41,13 @@ class Server implements EventDispatcherInterface
     use EventDispatcherTrait;
 
     /**
-     * @var \Cake\Core\HttpApplicationInterface
-     */
-    protected HttpApplicationInterface $app;
-
-    /**
      * Constructor
      *
      * @param \Cake\Core\HttpApplicationInterface $app The application to use.
      * @param \Cake\Http\Runner $runner Application runner.
      */
-    public function __construct(HttpApplicationInterface $app, protected Runner $runner = new Runner())
+    public function __construct(protected HttpApplicationInterface $app, protected Runner $runner = new Runner())
     {
-        $this->app = $app;
     }
 
     /**

--- a/src/I18n/ChainMessagesLoader.php
+++ b/src/I18n/ChainMessagesLoader.php
@@ -25,21 +25,13 @@ use Cake\Core\Exception\CakeException;
 class ChainMessagesLoader
 {
     /**
-     * The list of callables to execute one after another for loading messages
-     *
-     * @var array<callable>
-     */
-    protected array $loaders = [];
-
-    /**
      * Receives a list of callable functions or objects that will be executed
      * one after another until one of them returns a non-empty translations package
      *
-     * @param array<callable> $loaders List of callables to execute
+     * @param array<callable> $loaders The list of callables to execute one after another for loading messages
      */
-    public function __construct(array $loaders)
+    public function __construct(protected array $loaders)
     {
-        $this->loaders = $loaders;
     }
 
     /**

--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -32,32 +32,11 @@ use function Cake\Core\pluginSplit;
 class MessagesFileLoader
 {
     /**
-     * The package (domain) name.
-     *
-     * @var string
-     */
-    protected string $name;
-
-    /**
      * The package (domain) plugin
      *
      * @var string|null
      */
     protected ?string $plugin = null;
-
-    /**
-     * The locale to load for the given package.
-     *
-     * @var string
-     */
-    protected string $locale;
-
-    /**
-     * The extension name.
-     *
-     * @var string
-     */
-    protected string $extension;
 
     /**
      * Creates a translation file loader. The file to be loaded corresponds to
@@ -100,9 +79,11 @@ class MessagesFileLoader
      * @param string $extension The file extension to use. This will also be mapped
      * to a messages parser class.
      */
-    public function __construct(string $name, string $locale, string $extension = 'po')
-    {
-        $this->name = $name;
+    public function __construct(
+        protected string $name,
+        protected string $locale,
+        protected string $extension = 'po',
+    ) {
         // If space is not added after slash, the character after it remains lowercased
         $pluginName = Inflector::camelize(str_replace('/', '/ ', $this->name));
         if (strpos($this->name, '.')) {
@@ -110,8 +91,6 @@ class MessagesFileLoader
         } elseif (Plugin::isLoaded($pluginName)) {
             $this->plugin = $pluginName;
         }
-        $this->locale = $locale;
-        $this->extension = $extension;
     }
 
     /**

--- a/src/I18n/Middleware/LocaleSelectorMiddleware.php
+++ b/src/I18n/Middleware/LocaleSelectorMiddleware.php
@@ -30,21 +30,14 @@ use Psr\Http\Server\RequestHandlerInterface;
 class LocaleSelectorMiddleware implements MiddlewareInterface
 {
     /**
-     * List of valid locales for the request
-     *
-     * @var array
-     */
-    protected array $locales = [];
-
-    /**
      * Constructor.
      *
      * @param array $locales A list of accepted locales, or ['*'] to accept any
      *   locale header value.
      */
-    public function __construct(array $locales = [])
-    {
-        $this->locales = $locales;
+    public function __construct(
+        protected array $locales = [],
+    ) {
     }
 
     /**

--- a/src/I18n/Package.php
+++ b/src/I18n/Package.php
@@ -23,42 +23,17 @@ namespace Cake\I18n;
 class Package
 {
     /**
-     * Message keys and translations in this package.
-     *
-     * @var array<array|string>
-     */
-    protected array $messages = [];
-
-    /**
-     * The name of a fallback package to use when a message key does not
-     * exist.
-     *
-     * @var string|null
-     */
-    protected ?string $fallback = null;
-
-    /**
-     * The name of the formatter to use when formatting translated messages.
-     *
-     * @var string
-     */
-    protected string $formatter;
-
-    /**
      * Constructor.
      *
-     * @param string $formatter The name of the formatter to use.
-     * @param string|null $fallback The name of the fallback package to use.
-     * @param array<array|string> $messages The messages in this package.
+     * @param string $formatter The name of the formatter to use when formatting translated messages.
+     * @param string|null $fallback The name of a fallback package to use when a message key does not exist.
+     * @param array<array|string> $messages Message keys and translations in this package.
      */
     public function __construct(
-        string $formatter = 'default',
-        ?string $fallback = null,
-        array $messages = [],
+        protected string $formatter = 'default',
+        protected ?string $fallback = null,
+        protected array $messages = [],
     ) {
-        $this->formatter = $formatter;
-        $this->fallback = $fallback;
-        $this->messages = $messages;
     }
 
     /**

--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -29,34 +29,6 @@ class Translator
     public const string PLURAL_PREFIX = 'p:';
 
     /**
-     * A fallback translator.
-     *
-     * @var \Cake\I18n\Translator|null
-     */
-    protected ?self $fallback = null;
-
-    /**
-     * The formatter to use when translating messages.
-     *
-     * @var \Cake\I18n\FormatterInterface
-     */
-    protected FormatterInterface $formatter;
-
-    /**
-     * The locale being used for translations.
-     *
-     * @var string
-     */
-    protected string $locale;
-
-    /**
-     * The Package containing keys and translations.
-     *
-     * @var \Cake\I18n\Package
-     */
-    protected Package $package;
-
-    /**
      * Constructor
      *
      * @param string $locale The locale being used.
@@ -65,15 +37,11 @@ class Translator
      * @param \Cake\I18n\Translator|null $fallback A fallback translator.
      */
     public function __construct(
-        string $locale,
-        Package $package,
-        FormatterInterface $formatter,
-        ?self $fallback = null,
+        protected string $locale,
+        protected Package $package,
+        protected FormatterInterface $formatter,
+        protected ?Translator $fallback = null,
     ) {
-        $this->locale = $locale;
-        $this->package = $package;
-        $this->formatter = $formatter;
-        $this->fallback = $fallback;
     }
 
     /**

--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -40,7 +40,7 @@ class Translator
         protected string $locale,
         protected Package $package,
         protected FormatterInterface $formatter,
-        protected ?Translator $fallback = null,
+        protected ?self $fallback = null,
     ) {
     }
 

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -47,20 +47,6 @@ class TranslatorRegistry
     protected string $locale;
 
     /**
-     * A package locator.
-     *
-     * @var \Cake\I18n\PackageLocator
-     */
-    protected PackageLocator $packages;
-
-    /**
-     * A formatter locator.
-     *
-     * @var \Cake\I18n\FormatterLocator
-     */
-    protected FormatterLocator $formatters;
-
-    /**
      * A list of loader functions indexed by domain name. Loaders are
      * callables that are invoked as a default for building translation
      * packages where none can be found for the combination of translator
@@ -101,12 +87,10 @@ class TranslatorRegistry
      * @param string $locale The default locale code to use.
      */
     public function __construct(
-        PackageLocator $packages,
-        FormatterLocator $formatters,
+        protected PackageLocator $packages,
+        protected FormatterLocator $formatters,
         string $locale,
     ) {
-        $this->packages = $packages;
-        $this->formatters = $formatters;
         $this->setLocale($locale);
 
         $this->registerLoader(static::FALLBACK_LOADER, function ($name, $locale) {

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -146,13 +146,6 @@ abstract class Association
     protected bool $cascadeCallbacks = false;
 
     /**
-     * Source table instance
-     *
-     * @var \Cake\ORM\Table
-     */
-    protected Table $sourceTable;
-
-    /**
      * Target table instance
      *
      * @var \Cake\ORM\Table
@@ -209,10 +202,8 @@ abstract class Association
      * @param \Cake\ORM\Table $sourceTable The table instance for the source side of the association.
      * @param array<string, mixed> $options A list of properties to be set on this object
      */
-    public function __construct(string $alias, Table $sourceTable, array $options = [])
+    public function __construct(string $alias, protected Table $sourceTable, array $options = [])
     {
-        $this->sourceTable = $sourceTable;
-
         if (isset($options['cascadeCallbacks'])) {
             $this->cascadeCallbacks = $options['cascadeCallbacks'];
         }

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -117,13 +117,6 @@ class Behavior implements EventListenerInterface
     use InstanceConfigTrait;
 
     /**
-     * Table instance.
-     *
-     * @var \Cake\ORM\Table
-     */
-    protected Table $table;
-
-    /**
      * Reflection method cache for behaviors.
      *
      * Stores the reflected finder methods per class.
@@ -150,14 +143,13 @@ class Behavior implements EventListenerInterface
      * @param \Cake\ORM\Table $table The table this behavior is attached to.
      * @param array<string, mixed> $config The config for this behavior.
      */
-    public function __construct(Table $table, array $config = [])
+    public function __construct(protected Table $table, array $config = [])
     {
         $config = $this->resolveMethodAliases(
             'implementedFinders',
             $this->defaultConfig,
             $config,
         );
-        $this->table = $table;
         $this->setConfig($config);
         $this->initialize($config);
     }

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -347,7 +347,7 @@ class CounterCacheBehavior extends Behavior
 
             if (
                 isset($this->ignoreDirty[$assoc->getTarget()->getRegistryAlias()][$field]) &&
-                $this->ignoreDirty[$assoc->getTarget()->getRegistryAlias()][$field] === true
+                $this->ignoreDirty[$assoc->getTarget()->getRegistryAlias()][$field]
             ) {
                 continue;
             }

--- a/src/ORM/EagerLoadable.php
+++ b/src/ORM/EagerLoadable.php
@@ -29,13 +29,6 @@ use Cake\Database\Exception\DatabaseException;
 class EagerLoadable
 {
     /**
-     * The name of the association to load.
-     *
-     * @var string
-     */
-    protected string $name;
-
-    /**
      * A list of other associations to load from this level.
      *
      * @var array<string, \Cake\ORM\EagerLoadable>
@@ -130,9 +123,8 @@ class EagerLoadable
      * @param string $name The Association name.
      * @param array<string, mixed> $config The list of properties to set.
      */
-    public function __construct(string $name, array $config = [])
+    public function __construct(protected string $name, array $config = [])
     {
-        $this->name = $name;
         if (isset($config['associations'])) {
             $this->associations = $config['associations'];
         }

--- a/src/ORM/Exception/PersistenceFailedException.php
+++ b/src/ORM/Exception/PersistenceFailedException.php
@@ -25,13 +25,6 @@ use Throwable;
 class PersistenceFailedException extends CakeException
 {
     /**
-     * The entity on which the persistence operation failed
-     *
-     * @var \Cake\Datasource\EntityInterface
-     */
-    protected EntityInterface $entity;
-
-    /**
      * @inheritDoc
      */
     protected string $messageTemplate = 'Entity %s failure.';
@@ -46,15 +39,14 @@ class PersistenceFailedException extends CakeException
      * @param \Throwable|null $previous the previous exception.
      */
     public function __construct(
-        EntityInterface $entity,
+        protected EntityInterface $entity,
         array|string $message,
         ?int $code = null,
         ?Throwable $previous = null,
     ) {
-        $this->entity = $entity;
         if (is_array($message)) {
             $errors = [];
-            foreach (Hash::flatten($entity->getErrors()) as $field => $error) {
+            foreach (Hash::flatten($this->entity->getErrors()) as $field => $error) {
                 $errors[] = $field . ': "' . $error . '"';
             }
             if ($errors) {

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -42,20 +42,12 @@ class Marshaller
     use AssociationsNormalizerTrait;
 
     /**
-     * The table instance this marshaller is for.
-     *
-     * @var \Cake\ORM\Table
-     */
-    protected Table $table;
-
-    /**
      * Constructor.
      *
      * @param \Cake\ORM\Table $table The table this marshaller is for.
      */
-    public function __construct(Table $table)
+    public function __construct(protected Table $table)
     {
-        $this->table = $table;
     }
 
     /**

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -35,13 +35,6 @@ class ExistsIn
     protected array $fields;
 
     /**
-     * The repository where the field will be looked for
-     *
-     * @var \Cake\ORM\Table|\Cake\ORM\Association|string
-     */
-    protected Table|Association|string $repository;
-
-    /**
      * Options for the constructor
      *
      * @var array<string, mixed>
@@ -61,13 +54,15 @@ class ExistsIn
      *     Options 'allowNullableNulls' will make the rule pass if given foreign keys are set to `null`.
      *     Notice: allowNullableNulls cannot pass by database columns set to `NOT NULL`.
      */
-    public function __construct(array|string $fields, Table|Association|string $repository, array $options = [])
-    {
+    public function __construct(
+        array|string $fields,
+        protected Table|Association|string $repository,
+        array $options = [],
+    ) {
         $options += ['allowNullableNulls' => false];
         $this->options = $options;
 
         $this->fields = (array)$fields;
-        $this->repository = $repository;
     }
 
     /**

--- a/src/ORM/Rule/IsUnique.php
+++ b/src/ORM/Rule/IsUnique.php
@@ -25,13 +25,6 @@ use Cake\Utility\Hash;
 class IsUnique
 {
     /**
-     * The list of fields to check
-     *
-     * @var array<string>
-     */
-    protected array $fields;
-
-    /**
      * The unique check options
      *
      * @var array<string, mixed>
@@ -50,9 +43,8 @@ class IsUnique
      * @param array<string> $fields The list of fields to check uniqueness for
      * @param array<string, mixed> $options The options for unique checks.
      */
-    public function __construct(array $fields, array $options = [])
+    public function __construct(protected array $fields, array $options = [])
     {
-        $this->fields = $fields;
         $this->options = $options + $this->options;
     }
 

--- a/src/ORM/Rule/LinkConstraint.php
+++ b/src/ORM/Rule/LinkConstraint.php
@@ -42,13 +42,6 @@ class LinkConstraint
     public const string STATUS_NOT_LINKED = 'notLinked';
 
     /**
-     * The association that should be checked.
-     *
-     * @var \Cake\ORM\Association|string
-     */
-    protected Association|string $association;
-
-    /**
      * The link status that is required to be present in order for the check to succeed.
      *
      * @var string
@@ -62,15 +55,13 @@ class LinkConstraint
      * @param string $requiredLinkStatus The link status that is required to be present in order for the check to
      *  succeed.
      */
-    public function __construct(Association|string $association, string $requiredLinkStatus)
+    public function __construct(protected Association|string $association, string $requiredLinkStatus)
     {
         if (!in_array($requiredLinkStatus, [static::STATUS_LINKED, static::STATUS_NOT_LINKED], true)) {
             throw new InvalidArgumentException(
                 'Argument 2 is expected to match one of the `\Cake\ORM\Rule\LinkConstraint::STATUS_*` constants.',
             );
         }
-
-        $this->association = $association;
         $this->requiredLinkState = $requiredLinkStatus;
     }
 

--- a/src/ORM/Rule/ValidCount.php
+++ b/src/ORM/Rule/ValidCount.php
@@ -26,20 +26,12 @@ use Countable;
 class ValidCount
 {
     /**
-     * The field to check
-     *
-     * @var string
-     */
-    protected string $field;
-
-    /**
      * Constructor.
      *
      * @param string $field The field to check the count on.
      */
-    public function __construct(string $field)
+    public function __construct(protected string $field)
     {
-        $this->field = $field;
     }
 
     /**

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -37,20 +37,12 @@ use Psr\Http\Server\RequestHandlerInterface;
 class RoutingMiddleware implements MiddlewareInterface
 {
     /**
-     * The application that will have its routing hook invoked.
-     *
-     * @var \Cake\Routing\RoutingApplicationInterface
-     */
-    protected RoutingApplicationInterface $app;
-
-    /**
      * Constructor
      *
      * @param \Cake\Routing\RoutingApplicationInterface $app The application instance that routes are defined on.
      */
-    public function __construct(RoutingApplicationInterface $app)
+    public function __construct(protected RoutingApplicationInterface $app)
     {
-        $this->app = $app;
     }
 
     /**

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -55,13 +55,6 @@ class Route
     public array $defaults = [];
 
     /**
-     * The routes template string.
-     *
-     * @var string
-     */
-    public string $template;
-
-    /**
      * Is this route a greedy route? Greedy routes have a `/*` in their
      * template
      *
@@ -132,7 +125,7 @@ class Route
      * @param array<string, mixed> $options Array of additional options for the Route
      * @throws \InvalidArgumentException When `$options['_method']` are not in `VALID_METHODS` list.
      */
-    public function __construct(string $template, array $defaults = [], array $options = [])
+    public function __construct(public string $template, array $defaults = [], array $options = [])
     {
         $checker = function () use ($defaults): bool {
             foreach (['plugin', 'prefix', 'controller', 'action'] as $key) {
@@ -148,8 +141,6 @@ class Route
         };
 
         assert($checker());
-
-        $this->template = $template;
         $this->defaults = $defaults;
         $this->options = $options + ['_ext' => [], '_middleware' => []];
         $this->setExtensions((array)$this->options['_ext']);

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -74,32 +74,11 @@ class RouteBuilder
     protected array $extensions = [];
 
     /**
-     * The path prefix scope that this collection uses.
-     *
-     * @var string
-     */
-    protected string $path;
-
-    /**
-     * The scope parameters if there are any.
-     *
-     * @var array
-     */
-    protected array $params;
-
-    /**
      * Name prefix for connected routes.
      *
      * @var string
      */
     protected string $namePrefix = '';
-
-    /**
-     * The route collection routes should be added to.
-     *
-     * @var \Cake\Routing\RouteCollection
-     */
-    protected RouteCollection $collection;
 
     /**
      * The list of middleware that routes in this builder get
@@ -132,14 +111,11 @@ class RouteBuilder
      * @param array<string, mixed> $options Options list.
      */
     public function __construct(
-        RouteCollection $collection,
-        string $path = '/',
-        array $params = [],
+        protected RouteCollection $collection,
+        protected string $path = '/',
+        protected array $params = [],
         array $options = [],
     ) {
-        $this->collection = $collection;
-        $this->path = $path;
-        $this->params = $params;
         if (isset($options['routeClass'])) {
             $this->routeClass = $options['routeClass'];
         }

--- a/src/TestSuite/Constraint/Email/MailConstraintBase.php
+++ b/src/TestSuite/Constraint/Email/MailConstraintBase.php
@@ -27,18 +27,12 @@ use PHPUnit\Framework\Constraint\Constraint;
 abstract class MailConstraintBase extends Constraint
 {
     /**
-     * @var int|null
-     */
-    protected ?int $at = null;
-
-    /**
      * Constructor
      *
      * @param int|null $at At
      */
-    public function __construct(?int $at = null)
+    public function __construct(protected ?int $at = null)
     {
-        $this->at = $at;
     }
 
     /**

--- a/src/TestSuite/Constraint/EventFired.php
+++ b/src/TestSuite/Constraint/EventFired.php
@@ -27,21 +27,12 @@ use PHPUnit\Framework\Constraint\Constraint;
 class EventFired extends Constraint
 {
     /**
-     * Array of fired events
-     *
-     * @var \Cake\Event\EventManager
-     */
-    protected EventManager $eventManager;
-
-    /**
      * Constructor
      *
      * @param \Cake\Event\EventManager $eventManager Event manager to check
      */
-    public function __construct(EventManager $eventManager)
+    public function __construct(protected EventManager $eventManager)
     {
-        $this->eventManager = $eventManager;
-
         if ($this->eventManager->getEventList() === null) {
             throw new AssertionFailedError(
                 'The event manager you are asserting against is not configured to track events.',

--- a/src/TestSuite/Constraint/EventFiredWith.php
+++ b/src/TestSuite/Constraint/EventFiredWith.php
@@ -17,39 +17,17 @@ use PHPUnit\Framework\Constraint\Constraint;
 class EventFiredWith extends Constraint
 {
     /**
-     * Array of fired events
-     *
-     * @var \Cake\Event\EventManager
-     */
-    protected EventManager $eventManager;
-
-    /**
-     * Event data key
-     *
-     * @var string
-     */
-    protected string $dataKey;
-
-    /**
-     * Event data value
-     *
-     * @var mixed
-     */
-    protected mixed $dataValue;
-
-    /**
      * Constructor
      *
      * @param \Cake\Event\EventManager $eventManager Event manager to check
      * @param string $dataKey Data key
      * @param mixed $dataValue Data value
      */
-    public function __construct(EventManager $eventManager, string $dataKey, mixed $dataValue)
-    {
-        $this->eventManager = $eventManager;
-        $this->dataKey = $dataKey;
-        $this->dataValue = $dataValue;
-
+    public function __construct(
+        protected EventManager $eventManager,
+        protected string $dataKey,
+        protected mixed $dataValue,
+    ) {
         if ($this->eventManager->getEventList() === null) {
             throw new AssertionFailedError(
                 'The event manager you are asserting against is not configured to track events.',

--- a/src/TestSuite/Constraint/Response/BodyContains.php
+++ b/src/TestSuite/Constraint/Response/BodyContains.php
@@ -25,21 +25,14 @@ use Psr\Http\Message\ResponseInterface;
 class BodyContains extends ResponseBase
 {
     /**
-     * @var bool
-     */
-    protected bool $ignoreCase;
-
-    /**
      * Constructor.
      *
      * @param \Psr\Http\Message\ResponseInterface $response A response instance.
      * @param bool $ignoreCase Ignore case
      */
-    public function __construct(ResponseInterface $response, bool $ignoreCase = false)
+    public function __construct(ResponseInterface $response, protected bool $ignoreCase = false)
     {
         parent::__construct($response);
-
-        $this->ignoreCase = $ignoreCase;
     }
 
     /**

--- a/src/TestSuite/Constraint/Response/CookieEncryptedEquals.php
+++ b/src/TestSuite/Constraint/Response/CookieEncryptedEquals.php
@@ -34,16 +34,6 @@ class CookieEncryptedEquals extends CookieEquals
     protected ResponseInterface $response;
 
     /**
-     * @var string
-     */
-    protected string $key;
-
-    /**
-     * @var string
-     */
-    protected string $mode;
-
-    /**
      * Constructor.
      *
      * @param \Cake\Http\Response|null $response A response instance.
@@ -51,12 +41,9 @@ class CookieEncryptedEquals extends CookieEquals
      * @param string $mode Mode
      * @param string $key Key
      */
-    public function __construct(?Response $response, string $cookieName, string $mode, string $key)
+    public function __construct(?Response $response, string $cookieName, protected string $mode, protected string $key)
     {
         parent::__construct($response, $cookieName);
-
-        $this->key = $key;
-        $this->mode = $mode;
     }
 
     /**

--- a/src/TestSuite/Constraint/Response/CookieEquals.php
+++ b/src/TestSuite/Constraint/Response/CookieEquals.php
@@ -31,21 +31,14 @@ class CookieEquals extends ResponseBase
     protected ResponseInterface $response;
 
     /**
-     * @var string
-     */
-    protected string $cookieName;
-
-    /**
      * Constructor.
      *
      * @param \Cake\Http\Response|null $response A response instance.
      * @param string $cookieName Cookie name
      */
-    public function __construct(?Response $response, string $cookieName)
+    public function __construct(?Response $response, protected string $cookieName)
     {
         parent::__construct($response);
-
-        $this->cookieName = $cookieName;
     }
 
     /**

--- a/src/TestSuite/Constraint/Response/HeaderEquals.php
+++ b/src/TestSuite/Constraint/Response/HeaderEquals.php
@@ -25,21 +25,14 @@ use Psr\Http\Message\ResponseInterface;
 class HeaderEquals extends ResponseBase
 {
     /**
-     * @var string
-     */
-    protected string $headerName;
-
-    /**
      * Constructor.
      *
      * @param \Psr\Http\Message\ResponseInterface $response A response instance.
      * @param string $headerName Header name
      */
-    public function __construct(ResponseInterface $response, string $headerName)
+    public function __construct(ResponseInterface $response, protected string $headerName)
     {
         parent::__construct($response);
-
-        $this->headerName = $headerName;
     }
 
     /**

--- a/src/TestSuite/Constraint/Response/HeaderSet.php
+++ b/src/TestSuite/Constraint/Response/HeaderSet.php
@@ -25,21 +25,14 @@ use Psr\Http\Message\ResponseInterface;
 class HeaderSet extends ResponseBase
 {
     /**
-     * @var string
-     */
-    protected string $headerName;
-
-    /**
      * Constructor.
      *
      * @param \Psr\Http\Message\ResponseInterface|null $response A response instance.
      * @param string $headerName Header name
      */
-    public function __construct(?ResponseInterface $response, string $headerName)
+    public function __construct(?ResponseInterface $response, protected string $headerName)
     {
         parent::__construct($response);
-
-        $this->headerName = $headerName;
     }
 
     /**

--- a/src/TestSuite/Constraint/Session/FlashParamContains.php
+++ b/src/TestSuite/Constraint/Session/FlashParamContains.php
@@ -33,26 +33,6 @@ class FlashParamContains extends Constraint
     protected Session $session;
 
     /**
-     * @var string
-     */
-    protected string $key;
-
-    /**
-     * @var string
-     */
-    protected string $param;
-
-    /**
-     * @var int|null
-     */
-    protected ?int $at = null;
-
-    /**
-     * @var bool
-     */
-    protected bool $ignoreCase;
-
-    /**
      * Constructor
      *
      * @param \Cake\Http\Session|null $session Session
@@ -63,10 +43,10 @@ class FlashParamContains extends Constraint
      */
     public function __construct(
         ?Session $session,
-        string $key,
-        string $param,
-        ?int $at = null,
-        bool $ignoreCase = false,
+        protected string $key,
+        protected string $param,
+        protected ?int $at = null,
+        protected bool $ignoreCase = false,
     ) {
         if (!$session) {
             $message = 'There is no stored session data. Perhaps you need to run a request?';
@@ -75,10 +55,6 @@ class FlashParamContains extends Constraint
         }
 
         $this->session = $session;
-        $this->key = $key;
-        $this->param = $param;
-        $this->at = $at;
-        $this->ignoreCase = $ignoreCase;
     }
 
     /**

--- a/src/TestSuite/Constraint/Session/FlashParamEquals.php
+++ b/src/TestSuite/Constraint/Session/FlashParamEquals.php
@@ -33,21 +33,6 @@ class FlashParamEquals extends Constraint
     protected Session $session;
 
     /**
-     * @var string
-     */
-    protected string $key;
-
-    /**
-     * @var string
-     */
-    protected string $param;
-
-    /**
-     * @var int|null
-     */
-    protected ?int $at = null;
-
-    /**
      * Constructor
      *
      * @param \Cake\Http\Session|null $session Session
@@ -55,8 +40,12 @@ class FlashParamEquals extends Constraint
      * @param string $param Param to check
      * @param int|null $at Expected index
      */
-    public function __construct(?Session $session, string $key, string $param, ?int $at = null)
-    {
+    public function __construct(
+        ?Session $session,
+        protected string $key,
+        protected string $param,
+        protected ?int $at = null,
+    ) {
         if (!$session) {
             $message = 'There is no stored session data. Perhaps you need to run a request?';
             $message .= ' Additionally, ensure `$this->enableRetainFlashMessages()` has been enabled for the test.';
@@ -64,9 +53,6 @@ class FlashParamEquals extends Constraint
         }
 
         $this->session = $session;
-        $this->key = $key;
-        $this->param = $param;
-        $this->at = $at;
     }
 
     /**

--- a/src/TestSuite/Constraint/Session/SessionEquals.php
+++ b/src/TestSuite/Constraint/Session/SessionEquals.php
@@ -26,18 +26,12 @@ use PHPUnit\Framework\Constraint\Constraint;
 class SessionEquals extends Constraint
 {
     /**
-     * @var string
-     */
-    protected string $path;
-
-    /**
      * Constructor
      *
      * @param string $path Session Path
      */
-    public function __construct(string $path)
+    public function __construct(protected string $path)
     {
-        $this->path = $path;
     }
 
     /**

--- a/src/TestSuite/Constraint/Session/SessionHasKey.php
+++ b/src/TestSuite/Constraint/Session/SessionHasKey.php
@@ -26,18 +26,12 @@ use PHPUnit\Framework\Constraint\Constraint;
 class SessionHasKey extends Constraint
 {
     /**
-     * @var string
-     */
-    protected string $path;
-
-    /**
      * Constructor
      *
      * @param string $path Session Path
      */
-    public function __construct(string $path)
+    public function __construct(protected string $path)
     {
-        $this->path = $path;
     }
 
     /**

--- a/src/TestSuite/Constraint/View/TemplateFileEquals.php
+++ b/src/TestSuite/Constraint/View/TemplateFileEquals.php
@@ -25,18 +25,12 @@ use PHPUnit\Framework\Constraint\Constraint;
 class TemplateFileEquals extends Constraint
 {
     /**
-     * @var string
-     */
-    protected string $filename;
-
-    /**
      * Constructor
      *
      * @param string $filename Template file name
      */
-    public function __construct(string $filename)
+    public function __construct(protected string $filename)
     {
-        $this->filename = $filename;
     }
 
     /**

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -31,20 +31,12 @@ use Psr\Http\Message\ResponseInterface;
 class MiddlewareDispatcher
 {
     /**
-     * The application that is being dispatched.
-     *
-     * @var \Cake\Core\HttpApplicationInterface
-     */
-    protected HttpApplicationInterface $app;
-
-    /**
      * Constructor
      *
-     * @param \Cake\Core\HttpApplicationInterface $app The test case to run.
+     * @param \Cake\Core\HttpApplicationInterface $app The application that is being dispatched.
      */
-    public function __construct(HttpApplicationInterface $app)
+    public function __construct(protected HttpApplicationInterface $app)
     {
-        $this->app = $app;
     }
 
     /**

--- a/src/TestSuite/TestSession.php
+++ b/src/TestSuite/TestSession.php
@@ -26,16 +26,10 @@ use Cake\Utility\Hash;
 class TestSession
 {
     /**
-     * @var array|null
-     */
-    protected ?array $session = null;
-
-    /**
      * @param array|null $session Session data.
      */
-    public function __construct(?array $session)
+    public function __construct(protected ?array $session)
     {
-        $this->session = $session;
     }
 
     /**

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -64,22 +64,6 @@ abstract class Cell implements EventDispatcherInterface, Stringable
     protected View $View;
 
     /**
-     * An instance of a Cake\Http\ServerRequest object that contains information about the current request.
-     * This object contains all the information about a request and several methods for reading
-     * additional information about the request.
-     *
-     * @var \Cake\Http\ServerRequest
-     */
-    protected ServerRequest $request;
-
-    /**
-     * An instance of a Response object that contains information about the impending response
-     *
-     * @var \Cake\Http\Response
-     */
-    protected Response $response;
-
-    /**
      * The cell's action to invoke.
      *
      * @var string
@@ -125,16 +109,14 @@ abstract class Cell implements EventDispatcherInterface, Stringable
      * @param array<string, mixed> $cellOptions Cell options to apply.
      */
     public function __construct(
-        ServerRequest $request,
-        Response $response,
+        protected ServerRequest $request,
+        protected Response $response,
         ?EventManagerInterface $eventManager = null,
         array $cellOptions = [],
     ) {
         if ($eventManager !== null) {
             $this->setEventManager($eventManager);
         }
-        $this->request = $request;
-        $this->response = $response;
 
         $this->validCellOptions = array_merge(['action', 'args', 'plugin'], $this->validCellOptions);
         foreach ($this->validCellOptions as $var) {

--- a/src/View/Exception/MissingCellTemplateException.php
+++ b/src/View/Exception/MissingCellTemplateException.php
@@ -24,11 +24,6 @@ class MissingCellTemplateException extends MissingTemplateException
     /**
      * @var string
      */
-    protected string $name;
-
-    /**
-     * @var string
-     */
     protected string $type = 'Cell template';
 
     /**
@@ -41,14 +36,12 @@ class MissingCellTemplateException extends MissingTemplateException
      * @param \Throwable|null $previous the previous exception.
      */
     public function __construct(
-        string $name,
+        protected string $name,
         string $file,
         array $paths = [],
         ?int $code = null,
         ?Throwable $previous = null,
     ) {
-        $this->name = $name;
-
         parent::__construct($file, $paths, $code, $previous);
     }
 

--- a/src/View/Exception/MissingTemplateException.php
+++ b/src/View/Exception/MissingTemplateException.php
@@ -33,11 +33,6 @@ class MissingTemplateException extends CakeException
     protected string $filename;
 
     /**
-     * @var array<string>
-     */
-    protected array $paths;
-
-    /**
      * @var string
      */
     protected string $type = 'Template';
@@ -50,8 +45,12 @@ class MissingTemplateException extends CakeException
      * @param int|null $code The code of the error.
      * @param \Throwable|null $previous the previous exception.
      */
-    public function __construct(array|string $file, array $paths = [], ?int $code = null, ?Throwable $previous = null)
-    {
+    public function __construct(
+        array|string $file,
+        protected array $paths = [],
+        ?int $code = null,
+        ?Throwable $previous = null,
+    ) {
         if (is_array($file)) {
             $this->filename = (string)array_pop($file);
             $this->templateName = array_pop($file);
@@ -59,7 +58,6 @@ class MissingTemplateException extends CakeException
             $this->filename = $file;
             $this->templateName = null;
         }
-        $this->paths = $paths;
 
         parent::__construct($this->formatMessage(), $code, $previous);
     }

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -68,25 +68,17 @@ class Helper implements EventListenerInterface
     protected array $helperInstances = [];
 
     /**
-     * The View instance this helper is attached to
-     *
-     * @var TView
-     */
-    protected View $View;
-
-    /**
      * Default Constructor
      *
-     * @param TView $view The View this helper is being attached to.
+     * @param TView $View The View this helper is being attached to.
      * @param array<string, mixed> $config Configuration settings for the helper.
      */
-    public function __construct(View $view, array $config = [])
+    public function __construct(protected View $View, array $config = [])
     {
-        $this->View = $view;
         $this->setConfig($config);
 
         if ($this->helpers) {
-            $this->helpers = $view->helpers()->normalizeArray($this->helpers);
+            $this->helpers = $this->View->helpers()->normalizeArray($this->helpers);
         }
 
         $this->initialize($config);

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -37,21 +37,13 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
     use EventDispatcherTrait;
 
     /**
-     * View object to use when making helpers.
-     *
-     * @var \Cake\View\View
-     */
-    protected View $View;
-
-    /**
      * Constructor
      *
-     * @param \Cake\View\View $view View object.
+     * @param \Cake\View\View $View View object.
      */
-    public function __construct(View $view)
+    public function __construct(protected View $View)
     {
-        $this->View = $view;
-        $this->setEventManager($view->getEventManager());
+        $this->setEventManager($this->View->getEventManager());
     }
 
     /**

--- a/src/View/Widget/BasicWidget.php
+++ b/src/View/Widget/BasicWidget.php
@@ -29,13 +29,6 @@ use Cake\View\StringTemplate;
 class BasicWidget implements WidgetInterface
 {
     /**
-     * StringTemplate instance.
-     *
-     * @var \Cake\View\StringTemplate
-     */
-    protected StringTemplate $templates;
-
-    /**
      * Data defaults.
      *
      * @var array<string, mixed>
@@ -53,9 +46,8 @@ class BasicWidget implements WidgetInterface
      *
      * @param \Cake\View\StringTemplate $templates Templates list.
      */
-    public function __construct(StringTemplate $templates)
+    public function __construct(protected StringTemplate $templates)
     {
-        $this->templates = $templates;
     }
 
     /**

--- a/src/View/Widget/ButtonWidget.php
+++ b/src/View/Widget/ButtonWidget.php
@@ -30,20 +30,12 @@ use function Cake\Core\h;
 class ButtonWidget implements WidgetInterface
 {
     /**
-     * StringTemplate instance.
-     *
-     * @var \Cake\View\StringTemplate
-     */
-    protected StringTemplate $templates;
-
-    /**
      * Constructor.
      *
      * @param \Cake\View\StringTemplate $templates Templates list.
      */
-    public function __construct(StringTemplate $templates)
+    public function __construct(protected StringTemplate $templates)
     {
-        $this->templates = $templates;
     }
 
     /**

--- a/src/View/Widget/LabelWidget.php
+++ b/src/View/Widget/LabelWidget.php
@@ -29,13 +29,6 @@ use function Cake\Core\h;
 class LabelWidget implements WidgetInterface
 {
     /**
-     * Templates
-     *
-     * @var \Cake\View\StringTemplate
-     */
-    protected StringTemplate $templates;
-
-    /**
      * The template to use.
      *
      * @var string
@@ -52,9 +45,8 @@ class LabelWidget implements WidgetInterface
      *
      * @param \Cake\View\StringTemplate $templates Templates list.
      */
-    public function __construct(StringTemplate $templates)
+    public function __construct(protected StringTemplate $templates)
     {
-        $this->templates = $templates;
     }
 
     /**

--- a/src/View/Widget/WidgetLocator.php
+++ b/src/View/Widget/WidgetLocator.php
@@ -48,31 +48,17 @@ class WidgetLocator
     protected array $widgets = [];
 
     /**
-     * Templates to use.
-     *
-     * @var \Cake\View\StringTemplate
-     */
-    protected StringTemplate $templates;
-
-    /**
-     * View instance.
-     *
-     * @var \Cake\View\View
-     */
-    protected View $view;
-
-    /**
      * Constructor
      *
      * @param \Cake\View\StringTemplate $templates Templates instance to use.
      * @param \Cake\View\View $view The view instance to set as a widget.
      * @param array $widgets See add() method for more information.
      */
-    public function __construct(StringTemplate $templates, View $view, array $widgets = [])
-    {
-        $this->templates = $templates;
-        $this->view = $view;
-
+    public function __construct(
+        protected StringTemplate $templates,
+        protected View $view,
+        array $widgets = [],
+    ) {
         $this->add($widgets);
     }
 

--- a/src/View/Widget/YearWidget.php
+++ b/src/View/Widget/YearWidget.php
@@ -45,23 +45,16 @@ class YearWidget extends BasicWidget
     ];
 
     /**
-     * Select box widget.
-     *
-     * @var \Cake\View\Widget\SelectBoxWidget
-     */
-    protected SelectBoxWidget $select;
-
-    /**
      * Constructor
      *
      * @param \Cake\View\StringTemplate $templates Templates list.
-     * @param \Cake\View\Widget\SelectBoxWidget $selectBox Selectbox widget instance.
+     * @param \Cake\View\Widget\SelectBoxWidget $select Selectbox widget instance.
      */
-    public function __construct(StringTemplate $templates, SelectBoxWidget $selectBox)
-    {
+    public function __construct(
+        StringTemplate $templates,
+        protected SelectBoxWidget $select,
+    ) {
         parent::__construct($templates);
-
-        $this->select = $selectBox;
     }
 
     /**

--- a/tests/PHPStan/AssociationTableMixinClassReflectionExtension.php
+++ b/tests/PHPStan/AssociationTableMixinClassReflectionExtension.php
@@ -14,15 +14,8 @@ use PHPStan\Reflection\ReflectionProvider;
 
 class AssociationTableMixinClassReflectionExtension implements PropertiesClassReflectionExtension, MethodsClassReflectionExtension
 {
-    /**
-     * @var \PHPStan\Reflection\ReflectionProvider
-     */
-    private ReflectionProvider $reflectionProvider;
-
-    public function __construct(
-        ReflectionProvider $reflectionProvider,
-    ) {
-        $this->reflectionProvider = $reflectionProvider;
+    public function __construct(private ReflectionProvider $reflectionProvider)
+    {
     }
 
     protected function getTableReflection(): ClassReflection

--- a/tests/PHPStan/TableFindByPropertyMethodReflection.php
+++ b/tests/PHPStan/TableFindByPropertyMethodReflection.php
@@ -14,20 +14,8 @@ use PHPStan\Type\Type;
 
 class TableFindByPropertyMethodReflection implements MethodReflection
 {
-    /**
-     * @var string
-     */
-    private string $name;
-
-    /**
-     * @var \PHPStan\Reflection\ClassReflection
-     */
-    private ClassReflection $declaringClass;
-
-    public function __construct(string $name, ClassReflection $declaringClass)
+    public function __construct(private string $name, private ClassReflection $declaringClass)
     {
-        $this->name = $name;
-        $this->declaringClass = $declaringClass;
     }
 
     public function getDeclaringClass(): ClassReflection

--- a/tests/TestCase/Container/Asset/Baz.php
+++ b/tests/TestCase/Container/Asset/Baz.php
@@ -5,10 +5,7 @@ namespace Cake\Test\TestCase\Container\Asset;
 
 class Baz
 {
-    public ?BarInterface $bar;
-
-    public function __construct(?BarInterface $bar = null)
+    public function __construct(public ?BarInterface $bar = null)
     {
-        $this->bar = $bar;
     }
 }

--- a/tests/test_app/TestApp/Controller/Component/ConfiguredComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/ConfiguredComponent.php
@@ -29,23 +29,17 @@ class ConfiguredComponent extends Component
     public $configCopy;
 
     /**
-     * components property
-     *
-     * @var array
-     */
-    protected array $components = [];
-
-    /**
      * Constructor
      *
      * @param ComponentRegistry $registry A ComponentRegistry this component can use to lazy load its components
      * @param array $config Array of configuration settings.
      * @param array $components Array of child components.
      */
-    public function __construct(ComponentRegistry $registry, array $config, array $components = [])
-    {
-        $this->components = $components;
-
+    public function __construct(
+        ComponentRegistry $registry,
+        array $config,
+        protected array $components = [],
+    ) {
         parent::__construct($registry, $config);
     }
 

--- a/tests/test_app/TestApp/Controller/Component/InjectedServiceComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/InjectedServiceComponent.php
@@ -13,20 +13,14 @@ use TestApp\Service\TestService;
 class InjectedServiceComponent extends Component
 {
     /**
-     * @var \TestApp\Service\TestService
-     */
-    protected TestService $service;
-
-    /**
      * Constructor
      *
      * @param \Cake\Controller\ComponentRegistry $registry A ComponentRegistry
      * @param \TestApp\Service\TestService $service The injected service
      * @param array $config Array of configuration settings
      */
-    public function __construct(ComponentRegistry $registry, TestService $service, array $config = [])
+    public function __construct(ComponentRegistry $registry, protected TestService $service, array $config = [])
     {
-        $this->service = $service;
         parent::__construct($registry, $config);
     }
 

--- a/tests/test_app/TestApp/Controller/DependenciesController.php
+++ b/tests/test_app/TestApp/Controller/DependenciesController.php
@@ -17,16 +17,13 @@ use TestApp\ReflectionDependency;
  */
 class DependenciesController extends Controller
 {
-    public ?stdClass $inject;
-
     public function __construct(
         ?ServerRequest $request = null,
         ?string $name = null,
         ?EventManagerInterface $eventManager = null,
-        ?stdClass $inject = null,
+        public ?stdClass $inject = null,
     ) {
         parent::__construct($request, $name, $eventManager);
-        $this->inject = $inject;
     }
 
     /**

--- a/tests/test_app/TestApp/Database/Type/UuidValue.php
+++ b/tests/test_app/TestApp/Database/Type/UuidValue.php
@@ -8,13 +8,10 @@ namespace TestApp\Database\Type;
  */
 class UuidValue
 {
-    public $value;
-
     /**
      * @param mixed $value
      */
-    public function __construct($value)
+    public function __construct(public $value)
     {
-        $this->value = $value;
     }
 }

--- a/tests/test_app/TestApp/Datasource/FakeConnection.php
+++ b/tests/test_app/TestApp/Datasource/FakeConnection.php
@@ -10,16 +10,13 @@ use RuntimeException;
 
 class FakeConnection implements ConnectionInterface
 {
-    protected $config = [];
-
     /**
      * Constructor.
      *
      * @param array $config configuration for connecting to database
      */
-    public function __construct($config = [])
+    public function __construct(protected $config = [])
     {
-        $this->config = $config;
     }
 
     /**


### PR DESCRIPTION
This gets rid if

- duplicate PHPDocs as there were sometimes/often differing property and constructor arg PHPDocs
- unneeded property assignments in constructors
- property definitions above the constructor