### PR TITLE
Add strict mode to in_array() calls

### DIFF
--- a/src/Database/Driver/TupleComparisonTranslatorTrait.php
+++ b/src/Database/Driver/TupleComparisonTranslatorTrait.php
@@ -58,7 +58,7 @@ trait TupleComparisonTranslatorTrait
         }
 
         $operator = strtoupper($expression->getOperator());
-        if (!in_array($operator, ['IN', '='])) {
+        if (!in_array($operator, ['IN', '='], true)) {
             throw new InvalidArgumentException(
                 sprintf(
                     'Tuple comparison transform only supports the `IN` and `=` operators, `%s` given.',

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -631,7 +631,7 @@ class QueryExpression implements ExpressionInterface, Countable
             $isNot = false;
             if (!$numericKey) {
                 $normalizedKey = strtolower($k);
-                $isOperator = in_array($normalizedKey, $operators);
+                $isOperator = in_array($normalizedKey, $operators, true);
                 $isNot = $normalizedKey === 'not';
             }
 
@@ -705,7 +705,7 @@ class QueryExpression implements ExpressionInterface, Countable
 
         $type = $this->getTypeMap()->type($expression);
         $typeMultiple = (is_string($type) && str_contains($type, '[]'));
-        if (in_array($operator, ['IN', 'NOT IN']) || $typeMultiple) {
+        if (in_array($operator, ['IN', 'NOT IN'], true) || $typeMultiple) {
             $type = $type ?: 'string';
             if (!$typeMultiple) {
                 $type .= '[]';

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -226,6 +226,6 @@ class TupleComparison extends ComparisonExpression
      */
     public function isMulti(): bool
     {
-        return in_array(strtolower($this->_operator), ['in', 'not in']);
+        return in_array(strtolower($this->_operator), ['in', 'not in'], true);
     }
 }

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -215,6 +215,7 @@ class MysqlSchemaDialect extends SchemaDialect
                     TableSchema::GEOSPATIAL_TYPES,
                     [TableSchema::TYPE_BINARY, TableSchema::TYPE_JSON, TableSchema::TYPE_TEXT],
                 ),
+                true,
             )
         ) {
             // The default that comes back from MySQL for these types prefixes the collation type and
@@ -379,10 +380,10 @@ class MysqlSchemaDialect extends SchemaDialect
             return $type;
         }
 
-        if (in_array($col, ['date', 'time', 'year'])) {
+        if (in_array($col, ['date', 'time', 'year'], true)) {
             return ['type' => $col, 'length' => null];
         }
-        if (in_array($col, ['datetime', 'timestamp'])) {
+        if (in_array($col, ['datetime', 'timestamp'], true)) {
             $typeName = $col;
             if ($length > 0) {
                 $typeName = $col . 'fractional';
@@ -409,7 +410,7 @@ class MysqlSchemaDialect extends SchemaDialect
         if ($col === 'smallint') {
             return ['type' => TableSchemaInterface::TYPE_SMALLINTEGER, 'length' => null, 'unsigned' => $unsigned];
         }
-        if (in_array($col, ['int', 'integer', 'mediumint'])) {
+        if (in_array($col, ['int', 'integer', 'mediumint'], true)) {
             return ['type' => TableSchemaInterface::TYPE_INTEGER, 'length' => null, 'unsigned' => $unsigned];
         }
         if ($col === 'char' && $length === 36) {
@@ -433,7 +434,7 @@ class MysqlSchemaDialect extends SchemaDialect
         if ($col === 'uuid') {
             return ['type' => TableSchemaInterface::TYPE_NATIVE_UUID, 'length' => null];
         }
-        if (str_contains($col, 'blob') || in_array($col, ['binary', 'varbinary'])) {
+        if (str_contains($col, 'blob') || in_array($col, ['binary', 'varbinary'], true)) {
             $lengthName = substr($col, 0, -4);
             $length = TableSchema::$columnLengths[$lengthName] ?? $length;
 
@@ -464,7 +465,7 @@ class MysqlSchemaDialect extends SchemaDialect
         if (str_contains($col, 'json')) {
             return ['type' => TableSchemaInterface::TYPE_JSON, 'length' => null];
         }
-        if (in_array($col, TableSchemaInterface::GEOSPATIAL_TYPES)) {
+        if (in_array($col, TableSchemaInterface::GEOSPATIAL_TYPES, true)) {
             // TODO how can srid be preserved? It doesn't come back
             // in the output of show full columns from ...
             return [

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -195,7 +195,7 @@ class PostgresSchemaDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_JSON, 'length' => null];
         }
 
-        if (in_array($col, ['geometry', 'geography'])) {
+        if (in_array($col, ['geometry', 'geography'], true)) {
             return ['type' => $col, 'length' => null];
         }
 

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -101,7 +101,7 @@ class SqliteSchemaDialect extends SchemaDialect
                 'unsigned' => $unsigned,
             ];
         }
-        if (in_array($col, ['float', 'real', 'double'])) {
+        if (in_array($col, ['float', 'real', 'double'], true)) {
             return [
                 'type' => TableSchemaInterface::TYPE_FLOAT,
                 'length' => $length,
@@ -127,7 +127,7 @@ class SqliteSchemaDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_STRING, 'length' => $length];
         }
 
-        if (in_array($col, ['blob', 'clob', 'binary', 'varbinary'])) {
+        if (in_array($col, ['blob', 'clob', 'binary', 'varbinary'], true)) {
             return ['type' => TableSchemaInterface::TYPE_BINARY, 'length' => $length];
         }
 
@@ -140,7 +140,7 @@ class SqliteSchemaDialect extends SchemaDialect
             'datetime',
             'datetimefractional',
         ];
-        if (in_array($col, $datetimeTypes)) {
+        if (in_array($col, $datetimeTypes, true)) {
             return ['type' => $col, 'length' => null];
         }
 
@@ -154,7 +154,7 @@ class SqliteSchemaDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_JSON, 'length' => null];
         }
 
-        if (in_array($col, TableSchemaInterface::GEOSPATIAL_TYPES)) {
+        if (in_array($col, TableSchemaInterface::GEOSPATIAL_TYPES, true)) {
             // TODO how can srid be preserved? It doesn't come back
             // in the output of show full columns from ...
             return [

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -137,7 +137,7 @@ class SqlserverSchemaDialect extends SchemaDialect
             return $type;
         }
 
-        if (in_array($col, ['date', 'time'])) {
+        if (in_array($col, ['date', 'time'], true)) {
             return ['type' => $col, 'length' => null];
         }
 

--- a/src/Error/Renderer/WebExceptionRenderer.php
+++ b/src/Error/Renderer/WebExceptionRenderer.php
@@ -198,7 +198,7 @@ class WebExceptionRenderer implements ExceptionRendererInterface
      */
     protected function clearOutput(): void
     {
-        if (in_array(PHP_SAPI, ['cli', 'phpdbg'])) {
+        if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
             return;
         }
         while (ob_get_level()) {

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -910,7 +910,7 @@ class Message implements JsonSerializable
         $headersMultipleEmails = ['to', 'cc', 'bcc', 'replyTo'];
         foreach ($relation as $var => $header) {
             if ($include[$var]) {
-                if (in_array($var, $headersMultipleEmails)) {
+                if (in_array($var, $headersMultipleEmails, true)) {
                     $headers[$header] = implode(', ', $this->formatAddress($this->{$var}));
                 } else {
                     $headers[$header] = (string)current($this->formatAddress($this->{$var}));

--- a/src/TestSuite/Constraint/Email/MailSentWith.php
+++ b/src/TestSuite/Constraint/Email/MailSentWith.php
@@ -59,7 +59,7 @@ class MailSentWith extends MailConstraintBase
             }
             if (
                 !is_array($other)
-                && in_array($this->method, ['to', 'cc', 'bcc', 'from', 'replyTo', 'sender'])
+                && in_array($this->method, ['to', 'cc', 'bcc', 'from', 'replyTo', 'sender'], true)
                 && array_key_exists($other, $value)
             ) {
                 return true;

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -770,7 +770,7 @@ trait IntegrationTestTrait
             // the inverse.
             $this->_session[$this->_csrfKeyName] = $token;
             $this->_cookie[$this->_csrfKeyName] = $token;
-            if (!isset($data['_csrfToken']) && !in_array($method, ['GET', 'OPTIONS'])) {
+            if (!isset($data['_csrfToken']) && !in_array($method, ['GET', 'OPTIONS'], true)) {
                 $data['_csrfToken'] = $token;
             }
         }

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -345,7 +345,7 @@ class Validation
     {
         if (
             (!is_numeric($check1) || !is_numeric($check2)) &&
-            !in_array($operator, static::COMPARE_STRING)
+            !in_array($operator, static::COMPARE_STRING, true)
         ) {
             return false;
         }

--- a/tests/test_app/TestApp/Database/Schema/CompatDialect.php
+++ b/tests/test_app/TestApp/Database/Schema/CompatDialect.php
@@ -96,7 +96,7 @@ class CompatDialect extends SchemaDialect
                 'unsigned' => $unsigned,
             ];
         }
-        if (in_array($col, ['float', 'real', 'double'])) {
+        if (in_array($col, ['float', 'real', 'double'], true)) {
             return [
                 'type' => TableSchemaInterface::TYPE_FLOAT,
                 'length' => $length,
@@ -122,7 +122,7 @@ class CompatDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_STRING, 'length' => $length];
         }
 
-        if (in_array($col, ['blob', 'clob', 'binary', 'varbinary'])) {
+        if (in_array($col, ['blob', 'clob', 'binary', 'varbinary'], true)) {
             return ['type' => TableSchemaInterface::TYPE_BINARY, 'length' => $length];
         }
 
@@ -135,7 +135,7 @@ class CompatDialect extends SchemaDialect
             'datetime',
             'datetimefractional',
         ];
-        if (in_array($col, $datetimeTypes)) {
+        if (in_array($col, $datetimeTypes, true)) {
             return ['type' => $col, 'length' => null];
         }
 
@@ -147,7 +147,7 @@ class CompatDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_JSON, 'length' => null];
         }
 
-        if (in_array($col, TableSchemaInterface::GEOSPATIAL_TYPES)) {
+        if (in_array($col, TableSchemaInterface::GEOSPATIAL_TYPES, true)) {
             // TODO how can srid be preserved? It doesn't come back
             // in the output of show full columns from ...
             return [


### PR DESCRIPTION
## Summary
- Apply `StrictInArrayRector` fixes to add `true` as third parameter for strict type comparison in `in_array()` calls
- Fixes rector CI check failures