### PR TITLE
new 6.x CS ruleset

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "cakephp/validation": "self.version"
     },
     "require-dev": {
-        "cakephp/cakephp-codesniffer": "^5.3",
+        "cakephp/cakephp-codesniffer": "6.x-dev",
         "http-interop/http-factory-tests": "^2.0",
         "mikey179/vfsstream": "^1.6.12",
         "mockery/mockery": "^1.6.12",

--- a/src/AttributeResolver/AttributeCollection.php
+++ b/src/AttributeResolver/AttributeCollection.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\AttributeResolver;
 
-use Cake\AttributeResolver\Enum\AttributeTargetType;
+use Cake\AttributeResolver\Enum\AttributeTargetTypeEnum;
 use Cake\AttributeResolver\ValueObject\AttributeInfo;
 use Countable;
 use IteratorAggregate;
@@ -119,7 +119,7 @@ class AttributeCollection implements IteratorAggregate, Countable
             ? $item['target']['type']
             : $item['target']->type->value;
 
-        if ($targetType instanceof AttributeTargetType) {
+        if ($targetType instanceof AttributeTargetTypeEnum) {
             $targetType = $targetType->value;
         }
 
@@ -294,10 +294,10 @@ class AttributeCollection implements IteratorAggregate, Countable
     /**
      * Filter by target type(s). Uses index for fast lookup.
      *
-     * @param \Cake\AttributeResolver\Enum\AttributeTargetType|array<\Cake\AttributeResolver\Enum\AttributeTargetType> $types Target type(s) to filter by
+     * @param \Cake\AttributeResolver\Enum\AttributeTargetTypeEnum|array<\Cake\AttributeResolver\Enum\AttributeTargetTypeEnum> $types Target type(s) to filter by
      * @return static
      */
-    public function withTargetType(AttributeTargetType|array $types): static
+    public function withTargetType(AttributeTargetTypeEnum|array $types): static
     {
         $types = is_array($types) ? $types : [$types];
         $matchingIds = [];

--- a/src/AttributeResolver/Enum/AttributeTargetTypeEnum.php
+++ b/src/AttributeResolver/Enum/AttributeTargetTypeEnum.php
@@ -26,7 +26,7 @@ namespace Cake\AttributeResolver\Enum;
  * - Parameters
  * - Class constants
  */
-enum AttributeTargetType: string
+enum AttributeTargetTypeEnum: string
 {
     /**
      * Attribute attached to a class

--- a/src/AttributeResolver/Parser.php
+++ b/src/AttributeResolver/Parser.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\AttributeResolver;
 
-use Cake\AttributeResolver\Enum\AttributeTargetType;
+use Cake\AttributeResolver\Enum\AttributeTargetTypeEnum;
 use Cake\AttributeResolver\ValueObject\AttributeInfo;
 use Cake\AttributeResolver\ValueObject\AttributeTarget;
 use Generator;
@@ -253,7 +253,7 @@ class Parser
             $filePath,
             $startLine === false ? 0 : $startLine,
             $fileTime,
-            new AttributeTarget(AttributeTargetType::CLASS_TYPE, $className),
+            new AttributeTarget(AttributeTargetTypeEnum::CLASS_TYPE, $className),
             $pluginName,
         );
 
@@ -292,7 +292,7 @@ class Parser
     ): Generator {
         $startLine = $method->getStartLine();
         $target = new AttributeTarget(
-            AttributeTargetType::METHOD,
+            AttributeTargetTypeEnum::METHOD,
             $method->getName(),
             $className,
         );
@@ -337,7 +337,7 @@ class Parser
         ?string $pluginName,
     ): Generator {
         $target = new AttributeTarget(
-            AttributeTargetType::PROPERTY,
+            AttributeTargetTypeEnum::PROPERTY,
             $property->getName(),
             $className,
         );
@@ -376,7 +376,7 @@ class Parser
         $startLine = $declaringFunction instanceof ReflectionMethod ? $declaringFunction->getStartLine() : false;
 
         $target = new AttributeTarget(
-            AttributeTargetType::PARAMETER,
+            AttributeTargetTypeEnum::PARAMETER,
             $parameter->getName(),
             $className . '::' . $methodName,
         );
@@ -410,7 +410,7 @@ class Parser
         ?string $pluginName,
     ): Generator {
         $target = new AttributeTarget(
-            AttributeTargetType::CONSTANT,
+            AttributeTargetTypeEnum::CONSTANT,
             $constant->getName(),
             $className,
         );

--- a/src/AttributeResolver/ValueObject/AttributeTarget.php
+++ b/src/AttributeResolver/ValueObject/AttributeTarget.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\AttributeResolver\ValueObject;
 
-use Cake\AttributeResolver\Enum\AttributeTargetType;
+use Cake\AttributeResolver\Enum\AttributeTargetTypeEnum;
 use JsonSerializable;
 
 /**
@@ -34,12 +34,12 @@ readonly class AttributeTarget implements JsonSerializable
     /**
      * Constructor for AttributeTarget.
      *
-     * @param \Cake\AttributeResolver\Enum\AttributeTargetType $type Target type
+     * @param \Cake\AttributeResolver\Enum\AttributeTargetTypeEnum $type Target type
      * @param string $name Target name (e.g., method name, property name)
      * @param string|null $declaringClass Class name that declares this target
      */
     public function __construct(
-        public AttributeTargetType $type,
+        public AttributeTargetTypeEnum $type,
         public string $name,
         public ?string $declaringClass = null,
     ) {
@@ -68,8 +68,8 @@ readonly class AttributeTarget implements JsonSerializable
     public static function fromArray(array $data): self
     {
         $type = $data['type'];
-        if (!$type instanceof AttributeTargetType) {
-            $type = AttributeTargetType::from((string)$type);
+        if (!$type instanceof AttributeTargetTypeEnum) {
+            $type = AttributeTargetTypeEnum::from((string)$type);
         }
 
         return new self(

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -79,7 +79,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      *   If left null, a callback that filters out falsey values will be used.
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function filter(?callable $callback = null): CollectionInterface;
+    public function filter(?callable $callback = null): self;
 
     /**
      * Looks through each value in the collection, and returns another collection with
@@ -105,7 +105,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      *   If left null, a callback that filters out truthy values will be used.
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function reject(?callable $callback = null): CollectionInterface;
+    public function reject(?callable $callback = null): self;
 
     /**
      * Loops through each value in the collection and returns a new collection
@@ -118,7 +118,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      *   the value used to determine uniqueness. If left null, the element values themselves are used.
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function unique(?callable $callback = null): CollectionInterface;
+    public function unique(?callable $callback = null): self;
 
     /**
      * Returns true if all values in this collection pass the truth test provided
@@ -219,7 +219,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      *   returns the transformed value for each element.
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function map(callable $callback): CollectionInterface;
+    public function map(callable $callback): self;
 
     /**
      * Folds the values in this collection to a single value, as the result of
@@ -279,7 +279,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * of doing that.
      * @return \Cake\Collection\CollectionInterface<TKey, mixed>
      */
-    public function extract(callable|string $path): CollectionInterface;
+    public function extract(callable|string $path): self;
 
     /**
      * Returns the top element in this collection after being sorted by a property.
@@ -432,7 +432,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
         callable|string $path,
         int $order = SORT_DESC,
         int $sort = SORT_NUMERIC,
-    ): CollectionInterface;
+    ): self;
 
     /**
      * Splits a collection into sets, grouped by the result of running each value
@@ -475,7 +475,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * or a function returning the grouping key out of the provided element
      * @return \Cake\Collection\CollectionInterface<mixed, mixed>
      */
-    public function groupBy(callable|string $path): CollectionInterface;
+    public function groupBy(callable|string $path): self;
 
     /**
      * Given a list and a callback function that returns a key for each element
@@ -514,7 +514,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * or a function returning the indexing key out of the provided element
      * @return \Cake\Collection\CollectionInterface<mixed, TValue>
      */
-    public function indexBy(callable|string $path): CollectionInterface;
+    public function indexBy(callable|string $path): self;
 
     /**
      * Sorts a list into groups and returns a count for the number of elements
@@ -552,7 +552,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * or a function returning the indexing key out of the provided element
      * @return \Cake\Collection\CollectionInterface<mixed, int>
      */
-    public function countBy(callable|string $path): CollectionInterface;
+    public function countBy(callable|string $path): self;
 
     /**
      * Returns the total sum of all the values extracted with $matcher
@@ -587,7 +587,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      *
      * @return \Cake\Collection\CollectionInterface<int, TValue>
      */
-    public function shuffle(): CollectionInterface;
+    public function shuffle(): self;
 
     /**
      * Returns a new collection with maximum $length random elements
@@ -597,7 +597,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * take from this collection
      * @return \Cake\Collection\CollectionInterface<int, TValue>
      */
-    public function sample(int $length = 10): CollectionInterface;
+    public function sample(int $length = 10): self;
 
     /**
      * Returns a new collection with maximum $length elements in the internal
@@ -609,7 +609,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * @param int $offset A positional offset from where to take the elements
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function take(int $length = 1, int $offset = 0): CollectionInterface;
+    public function take(int $length = 1, int $offset = 0): self;
 
     /**
      * Returns the last N elements of a collection
@@ -628,7 +628,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * @param int $length The number of elements at the end of the collection
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function takeLast(int $length): CollectionInterface;
+    public function takeLast(int $length): self;
 
     /**
      * Returns a new collection that will skip the specified amount of elements
@@ -637,7 +637,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * @param int $length The number of elements to skip.
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function skip(int $length): CollectionInterface;
+    public function skip(int $length): self;
 
     /**
      * Looks through each value in the list, returning a Collection of all the
@@ -664,7 +664,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      *   and the value is the expected value to match against.
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function match(array $conditions): CollectionInterface;
+    public function match(array $conditions): self;
 
     /**
      * Returns the first result matching all the key-value pairs listed in
@@ -699,7 +699,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * @param iterable $items Items list.
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function append(iterable $items): CollectionInterface;
+    public function append(iterable $items): self;
 
     /**
      * Append a single item creating a new collection.
@@ -708,7 +708,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * @param mixed $key The key to append the item with. If null a key will be generated.
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function appendItem(mixed $item, mixed $key = null): CollectionInterface;
+    public function appendItem(mixed $item, mixed $key = null): self;
 
     /**
      * Prepend a set of items to a collection creating a new collection
@@ -716,7 +716,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * @param iterable $items The items to prepend.
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function prepend(iterable $items): CollectionInterface;
+    public function prepend(iterable $items): self;
 
     /**
      * Prepend a single item creating a new collection.
@@ -725,7 +725,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * @param mixed $key The key to prepend the item with. If null a key will be generated.
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function prependItem(mixed $item, mixed $key = null): CollectionInterface;
+    public function prependItem(mixed $item, mixed $key = null): self;
 
     /**
      * Returns a new collection where the values extracted based on a value path
@@ -771,7 +771,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
         callable|string $keyPath,
         callable|string $valuePath,
         callable|string|null $groupPath = null,
-    ): CollectionInterface;
+    ): self;
 
     /**
      * Returns a new collection where the values are nested in a tree-like structure
@@ -788,7 +788,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
         callable|string $idPath,
         callable|string $parentPath,
         string $nestingKey = 'children',
-    ): CollectionInterface;
+    ): self;
 
     /**
      * Returns a new collection containing each of the elements found in `$values` as
@@ -826,7 +826,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * values are matched with the elements in this collection by its positional index.
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function insert(string $path, mixed $values): CollectionInterface;
+    public function insert(string $path, mixed $values): self;
 
     /**
      * Returns an array representation of the results
@@ -890,7 +890,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * can help getting all items if keys are not important in the result.
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function compile(bool $keepKeys = true): CollectionInterface;
+    public function compile(bool $keepKeys = true): self;
 
     /**
      * Returns a new collection where any operations chained after it are guaranteed
@@ -900,7 +900,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      *
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function lazy(): CollectionInterface;
+    public function lazy(): self;
 
     /**
      * Returns a new collection where the operations performed by this collection.
@@ -911,7 +911,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      *
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function buffered(): CollectionInterface;
+    public function buffered(): self;
 
     /**
      * Returns a new collection with each of the elements of this collection
@@ -955,7 +955,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
     public function listNested(
         string|int $order = 'desc',
         callable|string $nestingKey = 'children',
-    ): CollectionInterface;
+    ): self;
 
     /**
      * Creates a new collection that when iterated will stop yielding results if
@@ -990,7 +990,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * and the value the condition against with each element will be matched.
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function stopWhen(callable|array $condition): CollectionInterface;
+    public function stopWhen(callable|array $condition): self;
 
     /**
      * Creates a new collection where the items are the
@@ -1025,7 +1025,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * the items in the collection and should return an array or Traversable object
      * @return \Cake\Collection\CollectionInterface<mixed, mixed>
      */
-    public function unfold(?callable $callback = null): CollectionInterface;
+    public function unfold(?callable $callback = null): self;
 
     /**
      * Passes this collection through a callable as its first argument.
@@ -1044,7 +1044,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * this collection as first argument.
      * @return \Cake\Collection\CollectionInterface<TKey, TValue>
      */
-    public function through(callable $callback): CollectionInterface;
+    public function through(callable $callback): self;
 
     /**
      * Combines the elements of this collection with each of the elements of the
@@ -1060,7 +1060,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * @param iterable ...$items The collections to zip.
      * @return \Cake\Collection\CollectionInterface<mixed, mixed>
      */
-    public function zip(iterable ...$items): CollectionInterface;
+    public function zip(iterable ...$items): self;
 
     // phpcs:disable
     /**
@@ -1100,7 +1100,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * @param int $chunkSize The maximum size for each chunk
      * @return \Cake\Collection\CollectionInterface<TKey, array<TValue>>
      */
-    public function chunk(int $chunkSize): CollectionInterface;
+    public function chunk(int $chunkSize): self;
 
     /**
      * Breaks the collection into smaller arrays of the given size.
@@ -1117,7 +1117,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      * @param bool $keepKeys If the keys of the array should be kept
      * @return \Cake\Collection\CollectionInterface<TKey, array<TKey, TValue>>
      */
-    public function chunkWithKeys(int $chunkSize, bool $keepKeys = true): CollectionInterface;
+    public function chunkWithKeys(int $chunkSize, bool $keepKeys = true): self;
 
     /**
      * Returns whether there are elements in this collection
@@ -1172,7 +1172,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      *
      * @return \Cake\Collection\CollectionInterface<int, array<mixed>>
      */
-    public function transpose(): CollectionInterface;
+    public function transpose(): self;
 
     /**
      * Returns the amount of elements in the collection.
@@ -1252,5 +1252,5 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      *   of the final results.
      * @return \Cake\Collection\CollectionInterface<int, array<mixed>>
      */
-    public function cartesianProduct(?callable $operation = null, ?callable $filter = null): CollectionInterface;
+    public function cartesianProduct(?callable $operation = null, ?callable $filter = null): self;
 }

--- a/src/Command/AttributesListCommand.php
+++ b/src/Command/AttributesListCommand.php
@@ -18,7 +18,7 @@ namespace Cake\Command;
 
 use Cake\AttributeResolver\AttributeCollection;
 use Cake\AttributeResolver\AttributeResolver;
-use Cake\AttributeResolver\Enum\AttributeTargetType;
+use Cake\AttributeResolver\Enum\AttributeTargetTypeEnum;
 use Cake\AttributeResolver\ValueObject\AttributeInfo;
 use Cake\Console\ConsoleOptionParser;
 
@@ -152,7 +152,7 @@ class AttributesListCommand extends Command
 
         $type = $this->args->getOption('type');
         if ($type) {
-            $targetType = AttributeTargetType::tryFrom((string)$type);
+            $targetType = AttributeTargetTypeEnum::tryFrom((string)$type);
             if ($targetType) {
                 $collection = $collection->withTargetType($targetType);
             } else {

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -121,7 +121,7 @@ class ConsoleInputArgument
      * @param \Cake\Console\ConsoleInputArgument $argument ConsoleInputArgument to compare to.
      * @return bool
      */
-    public function isEqualTo(ConsoleInputArgument $argument): bool
+    public function isEqualTo(self $argument): bool
     {
         return $this->name() === $argument->name() &&
             $this->usage() === $argument->usage();

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -239,9 +239,9 @@ class ConsoleOptionParser
      * @param \Cake\Console\ConsoleOptionParser|array $spec ConsoleOptionParser or spec to merge with.
      * @return $this
      */
-    public function merge(ConsoleOptionParser|array $spec): static
+    public function merge(self|array $spec): static
     {
-        if ($spec instanceof ConsoleOptionParser) {
+        if ($spec instanceof self) {
             $spec = $spec->toArray();
         }
         if (!empty($spec['arguments'])) {

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -273,7 +273,7 @@ class Container implements DefinitionContainerInterface
      * @param mixed $id
      * @param bool $new
      * @param array<string, mixed> $args
-     * @return mixed|object|array|null|void
+     * @return mixed
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
      */

--- a/src/Container/ContainerAwareInterface.php
+++ b/src/Container/ContainerAwareInterface.php
@@ -14,5 +14,5 @@ interface ContainerAwareInterface
      * @param \Cake\Container\DefinitionContainerInterface $container
      * @return $this
      */
-    public function setContainer(DefinitionContainerInterface $container): ContainerAwareInterface;
+    public function setContainer(DefinitionContainerInterface $container): self;
 }

--- a/src/Container/ContainerAwareTrait.php
+++ b/src/Container/ContainerAwareTrait.php
@@ -26,7 +26,7 @@ trait ContainerAwareTrait
 
         throw new BadMethodCallException(sprintf(
             'Attempt to use (%s) while not implementing (%s)',
-            ContainerAwareTrait::class,
+            self::class,
             ContainerAwareInterface::class,
         ));
     }

--- a/src/Container/Definition/DefinitionInterface.php
+++ b/src/Container/Definition/DefinitionInterface.php
@@ -12,32 +12,32 @@ interface DefinitionInterface extends ContainerAwareInterface
      * @param string|null $name
      * @return $this
      */
-    public function addArgument(mixed $arg, ?string $name = null): DefinitionInterface;
+    public function addArgument(mixed $arg, ?string $name = null): self;
 
     /**
      * @param array $args
      * @return $this
      */
-    public function addArguments(array $args): DefinitionInterface;
+    public function addArguments(array $args): self;
 
     /**
      * @param string $method
      * @param array $args
      * @return $this
      */
-    public function addMethodCall(string $method, array $args = []): DefinitionInterface;
+    public function addMethodCall(string $method, array $args = []): self;
 
     /**
      * @param array $methods
      * @return $this
      */
-    public function addMethodCalls(array $methods = []): DefinitionInterface;
+    public function addMethodCalls(array $methods = []): self;
 
     /**
      * @param string $tag
      * @return $this
      */
-    public function addTag(string $tag): DefinitionInterface;
+    public function addTag(string $tag): self;
 
     /**
      * @return string
@@ -74,17 +74,17 @@ interface DefinitionInterface extends ContainerAwareInterface
      * @param string $id
      * @return $this
      */
-    public function setAlias(string $id): DefinitionInterface;
+    public function setAlias(string $id): self;
 
     /**
      * @param mixed $concrete
      * @return $this
      */
-    public function setConcrete(mixed $concrete): DefinitionInterface;
+    public function setConcrete(mixed $concrete): self;
 
     /**
      * @param bool $shared
      * @return $this
      */
-    public function setShared(bool $shared): DefinitionInterface;
+    public function setShared(bool $shared): self;
 }

--- a/src/Container/Inflector/InflectorInterface.php
+++ b/src/Container/Inflector/InflectorInterface.php
@@ -21,24 +21,24 @@ interface InflectorInterface
      * @param array $args
      * @return $this
      */
-    public function invokeMethod(string $name, array $args): InflectorInterface;
+    public function invokeMethod(string $name, array $args): self;
 
     /**
      * @param array $methods
      * @return $this
      */
-    public function invokeMethods(array $methods): InflectorInterface;
+    public function invokeMethods(array $methods): self;
 
     /**
      * @param array $properties
      * @return $this
      */
-    public function setProperties(array $properties): InflectorInterface;
+    public function setProperties(array $properties): self;
 
     /**
      * @param string $property
      * @param mixed $value
      * @return $this
      */
-    public function setProperty(string $property, mixed $value): InflectorInterface;
+    public function setProperty(string $property, mixed $value): self;
 }

--- a/src/Container/ServiceProvider/ServiceProviderAggregateInterface.php
+++ b/src/Container/ServiceProvider/ServiceProviderAggregateInterface.php
@@ -15,7 +15,7 @@ interface ServiceProviderAggregateInterface extends ContainerAwareInterface, Ite
      * @param \Cake\Container\ServiceProvider\ServiceProviderInterface $provider
      * @return $this
      */
-    public function add(ServiceProviderInterface $provider): ServiceProviderAggregateInterface;
+    public function add(ServiceProviderInterface $provider): self;
 
     /**
      * @param string $id

--- a/src/Container/ServiceProvider/ServiceProviderInterface.php
+++ b/src/Container/ServiceProvider/ServiceProviderInterface.php
@@ -27,5 +27,5 @@ interface ServiceProviderInterface extends ContainerAwareInterface
      * @param string $id
      * @return $this
      */
-    public function setIdentifier(string $id): ServiceProviderInterface;
+    public function setIdentifier(string $id): self;
 }

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -141,7 +141,7 @@ class Component implements EventListenerInterface
      * @param string $name Name of component to get.
      * @return \Cake\Controller\Component|null A Component object or null.
      */
-    public function __get(string $name): ?Component
+    public function __get(string $name): ?self
     {
         if (isset($this->componentInstances[$name])) {
             return $this->componentInstances[$name];

--- a/src/Database/Schema/ForeignKey.php
+++ b/src/Database/Schema/ForeignKey.php
@@ -250,12 +250,12 @@ class ForeignKey extends Constraint
     protected function normalizeDeferrable(string $deferrable): string
     {
         $mapping = [
-            'DEFERRED' => ForeignKey::DEFERRED,
-            'IMMEDIATE' => ForeignKey::IMMEDIATE,
-            'NOT DEFERRED' => ForeignKey::NOT_DEFERRED,
-            ForeignKey::DEFERRED => ForeignKey::DEFERRED,
-            ForeignKey::IMMEDIATE => ForeignKey::IMMEDIATE,
-            ForeignKey::NOT_DEFERRED => ForeignKey::NOT_DEFERRED,
+            'DEFERRED' => self::DEFERRED,
+            'IMMEDIATE' => self::IMMEDIATE,
+            'NOT DEFERRED' => self::NOT_DEFERRED,
+            self::DEFERRED => self::DEFERRED,
+            self::IMMEDIATE => self::IMMEDIATE,
+            self::NOT_DEFERRED => self::NOT_DEFERRED,
         ];
         $normalized = strtoupper(str_replace('_', ' ', $deferrable));
         if (array_key_exists($normalized, $mapping)) {

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -701,7 +701,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
                 $this->table,
             ));
         }
-        if ($attrs['type'] !== TableSchema::CONSTRAINT_CHECK) {
+        if ($attrs['type'] !== self::CONSTRAINT_CHECK) {
             if (empty($attrs['columns'])) {
                 throw new DatabaseException(sprintf(
                     'Constraints in table `%s` must have at least one column.',

--- a/src/Database/Type/EnumType.php
+++ b/src/Database/Type/EnumType.php
@@ -211,7 +211,7 @@ class EnumType extends BaseType
     public static function from(string $enumClassName): string
     {
         $typeName = 'enum-' . strtolower(Text::slug($enumClassName));
-        $instance = new EnumType($typeName, $enumClassName);
+        $instance = new self($typeName, $enumClassName);
         TypeFactory::set($typeName, $instance);
 
         return $typeName;

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -115,7 +115,7 @@ class Debugger
             $instance[0] = new $class();
         }
         if (!$instance) {
-            $instance[0] = new Debugger();
+            $instance[0] = new self();
         }
 
         /** @var static */
@@ -339,7 +339,7 @@ class Debugger
         $backtrace = debug_backtrace();
         array_shift($backtrace);
 
-        return Debugger::formatTrace($backtrace, $options);
+        return self::formatTrace($backtrace, $options);
     }
 
     /**
@@ -392,7 +392,7 @@ class Debugger
                 if ($options['args'] && isset($frame['args'])) {
                     $args = [];
                     foreach ($frame['args'] as $arg) {
-                        $args[] = Debugger::exportVar($arg);
+                        $args[] = self::exportVar($arg);
                     }
                     $reference .= implode(', ', $args);
                 }

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -88,7 +88,7 @@ class ExceptionTrap
      *
      * @var \Cake\Error\ExceptionTrap|null
      */
-    protected static ?ExceptionTrap $registeredTrap = null;
+    protected static ?self $registeredTrap = null;
 
     /**
      * Track if this trap was removed from the global handler.

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -39,7 +39,7 @@ class EventManager implements EventManagerInterface
      *
      * @var \Cake\Event\EventManager|null
      */
-    protected static ?EventManager $generalManager = null;
+    protected static ?self $generalManager = null;
 
     /**
      * List of listener callbacks associated to
@@ -80,13 +80,13 @@ class EventManager implements EventManagerInterface
      * @param \Cake\Event\EventManager|null $manager Event manager instance.
      * @return \Cake\Event\EventManager The global event manager
      */
-    public static function instance(?EventManager $manager = null): EventManager
+    public static function instance(?self $manager = null): self
     {
         if ($manager === null && static::$generalManager) {
             return static::$generalManager;
         }
 
-        if ($manager instanceof EventManager) {
+        if ($manager instanceof self) {
             static::$generalManager = $manager;
         }
         static::$generalManager ??= new static();

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -320,8 +320,7 @@ class Cookie implements CookieInterface
         $value = $data['value'];
         unset($data['name'], $data['value']);
 
-        /** @phpstan-ignore return.type */
-        return Cookie::create(
+        return self::create(
             $name,
             $value,
             $data,

--- a/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
@@ -282,7 +282,7 @@ class SessionCsrfProtectionMiddleware implements MiddlewareInterface
      */
     public static function replaceToken(ServerRequest $request, string $key = 'csrfToken'): ServerRequest
     {
-        $middleware = new SessionCsrfProtectionMiddleware(['key' => $key]);
+        $middleware = new self(['key' => $key]);
 
         $token = $middleware->createToken();
         $request->getSession()->write($key, $token);

--- a/src/I18n/Date.php
+++ b/src/I18n/Date.php
@@ -46,7 +46,7 @@ class Date extends ChronosDate implements JsonSerializable, Stringable
      * @var string|int
      * @see \Cake\I18n\Date::i18nFormat()
      */
-    protected static string|int $_toStringFormat = IntlDateFormatter::SHORT;
+    protected static string|int $_toStringFormat = IntlDateFormatter::SHORT; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
     /**
      * The format to use when converting this object to JSON.

--- a/src/I18n/DateTime.php
+++ b/src/I18n/DateTime.php
@@ -68,7 +68,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
      * @var array<int>|string|int
      * @see \Cake\I18n\DateTime::i18nFormat()
      */
-    protected static array|string|int $_toStringFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::SHORT];
+    protected static array|string|int $_toStringFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::SHORT]; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
     /**
      * The format to use when converting this object to JSON.
@@ -429,7 +429,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
         DateTimeZone|string|null $timezone = null,
         ?string $locale = null,
     ): string|int {
-        if ($format === DateTime::UNIX_TIMESTAMP_FORMAT) {
+        if ($format === self::UNIX_TIMESTAMP_FORMAT) {
             return $this->getTimestamp();
         }
 
@@ -441,7 +441,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
 
         $format ??= static::$_toStringFormat;
         $format = is_int($format) ? [$format, $format] : $format;
-        $locale = $locale ?: DateTime::getDefaultLocale();
+        $locale = $locale ?: self::getDefaultLocale();
 
         return $this->formatObject($time, $format, $locale);
     }

--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -45,7 +45,7 @@ class Time extends ChronosTime implements JsonSerializable, Stringable
      * @var string|int
      * @see \Cake\I18n\Time::i18nFormat()
      */
-    protected static string|int $_toStringFormat = IntlDateFormatter::SHORT;
+    protected static string|int $_toStringFormat = IntlDateFormatter::SHORT; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
     /**
      * The format to use when converting this object to JSON.

--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -33,7 +33,7 @@ class Translator
      *
      * @var \Cake\I18n\Translator|null
      */
-    protected ?Translator $fallback = null;
+    protected ?self $fallback = null;
 
     /**
      * The formatter to use when translating messages.
@@ -68,7 +68,7 @@ class Translator
         string $locale,
         Package $package,
         FormatterInterface $formatter,
-        ?Translator $fallback = null,
+        ?self $fallback = null,
     ) {
         $this->locale = $locale;
         $this->package = $package;

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -1188,7 +1188,7 @@ abstract class Association
      * @return self
      * @throws \RuntimeException if no association with such a name exists
      */
-    public function __get(string $property): Association
+    public function __get(string $property): self
     {
         return $this->getTarget()->{$property};
     }

--- a/src/ORM/EagerLoadable.php
+++ b/src/ORM/EagerLoadable.php
@@ -166,7 +166,7 @@ class EagerLoadable
      * @param \Cake\ORM\EagerLoadable $association The association to load.
      * @return void
      */
-    public function addAssociation(string $name, EagerLoadable $association): void
+    public function addAssociation(string $name, self $association): void
     {
         $this->associations[$name] = $association;
     }

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -84,7 +84,7 @@ class EagerLoader
      *
      * @var \Cake\ORM\EagerLoader|null
      */
-    protected ?EagerLoader $matching = null;
+    protected ?self $matching = null;
 
     /**
      * A map of table aliases pointing to the association objects they represent

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -112,12 +112,12 @@ class Router
      * @var array<string, string>
      */
     protected static array $namedExpressions = [
-        'Action' => Router::ACTION,
-        'Year' => Router::YEAR,
-        'Month' => Router::MONTH,
-        'Day' => Router::DAY,
-        'ID' => Router::ID,
-        'UUID' => Router::UUID,
+        'Action' => self::ACTION,
+        'Year' => self::YEAR,
+        'Month' => self::MONTH,
+        'Day' => self::DAY,
+        'ID' => self::ID,
+        'UUID' => self::UUID,
     ];
 
     /**

--- a/src/Utility/Fs/Enum/DepthOperatorEnum.php
+++ b/src/Utility/Fs/Enum/DepthOperatorEnum.php
@@ -17,24 +17,39 @@ declare(strict_types=1);
 namespace Cake\Utility\Fs\Enum;
 
 /**
- * Enum for Finder iteration modes
+ * Enum for depth comparison operators
  *
- * Defines what type of filesystem items to iterate over.
+ * Defines the comparison operators that can be used with Finder::depth()
  */
-enum FinderMode
+enum DepthOperatorEnum: string
 {
     /**
-     * Iterate only files
+     * Equal to (==)
      */
-    case FILES;
+    case EQUAL = '==';
 
     /**
-     * Iterate only directories
+     * Not equal to (!=)
      */
-    case DIRECTORIES;
+    case NOT_EQUAL = '!=';
 
     /**
-     * Iterate both files and directories
+     * Less than (<)
      */
-    case ALL;
+    case LESS_THAN = '<';
+
+    /**
+     * Greater than (>)
+     */
+    case GREATER_THAN = '>';
+
+    /**
+     * Less than or equal to (<=)
+     */
+    case LESS_THAN_OR_EQUAL = '<=';
+
+    /**
+     * Greater than or equal to (>=)
+     */
+    case GREATER_THAN_OR_EQUAL = '>=';
 }

--- a/src/Utility/Fs/Enum/FinderModeEnum.php
+++ b/src/Utility/Fs/Enum/FinderModeEnum.php
@@ -17,39 +17,24 @@ declare(strict_types=1);
 namespace Cake\Utility\Fs\Enum;
 
 /**
- * Enum for depth comparison operators
+ * Enum for Finder iteration modes
  *
- * Defines the comparison operators that can be used with Finder::depth()
+ * Defines what type of filesystem items to iterate over.
  */
-enum DepthOperator: string
+enum FinderModeEnum
 {
     /**
-     * Equal to (==)
+     * Iterate only files
      */
-    case EQUAL = '==';
+    case FILES;
 
     /**
-     * Not equal to (!=)
+     * Iterate only directories
      */
-    case NOT_EQUAL = '!=';
+    case DIRECTORIES;
 
     /**
-     * Less than (<)
+     * Iterate both files and directories
      */
-    case LESS_THAN = '<';
-
-    /**
-     * Greater than (>)
-     */
-    case GREATER_THAN = '>';
-
-    /**
-     * Less than or equal to (<=)
-     */
-    case LESS_THAN_OR_EQUAL = '<=';
-
-    /**
-     * Greater than or equal to (>=)
-     */
-    case GREATER_THAN_OR_EQUAL = '>=';
+    case ALL;
 }

--- a/src/Utility/Fs/Finder.php
+++ b/src/Utility/Fs/Finder.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace Cake\Utility\Fs;
 
 use AppendIterator;
-use Cake\Utility\Fs\Enum\DepthOperator;
-use Cake\Utility\Fs\Enum\FinderMode;
+use Cake\Utility\Fs\Enum\DepthOperatorEnum;
+use Cake\Utility\Fs\Enum\FinderModeEnum;
 use Cake\Utility\Fs\Iterator\CallbackFilterIterator;
 use Cake\Utility\Fs\Iterator\ContainsPathFilterIterator;
 use Cake\Utility\Fs\Iterator\DepthFilterIterator;
@@ -116,7 +116,7 @@ class Finder
     /**
      * Depth conditions
      *
-     * @var array<array{0: \Cake\Utility\Fs\Enum\DepthOperator, 1: int}>
+     * @var array<array{0: \Cake\Utility\Fs\Enum\DepthOperatorEnum, 1: int}>
      */
     protected array $depths = [];
 
@@ -137,9 +137,9 @@ class Finder
     /**
      * The iteration mode (files, directories, or all)
      *
-     * @var \Cake\Utility\Fs\Enum\FinderMode|null
+     * @var \Cake\Utility\Fs\Enum\FinderModeEnum|null
      */
-    protected ?FinderMode $mode = null;
+    protected ?FinderModeEnum $mode = null;
 
     /**
      * Custom filter callbacks
@@ -266,10 +266,10 @@ class Finder
      * Add a depth condition.
      *
      * @param int $level The depth level (0 = top-level directory)
-     * @param \Cake\Utility\Fs\Enum\DepthOperator $operator The comparison operator (default: EQUAL)
+     * @param \Cake\Utility\Fs\Enum\DepthOperatorEnum $operator The comparison operator (default: EQUAL)
      * @return $this
      */
-    public function depth(int $level, DepthOperator $operator = DepthOperator::EQUAL)
+    public function depth(int $level, DepthOperatorEnum $operator = DepthOperatorEnum::EQUAL)
     {
         $this->depths[] = [$operator, $level];
 
@@ -308,7 +308,7 @@ class Finder
      */
     public function files(): Iterator
     {
-        $this->mode = FinderMode::FILES;
+        $this->mode = FinderModeEnum::FILES;
 
         return $this->iterate();
     }
@@ -320,7 +320,7 @@ class Finder
      */
     public function directories(): Iterator
     {
-        $this->mode = FinderMode::DIRECTORIES;
+        $this->mode = FinderModeEnum::DIRECTORIES;
 
         return $this->iterate();
     }
@@ -332,7 +332,7 @@ class Finder
      */
     public function all(): Iterator
     {
-        $this->mode = FinderMode::ALL;
+        $this->mode = FinderModeEnum::ALL;
 
         return $this->iterate();
     }
@@ -394,14 +394,14 @@ class Finder
 
         // Use SELF_FIRST when looking for directories to include them in iteration
         // Use LEAVES_ONLY when looking for files only for optimization
-        $iteratorMode = $this->mode === FinderMode::FILES
+        $iteratorMode = $this->mode === FinderModeEnum::FILES
             ? RecursiveIteratorIterator::LEAVES_ONLY
             : RecursiveIteratorIterator::SELF_FIRST;
 
         $iterator = new RecursiveIteratorIterator($directory, $iteratorMode);
 
         // Apply file type filtering
-        if ($this->mode !== null && $this->mode !== FinderMode::ALL) {
+        if ($this->mode !== null && $this->mode !== FinderModeEnum::ALL) {
             $iterator = new FileTypeFilterIterator($iterator, $this->mode);
         }
 
@@ -415,7 +415,7 @@ class Finder
 
         // Apply depth filtering (handles non-recursive mode when recursive=false)
         if (!$this->recursive) {
-            $iterator = new DepthFilterIterator($iterator, DepthOperator::EQUAL, 0);
+            $iterator = new DepthFilterIterator($iterator, DepthOperatorEnum::EQUAL, 0);
         }
         foreach ($this->depths as [$operator, $level]) {
             $iterator = new DepthFilterIterator($iterator, $operator, $level);

--- a/src/Utility/Fs/Iterator/DepthFilterIterator.php
+++ b/src/Utility/Fs/Iterator/DepthFilterIterator.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Utility\Fs\Iterator;
 
-use Cake\Utility\Fs\Enum\DepthOperator;
+use Cake\Utility\Fs\Enum\DepthOperatorEnum;
 use FilterIterator;
 use Iterator;
 use RecursiveIteratorIterator;
@@ -38,12 +38,12 @@ final class DepthFilterIterator extends FilterIterator
 {
     /**
      * @param \Iterator $iterator The iterator to filter (typically RecursiveIteratorIterator)
-     * @param \Cake\Utility\Fs\Enum\DepthOperator $operator Comparison operator
+     * @param \Cake\Utility\Fs\Enum\DepthOperatorEnum $operator Comparison operator
      * @param int $value Depth value to compare against
      */
     public function __construct(
         Iterator $iterator,
-        protected readonly DepthOperator $operator,
+        protected readonly DepthOperatorEnum $operator,
         protected readonly int $value,
     ) {
         parent::__construct($iterator);
@@ -76,12 +76,12 @@ final class DepthFilterIterator extends FilterIterator
         }
 
         return match ($this->operator) {
-            DepthOperator::EQUAL => $depth === $this->value,
-            DepthOperator::NOT_EQUAL => $depth !== $this->value,
-            DepthOperator::LESS_THAN => $depth < $this->value,
-            DepthOperator::LESS_THAN_OR_EQUAL => $depth <= $this->value,
-            DepthOperator::GREATER_THAN => $depth > $this->value,
-            DepthOperator::GREATER_THAN_OR_EQUAL => $depth >= $this->value,
+            DepthOperatorEnum::EQUAL => $depth === $this->value,
+            DepthOperatorEnum::NOT_EQUAL => $depth !== $this->value,
+            DepthOperatorEnum::LESS_THAN => $depth < $this->value,
+            DepthOperatorEnum::LESS_THAN_OR_EQUAL => $depth <= $this->value,
+            DepthOperatorEnum::GREATER_THAN => $depth > $this->value,
+            DepthOperatorEnum::GREATER_THAN_OR_EQUAL => $depth >= $this->value,
         };
     }
 }

--- a/src/Utility/Fs/Iterator/FileTypeFilterIterator.php
+++ b/src/Utility/Fs/Iterator/FileTypeFilterIterator.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Utility\Fs\Iterator;
 
-use Cake\Utility\Fs\Enum\FinderMode;
+use Cake\Utility\Fs\Enum\FinderModeEnum;
 use FilterIterator;
 use Iterator;
 
@@ -30,11 +30,11 @@ class FileTypeFilterIterator extends FilterIterator
 {
     /**
      * @param \Iterator $iterator The iterator to filter
-     * @param \Cake\Utility\Fs\Enum\FinderMode $mode The mode (FILES, DIRECTORIES, or ALL)
+     * @param \Cake\Utility\Fs\Enum\FinderModeEnum $mode The mode (FILES, DIRECTORIES, or ALL)
      */
     public function __construct(
         Iterator $iterator,
-        protected readonly FinderMode $mode,
+        protected readonly FinderModeEnum $mode,
     ) {
         parent::__construct($iterator);
     }
@@ -48,9 +48,9 @@ class FileTypeFilterIterator extends FilterIterator
         $current = $this->current();
 
         return match ($this->mode) {
-            FinderMode::FILES => $current->isFile(),
-            FinderMode::DIRECTORIES => $current->isDir(),
-            FinderMode::ALL => true,
+            FinderModeEnum::FILES => $current->isFile(),
+            FinderModeEnum::DIRECTORIES => $current->isDir(),
+            FinderModeEnum::ALL => true,
         };
     }
 }

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -126,7 +126,7 @@ class Security
     public static function randomString(int $length = 64): string
     {
         return substr(
-            bin2hex(Security::randomBytes((int)ceil($length / 2))),
+            bin2hex(self::randomBytes((int)ceil($length / 2))),
             0,
             $length,
         );

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -568,7 +568,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function addNested(
         string $field,
-        Validator $validator,
+        self $validator,
         ?string $message = null,
         Closure|string|null $when = null,
     ): static {
@@ -619,7 +619,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function addNestedMany(
         string $field,
-        Validator $validator,
+        self $validator,
         ?string $message = null,
         Closure|string|null $when = null,
     ): static {

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -98,7 +98,7 @@ class Helper implements EventListenerInterface
      * @param string $name Name of the property being accessed.
      * @return \Cake\View\Helper<\Cake\View\View>|null Helper instance if helper with provided name exists
      */
-    public function __get(string $name): ?Helper
+    public function __get(string $name): ?self
     {
         if (isset($this->helperInstances[$name])) {
             return $this->helperInstances[$name];

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -85,7 +85,7 @@ class ViewBlock
      * @throws \Cake\Core\Exception\CakeException When starting a block twice
      * @return void
      */
-    public function start(string $name, string $mode = ViewBlock::OVERRIDE): void
+    public function start(string $name, string $mode = self::OVERRIDE): void
     {
         if (array_key_exists($name, $this->active)) {
             throw new CakeException(sprintf('A view block with the name `%s` is already/still open.', $name));
@@ -116,7 +116,7 @@ class ViewBlock
         $mode = end($this->active);
         $active = key($this->active);
         $content = (string)ob_get_clean();
-        if ($mode === ViewBlock::OVERRIDE) {
+        if ($mode === self::OVERRIDE) {
             $this->blocks[$active] = $content;
         } else {
             $this->concat($active, $content, $mode);
@@ -139,7 +139,7 @@ class ViewBlock
      *   If ViewBlock::PREPEND it will be prepended.
      * @return void
      */
-    public function concat(string $name, mixed $value = null, string $mode = ViewBlock::APPEND): void
+    public function concat(string $name, mixed $value = null, string $mode = self::APPEND): void
     {
         if ($value === null) {
             $this->start($name, $mode);
@@ -150,7 +150,7 @@ class ViewBlock
         if (!isset($this->blocks[$name])) {
             $this->blocks[$name] = '';
         }
-        if ($mode === ViewBlock::PREPEND) {
+        if ($mode === self::PREPEND) {
             $this->blocks[$name] = $value . $this->blocks[$name];
         } else {
             $this->blocks[$name] .= $value;

--- a/tests/TestCase/AttributeResolver/AttributeCacheTest.php
+++ b/tests/TestCase/AttributeResolver/AttributeCacheTest.php
@@ -18,13 +18,13 @@ namespace Cake\Test\TestCase\AttributeResolver;
 
 use Cake\AttributeResolver\AttributeCache;
 use Cake\AttributeResolver\AttributeCollection;
-use Cake\AttributeResolver\Enum\AttributeTargetType;
+use Cake\AttributeResolver\Enum\AttributeTargetTypeEnum;
 use Cake\AttributeResolver\ValueObject\AttributeInfo;
 use Cake\AttributeResolver\ValueObject\AttributeTarget;
 use Cake\Cache\Cache;
 use Cake\TestSuite\TestCase;
 use stdClass;
-use TestApp\Attribute\Resolver\TestPriority;
+use TestApp\Attribute\Resolver\TestPriorityEnum;
 use TestApp\Attribute\Resolver\ValueObject\TestConfig;
 
 class AttributeCacheTest extends TestCase
@@ -76,7 +76,7 @@ class AttributeCacheTest extends TestCase
                 filePath: '/app/src/TestClass.php',
                 lineNumber: 10,
                 target: new AttributeTarget(
-                    type: AttributeTargetType::CLASS_TYPE,
+                    type: AttributeTargetTypeEnum::CLASS_TYPE,
                     name: 'TestClass',
                     declaringClass: 'App\\TestClass',
                 ),
@@ -114,7 +114,7 @@ class AttributeCacheTest extends TestCase
                 filePath: '/test1.php',
                 lineNumber: 1,
                 target: new AttributeTarget(
-                    type: AttributeTargetType::CLASS_TYPE,
+                    type: AttributeTargetTypeEnum::CLASS_TYPE,
                     name: 'TestClass1',
                     declaringClass: 'TestClass1',
                 ),
@@ -127,7 +127,7 @@ class AttributeCacheTest extends TestCase
                 filePath: '/test2.php',
                 lineNumber: 5,
                 target: new AttributeTarget(
-                    type: AttributeTargetType::METHOD,
+                    type: AttributeTargetTypeEnum::METHOD,
                     name: 'testMethod',
                     declaringClass: 'TestClass2',
                 ),
@@ -175,7 +175,7 @@ class AttributeCacheTest extends TestCase
                 filePath: '/test.php',
                 lineNumber: 1,
                 target: new AttributeTarget(
-                    type: AttributeTargetType::CLASS_TYPE,
+                    type: AttributeTargetTypeEnum::CLASS_TYPE,
                     name: 'Test',
                     declaringClass: 'Test',
                 ),
@@ -210,7 +210,7 @@ class AttributeCacheTest extends TestCase
                 filePath: $sourceFile,
                 lineNumber: 1,
                 target: new AttributeTarget(
-                    type: AttributeTargetType::CLASS_TYPE,
+                    type: AttributeTargetTypeEnum::CLASS_TYPE,
                     name: 'TestClass',
                     declaringClass: 'TestClass',
                 ),
@@ -257,7 +257,7 @@ class AttributeCacheTest extends TestCase
                 filePath: $sourceFile,
                 lineNumber: 1,
                 target: new AttributeTarget(
-                    type: AttributeTargetType::CLASS_TYPE,
+                    type: AttributeTargetTypeEnum::CLASS_TYPE,
                     name: 'TestClass',
                     declaringClass: 'TestClass',
                 ),
@@ -316,7 +316,7 @@ class AttributeCacheTest extends TestCase
             arguments: [
                 'path' => '/users/{id}',
                 'methods' => ['GET', 'POST'],
-                'targetType' => AttributeTargetType::METHOD,
+                'targetType' => AttributeTargetTypeEnum::METHOD,
                 'options' => [
                     'auth' => true,
                     'roles' => ['admin', 'user'],
@@ -328,7 +328,7 @@ class AttributeCacheTest extends TestCase
             filePath: '/app/src/Controller/UsersController.php',
             lineNumber: 25,
             target: new AttributeTarget(
-                type: AttributeTargetType::METHOD,
+                type: AttributeTargetTypeEnum::METHOD,
                 name: 'show',
                 declaringClass: 'App\\Controller\\UsersController',
             ),
@@ -365,7 +365,7 @@ class AttributeCacheTest extends TestCase
                 filePath: '/test.php',
                 lineNumber: 1,
                 target: new AttributeTarget(
-                    type: AttributeTargetType::CLASS_TYPE,
+                    type: AttributeTargetTypeEnum::CLASS_TYPE,
                     name: 'TestClass',
                     declaringClass: 'TestClass',
                 ),
@@ -396,7 +396,7 @@ class AttributeCacheTest extends TestCase
             filePath: '/non/existent/file.php',
             lineNumber: 1,
             target: new AttributeTarget(
-                type: AttributeTargetType::CLASS_TYPE,
+                type: AttributeTargetTypeEnum::CLASS_TYPE,
                 name: 'TestClass',
                 declaringClass: 'TestClass',
             ),
@@ -426,7 +426,7 @@ class AttributeCacheTest extends TestCase
                 filePath: '/test1.php',
                 lineNumber: 1,
                 target: new AttributeTarget(
-                    type: AttributeTargetType::CLASS_TYPE,
+                    type: AttributeTargetTypeEnum::CLASS_TYPE,
                     name: 'Class1',
                     declaringClass: 'Class1',
                 ),
@@ -439,7 +439,7 @@ class AttributeCacheTest extends TestCase
                 filePath: '/test2.php',
                 lineNumber: 2,
                 target: new AttributeTarget(
-                    type: AttributeTargetType::METHOD,
+                    type: AttributeTargetTypeEnum::METHOD,
                     name: 'testMethod',
                     declaringClass: 'Class2',
                 ),
@@ -458,8 +458,8 @@ class AttributeCacheTest extends TestCase
         $this->assertInstanceOf(AttributeInfo::class, $items[1]);
         $this->assertSame('Class1', $items[0]->className);
         $this->assertSame('Class2', $items[1]->className);
-        $this->assertSame(AttributeTargetType::CLASS_TYPE, $items[0]->target->type);
-        $this->assertSame(AttributeTargetType::METHOD, $items[1]->target->type);
+        $this->assertSame(AttributeTargetTypeEnum::CLASS_TYPE, $items[0]->target->type);
+        $this->assertSame(AttributeTargetTypeEnum::METHOD, $items[1]->target->type);
     }
 
     /**
@@ -512,7 +512,7 @@ class AttributeCacheTest extends TestCase
                     filePath: $sourceFile1,
                     lineNumber: 1,
                     target: new AttributeTarget(
-                        type: AttributeTargetType::CLASS_TYPE,
+                        type: AttributeTargetTypeEnum::CLASS_TYPE,
                         name: 'Test1',
                         declaringClass: 'Test1',
                     ),
@@ -525,7 +525,7 @@ class AttributeCacheTest extends TestCase
                     filePath: $sourceFile2,
                     lineNumber: 1,
                     target: new AttributeTarget(
-                        type: AttributeTargetType::CLASS_TYPE,
+                        type: AttributeTargetTypeEnum::CLASS_TYPE,
                         name: 'Test2',
                         declaringClass: 'Test2',
                     ),
@@ -587,7 +587,7 @@ class AttributeCacheTest extends TestCase
                 filePath: '/test.php',
                 lineNumber: 1,
                 target: new AttributeTarget(
-                    type: AttributeTargetType::METHOD,
+                    type: AttributeTargetTypeEnum::METHOD,
                     name: 'testMethod',
                     declaringClass: 'TestClass',
                 ),
@@ -633,7 +633,7 @@ class AttributeCacheTest extends TestCase
             filePath: '/app/src/Controller/UsersController.php',
             lineNumber: 10,
             target: new AttributeTarget(
-                type: AttributeTargetType::METHOD,
+                type: AttributeTargetTypeEnum::METHOD,
                 name: 'index',
                 declaringClass: 'App\\Controller\\UsersController',
             ),
@@ -665,13 +665,13 @@ class AttributeCacheTest extends TestCase
             className: 'App\\Service\\TaskService',
             attributeName: 'App\\Attribute\\TestComplexArgument',
             arguments: [
-                'priority' => TestPriority::HIGH,
-                'status' => TestPriority::CRITICAL,
+                'priority' => TestPriorityEnum::HIGH,
+                'status' => TestPriorityEnum::CRITICAL,
             ],
             filePath: '/app/src/Service/TaskService.php',
             lineNumber: 15,
             target: new AttributeTarget(
-                type: AttributeTargetType::METHOD,
+                type: AttributeTargetTypeEnum::METHOD,
                 name: 'execute',
                 declaringClass: 'App\\Service\\TaskService',
             ),
@@ -688,10 +688,10 @@ class AttributeCacheTest extends TestCase
         // Verify enum arguments are preserved
         $this->assertArrayHasKey('priority', $first->arguments);
         $this->assertArrayHasKey('status', $first->arguments);
-        $this->assertInstanceOf(TestPriority::class, $first->arguments['priority']);
-        $this->assertInstanceOf(TestPriority::class, $first->arguments['status']);
-        $this->assertSame(TestPriority::HIGH, $first->arguments['priority']);
-        $this->assertSame(TestPriority::CRITICAL, $first->arguments['status']);
+        $this->assertInstanceOf(TestPriorityEnum::class, $first->arguments['priority']);
+        $this->assertInstanceOf(TestPriorityEnum::class, $first->arguments['status']);
+        $this->assertSame(TestPriorityEnum::HIGH, $first->arguments['priority']);
+        $this->assertSame(TestPriorityEnum::CRITICAL, $first->arguments['status']);
     }
 
     /**
@@ -716,7 +716,7 @@ class AttributeCacheTest extends TestCase
             filePath: '/app/src/Model/Entity/User.php',
             lineNumber: 20,
             target: new AttributeTarget(
-                type: AttributeTargetType::PROPERTY,
+                type: AttributeTargetTypeEnum::PROPERTY,
                 name: 'settings',
                 declaringClass: 'App\\Model\\Entity\\User',
             ),

--- a/tests/TestCase/AttributeResolver/AttributeCollectionTest.php
+++ b/tests/TestCase/AttributeResolver/AttributeCollectionTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\AttributeResolver;
 
 use Cake\AttributeResolver\AttributeCollection;
-use Cake\AttributeResolver\Enum\AttributeTargetType;
+use Cake\AttributeResolver\Enum\AttributeTargetTypeEnum;
 use Cake\AttributeResolver\ValueObject\AttributeInfo;
 use Cake\AttributeResolver\ValueObject\AttributeTarget;
 use Cake\TestSuite\TestCase;
@@ -29,7 +29,7 @@ class AttributeCollectionTest extends TestCase
     private function createAttribute(
         string $attributeName,
         string $className,
-        AttributeTargetType $targetType,
+        AttributeTargetTypeEnum $targetType,
         ?string $pluginName = null,
     ): AttributeInfo {
         return new AttributeInfo(
@@ -73,7 +73,7 @@ class AttributeCollectionTest extends TestCase
     public function testAcceptsArrayOfAttributeInfoObjects(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
         ]);
 
         $this->assertCount(1, $collection);
@@ -115,10 +115,10 @@ class AttributeCollectionTest extends TestCase
     public function testFilterReturnsAttributeCollection(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
-            $this->createAttribute('App\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetType::METHOD),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
+            $this->createAttribute('App\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetTypeEnum::METHOD),
         ]);
-        $filtered = $collection->filter(fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetType::METHOD);
+        $filtered = $collection->filter(fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetTypeEnum::METHOD);
 
         $this->assertInstanceOf(AttributeCollection::class, $filtered);
         $this->assertCount(1, $filtered);
@@ -127,9 +127,9 @@ class AttributeCollectionTest extends TestCase
     public function testWithAttributeFiltersByExactName(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
-            $this->createAttribute('App\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetType::METHOD),
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\PostsController', AttributeTargetType::CONSTANT),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
+            $this->createAttribute('App\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetTypeEnum::METHOD),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\PostsController', AttributeTargetTypeEnum::CONSTANT),
         ]);
         $filtered = $collection->withAttribute('App\Attribute\Route');
 
@@ -140,9 +140,9 @@ class AttributeCollectionTest extends TestCase
     public function testWithAttributeAcceptsArrayWithOrLogic(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
-            $this->createAttribute('App\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetType::METHOD),
-            $this->createAttribute('App\Attribute\Validate', 'App\Model\Entity\User', AttributeTargetType::PROPERTY),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
+            $this->createAttribute('App\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetTypeEnum::METHOD),
+            $this->createAttribute('App\Attribute\Validate', 'App\Model\Entity\User', AttributeTargetTypeEnum::PROPERTY),
         ]);
         $filtered = $collection->withAttribute(['App\Attribute\Route', 'App\Attribute\Cache']);
 
@@ -155,7 +155,7 @@ class AttributeCollectionTest extends TestCase
     public function testWithAttributeReturnsEmptyWhenNoMatches(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
         ]);
         $filtered = $collection->withAttribute('App\Attribute\NonExistent');
 
@@ -165,9 +165,9 @@ class AttributeCollectionTest extends TestCase
     public function testWithNamespaceFiltersWithWildcards(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Controller\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
-            $this->createAttribute('App\Model\Attribute\Validate', 'App\Model\Entity\User', AttributeTargetType::PROPERTY),
-            $this->createAttribute('Plugin\Helper\Custom', 'App\View\Helper\MyHelper', AttributeTargetType::METHOD),
+            $this->createAttribute('App\Controller\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
+            $this->createAttribute('App\Model\Attribute\Validate', 'App\Model\Entity\User', AttributeTargetTypeEnum::PROPERTY),
+            $this->createAttribute('Plugin\Helper\Custom', 'App\View\Helper\MyHelper', AttributeTargetTypeEnum::METHOD),
         ]);
         $filtered = $collection->withNamespace('App\Controller\*');
 
@@ -178,8 +178,8 @@ class AttributeCollectionTest extends TestCase
     public function testWithNamespaceExactMatch(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
-            $this->createAttribute('App\Model\Route', 'App\Model\Entity\User', AttributeTargetType::PROPERTY),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
+            $this->createAttribute('App\Model\Route', 'App\Model\Entity\User', AttributeTargetTypeEnum::PROPERTY),
         ]);
         $filtered = $collection->withNamespace('App\Attribute\Route');
 
@@ -189,9 +189,9 @@ class AttributeCollectionTest extends TestCase
     public function testWithNamespaceMultipleWildcards(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Controller\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
-            $this->createAttribute('App\Controller\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetType::METHOD),
-            $this->createAttribute('App\Model\Attribute\Validate', 'App\Model\Entity\User', AttributeTargetType::PROPERTY),
+            $this->createAttribute('App\Controller\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
+            $this->createAttribute('App\Controller\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetTypeEnum::METHOD),
+            $this->createAttribute('App\Model\Attribute\Validate', 'App\Model\Entity\User', AttributeTargetTypeEnum::PROPERTY),
         ]);
         $filtered = $collection->withNamespace('App\*\Attribute\*');
 
@@ -201,11 +201,11 @@ class AttributeCollectionTest extends TestCase
     public function testWithTargetTypeFiltersBySingleEnum(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
-            $this->createAttribute('App\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetType::METHOD),
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\PostsController', AttributeTargetType::CONSTANT),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
+            $this->createAttribute('App\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetTypeEnum::METHOD),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\PostsController', AttributeTargetTypeEnum::CONSTANT),
         ]);
-        $filtered = $collection->withTargetType(AttributeTargetType::CONSTANT);
+        $filtered = $collection->withTargetType(AttributeTargetTypeEnum::CONSTANT);
 
         $this->assertCount(2, $filtered);
         $this->assertInstanceOf(AttributeCollection::class, $filtered);
@@ -214,11 +214,11 @@ class AttributeCollectionTest extends TestCase
     public function testWithTargetTypeAcceptsArray(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
-            $this->createAttribute('App\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetType::METHOD),
-            $this->createAttribute('App\Attribute\Validate', 'App\Model\Entity\User', AttributeTargetType::PROPERTY),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
+            $this->createAttribute('App\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetTypeEnum::METHOD),
+            $this->createAttribute('App\Attribute\Validate', 'App\Model\Entity\User', AttributeTargetTypeEnum::PROPERTY),
         ]);
-        $filtered = $collection->withTargetType([AttributeTargetType::METHOD, AttributeTargetType::PROPERTY]);
+        $filtered = $collection->withTargetType([AttributeTargetTypeEnum::METHOD, AttributeTargetTypeEnum::PROPERTY]);
 
         $this->assertCount(2, $filtered);
     }
@@ -226,9 +226,9 @@ class AttributeCollectionTest extends TestCase
     public function testWithClassNameFiltersByExactName(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
-            $this->createAttribute('App\Attribute\Cache', 'App\Controller\PostsController', AttributeTargetType::METHOD),
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::METHOD),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
+            $this->createAttribute('App\Attribute\Cache', 'App\Controller\PostsController', AttributeTargetTypeEnum::METHOD),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::METHOD),
         ]);
         $filtered = $collection->withClassName('App\Controller\UsersController');
 
@@ -239,9 +239,9 @@ class AttributeCollectionTest extends TestCase
     public function testWithClassNameAcceptsArray(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
-            $this->createAttribute('App\Attribute\Cache', 'App\Controller\PostsController', AttributeTargetType::METHOD),
-            $this->createAttribute('App\Attribute\Validate', 'App\Model\Entity\User', AttributeTargetType::PROPERTY),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
+            $this->createAttribute('App\Attribute\Cache', 'App\Controller\PostsController', AttributeTargetTypeEnum::METHOD),
+            $this->createAttribute('App\Attribute\Validate', 'App\Model\Entity\User', AttributeTargetTypeEnum::PROPERTY),
         ]);
         $filtered = $collection->withClassName(['App\Controller\UsersController', 'App\Controller\PostsController']);
 
@@ -251,9 +251,9 @@ class AttributeCollectionTest extends TestCase
     public function testWithAttributeContainsPartialMatching(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
-            $this->createAttribute('App\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetType::METHOD),
-            $this->createAttribute('Plugin\RouteAttribute', 'App\Controller\PostsController', AttributeTargetType::CONSTANT),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
+            $this->createAttribute('App\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetTypeEnum::METHOD),
+            $this->createAttribute('Plugin\RouteAttribute', 'App\Controller\PostsController', AttributeTargetTypeEnum::CONSTANT),
         ]);
         $filtered = $collection->withAttributeContains('Route');
 
@@ -263,8 +263,8 @@ class AttributeCollectionTest extends TestCase
     public function testWithAttributeContainsCaseSensitive(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
-            $this->createAttribute('App\Attribute\route', 'App\Controller\PostsController', AttributeTargetType::METHOD),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
+            $this->createAttribute('App\Attribute\route', 'App\Controller\PostsController', AttributeTargetTypeEnum::METHOD),
         ]);
         $filtered = $collection->withAttributeContains('Route');
 
@@ -274,9 +274,9 @@ class AttributeCollectionTest extends TestCase
     public function testWithClassNameContainsPartialMatching(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
-            $this->createAttribute('App\Attribute\Cache', 'App\Controller\PostsController', AttributeTargetType::METHOD),
-            $this->createAttribute('App\Attribute\Validate', 'App\Model\Entity\User', AttributeTargetType::PROPERTY),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
+            $this->createAttribute('App\Attribute\Cache', 'App\Controller\PostsController', AttributeTargetTypeEnum::METHOD),
+            $this->createAttribute('App\Attribute\Validate', 'App\Model\Entity\User', AttributeTargetTypeEnum::PROPERTY),
         ]);
         $filtered = $collection->withClassNameContains('Controller');
 
@@ -286,9 +286,9 @@ class AttributeCollectionTest extends TestCase
     public function testWithPluginFiltersByPluginName(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('TestPlugin\Attribute\Route', 'TestPlugin\Controller\UsersController', AttributeTargetType::METHOD, 'TestPlugin'),
-            $this->createAttribute('App\Attribute\Cache', 'App\Controller\PostsController', AttributeTargetType::METHOD),
-            $this->createAttribute('TestPlugin\Attribute\Cache', 'TestPlugin\Controller\PostsController', AttributeTargetType::METHOD, 'TestPlugin'),
+            $this->createAttribute('TestPlugin\Attribute\Route', 'TestPlugin\Controller\UsersController', AttributeTargetTypeEnum::METHOD, 'TestPlugin'),
+            $this->createAttribute('App\Attribute\Cache', 'App\Controller\PostsController', AttributeTargetTypeEnum::METHOD),
+            $this->createAttribute('TestPlugin\Attribute\Cache', 'TestPlugin\Controller\PostsController', AttributeTargetTypeEnum::METHOD, 'TestPlugin'),
         ]);
         $filtered = $collection->withPlugin('TestPlugin');
 
@@ -299,9 +299,9 @@ class AttributeCollectionTest extends TestCase
     public function testWithPluginNullFiltersAppAttributes(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('TestPlugin\Attribute\Route', 'TestPlugin\Controller\UsersController', AttributeTargetType::METHOD, 'TestPlugin'),
-            $this->createAttribute('App\Attribute\Cache', 'App\Controller\PostsController', AttributeTargetType::METHOD),
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::METHOD),
+            $this->createAttribute('TestPlugin\Attribute\Route', 'TestPlugin\Controller\UsersController', AttributeTargetTypeEnum::METHOD, 'TestPlugin'),
+            $this->createAttribute('App\Attribute\Cache', 'App\Controller\PostsController', AttributeTargetTypeEnum::METHOD),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::METHOD),
         ]);
         $filtered = $collection->withPlugin(null);
 
@@ -311,13 +311,13 @@ class AttributeCollectionTest extends TestCase
     public function testChainingMultipleFilters(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::CONSTANT),
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\PostsController', AttributeTargetType::METHOD),
-            $this->createAttribute('App\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetType::METHOD),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::CONSTANT),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\PostsController', AttributeTargetTypeEnum::METHOD),
+            $this->createAttribute('App\Attribute\Cache', 'App\Controller\UsersController', AttributeTargetTypeEnum::METHOD),
         ]);
         $filtered = $collection
             ->withAttribute('App\Attribute\Route')
-            ->withTargetType(AttributeTargetType::METHOD);
+            ->withTargetType(AttributeTargetTypeEnum::METHOD);
 
         $this->assertCount(1, $filtered);
         $this->assertInstanceOf(AttributeCollection::class, $filtered);
@@ -332,7 +332,7 @@ class AttributeCollectionTest extends TestCase
 
         $chained = $collection
             ->withNamespace('App\*')
-            ->withTargetType(AttributeTargetType::METHOD);
+            ->withTargetType(AttributeTargetTypeEnum::METHOD);
         $this->assertCount(0, $chained);
     }
 
@@ -348,7 +348,7 @@ class AttributeCollectionTest extends TestCase
             filePath: '/app/src/Controller/TestController.php',
             lineNumber: 10,
             target: new AttributeTarget(
-                type: AttributeTargetType::CLASS_TYPE,
+                type: AttributeTargetTypeEnum::CLASS_TYPE,
                 name: 'TestController',
                 declaringClass: 'App\Controller\TestController',
             ),
@@ -376,7 +376,7 @@ class AttributeCollectionTest extends TestCase
             filePath: '/app/src/Controller/FirstController.php',
             lineNumber: 5,
             target: new AttributeTarget(
-                type: AttributeTargetType::CLASS_TYPE,
+                type: AttributeTargetTypeEnum::CLASS_TYPE,
                 name: 'FirstController',
                 declaringClass: 'App\Controller\FirstController',
             ),
@@ -390,7 +390,7 @@ class AttributeCollectionTest extends TestCase
             filePath: '/app/src/Controller/SecondController.php',
             lineNumber: 10,
             target: new AttributeTarget(
-                type: AttributeTargetType::METHOD,
+                type: AttributeTargetTypeEnum::METHOD,
                 name: 'index',
                 declaringClass: 'App\Controller\SecondController',
             ),
@@ -445,13 +445,13 @@ class AttributeCollectionTest extends TestCase
         $this->assertCount(2, $routes);
 
         // Filter by target type
-        $methods = $collection->withTargetType(AttributeTargetType::METHOD);
+        $methods = $collection->withTargetType(AttributeTargetTypeEnum::METHOD);
         $this->assertCount(2, $methods);
 
         // Chained filtering
         $routeMethods = $collection
             ->withAttribute('App\Attribute\Route')
-            ->withTargetType(AttributeTargetType::METHOD);
+            ->withTargetType(AttributeTargetTypeEnum::METHOD);
         $this->assertCount(1, $routeMethods);
     }
 
@@ -501,8 +501,8 @@ class AttributeCollectionTest extends TestCase
     public function testGetCacheDataReturnsArraysAndIndexes(): void
     {
         $collection = new AttributeCollection([
-            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetType::METHOD),
-            $this->createAttribute('App\Attribute\Cache', 'App\Controller\PostsController', AttributeTargetType::PROPERTY),
+            $this->createAttribute('App\Attribute\Route', 'App\Controller\UsersController', AttributeTargetTypeEnum::METHOD),
+            $this->createAttribute('App\Attribute\Cache', 'App\Controller\PostsController', AttributeTargetTypeEnum::PROPERTY),
         ]);
 
         $cacheData = $collection->getCacheData();

--- a/tests/TestCase/AttributeResolver/Enum/AttributeTargetTypeTest.php
+++ b/tests/TestCase/AttributeResolver/Enum/AttributeTargetTypeTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\AttributeResolver\Enum;
 
-use Cake\AttributeResolver\Enum\AttributeTargetType;
+use Cake\AttributeResolver\Enum\AttributeTargetTypeEnum;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -29,14 +29,14 @@ class AttributeTargetTypeTest extends TestCase
      */
     public function testEnumCases(): void
     {
-        $cases = AttributeTargetType::cases();
+        $cases = AttributeTargetTypeEnum::cases();
 
         $this->assertCount(5, $cases);
-        $this->assertContains(AttributeTargetType::CLASS_TYPE, $cases);
-        $this->assertContains(AttributeTargetType::METHOD, $cases);
-        $this->assertContains(AttributeTargetType::PROPERTY, $cases);
-        $this->assertContains(AttributeTargetType::PARAMETER, $cases);
-        $this->assertContains(AttributeTargetType::CONSTANT, $cases);
+        $this->assertContains(AttributeTargetTypeEnum::CLASS_TYPE, $cases);
+        $this->assertContains(AttributeTargetTypeEnum::METHOD, $cases);
+        $this->assertContains(AttributeTargetTypeEnum::PROPERTY, $cases);
+        $this->assertContains(AttributeTargetTypeEnum::PARAMETER, $cases);
+        $this->assertContains(AttributeTargetTypeEnum::CONSTANT, $cases);
     }
 
     /**
@@ -44,11 +44,11 @@ class AttributeTargetTypeTest extends TestCase
      */
     public function testEnumValues(): void
     {
-        $this->assertSame('class', AttributeTargetType::CLASS_TYPE->value);
-        $this->assertSame('method', AttributeTargetType::METHOD->value);
-        $this->assertSame('property', AttributeTargetType::PROPERTY->value);
-        $this->assertSame('parameter', AttributeTargetType::PARAMETER->value);
-        $this->assertSame('constant', AttributeTargetType::CONSTANT->value);
+        $this->assertSame('class', AttributeTargetTypeEnum::CLASS_TYPE->value);
+        $this->assertSame('method', AttributeTargetTypeEnum::METHOD->value);
+        $this->assertSame('property', AttributeTargetTypeEnum::PROPERTY->value);
+        $this->assertSame('parameter', AttributeTargetTypeEnum::PARAMETER->value);
+        $this->assertSame('constant', AttributeTargetTypeEnum::CONSTANT->value);
     }
 
     /**
@@ -56,11 +56,11 @@ class AttributeTargetTypeTest extends TestCase
      */
     public function testFromValue(): void
     {
-        $this->assertSame(AttributeTargetType::CLASS_TYPE, AttributeTargetType::from('class'));
-        $this->assertSame(AttributeTargetType::METHOD, AttributeTargetType::from('method'));
-        $this->assertSame(AttributeTargetType::PROPERTY, AttributeTargetType::from('property'));
-        $this->assertSame(AttributeTargetType::PARAMETER, AttributeTargetType::from('parameter'));
-        $this->assertSame(AttributeTargetType::CONSTANT, AttributeTargetType::from('constant'));
+        $this->assertSame(AttributeTargetTypeEnum::CLASS_TYPE, AttributeTargetTypeEnum::from('class'));
+        $this->assertSame(AttributeTargetTypeEnum::METHOD, AttributeTargetTypeEnum::from('method'));
+        $this->assertSame(AttributeTargetTypeEnum::PROPERTY, AttributeTargetTypeEnum::from('property'));
+        $this->assertSame(AttributeTargetTypeEnum::PARAMETER, AttributeTargetTypeEnum::from('parameter'));
+        $this->assertSame(AttributeTargetTypeEnum::CONSTANT, AttributeTargetTypeEnum::from('constant'));
     }
 
     /**
@@ -68,6 +68,6 @@ class AttributeTargetTypeTest extends TestCase
      */
     public function testTryFromInvalidValue(): void
     {
-        $this->assertNull(AttributeTargetType::tryFrom('invalid'));
+        $this->assertNull(AttributeTargetTypeEnum::tryFrom('invalid'));
     }
 }

--- a/tests/TestCase/AttributeResolver/ParserTest.php
+++ b/tests/TestCase/AttributeResolver/ParserTest.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\AttributeResolver;
 
-use Cake\AttributeResolver\Enum\AttributeTargetType;
+use Cake\AttributeResolver\Enum\AttributeTargetTypeEnum;
 use Cake\AttributeResolver\Parser;
 use Cake\AttributeResolver\ValueObject\AttributeInfo;
 use Cake\TestSuite\TestCase;
 use SplFileInfo;
-use TestApp\Attribute\Resolver\TestPriority;
+use TestApp\Attribute\Resolver\TestPriorityEnum;
 use TestApp\Attribute\Resolver\ValueObject\TestConfig;
 
 class ParserTest extends TestCase
@@ -44,7 +44,7 @@ class ParserTest extends TestCase
         // Should find 1 class attribute + 4 method attributes
         $this->assertCount(5, $results);
 
-        $classAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetType::CLASS_TYPE);
+        $classAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetTypeEnum::CLASS_TYPE);
         $this->assertCount(1, $classAttrs);
 
         $classAttr = array_values($classAttrs)[0];
@@ -57,11 +57,11 @@ class ParserTest extends TestCase
         $filePath = $this->testDataPath . 'TestController.php';
         $results = iterator_to_array($this->parser->parseFile(new SplFileInfo($filePath)), false);
 
-        $methodAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetType::METHOD);
+        $methodAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetTypeEnum::METHOD);
         $this->assertCount(4, $methodAttrs);
 
         foreach ($methodAttrs as $attr) {
-            $this->assertSame(AttributeTargetType::METHOD, $attr->target->type);
+            $this->assertSame(AttributeTargetTypeEnum::METHOD, $attr->target->type);
             $this->assertSame('TestApp\\Attribute\\Resolver\\TestRoute', $attr->attributeName);
         }
     }
@@ -74,7 +74,7 @@ class ParserTest extends TestCase
         $this->assertCount(3, $results);
 
         foreach ($results as $result) {
-            $this->assertSame(AttributeTargetType::PROPERTY, $result->target->type);
+            $this->assertSame(AttributeTargetTypeEnum::PROPERTY, $result->target->type);
             $this->assertSame('TestApp\\Attribute\\Resolver\\TestColumn', $result->attributeName);
         }
     }
@@ -87,7 +87,7 @@ class ParserTest extends TestCase
         $this->assertCount(2, $results);
 
         foreach ($results as $result) {
-            $this->assertSame(AttributeTargetType::PARAMETER, $result->target->type);
+            $this->assertSame(AttributeTargetTypeEnum::PARAMETER, $result->target->type);
             $this->assertSame('TestApp\\Attribute\\Resolver\\TestInject', $result->attributeName);
         }
     }
@@ -100,7 +100,7 @@ class ParserTest extends TestCase
         $this->assertCount(2, $results);
 
         foreach ($results as $result) {
-            $this->assertSame(AttributeTargetType::CONSTANT, $result->target->type);
+            $this->assertSame(AttributeTargetTypeEnum::CONSTANT, $result->target->type);
             $this->assertSame('TestApp\\Attribute\\Resolver\\TestStatus', $result->attributeName);
         }
     }
@@ -180,7 +180,7 @@ class ParserTest extends TestCase
         $this->assertCount(3, $results);
 
         foreach ($results as $result) {
-            $this->assertSame(AttributeTargetType::PROPERTY, $result->target->type);
+            $this->assertSame(AttributeTargetTypeEnum::PROPERTY, $result->target->type);
             $this->assertSame('TestApp\\Attribute\\Resolver\\TestColumn', $result->attributeName);
         }
     }
@@ -227,8 +227,8 @@ class ParserTest extends TestCase
 
         $attr = array_values($withEnum)[0];
         $this->assertArrayHasKey('enum', $attr->arguments);
-        $this->assertInstanceOf(TestPriority::class, $attr->arguments['enum']);
-        $this->assertSame(TestPriority::HIGH, $attr->arguments['enum']);
+        $this->assertInstanceOf(TestPriorityEnum::class, $attr->arguments['enum']);
+        $this->assertSame(TestPriorityEnum::HIGH, $attr->arguments['enum']);
     }
 
     public function testComplexArgumentsWithConstants(): void
@@ -308,10 +308,10 @@ class ParserTest extends TestCase
         // Should find interface-level and method attributes
         $this->assertGreaterThan(0, count($results));
 
-        $interfaceAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetType::CLASS_TYPE);
+        $interfaceAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetTypeEnum::CLASS_TYPE);
         $this->assertCount(1, $interfaceAttrs);
 
-        $methodAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetType::METHOD);
+        $methodAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetTypeEnum::METHOD);
         $this->assertCount(1, $methodAttrs);
     }
 
@@ -323,10 +323,10 @@ class ParserTest extends TestCase
         // Should find trait-level and method attributes
         $this->assertGreaterThan(0, count($results));
 
-        $traitAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetType::CLASS_TYPE);
+        $traitAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetTypeEnum::CLASS_TYPE);
         $this->assertCount(1, $traitAttrs);
 
-        $methodAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetType::METHOD);
+        $methodAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetTypeEnum::METHOD);
         $this->assertCount(1, $methodAttrs);
     }
 
@@ -338,11 +338,11 @@ class ParserTest extends TestCase
         // Should find enum-level and case attributes
         $this->assertGreaterThan(0, count($results));
 
-        $enumAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetType::CLASS_TYPE);
+        $enumAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetTypeEnum::CLASS_TYPE);
         $this->assertCount(1, $enumAttrs);
 
         // Enum cases are treated as class constants
-        $caseAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetType::CONSTANT);
+        $caseAttrs = array_filter($results, fn(AttributeInfo $attr) => $attr->target->type === AttributeTargetTypeEnum::CONSTANT);
         $this->assertCount(2, $caseAttrs);
     }
 

--- a/tests/TestCase/AttributeResolver/ValueObject/AttributeInfoTest.php
+++ b/tests/TestCase/AttributeResolver/ValueObject/AttributeInfoTest.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\AttributeResolver\ValueObject;
 
 use Attribute;
-use Cake\AttributeResolver\Enum\AttributeTargetType;
+use Cake\AttributeResolver\Enum\AttributeTargetTypeEnum;
 use Cake\AttributeResolver\ValueObject\AttributeInfo;
 use Cake\AttributeResolver\ValueObject\AttributeTarget;
 use Cake\TestSuite\TestCase;
@@ -61,7 +61,7 @@ class AttributeInfoTest extends TestCase
     public function testConstructor(): void
     {
         $target = new AttributeTarget(
-            type: AttributeTargetType::METHOD,
+            type: AttributeTargetTypeEnum::METHOD,
             name: 'index',
             declaringClass: 'App\Controller\UsersController',
         );
@@ -93,7 +93,7 @@ class AttributeInfoTest extends TestCase
     public function testConstructorDefaults(): void
     {
         $target = new AttributeTarget(
-            type: AttributeTargetType::CLASS_TYPE,
+            type: AttributeTargetTypeEnum::CLASS_TYPE,
             name: 'MyClass',
         );
 
@@ -116,7 +116,7 @@ class AttributeInfoTest extends TestCase
     public function testToArray(): void
     {
         $target = new AttributeTarget(
-            type: AttributeTargetType::PROPERTY,
+            type: AttributeTargetTypeEnum::PROPERTY,
             name: 'title',
             declaringClass: 'App\Model\Entity\Article',
         );
@@ -177,7 +177,7 @@ class AttributeInfoTest extends TestCase
         $this->assertSame(['value' => 'index'], $info->arguments);
         $this->assertSame('/app/src/Controller/ArticlesController.php', $info->filePath);
         $this->assertSame(50, $info->lineNumber);
-        $this->assertSame(AttributeTargetType::METHOD, $info->target->type);
+        $this->assertSame(AttributeTargetTypeEnum::METHOD, $info->target->type);
         $this->assertSame('index', $info->target->name);
         $this->assertSame(1111111111, $info->fileTime);
         $this->assertSame('Admin', $info->pluginName);
@@ -189,7 +189,7 @@ class AttributeInfoTest extends TestCase
     public function testRoundTripSerialization(): void
     {
         $target = new AttributeTarget(
-            type: AttributeTargetType::PARAMETER,
+            type: AttributeTargetTypeEnum::PARAMETER,
             name: 'userId',
             declaringClass: 'App\Controller\UsersController',
         );
@@ -217,7 +217,7 @@ class AttributeInfoTest extends TestCase
     public function testGetInstance(): void
     {
         $target = new AttributeTarget(
-            type: AttributeTargetType::CLASS_TYPE,
+            type: AttributeTargetTypeEnum::CLASS_TYPE,
             name: 'TestClass',
         );
 
@@ -243,7 +243,7 @@ class AttributeInfoTest extends TestCase
     public function testGetInstanceWithExpectedClass(): void
     {
         $target = new AttributeTarget(
-            type: AttributeTargetType::CLASS_TYPE,
+            type: AttributeTargetTypeEnum::CLASS_TYPE,
             name: 'TestClass',
         );
 
@@ -270,7 +270,7 @@ class AttributeInfoTest extends TestCase
         $this->expectExceptionMessage('Attribute class "NonExistent\Class" does not exist');
 
         $target = new AttributeTarget(
-            type: AttributeTargetType::CLASS_TYPE,
+            type: AttributeTargetTypeEnum::CLASS_TYPE,
             name: 'TestClass',
         );
 
@@ -295,7 +295,7 @@ class AttributeInfoTest extends TestCase
         $this->expectExceptionMessageMatches('/is not an instance of/');
 
         $target = new AttributeTarget(
-            type: AttributeTargetType::CLASS_TYPE,
+            type: AttributeTargetTypeEnum::CLASS_TYPE,
             name: 'TestClass',
         );
 
@@ -317,7 +317,7 @@ class AttributeInfoTest extends TestCase
     public function testIsInstanceOf(): void
     {
         $target = new AttributeTarget(
-            type: AttributeTargetType::CLASS_TYPE,
+            type: AttributeTargetTypeEnum::CLASS_TYPE,
             name: 'TestClass',
         );
 
@@ -340,7 +340,7 @@ class AttributeInfoTest extends TestCase
     public function testPhpSerializeRoundTrip(): void
     {
         $target = new AttributeTarget(
-            type: AttributeTargetType::METHOD,
+            type: AttributeTargetTypeEnum::METHOD,
             name: 'view',
             declaringClass: 'App\Controller\ArticlesController',
         );
@@ -381,7 +381,7 @@ class AttributeInfoTest extends TestCase
     public function testPhpSerializeWithNullPluginName(): void
     {
         $target = new AttributeTarget(
-            type: AttributeTargetType::CLASS_TYPE,
+            type: AttributeTargetTypeEnum::CLASS_TYPE,
             name: 'MyClass',
         );
 
@@ -409,7 +409,7 @@ class AttributeInfoTest extends TestCase
     public function testJsonEncode(): void
     {
         $target = new AttributeTarget(
-            type: AttributeTargetType::METHOD,
+            type: AttributeTargetTypeEnum::METHOD,
             name: 'index',
             declaringClass: 'App\Controller\UsersController',
         );

--- a/tests/TestCase/AttributeResolver/ValueObject/AttributeTargetTest.php
+++ b/tests/TestCase/AttributeResolver/ValueObject/AttributeTargetTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\AttributeResolver\ValueObject;
 
-use Cake\AttributeResolver\Enum\AttributeTargetType;
+use Cake\AttributeResolver\Enum\AttributeTargetTypeEnum;
 use Cake\AttributeResolver\ValueObject\AttributeTarget;
 use Cake\TestSuite\TestCase;
 
@@ -31,12 +31,12 @@ class AttributeTargetTest extends TestCase
     public function testConstructor(): void
     {
         $target = new AttributeTarget(
-            type: AttributeTargetType::METHOD,
+            type: AttributeTargetTypeEnum::METHOD,
             name: 'myMethod',
             declaringClass: 'App\Controller\UsersController',
         );
 
-        $this->assertSame(AttributeTargetType::METHOD, $target->type);
+        $this->assertSame(AttributeTargetTypeEnum::METHOD, $target->type);
         $this->assertSame('myMethod', $target->name);
         $this->assertSame('App\Controller\UsersController', $target->declaringClass);
     }
@@ -47,11 +47,11 @@ class AttributeTargetTest extends TestCase
     public function testConstructorNullDeclaringClass(): void
     {
         $target = new AttributeTarget(
-            type: AttributeTargetType::CLASS_TYPE,
+            type: AttributeTargetTypeEnum::CLASS_TYPE,
             name: 'MyClass',
         );
 
-        $this->assertSame(AttributeTargetType::CLASS_TYPE, $target->type);
+        $this->assertSame(AttributeTargetTypeEnum::CLASS_TYPE, $target->type);
         $this->assertSame('MyClass', $target->name);
         $this->assertNull($target->declaringClass);
     }
@@ -62,7 +62,7 @@ class AttributeTargetTest extends TestCase
     public function testToArray(): void
     {
         $target = new AttributeTarget(
-            type: AttributeTargetType::PROPERTY,
+            type: AttributeTargetTypeEnum::PROPERTY,
             name: 'title',
             declaringClass: 'App\Model\Entity\Article',
         );
@@ -82,7 +82,7 @@ class AttributeTargetTest extends TestCase
     public function testToArrayNullDeclaringClass(): void
     {
         $target = new AttributeTarget(
-            type: AttributeTargetType::CLASS_TYPE,
+            type: AttributeTargetTypeEnum::CLASS_TYPE,
             name: 'TestClass',
         );
 
@@ -108,7 +108,7 @@ class AttributeTargetTest extends TestCase
 
         $target = AttributeTarget::fromArray($data);
 
-        $this->assertSame(AttributeTargetType::METHOD, $target->type);
+        $this->assertSame(AttributeTargetTypeEnum::METHOD, $target->type);
         $this->assertSame('index', $target->name);
         $this->assertSame('App\Controller\ArticlesController', $target->declaringClass);
     }
@@ -126,7 +126,7 @@ class AttributeTargetTest extends TestCase
 
         $target = AttributeTarget::fromArray($data);
 
-        $this->assertSame(AttributeTargetType::PARAMETER, $target->type);
+        $this->assertSame(AttributeTargetTypeEnum::PARAMETER, $target->type);
         $this->assertSame('userId', $target->name);
         $this->assertNull($target->declaringClass);
     }
@@ -137,7 +137,7 @@ class AttributeTargetTest extends TestCase
     public function testRoundTripSerialization(): void
     {
         $original = new AttributeTarget(
-            type: AttributeTargetType::METHOD,
+            type: AttributeTargetTypeEnum::METHOD,
             name: 'save',
             declaringClass: 'App\Model\Table\ArticlesTable',
         );
@@ -157,7 +157,7 @@ class AttributeTargetTest extends TestCase
     public function testPhpSerializeRoundTrip(): void
     {
         $original = new AttributeTarget(
-            type: AttributeTargetType::PROPERTY,
+            type: AttributeTargetTypeEnum::PROPERTY,
             name: 'email',
             declaringClass: 'App\Model\Entity\User',
         );
@@ -177,7 +177,7 @@ class AttributeTargetTest extends TestCase
     public function testPhpSerializeWithNullDeclaringClass(): void
     {
         $original = new AttributeTarget(
-            type: AttributeTargetType::CLASS_TYPE,
+            type: AttributeTargetTypeEnum::CLASS_TYPE,
             name: 'MyClass',
         );
 
@@ -185,7 +185,7 @@ class AttributeTargetTest extends TestCase
         $restored = unserialize($serialized);
 
         $this->assertInstanceOf(AttributeTarget::class, $restored);
-        $this->assertSame(AttributeTargetType::CLASS_TYPE, $restored->type);
+        $this->assertSame(AttributeTargetTypeEnum::CLASS_TYPE, $restored->type);
         $this->assertSame('MyClass', $restored->name);
         $this->assertNull($restored->declaringClass);
     }
@@ -196,7 +196,7 @@ class AttributeTargetTest extends TestCase
     public function testJsonEncode(): void
     {
         $target = new AttributeTarget(
-            type: AttributeTargetType::METHOD,
+            type: AttributeTargetTypeEnum::METHOD,
             name: 'index',
             declaringClass: 'App\Controller\UsersController',
         );

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -37,9 +37,9 @@ use NoRewindIterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Collection\CountableIterator;
 use TestApp\Collection\TestCollection;
-use TestApp\Model\Enum\ArticleStatus;
-use TestApp\Model\Enum\NonBacked;
-use TestApp\Model\Enum\Priority;
+use TestApp\Model\Enum\ArticleStatusEnum;
+use TestApp\Model\Enum\NonBackedEnum;
+use TestApp\Model\Enum\PriorityEnum;
 use function Cake\Collection\collection;
 
 /**
@@ -762,19 +762,19 @@ class CollectionTest extends TestCase
     public function testGroupByEnum(): void
     {
         $items = [
-            ['id' => 1, 'name' => 'foo', 'thing' => NonBacked::Basic],
-            ['id' => 2, 'name' => 'bar', 'thing' => NonBacked::Advanced],
-            ['id' => 3, 'name' => 'baz', 'thing' => NonBacked::Basic],
+            ['id' => 1, 'name' => 'foo', 'thing' => NonBackedEnum::Basic],
+            ['id' => 2, 'name' => 'bar', 'thing' => NonBackedEnum::Advanced],
+            ['id' => 3, 'name' => 'baz', 'thing' => NonBackedEnum::Basic],
         ];
         $collection = new Collection($items);
         $grouped = $collection->groupBy('thing');
         $expected = [
-            NonBacked::Basic->name => [
-                ['id' => 1, 'name' => 'foo', 'thing' => NonBacked::Basic],
-                ['id' => 3, 'name' => 'baz', 'thing' => NonBacked::Basic],
+            NonBackedEnum::Basic->name => [
+                ['id' => 1, 'name' => 'foo', 'thing' => NonBackedEnum::Basic],
+                ['id' => 3, 'name' => 'baz', 'thing' => NonBackedEnum::Basic],
             ],
-            NonBacked::Advanced->name => [
-                ['id' => 2, 'name' => 'bar', 'thing' => NonBacked::Advanced],
+            NonBackedEnum::Advanced->name => [
+                ['id' => 2, 'name' => 'bar', 'thing' => NonBackedEnum::Advanced],
             ],
         ];
         $this->assertEquals($expected, iterator_to_array($grouped));
@@ -786,19 +786,19 @@ class CollectionTest extends TestCase
     public function testGroupByBackedEnum(): void
     {
         $items = [
-            ['id' => 1, 'name' => 'foo', 'thing' => Priority::Medium],
-            ['id' => 2, 'name' => 'bar', 'thing' => Priority::High],
-            ['id' => 3, 'name' => 'baz', 'thing' => Priority::Medium],
+            ['id' => 1, 'name' => 'foo', 'thing' => PriorityEnum::Medium],
+            ['id' => 2, 'name' => 'bar', 'thing' => PriorityEnum::High],
+            ['id' => 3, 'name' => 'baz', 'thing' => PriorityEnum::Medium],
         ];
         $collection = new Collection($items);
         $grouped = $collection->groupBy('thing');
         $expected = [
-            Priority::Medium->value => [
-                ['id' => 1, 'name' => 'foo', 'thing' => Priority::Medium],
-                ['id' => 3, 'name' => 'baz', 'thing' => Priority::Medium],
+            PriorityEnum::Medium->value => [
+                ['id' => 1, 'name' => 'foo', 'thing' => PriorityEnum::Medium],
+                ['id' => 3, 'name' => 'baz', 'thing' => PriorityEnum::Medium],
             ],
-            Priority::High->value => [
-                ['id' => 2, 'name' => 'bar', 'thing' => Priority::High],
+            PriorityEnum::High->value => [
+                ['id' => 2, 'name' => 'bar', 'thing' => PriorityEnum::High],
             ],
         ];
         $this->assertEquals($expected, iterator_to_array($grouped));
@@ -882,16 +882,16 @@ class CollectionTest extends TestCase
     public function testIndexByEnum(): void
     {
         $items = [
-            ['id' => 1, 'name' => 'foo', 'thing' => NonBacked::Basic],
-            ['id' => 2, 'name' => 'bar', 'thing' => NonBacked::Advanced],
+            ['id' => 1, 'name' => 'foo', 'thing' => NonBackedEnum::Basic],
+            ['id' => 2, 'name' => 'bar', 'thing' => NonBackedEnum::Advanced],
         ];
         $collection = new Collection($items);
         $grouped = $collection->indexBy(function ($element) {
             return $element['thing'];
         });
         $expected = [
-            NonBacked::Basic->name => ['id' => 1, 'name' => 'foo', 'thing' => NonBacked::Basic],
-            NonBacked::Advanced->name => ['id' => 2, 'name' => 'bar', 'thing' => NonBacked::Advanced],
+            NonBackedEnum::Basic->name => ['id' => 1, 'name' => 'foo', 'thing' => NonBackedEnum::Basic],
+            NonBackedEnum::Advanced->name => ['id' => 2, 'name' => 'bar', 'thing' => NonBackedEnum::Advanced],
         ];
         $this->assertEquals($expected, iterator_to_array($grouped));
     }
@@ -902,16 +902,16 @@ class CollectionTest extends TestCase
     public function testIndexByBackedEnum(): void
     {
         $items = [
-            ['id' => 1, 'name' => 'foo', 'thing' => Priority::Medium],
-            ['id' => 2, 'name' => 'bar', 'thing' => Priority::High],
+            ['id' => 1, 'name' => 'foo', 'thing' => PriorityEnum::Medium],
+            ['id' => 2, 'name' => 'bar', 'thing' => PriorityEnum::High],
         ];
         $collection = new Collection($items);
         $grouped = $collection->indexBy(function ($element) {
             return $element['thing'];
         });
         $expected = [
-            Priority::Medium->value => ['id' => 1, 'name' => 'foo', 'thing' => Priority::Medium],
-            Priority::High->value => ['id' => 2, 'name' => 'bar', 'thing' => Priority::High],
+            PriorityEnum::Medium->value => ['id' => 1, 'name' => 'foo', 'thing' => PriorityEnum::Medium],
+            PriorityEnum::High->value => ['id' => 2, 'name' => 'bar', 'thing' => PriorityEnum::High],
         ];
         $this->assertEquals($expected, iterator_to_array($grouped));
     }
@@ -1402,8 +1402,8 @@ class CollectionTest extends TestCase
         $this->assertEquals([1 => null, 2 => null, 3 => null], $collection->toArray());
 
         $collection = new Collection([
-            ['amount' => 10, 'article_status' => ArticleStatus::from('Y')],
-            ['amount' => 2, 'article_status' => ArticleStatus::from('N')],
+            ['amount' => 10, 'article_status' => ArticleStatusEnum::from('Y')],
+            ['amount' => 2, 'article_status' => ArticleStatusEnum::from('N')],
         ])->combine('article_status', 'amount');
         $this->assertEquals(['Y' => 10, 'N' => 2], $collection->toArray());
     }
@@ -1411,8 +1411,8 @@ class CollectionTest extends TestCase
     public function testCombineWithNonBackedEnum(): void
     {
         $collection = new Collection([
-            ['amount' => 10, 'type' => NonBacked::Basic],
-            ['amount' => 2, 'type' => NonBacked::Advanced],
+            ['amount' => 10, 'type' => NonBackedEnum::Basic],
+            ['amount' => 2, 'type' => NonBackedEnum::Advanced],
         ])->combine('type', 'amount');
         $this->assertEquals(['Basic' => 10, 'Advanced' => 2], $collection->toArray());
     }

--- a/tests/TestCase/Command/Helper/TreeHelperTest.php
+++ b/tests/TestCase/Command/Helper/TreeHelperTest.php
@@ -21,9 +21,9 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\TestSuite\TestCase;
 use Stringable;
-use TestApp\Model\Enum\Gender;
-use TestApp\Model\Enum\NonBacked;
-use TestApp\Model\Enum\Priority;
+use TestApp\Model\Enum\GenderEnum;
+use TestApp\Model\Enum\NonBackedEnum;
+use TestApp\Model\Enum\PriorityEnum;
 
 /**
  * TreeHelper test.
@@ -114,7 +114,7 @@ class TreeHelperTest extends TestCase
 
     public function testEnumValue(): void
     {
-        $this->helper->output([NonBacked::Basic, Gender::NoSelection, Priority::Low]);
+        $this->helper->output([NonBackedEnum::Basic, GenderEnum::NoSelection, PriorityEnum::Low]);
         $this->assertEquals([
             '├── Basic',
             '├── ',

--- a/tests/TestCase/Container/Asset/ProBar.php
+++ b/tests/TestCase/Container/Asset/ProBar.php
@@ -9,7 +9,7 @@ class ProBar implements BarInterface
     {
     }
 
-    public static function factory(): ProBar
+    public static function factory(): self
     {
         return new self();
     }

--- a/tests/TestCase/Database/Type/EnumTypeTest.php
+++ b/tests/TestCase/Database/Type/EnumTypeTest.php
@@ -24,10 +24,10 @@ use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use PDO;
 use TestApp\Model\Entity\Article;
-use TestApp\Model\Enum\ArticleStatus;
-use TestApp\Model\Enum\Gender;
-use TestApp\Model\Enum\NonBacked;
-use TestApp\Model\Enum\Priority;
+use TestApp\Model\Enum\ArticleStatusEnum;
+use TestApp\Model\Enum\GenderEnum;
+use TestApp\Model\Enum\NonBackedEnum;
+use TestApp\Model\Enum\PriorityEnum;
 use ValueError;
 
 /**
@@ -81,14 +81,14 @@ class EnumTypeTest extends TestCase
         $this->driver = ConnectionManager::get('test')->getDriver();
 
         $this->originalMap = TypeFactory::getMap();
-        $this->stringType = TypeFactory::build(EnumType::from(ArticleStatus::class));
-        $this->intType = TypeFactory::build(EnumType::from(Priority::class));
+        $this->stringType = TypeFactory::build(EnumType::from(ArticleStatusEnum::class));
+        $this->intType = TypeFactory::build(EnumType::from(PriorityEnum::class));
 
         $this->Articles = $this->getTableLocator()->get('Articles');
-        $this->Articles->getSchema()->setColumnType('published', EnumType::from(ArticleStatus::class));
+        $this->Articles->getSchema()->setColumnType('published', EnumType::from(ArticleStatusEnum::class));
 
         $this->FeaturedTags = $this->getTableLocator()->get('FeaturedTags');
-        $this->FeaturedTags->getSchema()->setColumnType('priority', EnumType::from(Priority::class));
+        $this->FeaturedTags->getSchema()->setColumnType('priority', EnumType::from(PriorityEnum::class));
     }
 
     /**
@@ -127,9 +127,9 @@ class EnumTypeTest extends TestCase
     public function testInvalidEnumWithoutBackingType(): void
     {
         $this->expectException(DatabaseException::class);
-        $this->expectExceptionMessage('Unable to use enum `TestApp\Model\Enum\NonBacked` for type `invalid`, must be a backed enum');
+        $this->expectExceptionMessage('Unable to use enum `TestApp\Model\Enum\NonBackedEnum` for type `invalid`, must be a backed enum');
 
-        new EnumType('invalid', NonBacked::class);
+        new EnumType('invalid', NonBackedEnum::class);
     }
 
     /**
@@ -137,8 +137,8 @@ class EnumTypeTest extends TestCase
      */
     public function testGetEnumClassString(): void
     {
-        $this->assertSame(ArticleStatus::class, $this->stringType->getEnumClassName());
-        $this->assertSame(Priority::class, $this->intType->getEnumClassName());
+        $this->assertSame(ArticleStatusEnum::class, $this->stringType->getEnumClassName());
+        $this->assertSame(PriorityEnum::class, $this->intType->getEnumClassName());
     }
 
     /**
@@ -147,28 +147,28 @@ class EnumTypeTest extends TestCase
     public function testToDatabaseEnum(): void
     {
         $this->assertNull($this->stringType->toDatabase(null, $this->driver));
-        $this->assertSame('Y', $this->stringType->toDatabase(ArticleStatus::Published, $this->driver));
-        $this->assertSame(3, $this->intType->toDatabase(Priority::High, $this->driver));
+        $this->assertSame('Y', $this->stringType->toDatabase(ArticleStatusEnum::Published, $this->driver));
+        $this->assertSame(3, $this->intType->toDatabase(PriorityEnum::High, $this->driver));
     }
 
     public function testToDatabaseValidValue(): void
     {
-        $this->assertSame('Y', $this->stringType->toDatabase(ArticleStatus::Published->value, $this->driver));
-        $this->assertSame(3, $this->intType->toDatabase(Priority::High->value, $this->driver));
+        $this->assertSame('Y', $this->stringType->toDatabase(ArticleStatusEnum::Published->value, $this->driver));
+        $this->assertSame(3, $this->intType->toDatabase(PriorityEnum::High->value, $this->driver));
         $this->assertSame(3, $this->intType->toDatabase('3', $this->driver));
     }
 
     public function testToDatabaseInValidValue(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('`invalid` is not a valid value for `TestApp\Model\Enum\ArticleStatus`');
+        $this->expectExceptionMessage('`invalid` is not a valid value for `TestApp\Model\Enum\ArticleStatusEnum`');
         $this->stringType->toDatabase('invalid', $this->driver);
     }
 
     public function testToDatabaseInValidValueType(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Given value `1` of type `int` does not match associated `string` backed enum in `TestApp\Model\Enum\ArticleStatus`');
+        $this->expectExceptionMessage('Given value `1` of type `int` does not match associated `string` backed enum in `TestApp\Model\Enum\ArticleStatusEnum`');
         $this->stringType->toDatabase(1, $this->driver);
     }
 
@@ -178,7 +178,7 @@ class EnumTypeTest extends TestCase
     public function testToPHPStringEnum(): void
     {
         $this->assertNull($this->stringType->toPHP(null, $this->driver));
-        $this->assertSame(ArticleStatus::Published, $this->stringType->toPHP('Y', $this->driver));
+        $this->assertSame(ArticleStatusEnum::Published, $this->stringType->toPHP('Y', $this->driver));
     }
 
     /**
@@ -187,8 +187,8 @@ class EnumTypeTest extends TestCase
     public function testToPHPIntEnum(): void
     {
         $this->assertNull($this->intType->toPHP(null, $this->driver));
-        $this->assertSame(Priority::High, $this->intType->toPHP(3, $this->driver));
-        $this->assertSame(Priority::High, $this->intType->toPHP('3', $this->driver));
+        $this->assertSame(PriorityEnum::High, $this->intType->toPHP(3, $this->driver));
+        $this->assertSame(PriorityEnum::High, $this->intType->toPHP('3', $this->driver));
     }
 
     public function testToPHPInvalidEnumValue(): void
@@ -213,11 +213,11 @@ class EnumTypeTest extends TestCase
     {
         $this->assertNull($this->stringType->marshal(null));
         $this->assertNull($this->stringType->marshal(''));
-        $this->assertSame(ArticleStatus::Published, $this->stringType->marshal('Y'));
-        $this->assertSame(ArticleStatus::Published, $this->stringType->marshal(ArticleStatus::Published));
+        $this->assertSame(ArticleStatusEnum::Published, $this->stringType->marshal('Y'));
+        $this->assertSame(ArticleStatusEnum::Published, $this->stringType->marshal(ArticleStatusEnum::Published));
 
-        $genderType = TypeFactory::build(EnumType::from(Gender::class));
-        $this->assertSame(Gender::NoSelection, $genderType->marshal(''));
+        $genderType = TypeFactory::build(EnumType::from(GenderEnum::class));
+        $this->assertSame(GenderEnum::NoSelection, $genderType->marshal(''));
 
         // Invalid value returns null
         $this->assertNull($this->stringType->marshal('X'));
@@ -231,9 +231,9 @@ class EnumTypeTest extends TestCase
     {
         $this->assertNull($this->intType->marshal(null));
         $this->assertNull($this->intType->marshal(''));
-        $this->assertSame(Priority::Low, $this->intType->marshal(1));
-        $this->assertSame(Priority::Low, $this->intType->marshal('1'));
-        $this->assertSame(Priority::Medium, $this->intType->marshal(Priority::Medium));
+        $this->assertSame(PriorityEnum::Low, $this->intType->marshal(1));
+        $this->assertSame(PriorityEnum::Low, $this->intType->marshal('1'));
+        $this->assertSame(PriorityEnum::Medium, $this->intType->marshal(PriorityEnum::Medium));
 
         // Invalid value returns null
         $this->assertNull($this->intType->marshal(10));
@@ -250,13 +250,13 @@ class EnumTypeTest extends TestCase
             'author_id' => 1,
             'title' => 'My Title',
             'body' => 'My post',
-            'published' => ArticleStatus::Published,
+            'published' => ArticleStatusEnum::Published,
         ]);
         $saved = $this->Articles->save($entity);
         $this->assertNotFalse($saved);
-        $this->assertSame(ArticleStatus::Published, $entity->published);
+        $this->assertSame(ArticleStatusEnum::Published, $entity->published);
 
-        $this->assertSame(ArticleStatus::Published, $this->Articles->get(4)->published);
+        $this->assertSame(ArticleStatusEnum::Published, $this->Articles->get(4)->published);
     }
 
     /**
@@ -273,9 +273,9 @@ class EnumTypeTest extends TestCase
         ]);
         $saved = $this->Articles->save($entity);
         $this->assertNotFalse($saved);
-        $this->assertSame(ArticleStatus::Published, $entity->published);
+        $this->assertSame(ArticleStatusEnum::Published, $entity->published);
 
-        $this->assertSame(ArticleStatus::Published, $this->Articles->get(4)->published);
+        $this->assertSame(ArticleStatusEnum::Published, $this->Articles->get(4)->published);
     }
 
     /**
@@ -286,13 +286,13 @@ class EnumTypeTest extends TestCase
         /** @var \Cake\Datasource\EntityInterface $entity */
         $entity = $this->FeaturedTags->newEntity([
             'tag_id' => 4,
-            'priority' => Priority::Medium,
+            'priority' => PriorityEnum::Medium,
         ]);
         $saved = $this->FeaturedTags->save($entity);
         $this->assertNotFalse($saved);
-        $this->assertSame(Priority::Medium, $entity->priority);
+        $this->assertSame(PriorityEnum::Medium, $entity->priority);
 
-        $this->assertSame(Priority::Medium, $this->FeaturedTags->get(4)->priority);
+        $this->assertSame(PriorityEnum::Medium, $this->FeaturedTags->get(4)->priority);
     }
 
     /**
@@ -307,9 +307,9 @@ class EnumTypeTest extends TestCase
         ]);
         $saved = $this->FeaturedTags->save($entity);
         $this->assertNotFalse($saved);
-        $this->assertSame(Priority::Medium, $entity->priority);
+        $this->assertSame(PriorityEnum::Medium, $entity->priority);
 
-        $this->assertSame(Priority::Medium, $this->FeaturedTags->get(4)->priority);
+        $this->assertSame(PriorityEnum::Medium, $this->FeaturedTags->get(4)->priority);
     }
 
     /**
@@ -317,13 +317,13 @@ class EnumTypeTest extends TestCase
      */
     public function testUpdateEnumField(): void
     {
-        $this->assertSame(ArticleStatus::Published, $this->Articles->get(1)->published);
+        $this->assertSame(ArticleStatusEnum::Published, $this->Articles->get(1)->published);
 
         $entity = $this->Articles->get(1);
-        $entity->published = ArticleStatus::Unpublished;
+        $entity->published = ArticleStatusEnum::Unpublished;
         $this->Articles->save($entity);
-        $this->assertSame(ArticleStatus::Unpublished, $entity->published);
+        $this->assertSame(ArticleStatusEnum::Unpublished, $entity->published);
 
-        $this->assertSame(ArticleStatus::Unpublished, $this->Articles->get(1)->published);
+        $this->assertSame(ArticleStatusEnum::Unpublished, $this->Articles->get(1)->published);
     }
 }

--- a/tests/TestCase/Http/Session/CacheSessionTest.php
+++ b/tests/TestCase/Http/Session/CacheSessionTest.php
@@ -28,7 +28,7 @@ use InvalidArgumentException;
  */
 class CacheSessionTest extends TestCase
 {
-    protected static $_sessionBackup;
+    protected static $sessionBackup;
 
     /**
      * @var \Cake\Http\Session\CacheSession

--- a/tests/TestCase/Routing/Route/EntityRouteTest.php
+++ b/tests/TestCase/Routing/Route/EntityRouteTest.php
@@ -20,9 +20,9 @@ use Cake\Core\Exception\CakeException;
 use Cake\Routing\Route\EntityRoute;
 use Cake\TestSuite\TestCase;
 use TestApp\Model\Entity\Article;
-use TestApp\Model\Enum\ArticleStatus;
-use TestApp\Model\Enum\NonBacked;
-use TestApp\Model\Enum\Priority;
+use TestApp\Model\Enum\ArticleStatusEnum;
+use TestApp\Model\Enum\NonBackedEnum;
+use TestApp\Model\Enum\PriorityEnum;
 
 /**
  * Test case for EntityRoute
@@ -87,7 +87,7 @@ class EntityRouteTest extends TestCase
     {
         $entity = new Article([
             'category_id' => 2,
-            'published' => ArticleStatus::Published,
+            'published' => ArticleStatusEnum::Published,
         ]);
 
         $route = new EntityRoute(
@@ -112,7 +112,7 @@ class EntityRouteTest extends TestCase
     {
         $entity = new Article([
             'category_id' => 2,
-            'prio' => Priority::High,
+            'prio' => PriorityEnum::High,
         ]);
 
         $route = new EntityRoute(
@@ -137,7 +137,7 @@ class EntityRouteTest extends TestCase
     {
         $entity = new Article([
             'category_id' => 2,
-            'level' => NonBacked::Advanced,
+            'level' => NonBackedEnum::Advanced,
         ]);
 
         $route = new EntityRoute(

--- a/tests/TestCase/Utility/Fs/FinderTest.php
+++ b/tests/TestCase/Utility/Fs/FinderTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Utility\Fs;
 
 use Cake\TestSuite\TestCase;
-use Cake\Utility\Fs\Enum\DepthOperator;
+use Cake\Utility\Fs\Enum\DepthOperatorEnum;
 use Cake\Utility\Fs\Finder;
 use Iterator;
 use org\bovigo\vfs\vfsStream;
@@ -158,7 +158,7 @@ class FinderTest extends TestCase
         $finder = new Finder();
         $files = $finder
             ->in(vfsStream::url('root/src'))
-            ->depth(3, DepthOperator::LESS_THAN)
+            ->depth(3, DepthOperatorEnum::LESS_THAN)
             ->files();
 
         $count = 0;
@@ -259,7 +259,7 @@ class FinderTest extends TestCase
             ->in(vfsStream::url('root/src'))
             ->name('*.php')
             ->exclude('View')
-            ->depth(3, DepthOperator::LESS_THAN);
+            ->depth(3, DepthOperatorEnum::LESS_THAN);
 
         $this->assertInstanceOf(Finder::class, $result);
     }
@@ -1101,7 +1101,7 @@ class FinderTest extends TestCase
         $finder = new Finder();
         $files = $finder
             ->in(vfsStream::url('root/src'))
-            ->depth(0, DepthOperator::NOT_EQUAL)
+            ->depth(0, DepthOperatorEnum::NOT_EQUAL)
             ->files();
 
         $paths = [];
@@ -1123,7 +1123,7 @@ class FinderTest extends TestCase
         $finder = new Finder();
         $files = $finder
             ->in(vfsStream::url('root/src'))
-            ->depth(0, DepthOperator::GREATER_THAN)
+            ->depth(0, DepthOperatorEnum::GREATER_THAN)
             ->files();
 
         $paths = [];
@@ -1144,7 +1144,7 @@ class FinderTest extends TestCase
         $finder = new Finder();
         $files = $finder
             ->in(vfsStream::url('root/src'))
-            ->depth(1, DepthOperator::LESS_THAN_OR_EQUAL)
+            ->depth(1, DepthOperatorEnum::LESS_THAN_OR_EQUAL)
             ->files();
 
         $paths = [];
@@ -1165,7 +1165,7 @@ class FinderTest extends TestCase
         $finder = new Finder();
         $files = $finder
             ->in(vfsStream::url('root/src'))
-            ->depth(1, DepthOperator::GREATER_THAN_OR_EQUAL)
+            ->depth(1, DepthOperatorEnum::GREATER_THAN_OR_EQUAL)
             ->files();
 
         $paths = [];
@@ -1185,8 +1185,8 @@ class FinderTest extends TestCase
         $finder = new Finder();
         $files = $finder
             ->in(vfsStream::url('root/src'))
-            ->depth(0, DepthOperator::GREATER_THAN) // Greater than 0
-            ->depth(2, DepthOperator::LESS_THAN) // Less than 2
+            ->depth(0, DepthOperatorEnum::GREATER_THAN) // Greater than 0
+            ->depth(2, DepthOperatorEnum::LESS_THAN) // Less than 2
             ->files();
 
         $paths = [];

--- a/tests/TestCase/Utility/Fs/Iterator/FilterIteratorTest.php
+++ b/tests/TestCase/Utility/Fs/Iterator/FilterIteratorTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Utility\Fs\Iterator;
 
 use Cake\TestSuite\TestCase;
-use Cake\Utility\Fs\Enum\FinderMode;
+use Cake\Utility\Fs\Enum\FinderModeEnum;
 use Cake\Utility\Fs\Iterator\CallbackFilterIterator;
 use Cake\Utility\Fs\Iterator\ExcludeDirectoryFilterIterator;
 use Cake\Utility\Fs\Iterator\FileTypeFilterIterator;
@@ -96,7 +96,7 @@ class FilterIteratorTest extends TestCase
             FilesystemIterator::SKIP_DOTS,
         );
 
-        $filtered = new FileTypeFilterIterator($directory, FinderMode::FILES);
+        $filtered = new FileTypeFilterIterator($directory, FinderModeEnum::FILES);
 
         $items = [];
         foreach ($filtered as $file) {
@@ -115,7 +115,7 @@ class FilterIteratorTest extends TestCase
             FilesystemIterator::SKIP_DOTS,
         );
 
-        $filtered = new FileTypeFilterIterator($directory, FinderMode::DIRECTORIES);
+        $filtered = new FileTypeFilterIterator($directory, FinderModeEnum::DIRECTORIES);
 
         $items = [];
         foreach ($filtered as $file) {
@@ -135,7 +135,7 @@ class FilterIteratorTest extends TestCase
             FilesystemIterator::SKIP_DOTS,
         );
 
-        $filtered = new FileTypeFilterIterator($directory, FinderMode::ALL);
+        $filtered = new FileTypeFilterIterator($directory, FinderModeEnum::ALL);
 
         $items = [];
         foreach ($filtered as $file) {
@@ -198,7 +198,7 @@ class FilterIteratorTest extends TestCase
         $filtered = new HiddenFileFilterIterator($directory);
         $filtered = new ExcludeDirectoryFilterIterator($filtered, ['vendor']);
         $iterator = new RecursiveIteratorIterator($filtered);
-        $filtered = new FileTypeFilterIterator($iterator, FinderMode::FILES);
+        $filtered = new FileTypeFilterIterator($iterator, FinderModeEnum::FILES);
 
         $files = [];
         foreach ($filtered as $file) {

--- a/tests/TestCase/Utility/Fs/Iterator/PatternFilterIteratorTest.php
+++ b/tests/TestCase/Utility/Fs/Iterator/PatternFilterIteratorTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Utility\Fs\Iterator;
 
 use Cake\TestSuite\TestCase;
-use Cake\Utility\Fs\Enum\DepthOperator;
+use Cake\Utility\Fs\Enum\DepthOperatorEnum;
 use Cake\Utility\Fs\Iterator\ContainsPathFilterIterator;
 use Cake\Utility\Fs\Iterator\DepthFilterIterator;
 use Cake\Utility\Fs\Iterator\FilenameFilterIterator;
@@ -153,7 +153,7 @@ class PatternFilterIteratorTest extends TestCase
             RecursiveDirectoryIterator::SKIP_DOTS,
         );
         $recursiveIterator = new RecursiveIteratorIterator($iterator);
-        $filtered = new DepthFilterIterator($recursiveIterator, DepthOperator::EQUAL, 0);
+        $filtered = new DepthFilterIterator($recursiveIterator, DepthOperatorEnum::EQUAL, 0);
 
         $files = [];
         foreach ($filtered as $file) {
@@ -176,7 +176,7 @@ class PatternFilterIteratorTest extends TestCase
             RecursiveDirectoryIterator::SKIP_DOTS,
         );
         $recursiveIterator = new RecursiveIteratorIterator($iterator);
-        $filtered = new DepthFilterIterator($recursiveIterator, DepthOperator::GREATER_THAN, 1);
+        $filtered = new DepthFilterIterator($recursiveIterator, DepthOperatorEnum::GREATER_THAN, 1);
 
         $files = [];
         foreach ($filtered as $file) {
@@ -201,7 +201,7 @@ class PatternFilterIteratorTest extends TestCase
             RecursiveDirectoryIterator::SKIP_DOTS,
         );
         $recursiveIterator = new RecursiveIteratorIterator($iterator);
-        $filtered = new DepthFilterIterator($recursiveIterator, DepthOperator::LESS_THAN_OR_EQUAL, 0);
+        $filtered = new DepthFilterIterator($recursiveIterator, DepthOperatorEnum::LESS_THAN_OR_EQUAL, 0);
 
         $files = [];
         foreach ($filtered as $file) {
@@ -226,7 +226,7 @@ class PatternFilterIteratorTest extends TestCase
             RecursiveDirectoryIterator::SKIP_DOTS,
         );
         $recursiveIterator = new RecursiveIteratorIterator($iterator);
-        $filtered = new DepthFilterIterator($recursiveIterator, DepthOperator::NOT_EQUAL, 0);
+        $filtered = new DepthFilterIterator($recursiveIterator, DepthOperatorEnum::NOT_EQUAL, 0);
 
         $files = [];
         foreach ($filtered as $file) {
@@ -253,7 +253,7 @@ class PatternFilterIteratorTest extends TestCase
             RecursiveDirectoryIterator::SKIP_DOTS,
         );
         $recursiveIterator = new RecursiveIteratorIterator($iterator);
-        $filtered = new DepthFilterIterator($recursiveIterator, DepthOperator::LESS_THAN, 1);
+        $filtered = new DepthFilterIterator($recursiveIterator, DepthOperatorEnum::LESS_THAN, 1);
 
         $files = [];
         foreach ($filtered as $file) {
@@ -278,7 +278,7 @@ class PatternFilterIteratorTest extends TestCase
             RecursiveDirectoryIterator::SKIP_DOTS,
         );
         $recursiveIterator = new RecursiveIteratorIterator($iterator);
-        $filtered = new DepthFilterIterator($recursiveIterator, DepthOperator::GREATER_THAN_OR_EQUAL, 2);
+        $filtered = new DepthFilterIterator($recursiveIterator, DepthOperatorEnum::GREATER_THAN_OR_EQUAL, 2);
 
         $files = [];
         foreach ($filtered as $file) {

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -28,9 +28,9 @@ use DOMDocument;
 use Exception;
 use PHPUnit\Framework\Attributes\DataProvider;
 use SimpleXMLElement;
-use TestApp\Model\Enum\ArticleStatus;
-use TestApp\Model\Enum\NonBacked;
-use TestApp\Model\Enum\Priority;
+use TestApp\Model\Enum\ArticleStatusEnum;
+use TestApp\Model\Enum\NonBackedEnum;
+use TestApp\Model\Enum\PriorityEnum;
 use TypeError;
 
 /**
@@ -1150,9 +1150,9 @@ XML;
             'root' => [
                 'tag' => [
                     'xmlns:pref' => 'http://cakephp.org',
-                    'backed-int' => Priority::Medium,
-                    'backend-string' => ArticleStatus::Published,
-                    'non-backed' => NonBacked::Basic,
+                    'backed-int' => PriorityEnum::Medium,
+                    'backend-string' => ArticleStatusEnum::Published,
+                    'non-backed' => NonBackedEnum::Basic,
                 ],
             ],
         ];

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -32,9 +32,9 @@ use Laminas\Diactoros\UploadedFile;
 use Locale;
 use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
-use TestApp\Model\Enum\ArticleStatus;
-use TestApp\Model\Enum\NonBacked;
-use TestApp\Model\Enum\Priority;
+use TestApp\Model\Enum\ArticleStatusEnum;
+use TestApp\Model\Enum\NonBackedEnum;
+use TestApp\Model\Enum\PriorityEnum;
 
 require_once __DIR__ . '/stubs.php';
 
@@ -2084,34 +2084,34 @@ class ValidationTest extends TestCase
 
     public function testEnum(): void
     {
-        $this->assertTrue(Validation::enum(ArticleStatus::Published, ArticleStatus::class));
-        $this->assertTrue(Validation::enum('Y', ArticleStatus::class));
+        $this->assertTrue(Validation::enum(ArticleStatusEnum::Published, ArticleStatusEnum::class));
+        $this->assertTrue(Validation::enum('Y', ArticleStatusEnum::class));
 
-        $this->assertTrue(Validation::enum(Priority::Low, Priority::class));
-        $this->assertTrue(Validation::enum(1, Priority::class));
+        $this->assertTrue(Validation::enum(PriorityEnum::Low, PriorityEnum::class));
+        $this->assertTrue(Validation::enum(1, PriorityEnum::class));
 
-        $this->assertFalse(Validation::enum(Priority::Low, ArticleStatus::class));
-        $this->assertFalse(Validation::enum(1, ArticleStatus::class));
-        $this->assertFalse(Validation::enum('non-existent', ArticleStatus::class));
+        $this->assertFalse(Validation::enum(PriorityEnum::Low, ArticleStatusEnum::class));
+        $this->assertFalse(Validation::enum(1, ArticleStatusEnum::class));
+        $this->assertFalse(Validation::enum('non-existent', ArticleStatusEnum::class));
 
-        $this->assertFalse(Validation::enum(ArticleStatus::Published, Priority::class));
-        $this->assertFalse(Validation::enum('wrong type', Priority::class));
-        $this->assertFalse(Validation::enum(123, Priority::class));
+        $this->assertFalse(Validation::enum(ArticleStatusEnum::Published, PriorityEnum::class));
+        $this->assertFalse(Validation::enum('wrong type', PriorityEnum::class));
+        $this->assertFalse(Validation::enum(123, PriorityEnum::class));
 
-        $this->assertTrue(Validation::enum('1', Priority::class));
-        $this->assertFalse(Validation::enum('a1', Priority::class));
+        $this->assertTrue(Validation::enum('1', PriorityEnum::class));
+        $this->assertFalse(Validation::enum('a1', PriorityEnum::class));
     }
 
     public function testEnumOnly(): void
     {
-        $this->assertTrue(Validation::enumOnly(ArticleStatus::Published, [ArticleStatus::Published]));
-        $this->assertFalse(Validation::enumOnly(ArticleStatus::Published, [ArticleStatus::Unpublished]));
+        $this->assertTrue(Validation::enumOnly(ArticleStatusEnum::Published, [ArticleStatusEnum::Published]));
+        $this->assertFalse(Validation::enumOnly(ArticleStatusEnum::Published, [ArticleStatusEnum::Unpublished]));
     }
 
     public function testEnumExcept(): void
     {
-        $this->assertFalse(Validation::enumExcept(ArticleStatus::Published, [ArticleStatus::Published]));
-        $this->assertTrue(Validation::enumExcept(ArticleStatus::Published, [ArticleStatus::Unpublished]));
+        $this->assertFalse(Validation::enumExcept(ArticleStatusEnum::Published, [ArticleStatusEnum::Published]));
+        $this->assertTrue(Validation::enumExcept(ArticleStatusEnum::Published, [ArticleStatusEnum::Unpublished]));
     }
 
     public function testEnumNonBacked(): void
@@ -2119,7 +2119,7 @@ class ValidationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The `$enumClassName` argument must be the classname of a valid backed enum.');
 
-        Validation::enum(NonBacked::Basic, NonBacked::class);
+        Validation::enum(NonBackedEnum::Basic, NonBackedEnum::class);
     }
 
     public function testEnumNonEnum(): void

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -26,9 +26,9 @@ use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use Locale;
 use stdClass;
-use TestApp\Model\Enum\ArticleStatus;
-use TestApp\Model\Enum\NonBacked;
-use TestApp\Model\Enum\Priority;
+use TestApp\Model\Enum\ArticleStatusEnum;
+use TestApp\Model\Enum\NonBackedEnum;
+use TestApp\Model\Enum\PriorityEnum;
 use Traversable;
 
 /**
@@ -2753,20 +2753,20 @@ class ValidatorTest extends TestCase
     public function testEnum(): void
     {
         $validator = new Validator();
-        $validator->enum('status', ArticleStatus::class);
+        $validator->enum('status', ArticleStatusEnum::class);
 
-        $this->assertEmpty($validator->validate(['status' => ArticleStatus::Published]));
+        $this->assertEmpty($validator->validate(['status' => ArticleStatusEnum::Published]));
         $this->assertEmpty($validator->validate(['status' => 'Y']));
 
-        $this->assertNotEmpty($validator->validate(['status' => Priority::Low]));
+        $this->assertNotEmpty($validator->validate(['status' => PriorityEnum::Low]));
         $this->assertNotEmpty($validator->validate(['status' => 'wrong type']));
         $this->assertNotEmpty($validator->validate(['status' => 123]));
-        $this->assertNotEmpty($validator->validate(['status' => NonBacked::Basic]));
+        $this->assertNotEmpty($validator->validate(['status' => NonBackedEnum::Basic]));
 
         $fieldName = 'status';
         $rule = 'enum';
         $expectedMessage = 'The provided value must be one of `Y`, `N`';
-        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, ArticleStatus::class);
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, ArticleStatusEnum::class);
     }
 
     public function testEnumNonBacked(): void
@@ -2775,7 +2775,7 @@ class ValidatorTest extends TestCase
         $this->expectExceptionMessage('The `$enumClassName` argument must be the classname of a valid backed enum.');
 
         $validator = new Validator();
-        $validator->enum('status', NonBacked::class);
+        $validator->enum('status', NonBackedEnum::class);
     }
 
     public function testEnumNonEnum(): void

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -50,9 +50,9 @@ use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 use TestApp\Model\Entity\Article;
-use TestApp\Model\Enum\ArticleStatus;
-use TestApp\Model\Enum\ArticleStatusLabel;
-use TestApp\Model\Enum\Priority;
+use TestApp\Model\Enum\ArticleStatusEnum;
+use TestApp\Model\Enum\ArticleStatusLabelEnum;
+use TestApp\Model\Enum\PriorityEnum;
 use TestApp\Model\Table\ContactsTable;
 use TestApp\Model\Table\ValidateUsersTable;
 use TestApp\View\Form\StubContext;
@@ -3855,7 +3855,7 @@ class FormHelperTest extends TestCase
         $articlesTable = $this->getTableLocator()->get('Articles');
         $articlesTable->getSchema()->setColumnType(
             'published',
-            EnumType::from(ArticleStatus::class),
+            EnumType::from(ArticleStatusEnum::class),
         );
         $this->Form->create($articlesTable->newEmptyEntity());
         $result = $this->Form->control('published');
@@ -3878,7 +3878,7 @@ class FormHelperTest extends TestCase
 
         $articlesTable->getSchema()->setColumnType(
             'published',
-            EnumType::from(ArticleStatusLabel::class),
+            EnumType::from(ArticleStatusLabelEnum::class),
         );
 
         $this->Form->create($articlesTable->newEmptyEntity());
@@ -3903,7 +3903,7 @@ class FormHelperTest extends TestCase
         $articlePriosTable = $this->getTableLocator()->get('ArticlePrios');
         $articlePriosTable->getSchema()->setColumnType(
             'priority',
-            EnumType::from(Priority::class),
+            EnumType::from(PriorityEnum::class),
         );
 
         $this->Form->create($articlePriosTable->newEmptyEntity());
@@ -4803,7 +4803,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $article = new Article([
-            'status' => ArticleStatus::Unpublished,
+            'status' => ArticleStatusEnum::Unpublished,
         ]);
         $this->Form->create($article);
         $result = $this->Form->radio('status', ['Y' => 'Published', 'N' => 'Unpublished']);
@@ -5015,7 +5015,7 @@ class FormHelperTest extends TestCase
         $articlesTable = $this->getTableLocator()->get('Articles');
         $articlesTable->getSchema()->setColumnType(
             'published',
-            EnumType::from(ArticleStatus::class),
+            EnumType::from(ArticleStatusEnum::class),
         );
         $this->Form->create($articlesTable->newEmptyEntity());
         $result = $this->Form->control('published', [
@@ -5231,7 +5231,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $article = new Article([
-            'status' => ArticleStatus::Unpublished,
+            'status' => ArticleStatusEnum::Unpublished,
         ]);
         $this->Form->create($article);
         $result = $this->Form->select('status', ['Y' => 'Published', 'N' => 'Unpublished']);
@@ -6812,7 +6812,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $article = new Article([
-            'status' => ArticleStatus::Unpublished,
+            'status' => ArticleStatusEnum::Unpublished,
         ]);
         $this->Form->create($article);
         $result = $this->Form->hidden('status');

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/Model/Table/TestPluginThreeCommentsTable.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/Model/Table/TestPluginThreeCommentsTable.php
@@ -23,5 +23,5 @@ use Cake\ORM\Table;
  */
 class TestPluginThreeCommentsTable extends Table
 {
-    protected ?string $_table = 'test_plugin_three_comments';
+    protected ?string $table = 'test_plugin_three_comments';
 }

--- a/tests/test_app/TestApp/Attribute/Resolver/Fixture/TestComplexArguments.php
+++ b/tests/test_app/TestApp/Attribute/Resolver/Fixture/TestComplexArguments.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TestApp\Attribute\Resolver\Fixture;
 
 use TestApp\Attribute\Resolver\TestComplexArgument;
-use TestApp\Attribute\Resolver\TestPriority;
+use TestApp\Attribute\Resolver\TestPriorityEnum;
 use TestApp\Attribute\Resolver\ValueObject\TestConfig;
 
 class TestComplexArguments
@@ -15,7 +15,7 @@ class TestComplexArguments
     #[TestComplexArgument(
         value: 'simple_string',
         object: new TestConfig('database', ['host' => 'localhost', 'port' => 3306]),
-        enum: TestPriority::HIGH,
+        enum: TestPriorityEnum::HIGH,
         constant: self::DEFAULT_TIMEOUT,
     )]
     public function methodWithComplexAttributes(): void
@@ -24,7 +24,7 @@ class TestComplexArguments
 
     #[TestComplexArgument(
         object: new TestConfig('cache', ['driver' => 'redis']),
-        enum: TestPriority::CRITICAL,
+        enum: TestPriorityEnum::CRITICAL,
     )]
     public string $propertyWithObject;
 
@@ -43,7 +43,7 @@ class TestComplexArguments
     }
 
     #[TestComplexArgument(constant: self::MAX_RETRIES)]
-    #[TestComplexArgument(enum: TestPriority::LOW)]
+    #[TestComplexArgument(enum: TestPriorityEnum::LOW)]
     #[TestComplexArgument(object: new TestConfig('multi', []))]
     public function multipleAttributes(): void
     {

--- a/tests/test_app/TestApp/Attribute/Resolver/TestPriorityEnum.php
+++ b/tests/test_app/TestApp/Attribute/Resolver/TestPriorityEnum.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace TestApp\Attribute\Resolver;
 
-enum TestPriority: int
+enum TestPriorityEnum: int
 {
     case LOW = 1;
     case MEDIUM = 2;

--- a/tests/test_app/TestApp/Model/Entity/ProtectedUser.php
+++ b/tests/test_app/TestApp/Model/Entity/ProtectedUser.php
@@ -10,5 +10,5 @@ use Cake\ORM\Entity;
  */
 class ProtectedUser extends Entity
 {
-    protected array $_hidden = ['password'];
+    protected array $hidden = ['password'];
 }

--- a/tests/test_app/TestApp/Model/Entity/VirtualUser.php
+++ b/tests/test_app/TestApp/Model/Entity/VirtualUser.php
@@ -7,7 +7,7 @@ use Cake\ORM\Entity;
 
 class VirtualUser extends Entity
 {
-    protected array $_virtual = [
+    protected array $virtual = [
         'bonus',
     ];
 

--- a/tests/test_app/TestApp/Model/Enum/ArticleStatusEnum.php
+++ b/tests/test_app/TestApp/Model/Enum/ArticleStatusEnum.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  */
 namespace TestApp\Model\Enum;
 
-enum ArticleStatus: string
+enum ArticleStatusEnum: string
 {
     case Published = 'Y';
     case Unpublished = 'N';

--- a/tests/test_app/TestApp/Model/Enum/ArticleStatusLabelEnum.php
+++ b/tests/test_app/TestApp/Model/Enum/ArticleStatusLabelEnum.php
@@ -17,7 +17,7 @@ namespace TestApp\Model\Enum;
 use Cake\Database\Type\EnumLabelInterface;
 use Cake\Utility\Inflector;
 
-enum ArticleStatusLabel: string implements EnumLabelInterface
+enum ArticleStatusLabelEnum: string implements EnumLabelInterface
 {
     case Published = 'Y';
     case Unpublished = 'N';

--- a/tests/test_app/TestApp/Model/Enum/GenderEnum.php
+++ b/tests/test_app/TestApp/Model/Enum/GenderEnum.php
@@ -9,25 +9,14 @@ declare(strict_types=1);
  * Redistributions of files must retain the above copyright notice
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @since         5.0.0
+ * @since         5.1.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestApp\Model\Enum;
 
-use Cake\Database\Type\EnumLabelInterface;
-use Cake\Utility\Inflector;
-
-enum Priority: int implements EnumLabelInterface
+enum GenderEnum: string
 {
-    case Low = 1;
-    case Medium = 2;
-    case High = 3;
-
-    /**
-     * @return string
-     */
-    public function label(): string
-    {
-        return 'Is ' . Inflector::humanize(Inflector::underscore($this->name));
-    }
+    case NoSelection = '';
+    case Male = 'Male';
+    case Female = 'Female';
 }

--- a/tests/test_app/TestApp/Model/Enum/NonBackedEnum.php
+++ b/tests/test_app/TestApp/Model/Enum/NonBackedEnum.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  */
 namespace TestApp\Model\Enum;
 
-enum NonBacked
+enum NonBackedEnum
 {
     case Basic;
     case Advanced;

--- a/tests/test_app/TestApp/Model/Enum/PriorityEnum.php
+++ b/tests/test_app/TestApp/Model/Enum/PriorityEnum.php
@@ -9,14 +9,25 @@ declare(strict_types=1);
  * Redistributions of files must retain the above copyright notice
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @since         5.1.0
+ * @since         5.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestApp\Model\Enum;
 
-enum Gender: string
+use Cake\Database\Type\EnumLabelInterface;
+use Cake\Utility\Inflector;
+
+enum PriorityEnum: int implements EnumLabelInterface
 {
-    case NoSelection = '';
-    case Male = 'Male';
-    case Female = 'Female';
+    case Low = 1;
+    case Medium = 2;
+    case High = 3;
+
+    /**
+     * @return string
+     */
+    public function label(): string
+    {
+        return 'Is ' . Inflector::humanize(Inflector::underscore($this->name));
+    }
 }

--- a/tests/test_app/TestApp/Model/Table/PostsTable.php
+++ b/tests/test_app/TestApp/Model/Table/PostsTable.php
@@ -21,5 +21,5 @@ use Cake\ORM\Table;
 
 class PostsTable extends Table
 {
-    protected ?string $_table = 'posts';
+    protected ?string $table = 'posts';
 }


### PR DESCRIPTION
Since the new `Enums need to be suffixed with Enum` rule has dropped in our codesniffer this was a good point to apply it in our 6.x codebase.

There are a few problems though, see e.g. https://github.com/cakephp/cakephp-codesniffer/issues/426

