### PR TITLE
Remove underscore prefix from property names in test files

### DIFF
--- a/tests/TestCase/Http/Session/CacheSessionTest.php
+++ b/tests/TestCase/Http/Session/CacheSessionTest.php
@@ -28,7 +28,7 @@ use InvalidArgumentException;
  */
 class CacheSessionTest extends TestCase
 {
-    protected static $_sessionBackup;
+    protected static $sessionBackup;
 
     /**
      * @var \Cake\Http\Session\CacheSession

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/Model/Table/TestPluginThreeCommentsTable.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/Model/Table/TestPluginThreeCommentsTable.php
@@ -23,5 +23,5 @@ use Cake\ORM\Table;
  */
 class TestPluginThreeCommentsTable extends Table
 {
-    protected ?string $_table = 'test_plugin_three_comments';
+    protected ?string $table = 'test_plugin_three_comments';
 }

--- a/tests/test_app/TestApp/Model/Entity/ProtectedUser.php
+++ b/tests/test_app/TestApp/Model/Entity/ProtectedUser.php
@@ -10,5 +10,5 @@ use Cake\ORM\Entity;
  */
 class ProtectedUser extends Entity
 {
-    protected array $_hidden = ['password'];
+    protected array $hidden = ['password'];
 }

--- a/tests/test_app/TestApp/Model/Entity/VirtualUser.php
+++ b/tests/test_app/TestApp/Model/Entity/VirtualUser.php
@@ -7,7 +7,7 @@ use Cake\ORM\Entity;
 
 class VirtualUser extends Entity
 {
-    protected array $_virtual = [
+    protected array $virtual = [
         'bonus',
     ];
 

--- a/tests/test_app/TestApp/Model/Table/PostsTable.php
+++ b/tests/test_app/TestApp/Model/Table/PostsTable.php
@@ -21,5 +21,5 @@ use Cake\ORM\Table;
 
 class PostsTable extends Table
 {
-    protected ?string $_table = 'posts';
+    protected ?string $table = 'posts';
 }


### PR DESCRIPTION
## Summary
- Removes underscore prefix from property names in test files to comply with CakePHP coding standards
- The underscore prefix should not be used to indicate visibility in PHP

Aims to be green in CI for https://github.com/cakephp/cakephp-codesniffer/pull/424 then

Properties renamed:
- `$_sessionBackup` -> `$sessionBackup` in CacheSessionTest
- `$_table` -> `$table` in test app table files
- `$_hidden` -> `$hidden` in ProtectedUser entity
- `$_virtual` -> `$virtual` in VirtualUser entity

Note: The `$_toStringFormat` properties in I18n classes (Date, DateTime, Time) cannot be renamed as they intentionally use the underscore prefix to avoid type conflicts with parent Chronos classes.  
=> https://github.com/cakephp/chronos/pull/497 
Will be release with Chronos major in the future.
