### PR TITLE
Use Enum/ namespace instead of Enum suffix for enums

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database;
 
 use Cake\Cache\Cache;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Core\App;
 use Cake\Core\Exception\CakeException;
 use Cake\Core\Retry\CommandRetry;
@@ -553,7 +554,7 @@ class Connection implements ConnectionInterface
         if ($enable === false) {
             $this->_useSavePoints = false;
         } else {
-            $this->_useSavePoints = $this->getWriteDriver()->supports(DriverFeatureEnum::SAVEPOINT);
+            $this->_useSavePoints = $this->getWriteDriver()->supports(DriverFeature::SAVEPOINT);
         }
 
         return $this;

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database;
 
 use Cake\Core\App;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Core\Exception\CakeException;
 use Cake\Core\Retry\CommandRetry;
 use Cake\Database\Exception\DatabaseException;
@@ -908,10 +909,10 @@ abstract class Driver implements LoggerAwareInterface
      *
      * Should return false for unknown features.
      *
-     * @param \Cake\Database\DriverFeatureEnum $feature Driver feature
+     * @param \Cake\Database\Enum\DriverFeature $feature Driver feature
      * @return bool
      */
-    abstract public function supports(DriverFeatureEnum $feature): bool;
+    abstract public function supports(DriverFeature $feature): bool;
 
     /**
      * Transforms the passed query to this Driver's dialect and returns an instance

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Driver;
 
 use Cake\Database\Driver;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Query;
 use Cake\Database\Query\SelectQuery;
 use Cake\Database\Schema\MysqlSchemaDialect;
@@ -236,7 +236,7 @@ class Mysql extends Driver
     /**
      * @inheritDoc
      */
