### PR TITLE
Use `subtree split` instead of `filter-tree` for updating split packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,8 +171,7 @@ component-%:
 	git checkout $(CURRENT_BRANCH) > /dev/null
 	- (git remote add pkg-$* git@github.com:$(OWNER)/$*.git -f 2> /dev/null)
 	- (git branch -D $* 2> /dev/null)
-	git checkout -b $*
-	git filter-branch --prune-empty --subdirectory-filter src/$(shell php -r "echo ucfirst('$*');") -f $*
+	git subtree split --prefix=src/$(shell php -r "echo ucfirst('$*');") -b $*
 	git push -f pkg-$* $*:$(CURRENT_BRANCH)
 	git checkout $(CURRENT_BRANCH) > /dev/null
 


### PR DESCRIPTION
The latter is deprecated and slower.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
