### PR TITLE
Show warning when component alias clashes with default table name.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -47,6 +47,7 @@ use ReflectionException;
 use ReflectionMethod;
 use function Cake\Core\namespaceSplit;
 use function Cake\Core\pluginSplit;
+use function Cake\Core\triggerWarning;
 
 /**
  * Application controller class for organization of business logic.
@@ -282,6 +283,28 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      */
     public function loadComponent(string $name, array $config = []): Component
     {
+        [, $alias] = pluginSplit($name);
+
+        if ($this->defaultTable) {
+            if (str_contains($this->defaultTable, '\\')) {
+                $tableAlias = App::shortName($this->defaultTable, 'Model/Table', 'Table');
+            } else {
+                [, $tableAlias] = pluginSplit($this->defaultTable, true);
+            }
+
+            if ($alias === $tableAlias) {
+                triggerWarning(sprintf(
+                    'Component alias `%s` clashes with the default table name `%s`. ' .
+                    'The table name will take precedence when accessing `$this->%s`. ' .
+                    'Consider using a different component alias or set `Controller::$defaultTable` to ' .
+                    "an empty string if the controller doesn't use a table.",
+                    $alias,
+                    $this->defaultTable,
+                    $alias,
+                ));
+            }
+        }
+
         return $this->components()->load($name, $config);
     }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -1011,6 +1011,22 @@ class ControllerTest extends TestCase
     }
 
     /**
+     * Test that loading a component with the same name as defaultTable triggers a warning.
+     */
+    public function testLoadComponentNameClashWithDefaultTable(): void
+    {
+        $request = new ServerRequest(['url' => '/']);
+        $controller = new WithDefaultTableController($request);
+
+        $this->expectWarningMessageMatches(
+            '/Component alias `Posts` clashes with the default table name `Posts`/',
+            function () use ($controller): void {
+                $controller->loadComponent('Posts');
+            },
+        );
+    }
+
+    /**
      * Test the isAction method.
      */
     public function testIsAction(): void


### PR DESCRIPTION
Closes #19352
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