-    public function supports(DriverFeatureEnum $feature): bool
+    public function supports(DriverFeature $feature): bool
     {
         $versionCompare = function () use ($feature) {
             return version_compare(
@@ -247,19 +247,19 @@ class Mysql extends Driver
         };
 
         return match ($feature) {
-            DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION,
-            DriverFeatureEnum::SAVEPOINT => true,
+            DriverFeature::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION,
+            DriverFeature::SAVEPOINT => true,
 
-            DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS => false,
+            DriverFeature::TRUNCATE_WITH_CONSTRAINTS => false,
 
-            DriverFeatureEnum::CTE,
-            DriverFeatureEnum::JSON,
-            DriverFeatureEnum::WINDOW => $versionCompare(),
-            DriverFeatureEnum::INTERSECT => $versionCompare(),
-            DriverFeatureEnum::INTERSECT_ALL => $versionCompare(),
-            DriverFeatureEnum::CHECK_CONSTRAINTS => $versionCompare(),
-            DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => true,
-            DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => true,
+            DriverFeature::CTE,
+            DriverFeature::JSON,
+            DriverFeature::WINDOW => $versionCompare(),
+            DriverFeature::INTERSECT => $versionCompare(),
+            DriverFeature::INTERSECT_ALL => $versionCompare(),
+            DriverFeature::CHECK_CONSTRAINTS => $versionCompare(),
+            DriverFeature::SET_OPERATIONS_ORDER_BY => true,
+            DriverFeature::OPTIMIZER_HINT_COMMENT => true,
         };
     }
 

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Driver;
 
 use Cake\Database\Driver;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\StringExpression;
@@ -198,20 +198,20 @@ class Postgres extends Driver
     /**
      * @inheritDoc
      */
-    public function supports(DriverFeatureEnum $feature): bool
+    public function supports(DriverFeature $feature): bool
     {
         return match ($feature) {
-            DriverFeatureEnum::CTE,
-            DriverFeatureEnum::JSON,
-            DriverFeatureEnum::SAVEPOINT,
-            DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS,
-            DriverFeatureEnum::WINDOW => true,
-            DriverFeatureEnum::INTERSECT => true,
-            DriverFeatureEnum::INTERSECT_ALL => true,
-            DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => true,
-            DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION => false,
-            DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => true,
-            DriverFeatureEnum::CHECK_CONSTRAINTS => true,
+            DriverFeature::CTE,
+            DriverFeature::JSON,
+            DriverFeature::SAVEPOINT,
+            DriverFeature::TRUNCATE_WITH_CONSTRAINTS,
+            DriverFeature::WINDOW => true,
+            DriverFeature::INTERSECT => true,
+            DriverFeature::INTERSECT_ALL => true,
+            DriverFeature::SET_OPERATIONS_ORDER_BY => true,
+            DriverFeature::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION => false,
+            DriverFeature::OPTIMIZER_HINT_COMMENT => true,
+            DriverFeature::CHECK_CONSTRAINTS => true,
         };
     }
 

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Driver;
 
 use Cake\Database\Driver;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\Schema\SchemaDialect;
@@ -189,26 +189,26 @@ class Sqlite extends Driver
     /**
      * @inheritDoc
      */
-    public function supports(DriverFeatureEnum $feature): bool
+    public function supports(DriverFeature $feature): bool
     {
         return match ($feature) {
-            DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION,
-            DriverFeatureEnum::SAVEPOINT,
-            DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS => true,
+            DriverFeature::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION,
+            DriverFeature::SAVEPOINT,
+            DriverFeature::TRUNCATE_WITH_CONSTRAINTS => true,
 
-            DriverFeatureEnum::JSON => false,
+            DriverFeature::JSON => false,
 
-            DriverFeatureEnum::CTE,
-            DriverFeatureEnum::WINDOW => version_compare(
+            DriverFeature::CTE,
+            DriverFeature::WINDOW => version_compare(
                 $this->version(),
                 $this->featureVersions[$feature->value],
                 '>=',
             ),
-            DriverFeatureEnum::INTERSECT => true,
-            DriverFeatureEnum::INTERSECT_ALL => false,
-            DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => false,
-            DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => false,
-            DriverFeatureEnum::CHECK_CONSTRAINTS => true,
+            DriverFeature::INTERSECT => true,
+            DriverFeature::INTERSECT_ALL => false,
+            DriverFeature::SET_OPERATIONS_ORDER_BY => false,
+            DriverFeature::OPTIMIZER_HINT_COMMENT => false,
+            DriverFeature::CHECK_CONSTRAINTS => true,
         };
     }
 

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Driver;
 
 use Cake\Database\Driver;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\OrderClauseExpression;
@@ -276,20 +276,20 @@ class Sqlserver extends Driver
     /**
      * @inheritDoc
      */
-    public function supports(DriverFeatureEnum $feature): bool
+    public function supports(DriverFeature $feature): bool
     {
         return match ($feature) {
-            DriverFeatureEnum::CTE,
-            DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION,
-            DriverFeatureEnum::SAVEPOINT,
-            DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS,
-            DriverFeatureEnum::WINDOW => true,
-            DriverFeatureEnum::INTERSECT => true,
-            DriverFeatureEnum::INTERSECT_ALL => false,
-            DriverFeatureEnum::JSON => false,
-            DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => false,
-            DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => false,
-            DriverFeatureEnum::CHECK_CONSTRAINTS => false,
+            DriverFeature::CTE,
+            DriverFeature::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION,
+            DriverFeature::SAVEPOINT,
+            DriverFeature::TRUNCATE_WITH_CONSTRAINTS,
+            DriverFeature::WINDOW => true,
+            DriverFeature::INTERSECT => true,
+            DriverFeature::INTERSECT_ALL => false,
+            DriverFeature::JSON => false,
+            DriverFeature::SET_OPERATIONS_ORDER_BY => false,
+            DriverFeature::OPTIMIZER_HINT_COMMENT => false,
+            DriverFeature::CHECK_CONSTRAINTS => false,
         };
     }
 

--- a/src/Database/Enum/DriverFeature.php
+++ b/src/Database/Enum/DriverFeature.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
  * @since         5.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Database;
+namespace Cake\Database\Enum;
 
-enum DriverFeatureEnum: string
+enum DriverFeature: string
 {
     /**
      * Common Table Expressions (with clause) support.

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database;
 
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Exception\DatabaseException;
 use Closure;
 use Countable;
@@ -192,7 +193,7 @@ class QueryCompiler
         $select = 'SELECT%s%s %s%s';
         if (
             ($query->clause('union') || $query->clause('intersect')) &&
-            $driver->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY)
+            $driver->supports(DriverFeature::SET_OPERATIONS_ORDER_BY)
         ) {
             $select = '(SELECT%s%s %s%s';
         }
@@ -359,7 +360,7 @@ class QueryCompiler
         $setOperationsOrderBy = $query
             ->getConnection()
             ->getDriver($query->getConnectionRole())
-            ->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY);
+            ->supports(DriverFeature::SET_OPERATIONS_ORDER_BY);
 
         $parts = array_map(function (array $p) use ($binder, $setOperationsOrderBy) {
             /** @var \Cake\Database\Expression\IdentifierExpression $expr */
@@ -475,7 +476,7 @@ class QueryCompiler
      */
     protected function _buildOptimizerHintPart(array $parts, Query $query, ValueBinder $binder): string
     {
-        if ($parts === [] || !$query->getDriver()->supports(DriverFeatureEnum::OPTIMIZER_HINT_COMMENT)) {
+        if ($parts === [] || !$query->getDriver()->supports(DriverFeature::OPTIMIZER_HINT_COMMENT)) {
             return '';
         }
 

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Schema;
 
 use Cake\Database\Driver\Mysql;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Exception\DatabaseException;
 use PDOException;
 
@@ -635,7 +635,7 @@ class MysqlSchemaDialect extends SchemaDialect
      */
     public function describeCheckConstraints(string $tableName): array
     {
-        if (!$this->_driver->supports(DriverFeatureEnum::CHECK_CONSTRAINTS)) {
+        if (!$this->_driver->supports(DriverFeature::CHECK_CONSTRAINTS)) {
             return [];
         }
 
@@ -710,7 +710,7 @@ SQL;
         ];
 
         $out = $this->_driver->quoteIdentifier($name);
-        $nativeJson = $this->_driver->supports(DriverFeatureEnum::JSON);
+        $nativeJson = $this->_driver->supports(DriverFeature::JSON);
 
         $typeMap = [
             TableSchemaInterface::TYPE_TINYINTEGER => ' TINYINT',

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -110,9 +110,9 @@ class Cookie implements CookieInterface
     /**
      * Samesite
      *
-     * @var \Cake\Http\Cookie\SameSiteEnum|null
+     * @var \Cake\Http\Cookie\Enum\SameSite|null
      */
-    protected ?SameSiteEnum $sameSite = null;
+    protected ?Enum\SameSite $sameSite = null;
 
     /**
      * Default attributes for a cookie.
@@ -144,7 +144,7 @@ class Cookie implements CookieInterface
      * @param string|null $domain Domain
      * @param bool|null $secure Is secure
      * @param bool|null $httpOnly HTTP Only
-     * @param \Cake\Http\Cookie\SameSiteEnum|string|null $sameSite Samesite
+     * @param \Cake\Http\Cookie\Enum\SameSite|string|null $sameSite Samesite
      */
     public function __construct(
         string $name,
@@ -154,7 +154,7 @@ class Cookie implements CookieInterface
         ?string $domain = null,
         ?bool $secure = null,
         ?bool $httpOnly = null,
-        SameSiteEnum|string|null $sameSite = null,
+        Enum\SameSite|string|null $sameSite = null,
     ) {
         $this->validateName($name);
         $this->name = $name;
@@ -165,7 +165,7 @@ class Cookie implements CookieInterface
         $this->httpOnly = $httpOnly ?? static::$defaults['httponly'];
         $this->path = $path ?? static::$defaults['path'];
         $this->secure = $secure ?? static::$defaults['secure'];
-        $this->sameSite = static::resolveSameSiteEnum($sameSite ?? static::$defaults['samesite']);
+        $this->sameSite = static::resolveEnum\SameSite($sameSite ?? static::$defaults['samesite']);
 
         if ($expiresAt) {
             if ($expiresAt instanceof DateTime) {
@@ -201,7 +201,7 @@ class Cookie implements CookieInterface
             $options['expires'] = static::dateTimeInstance($options['expires']);
         }
         if (isset($options['samesite'])) {
-            $options['samesite'] = static::resolveSameSiteEnum($options['samesite']);
+            $options['samesite'] = static::resolveEnum\SameSite($options['samesite']);
         }
 
         static::$defaults = $options + static::$defaults;
@@ -310,7 +310,7 @@ class Cookie implements CookieInterface
         // https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-4.1
         if (isset($data['samesite'])) {
             try {
-                $data['samesite'] = static::resolveSameSiteEnum($data['samesite']);
+                $data['samesite'] = static::resolveEnum\SameSite($data['samesite']);
             } catch (ValueError) {
                 unset($data['samesite']);
             }
@@ -629,7 +629,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function getSameSite(): ?SameSiteEnum
+    public function getSameSite(): ?Enum\SameSite
     {
         return $this->sameSite;
     }
@@ -637,26 +637,26 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withSameSite(SameSiteEnum|string|null $sameSite): static
+    public function withSameSite(Enum\SameSite|string|null $sameSite): static
     {
         $new = clone $this;
-        $new->sameSite = static::resolveSameSiteEnum($sameSite);
+        $new->sameSite = static::resolveEnum\SameSite($sameSite);
 
         return $new;
     }
 
     /**
-     * Create SameSiteEnum instance.
+     * Create Enum\SameSite instance.
      *
-     * @param \Cake\Http\Cookie\SameSiteEnum|string|null $sameSite SameSite value
-     * @return \Cake\Http\Cookie\SameSiteEnum|null
+     * @param \Cake\Http\Cookie\Enum\SameSite|string|null $sameSite SameSite value
+     * @return \Cake\Http\Cookie\Enum\SameSite|null
      */
-    protected static function resolveSameSiteEnum(SameSiteEnum|string|null $sameSite): ?SameSiteEnum
+    protected static function resolveEnum\SameSite(Enum\SameSite|string|null $sameSite): ?Enum\SameSite
     {
         return match (true) {
             $sameSite === null => $sameSite,
-            $sameSite instanceof SameSiteEnum => $sameSite,
-            default => SameSiteEnum::from(ucfirst(strtolower($sameSite))),
+            $sameSite instanceof Enum\SameSite => $sameSite,
+            default => Enum\SameSite::from(ucfirst(strtolower($sameSite))),
         };
     }
 

--- a/src/Http/Cookie/CookieInterface.php
+++ b/src/Http/Cookie/CookieInterface.php
@@ -227,17 +227,17 @@ interface CookieInterface
     /**
      * Get the SameSite attribute.
      *
-     * @return \Cake\Http\Cookie\SameSiteEnum|null
+     * @return \Cake\Http\Cookie\Enum\SameSite|null
      */
-    public function getSameSite(): ?SameSiteEnum;
+    public function getSameSite(): ?Enum\SameSite;
 
     /**
      * Create a cookie with an updated SameSite option.
      *
-     * @param \Cake\Http\Cookie\SameSiteEnum|string|null $sameSite Value for to set for Samesite option.
+     * @param \Cake\Http\Cookie\Enum\SameSite|string|null $sameSite Value for to set for Samesite option.
      * @return static
      */
-    public function withSameSite(SameSiteEnum|string|null $sameSite): static;
+    public function withSameSite(Enum\SameSite|string|null $sameSite): static;
 
     /**
      * Get cookie options

--- a/src/Http/Cookie/Enum/SameSite.php
+++ b/src/Http/Cookie/Enum/SameSite.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
  * @since         5.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Http\Cookie;
+namespace Cake\Http\Cookie\Enum;
 
-enum SameSiteEnum: string
+enum SameSite: string
 {
     case LAX = 'Lax';
     case STRICT = 'Strict';

--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 namespace Cake\TestSuite;
 
 use Cake\Database\Connection;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Log\QueryLogger;
 use Cake\Datasource\ConnectionManager;
 use Closure;
@@ -150,7 +150,7 @@ class ConnectionHelper
      */
     public static function runWithoutConstraints(Connection $connection, Closure $callback): void
     {
-        if ($connection->getWriteDriver()->supports(DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION)) {
+        if ($connection->getWriteDriver()->supports(DriverFeature::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION)) {
             $connection->disableConstraints(fn(Connection $connection) => $callback($connection));
         } else {
             $connection->transactional(function (Connection $connection) use ($callback): void {

--- a/src/TestSuite/Fixture/FixtureHelper.php
+++ b/src/TestSuite/Fixture/FixtureHelper.php
@@ -19,7 +19,7 @@ namespace Cake\TestSuite\Fixture;
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use Cake\Database\Connection;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
@@ -183,7 +183,7 @@ class FixtureHelper
         $this->runPerConnection(function (ConnectionInterface $connection, array $groupFixtures): void {
             if ($connection instanceof Connection) {
                 $sortedFixtures = null;
-                if ($connection->getWriteDriver()->supports(DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS)) {
+                if ($connection->getWriteDriver()->supports(DriverFeature::TRUNCATE_WITH_CONSTRAINTS)) {
                     $sortedFixtures = $this->sortByConstraint($connection, $groupFixtures);
                 }
 

--- a/tests/TestCase/Database/Driver/BaseDriverTrait.php
+++ b/tests/TestCase/Database/Driver/BaseDriverTrait.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Driver;
 
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Schema\SchemaDialect;
 use Cake\Database\Schema\SqliteSchemaDialect;
 use Mockery;
@@ -50,7 +50,7 @@ trait BaseDriverTrait
         return new SqliteSchemaDialect($this);
     }
 
-    public function supports(DriverFeatureEnum $feature): bool
+    public function supports(DriverFeature $feature): bool
     {
         return true;
     }

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database\Driver;
 
 use Cake\Database\Driver\Mysql;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Mockery;
@@ -234,14 +234,14 @@ class MysqlTest extends TestCase
         foreach ($featureVersions[$serverType] as $feature => $version) {
             $this->assertSame(
                 version_compare($driver->version(), $version, '>='),
-                $driver->supports(DriverFeatureEnum::from($feature)),
+                $driver->supports(DriverFeature::from($feature)),
             );
         }
 
-        $this->assertTrue($driver->supports(DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::SAVEPOINT));
+        $this->assertTrue($driver->supports(DriverFeature::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));
+        $this->assertTrue($driver->supports(DriverFeature::SAVEPOINT));
 
-        $this->assertFalse($driver->supports(DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS));
+        $this->assertFalse($driver->supports(DriverFeature::TRUNCATE_WITH_CONSTRAINTS));
     }
 
     /**

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -18,7 +18,7 @@ namespace Cake\Test\TestCase\Database\Driver;
 
 use Cake\Database\Connection;
 use Cake\Database\Driver\Postgres;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Query\SelectQuery;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
@@ -230,16 +230,16 @@ class PostgresTest extends TestCase
         $driver = ConnectionManager::get('test')->getDriver();
         $this->skipIf(!$driver instanceof Postgres);
 
-        $this->assertTrue($driver->supports(DriverFeatureEnum::CTE));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::JSON));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::SAVEPOINT));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::WINDOW));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::INTERSECT));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::INTERSECT_ALL));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY));
+        $this->assertTrue($driver->supports(DriverFeature::CTE));
+        $this->assertTrue($driver->supports(DriverFeature::JSON));
+        $this->assertTrue($driver->supports(DriverFeature::SAVEPOINT));
+        $this->assertTrue($driver->supports(DriverFeature::TRUNCATE_WITH_CONSTRAINTS));
+        $this->assertTrue($driver->supports(DriverFeature::WINDOW));
+        $this->assertTrue($driver->supports(DriverFeature::INTERSECT));
+        $this->assertTrue($driver->supports(DriverFeature::INTERSECT_ALL));
+        $this->assertTrue($driver->supports(DriverFeature::SET_OPERATIONS_ORDER_BY));
 
-        $this->assertFalse($driver->supports(DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));
+        $this->assertFalse($driver->supports(DriverFeature::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));
     }
 
     /**

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -19,7 +19,7 @@ namespace Cake\Test\TestCase\Database\Driver;
 use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Mockery;
@@ -207,18 +207,18 @@ class SqliteTest extends TestCase
         foreach ($featureVersions as $feature => $version) {
             $this->assertSame(
                 version_compare($driver->version(), $version, '>='),
-                $driver->supports(DriverFeatureEnum::from($feature)),
+                $driver->supports(DriverFeature::from($feature)),
             );
         }
 
-        $this->assertTrue($driver->supports(DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::SAVEPOINT));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::INTERSECT));
+        $this->assertTrue($driver->supports(DriverFeature::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));
+        $this->assertTrue($driver->supports(DriverFeature::SAVEPOINT));
+        $this->assertTrue($driver->supports(DriverFeature::TRUNCATE_WITH_CONSTRAINTS));
+        $this->assertTrue($driver->supports(DriverFeature::INTERSECT));
 
-        $this->assertFalse($driver->supports(DriverFeatureEnum::INTERSECT_ALL));
-        $this->assertFalse($driver->supports(DriverFeatureEnum::JSON));
-        $this->assertFalse($driver->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY));
+        $this->assertFalse($driver->supports(DriverFeature::INTERSECT_ALL));
+        $this->assertFalse($driver->supports(DriverFeature::JSON));
+        $this->assertFalse($driver->supports(DriverFeature::SET_OPERATIONS_ORDER_BY));
     }
 
     /**

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -19,7 +19,7 @@ namespace Cake\Test\TestCase\Database\Driver;
 
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlserver;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Query\InsertQuery;
 use Cake\Database\Query\SelectQuery;
@@ -556,15 +556,15 @@ class SqlserverTest extends TestCase
         $driver = ConnectionManager::get('test')->getDriver();
         $this->skipIf(!$driver instanceof Sqlserver);
 
-        $this->assertTrue($driver->supports(DriverFeatureEnum::CTE));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::SAVEPOINT));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::WINDOW));
-        $this->assertTrue($driver->supports(DriverFeatureEnum::INTERSECT));
+        $this->assertTrue($driver->supports(DriverFeature::CTE));
+        $this->assertTrue($driver->supports(DriverFeature::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));
+        $this->assertTrue($driver->supports(DriverFeature::SAVEPOINT));
+        $this->assertTrue($driver->supports(DriverFeature::TRUNCATE_WITH_CONSTRAINTS));
+        $this->assertTrue($driver->supports(DriverFeature::WINDOW));
+        $this->assertTrue($driver->supports(DriverFeature::INTERSECT));
 
-        $this->assertFalse($driver->supports(DriverFeatureEnum::INTERSECT_ALL));
-        $this->assertFalse($driver->supports(DriverFeatureEnum::JSON));
-        $this->assertFalse($driver->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY));
+        $this->assertFalse($driver->supports(DriverFeature::INTERSECT_ALL));
+        $this->assertFalse($driver->supports(DriverFeature::JSON));
+        $this->assertFalse($driver->supports(DriverFeature::SET_OPERATIONS_ORDER_BY));
     }
 }

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -22,7 +22,7 @@ use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Postgres;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Driver\Sqlserver;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\CommonTableExpression;
 use Cake\Database\Expression\IdentifierExpression;
@@ -2658,7 +2658,7 @@ class SelectQueryTest extends TestCase
     public function testUnionOrderBy(): void
     {
         $this->skipIf(
-            !$this->connection->getDriver()->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY),
+            !$this->connection->getDriver()->supports(DriverFeature::SET_OPERATIONS_ORDER_BY),
             'Driver does not support ORDER BY on UNIONed queries.',
         );
 
@@ -2712,7 +2712,7 @@ class SelectQueryTest extends TestCase
     public function testIntersect(): void
     {
         $this->skipIf(
-            !$this->connection->getDriver()->supports(DriverFeatureEnum::INTERSECT),
+            !$this->connection->getDriver()->supports(DriverFeature::INTERSECT),
             'Driver does not support INTERSECT clause.',
         );
 
@@ -2761,11 +2761,11 @@ class SelectQueryTest extends TestCase
     public function testIntersectOrderBy(): void
     {
         $this->skipIf(
-            !$this->connection->getDriver()->supports(DriverFeatureEnum::INTERSECT),
+            !$this->connection->getDriver()->supports(DriverFeature::INTERSECT),
             'Driver does not support INTERSECT clause.',
         );
         $this->skipIf(
-            !$this->connection->getDriver()->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY),
+            !$this->connection->getDriver()->supports(DriverFeature::SET_OPERATIONS_ORDER_BY),
             'Driver does not support ORDER BY on INTERSECTed queries.',
         );
         $intersect = (new SelectQuery($this->connection))
@@ -2790,7 +2790,7 @@ class SelectQueryTest extends TestCase
     public function testIntersectAll(): void
     {
         $this->skipIf(
-            !$this->connection->getDriver()->supports(DriverFeatureEnum::INTERSECT_ALL),
+            !$this->connection->getDriver()->supports(DriverFeature::INTERSECT_ALL),
             'Driver does not support INTERSECT ALL clause.',
         );
         $intersect = (new SelectQuery($this->connection))->select(['id', 'comment'])->from(['c' => 'comments'])->where(['article_id' => 1]);

--- a/tests/TestCase/Database/QueryCompilerTest.php
+++ b/tests/TestCase/Database/QueryCompilerTest.php
@@ -16,7 +16,7 @@ namespace Cake\Test\TestCase\Database;
 
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlserver;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Query;
 use Cake\Database\QueryCompiler;
 use Cake\Database\StatementInterface;
@@ -117,7 +117,7 @@ class QueryCompilerTest extends TestCase
             ->optimizerHint(['TEST_HINT1(param)', 'TEST_HINT2(param)']);
         $result = $this->compiler->compile($query, $this->binder);
 
-        if ($query->getDriver()->supports(DriverFeatureEnum::OPTIMIZER_HINT_COMMENT)) {
+        if ($query->getDriver()->supports(DriverFeature::OPTIMIZER_HINT_COMMENT)) {
             $this->assertSame('SELECT /*+ TEST_HINT1(param) TEST_HINT2(param) */ * FROM articles', $result);
         } else {
             $this->assertSame('SELECT * FROM articles', $result);
@@ -178,7 +178,7 @@ class QueryCompilerTest extends TestCase
             ->optimizerHint(['TEST_HINT1(param)', 'TEST_HINT2(param)']);
         $result = $this->compiler->compile($query, $this->binder);
 
-        if ($query->getDriver()->supports(DriverFeatureEnum::OPTIMIZER_HINT_COMMENT)) {
+        if ($query->getDriver()->supports(DriverFeature::OPTIMIZER_HINT_COMMENT)) {
             $this->assertSame('INSERT /*+ TEST_HINT1(param) TEST_HINT2(param) */ INTO articles (title) VALUES (:c0)', $result);
         } elseif ($query->getDriver() instanceof Sqlserver) {
             $this->assertSame('INSERT INTO articles (title) OUTPUT INSERTED.* VALUES (:c0)', $result);
@@ -232,7 +232,7 @@ class QueryCompilerTest extends TestCase
             ->optimizerHint(['TEST_HINT1(param)', 'TEST_HINT2(param)']);
         $result = $this->compiler->compile($query, $this->binder);
 
-        if ($query->getDriver()->supports(DriverFeatureEnum::OPTIMIZER_HINT_COMMENT)) {
+        if ($query->getDriver()->supports(DriverFeature::OPTIMIZER_HINT_COMMENT)) {
             $this->assertSame('UPDATE /*+ TEST_HINT1(param) TEST_HINT2(param) */ articles SET title = :c0 WHERE id = :c1', $result);
         } else {
             $this->assertSame('UPDATE articles SET title = :c0 WHERE id = :c1', $result);
@@ -284,7 +284,7 @@ class QueryCompilerTest extends TestCase
             ->optimizerHint(['TEST_HINT1(param)', 'TEST_HINT2(param)']);
         $result = $this->compiler->compile($query, $this->binder);
 
-        if ($query->getDriver()->supports(DriverFeatureEnum::OPTIMIZER_HINT_COMMENT)) {
+        if ($query->getDriver()->supports(DriverFeature::OPTIMIZER_HINT_COMMENT)) {
             $this->assertSame('DELETE /*+ TEST_HINT1(param) TEST_HINT2(param) */ FROM articles WHERE id != :c0', $result);
         } else {
             $this->assertSame('DELETE FROM articles WHERE id != :c0', $result);

--- a/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
@@ -19,7 +19,7 @@ namespace Cake\Test\TestCase\Database\QueryTests;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Driver\Sqlserver;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Expression\CommonTableExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Query;
@@ -54,7 +54,7 @@ class CommonTableExpressionQueryTest extends TestCase
         $this->autoQuote = $this->connection->getDriver()->isAutoQuotingEnabled();
 
         $this->skipIf(
-            !$this->connection->getDriver()->supports(DriverFeatureEnum::CTE),
+            !$this->connection->getDriver()->supports(DriverFeature::CTE),
             'The current driver does not support common table expressions.',
         );
     }

--- a/tests/TestCase/Database/QueryTests/WindowQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/WindowQueryTest.php
@@ -19,7 +19,7 @@ use Cake\Core\Exception\CakeException;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Driver\Sqlserver;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\WindowExpression;
 use Cake\Database\Query\SelectQuery;
@@ -61,7 +61,7 @@ class WindowQueryTest extends TestCase
             $driver instanceof Mysql ||
             $driver instanceof Sqlite
         ) {
-            $this->skipTests = !$this->connection->getDriver()->supports(DriverFeatureEnum::WINDOW);
+            $this->skipTests = !$this->connection->getDriver()->supports(DriverFeature::WINDOW);
         } else {
             $this->skipTests = false;
         }

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -19,7 +19,7 @@ namespace Cake\Test\TestCase\Database\Schema;
 use Cake\Database\Connection;
 use Cake\Database\Driver;
 use Cake\Database\Driver\Mysql;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\CheckConstraint;
 use Cake\Database\Schema\Collection as SchemaCollection;
@@ -384,7 +384,7 @@ SQL;
 SQL;
         $connection->execute($table);
 
-        if ($connection->getDriver()->supports(DriverFeatureEnum::JSON)) {
+        if ($connection->getDriver()->supports(DriverFeature::JSON)) {
             $table = <<<SQL
                 CREATE TABLE schema_json (
                     id INT PRIMARY KEY AUTO_INCREMENT,
@@ -1000,7 +1000,7 @@ SQL;
         $this->_needsConnection();
         $connection = ConnectionManager::get('test');
         $driver = $connection->getDriver();
-        $this->skipIf(!$driver->supports(DriverFeatureEnum::CHECK_CONSTRAINTS), 'This test requires check constraint support');
+        $this->skipIf(!$driver->supports(DriverFeature::CHECK_CONSTRAINTS), 'This test requires check constraint support');
 
         $connection->execute('DROP TABLE IF EXISTS schema_constraints');
         $table = <<<SQL
@@ -2041,7 +2041,7 @@ SQL;
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
-        $this->skipIf(!$connection->getDriver()->supports(DriverFeatureEnum::JSON), 'Does not support native json');
+        $this->skipIf(!$connection->getDriver()->supports(DriverFeature::JSON), 'Does not support native json');
         $this->skipIf($connection->getDriver()->isMariadb(), 'MariaDb internally uses TEXT for JSON columns');
 
         $schema = new SchemaCollection($connection);

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -17,7 +17,7 @@ namespace Cake\Test\TestCase\Http\Cookie;
 use Cake\Chronos\Chronos;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieInterface;
-use Cake\Http\Cookie\SameSiteEnum;
+use Cake\Http\Cookie\Enum\SameSite;
 use Cake\TestSuite\TestCase;
 use DateTimeInterface;
 use InvalidArgumentException;
@@ -151,7 +151,7 @@ class CookieTest extends TestCase
         $this->assertStringNotContainsString('samesite=Lax', $cookie->toHeaderValue(), 'old instance not modified');
         $this->assertStringContainsString('samesite=Lax', $new->toHeaderValue());
 
-        $new = $cookie->withSameSite(SameSiteEnum::STRICT);
+        $new = $cookie->withSameSite(SameSite::STRICT);
         $this->assertStringContainsString('samesite=Strict', $new->toHeaderValue());
     }
 
@@ -169,7 +169,7 @@ class CookieTest extends TestCase
     public function testGetSameSite(): void
     {
         $cookie = new Cookie(name: 'cakephp', value: 'cakephp-rocks', sameSite: 'NONE');
-        $this->assertSame(SameSiteEnum::NONE, $cookie->getSameSite());
+        $this->assertSame(SameSite::NONE, $cookie->getSameSite());
     }
 
     /**

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -22,7 +22,7 @@ use Cake\Cache\Engine\FileEngine;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlite;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\CommonTableExpression;
 use Cake\Database\Expression\FunctionExpression;
@@ -3948,7 +3948,7 @@ class SelectQueryTest extends TestCase
     public function testWith(): void
     {
         $this->skipIf(
-            !$this->connection->getDriver()->supports(DriverFeatureEnum::CTE),
+            !$this->connection->getDriver()->supports(DriverFeature::CTE),
             'The current driver does not support common table expressions.',
         );
         $this->skipIf(
@@ -3956,7 +3956,7 @@ class SelectQueryTest extends TestCase
                 $this->connection->getDriver() instanceof Mysql ||
                 $this->connection->getDriver() instanceof Sqlite
             ) &&
-            !$this->connection->getDriver()->supports(DriverFeatureEnum::WINDOW),
+            !$this->connection->getDriver()->supports(DriverFeature::WINDOW),
             'The current driver does not support window functions.',
         );
 

--- a/tests/test_app/TestApp/Database/Driver/StubDriver.php
+++ b/tests/test_app/TestApp/Database/Driver/StubDriver.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 namespace TestApp\Database\Driver;
 
 use Cake\Database\Driver;
-use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Schema\SchemaDialect;
 use Cake\Database\Schema\SqliteSchemaDialect;
 
@@ -47,7 +47,7 @@ class StubDriver extends Driver
         return new SqliteSchemaDialect($this);
     }
 
-    public function supports(DriverFeatureEnum $feature): bool
+    public function supports(DriverFeature $feature): bool
     {
         return true;
     }


### PR DESCRIPTION
## Summary

- Move `DriverFeatureEnum` to `Database/Enum/DriverFeature`
- Move `SameSiteEnum` to `Http/Cookie/Enum/SameSite`

This follows the pattern already used by other enums in the codebase (e.g., `Utility/Fs/Enum/FinderMode`, `Model/Enum/*`) and prepares for future codesniffer rules that allow omitting the `Enum` suffix when the enum is in an `Enum` namespace segment.

Related: cakephp/cakephp-codesniffer#428