### PR TITLE
5.next: Allow chronos 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "cakephp/chronos": "^3.3",
+        "cakephp/chronos": "^3.3 || ^4.0",
         "composer/ca-bundle": "^1.5",
         "laminas/laminas-diactoros": "^3.8",
         "laminas/laminas-httphandlerrunner": "^2.6",


### PR DESCRIPTION
Allow chronos 4.x alongside 3.x for forward compatibility.

Since the upgrade path is 0, no changes needed, we could also think about directly going v4 only here for simplicity, once we release 5.4 and soon then also 6.0.