### PR TITLE
Return null from Number::parseFloat() on parse failure

### DIFF
--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -175,12 +175,17 @@ class DecimalType extends BaseType implements BatchCastingInterface
      * the locale aware parser.
      *
      * @param string $value The value to parse and convert to an float.
-     * @return string
+     * @return string|null
      */
-    protected function _parseValue(string $value): string
+    protected function _parseValue(string $value): ?string
     {
         $class = static::$numberClass;
+        $result = $class::parseFloat($value);
 
-        return (string)$class::parseFloat($value);
+        if ($result === null) {
+            return null;
+        }
+
+        return (string)$result;
     }
 }

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -155,9 +155,9 @@ class FloatType extends BaseType implements BatchCastingInterface
      * aware parser.
      *
      * @param string $value The value to parse and convert to an float.
-     * @return float
+     * @return float|null
      */
-    protected function _parseValue(string $value): float
+    protected function _parseValue(string $value): ?float
     {
         $class = static::$numberClass;
 

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -201,13 +201,18 @@ class Number
      *
      * @param string $value A numeric string.
      * @param array<string, mixed> $options An array with options.
-     * @return float point number
+     * @return float|null Parsed float or null if parsing failed.
      */
-    public static function parseFloat(string $value, array $options = []): float
+    public static function parseFloat(string $value, array $options = []): ?float
     {
         $formatter = static::formatter($options);
+        $result = $formatter->parse($value, NumberFormatter::TYPE_DOUBLE);
 
-        return (float)$formatter->parse($value, NumberFormatter::TYPE_DOUBLE);
+        if ($result === false) {
+            return null;
+        }
+
+        return (float)$result;
     }
 
     /**

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -228,6 +228,20 @@ class DecimalTypeTest extends TestCase
     }
 
     /**
+     * Tests marshalling invalid numbers returns null when using locale parser
+     */
+    public function testMarshalWithLocaleParsingInvalidReturnsNull(): void
+    {
+        $this->type->useLocaleParser();
+
+        I18n::setLocale('en_US');
+        $this->assertNull($this->type->marshal('invalid'));
+        $this->assertNull($this->type->marshal('abc'));
+
+        $this->type->useLocaleParser(false);
+    }
+
+    /**
      * Test that exceptions are raised on invalid parsers.
      */
     public function testUseLocaleParsingInvalid(): void

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -176,6 +176,20 @@ class FloatTypeTest extends TestCase
     }
 
     /**
+     * Tests marshalling invalid numbers returns null when using locale parser
+     */
+    public function testMarshalWithLocaleParsingInvalidReturnsNull(): void
+    {
+        $this->type->useLocaleParser();
+
+        I18n::setLocale('en_US');
+        $this->assertNull($this->type->marshal('invalid'));
+        $this->assertNull($this->type->marshal('abc'));
+
+        $this->type->useLocaleParser(false);
+    }
+
+    /**
      * Test that exceptions are raised on invalid parsers.
      */
     public function testUseLocaleParsingInvalid(): void

--- a/tests/TestCase/I18n/NumberTest.php
+++ b/tests/TestCase/I18n/NumberTest.php
@@ -129,6 +129,17 @@ class NumberTest extends TestCase
     }
 
     /**
+     * testParseFloatReturnsNullOnFailure method
+     */
+    public function testParseFloatReturnsNullOnFailure(): void
+    {
+        I18n::setLocale('en_US');
+        $this->assertNull($this->Number->parseFloat('abc'));
+        $this->assertNull($this->Number->parseFloat('invalid'));
+        $this->assertNull($this->Number->parseFloat(''));
+    }
+
+    /**
      * testFormatDelta method
      */
     public function testFormatDelta(): void


### PR DESCRIPTION
## Summary

- `Number::parseFloat()` now returns `null` instead of `0.0` when parsing fails
- `FloatType::_parseValue()` and `DecimalType::_parseValue()` updated to propagate null
- Invalid locale-formatted form input now results in `null` entity values (empty field) instead of `0`

Previously, when `NumberFormatter::parse()` failed it returned `false`, which was cast to `0.0`. This silently converted invalid input like `"abc"` to `0.0`, making it impossible to distinguish from valid `"0"` input.

This is consistent with the date parsing pattern in `DateFormatTrait` which returns `null` on failure.

Fixes #19346

I think this is straight forward in handling invalid values only for a minor release, including 5.4 changelog communication.