### PR TITLE
5.next: make new builtin CakeContainer opt in

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -48,12 +48,16 @@ class Container implements DefinitionContainerInterface
     /**
      * @inheritDoc
      */
-    public function add(string $id, $concrete = null): DefinitionInterface
+    public function add(string $id, $concrete = null, bool $overwrite = false): DefinitionInterface
     {
         $concrete ??= $id;
 
+        if ($overwrite && $this->definitions->has($id)) {
+            return $this->definitions->getDefinition($id)->setConcrete($concrete);
+        }
+
         if ($this->defaultToShared) {
-            return $this->addShared($id, $concrete);
+            return $this->addShared($id, $concrete, $overwrite);
         }
 
         return $this->definitions->add($id, $concrete);
@@ -62,9 +66,15 @@ class Container implements DefinitionContainerInterface
     /**
      * @inheritDoc
      */
-    public function addShared(string $id, $concrete = null): DefinitionInterface
+    public function addShared(string $id, $concrete = null, bool $overwrite = false): DefinitionInterface
     {
         $concrete ??= $id;
+
+        if ($overwrite && $this->definitions->has($id)) {
+            return $this->definitions->getDefinition($id)
+                ->setConcrete($concrete)
+                ->setShared(true);
+        }
 
         return $this->definitions->addShared($id, $concrete);
     }
@@ -147,8 +157,16 @@ class Container implements DefinitionContainerInterface
     /**
      * @inheritDoc
      */
-    public function addServiceProvider(ServiceProviderInterface $provider): DefinitionContainerInterface
+    public function addServiceProvider(mixed $provider): DefinitionContainerInterface
     {
+        if (!$provider instanceof ServiceProviderInterface) {
+            throw new ContainerException(sprintf(
+                'Service provider must implement `%s`, got `%s` instead.',
+                ServiceProviderInterface::class,
+                get_debug_type($provider),
+            ));
+        }
+
         $this->providers->add($provider);
 
         return $this;
@@ -244,6 +262,8 @@ class Container implements DefinitionContainerInterface
     }
 
     /**
+     * Add a container delegate.
+     *
      * @param \Psr\Container\ContainerInterface $container
      * @return $this
      */
@@ -251,7 +271,7 @@ class Container implements DefinitionContainerInterface
     {
         $this->delegates[] = $container;
 
-        if ($container instanceof ContainerAwareInterface) {
+        if ($container instanceof ReflectionContainer) {
             $container->setContainer($this);
         }
 
@@ -259,15 +279,21 @@ class Container implements DefinitionContainerInterface
     }
 
     /**
+     * Enable autowiring by delegating to the reflection container.
+     *
      * @param bool $cache
      * @return void
      */
     public function enableAutoWiring(bool $cache = true): void
     {
-        $this->delegate(new ReflectionContainer($cache));
+        $reflectionContainer = new ReflectionContainer($cache);
+        $reflectionContainer->setContainer($this);
+        $this->delegate($reflectionContainer);
     }
 
     /**
+     * Disable autowiring by clearing delegates.
+     *
      * @return void
      */
     public function disableAutoWiring(): void
@@ -276,58 +302,65 @@ class Container implements DefinitionContainerInterface
     }
 
     /**
-     * @param mixed $id
+     * @param string $id
      * @param bool $new
      * @param array<string, mixed> $args
-     * @return mixed|object|array|null|void
+     * @return mixed
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
      */
-    protected function resolve(mixed $id, bool $new = false, array $args = []): mixed
+    protected function resolve(string $id, bool $new = false, array $args = []): mixed
     {
         if ($this->definitions->has($id)) {
-            $resolved = $new ? $this->definitions->resolveNew($id) : $this->definitions->resolve($id);
+            $definition = $this->definitions->getDefinition($id);
+            if ($args !== []) {
+                $definition = clone $definition;
+                $definition->addArguments($args);
+            }
 
-            return $this->inflectors->inflect($resolved);
+            $instance = $new ? $definition->resolveNew() : $definition->resolve();
+            $this->inflectors->inflect($instance);
+
+            return $instance;
         }
 
         if ($this->definitions->hasTag($id)) {
-            $arrayOf = $new
-                ? $this->definitions->resolveTaggedNew($id)
-                : $this->definitions->resolveTagged($id);
-
-            array_walk($arrayOf, function (object &$resolved): void {
+            $instances = $new ? $this->definitions->resolveTaggedNew($id) : $this->definitions->resolveTagged($id);
+            array_walk($instances, function (object &$resolved): void {
                 $resolved = $this->inflectors->inflect($resolved);
             });
 
-            return $arrayOf;
+            return $instances;
         }
 
         if ($this->providers->provides($id)) {
             $this->providers->register($id);
 
-            if (!$this->definitions->has($id) && !$this->definitions->hasTag($id)) {
+            try {
+                return $this->resolve($id, $new, $args);
+            } catch (NotFoundException) {
                 throw new ContainerException(sprintf('Service provider lied about providing (%s) service', $id));
             }
-
-            return $this->resolve($id, $new, $args);
         }
 
         foreach ($this->delegates as $delegate) {
             if ($delegate->has($id)) {
-                // Use getNew() for ReflectionContainer when $new is true or args are provided
                 if ($delegate instanceof ReflectionContainer) {
-                    $resolved = $new || $args !== []
+                    $instance = $new || $args !== []
                         ? $delegate->getNew($id, $args)
                         : $delegate->get($id, $args);
                 } else {
-                    $resolved = $delegate->get($id);
+                    $instance = $delegate->get($id);
                 }
+                $this->inflectors->inflect($instance);
 
-                return $this->inflectors->inflect($resolved);
+                return $instance;
             }
         }
 
-        throw new NotFoundException(sprintf('Alias (%s) is not being managed by the container or delegates', $id));
+        throw new NotFoundException(sprintf(
+            'Alias (%s) is not being managed by the container or delegates',
+            $id,
+        ));
     }
 }

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -336,11 +336,11 @@ class Container implements DefinitionContainerInterface
         if ($this->providers->provides($id)) {
             $this->providers->register($id);
 
-            try {
-                return $this->resolve($id, $new, $args);
-            } catch (NotFoundException) {
+            if (!$this->providerRegisteredDefinition($id)) {
                 throw new ContainerException(sprintf('Service provider lied about providing (%s) service', $id));
             }
+
+            return $this->resolve($id, $new, $args);
         }
 
         foreach ($this->delegates as $delegate) {
@@ -362,5 +362,16 @@ class Container implements DefinitionContainerInterface
             'Alias (%s) is not being managed by the container or delegates',
             $id,
         ));
+    }
+
+    /**
+     * Check whether registering a service provider materialized a definition or tag.
+     *
+     * @param string $id
+     * @return bool
+     */
+    protected function providerRegisteredDefinition(string $id): bool
+    {
+        return $this->definitions->has($id) || $this->definitions->hasTag($id);
     }
 }

--- a/src/Container/Definition/Definition.php
+++ b/src/Container/Definition/Definition.php
@@ -90,6 +90,14 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
     /**
      * @inheritDoc
      */
+    public function getTags(): array
+    {
+        return array_keys($this->tags);
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function setAlias(string $id): DefinitionInterface
     {
         $id = static::normaliseAlias($id);

--- a/src/Container/Definition/DefinitionInterface.php
+++ b/src/Container/Definition/DefinitionInterface.php
@@ -50,6 +50,11 @@ interface DefinitionInterface extends ContainerAwareInterface
     public function getConcrete(): mixed;
 
     /**
+     * @return array<string>
+     */
+    public function getTags(): array;
+
+    /**
      * @param string $tag
      * @return bool
      */

--- a/src/Container/DefinitionContainerInterface.php
+++ b/src/Container/DefinitionContainerInterface.php
@@ -5,7 +5,6 @@ namespace Cake\Container;
 
 use Cake\Container\Definition\DefinitionInterface;
 use Cake\Container\Inflector\InflectorInterface;
-use Cake\Container\ServiceProvider\ServiceProviderInterface;
 use Psr\Container\ContainerInterface;
 
 interface DefinitionContainerInterface extends ContainerInterface
@@ -15,7 +14,7 @@ interface DefinitionContainerInterface extends ContainerInterface
      * @param mixed $concrete
      * @return \Cake\Container\Definition\DefinitionInterface
      */
-    public function add(string $id, mixed $concrete = null): DefinitionInterface;
+    public function add(string $id, mixed $concrete = null, bool $overwrite = false): DefinitionInterface;
 
     /**
      * Add multiple definitions at once.
@@ -34,18 +33,19 @@ interface DefinitionContainerInterface extends ContainerInterface
      * @param \Cake\Container\ServiceProvider\ServiceProviderInterface $provider
      * @return self
      */
-    public function addServiceProvider(ServiceProviderInterface $provider): self;
+    public function addServiceProvider(mixed $provider): self;
 
     /**
      * @param string $id
      * @param mixed $concrete
      * @return \Cake\Container\Definition\DefinitionInterface
      */
-    public function addShared(string $id, mixed $concrete = null): DefinitionInterface;
+    public function addShared(string $id, mixed $concrete = null, bool $overwrite = false): DefinitionInterface;
 
     /**
      * @param string $id
      * @return \Cake\Container\Definition\DefinitionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
      */
     public function extend(string $id): DefinitionInterface;
 

--- a/src/Container/ReflectionContainer.php
+++ b/src/Container/ReflectionContainer.php
@@ -7,20 +7,34 @@ use Cake\Container\Argument\ArgumentResolverInterface;
 use Cake\Container\Argument\ArgumentResolverTrait;
 use Cake\Container\Exception\ContainerException;
 use Cake\Container\Exception\NotFoundException;
+use League\Container\Attribute\AttributeInterface;
 use Psr\Container\ContainerInterface;
+use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionFunction;
+use ReflectionFunctionAbstract;
 use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionParameter;
+use ReflectionUnionType;
 
 class ReflectionContainer implements ArgumentResolverInterface, ContainerInterface
 {
     use ArgumentResolverTrait;
     use ContainerAwareTrait;
 
+    public const AUTO_WIRING = 0x01;
+    public const ATTRIBUTE_RESOLUTION = 0x02;
+
     /**
      * @var bool
      */
     protected bool $cacheResolutions;
+
+    /**
+     * @var int
+     */
+    protected int $mode;
 
     /**
      * @var array
@@ -30,9 +44,29 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
     /**
      * @param bool $cacheResolutions
      */
-    public function __construct(bool $cacheResolutions = false)
-    {
+    public function __construct(
+        bool $cacheResolutions = false,
+        int $mode = self::AUTO_WIRING | self::ATTRIBUTE_RESOLUTION,
+    ) {
         $this->cacheResolutions = $cacheResolutions;
+        $this->mode = $mode;
+    }
+
+    /**
+     * @param int $mode
+     * @return void
+     */
+    public function setMode(int $mode): void
+    {
+        $this->mode = $mode;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMode(): int
+    {
+        return $this->mode;
     }
 
     /**
@@ -159,6 +193,114 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
         throw new NotFoundException(sprintf(
             'Callable (%s) is not a valid callable',
             $callable,
+        ));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reflectArguments(ReflectionFunctionAbstract $method, array $args = []): array
+    {
+        $params = $method->getParameters();
+        $arguments = [];
+
+        foreach ($params as $param) {
+            $name = $param->getName();
+
+            if (array_key_exists($name, $args)) {
+                $arguments[] = new Argument\LiteralArgument($args[$name]);
+                continue;
+            }
+
+            if ($this->mode & self::ATTRIBUTE_RESOLUTION) {
+                foreach ($param->getAttributes() as $attribute) {
+                    $argument = $this->resolveArgumentFromAttribute($attribute);
+                    if ($argument !== null) {
+                        $arguments[] = $argument;
+                        continue 2;
+                    }
+                }
+            }
+
+            $type = $param->getType();
+
+            if ($type instanceof ReflectionUnionType) {
+                $this->throwParameterException(
+                    $param,
+                    'Union types are not supported',
+                );
+            }
+
+            if (($this->mode & self::AUTO_WIRING) && $type instanceof ReflectionNamedType) {
+                if ($type->getName() === 'mixed') {
+                    $this->throwParameterException(
+                        $param,
+                        'Mixed types are not supported',
+                    );
+                }
+
+                $typeHint = ltrim($type->getName(), '?');
+
+                if ($param->isDefaultValueAvailable()) {
+                    $arguments[] = new Argument\DefaultValueArgument($typeHint, $param->getDefaultValue());
+                    continue;
+                }
+
+                $arguments[] = new Argument\ResolvableArgument($typeHint);
+                continue;
+            }
+
+            if ($param->isDefaultValueAvailable()) {
+                $arguments[] = new Argument\LiteralArgument($param->getDefaultValue());
+                continue;
+            }
+
+            $this->throwParameterException(
+                $param,
+                'No default value available and no type hint to resolve',
+            );
+        }
+
+        return $this->resolveArguments($arguments);
+    }
+
+    /**
+     * @param \ReflectionAttribute<object> $attribute
+     * @return \Cake\Container\Argument\LiteralArgument|null
+     */
+    protected function resolveArgumentFromAttribute(ReflectionAttribute $attribute): ?Argument\LiteralArgument
+    {
+        $attributeClass = $attribute->getName();
+        if (!is_subclass_of($attributeClass, AttributeInterface::class)) {
+            return null;
+        }
+
+        $instance = $attribute->newInstance();
+        if ($instance instanceof ContainerAwareInterface) {
+            $instance->setContainer($this->getContainer());
+        }
+
+        /** @var \League\Container\Attribute\AttributeInterface $instance */
+        return new Argument\LiteralArgument($instance->resolve());
+    }
+
+    /**
+     * @param \ReflectionParameter $parameter
+     * @param string $message
+     * @return void
+     */
+    protected function throwParameterException(ReflectionParameter $parameter, string $message): void
+    {
+        $function = $parameter->getDeclaringFunction();
+        $class = $parameter->getDeclaringClass()?->getName();
+        $suffix = $function instanceof ReflectionMethod && $function->isClosure() ? ' [closure]' : '';
+
+        throw new NotFoundException(sprintf(
+            'Unable to resolve parameter ($%s) in %s%s()%s',
+            $parameter->getName(),
+            $class ? $class . '::' : '',
+            $function->getName(),
+            $suffix ? ' - ' . trim($message . $suffix) : ' - ' . $message,
         ));
     }
 }

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Controller;
 
+use Cake\Container\ReflectionContainer;
 use Cake\Controller\Exception\MissingComponentException;
 use Cake\Core\App;
 use Cake\Core\ContainerInterface;
@@ -23,12 +24,7 @@ use Cake\Core\Exception\CakeException;
 use Cake\Core\ObjectRegistry;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
-use League\Container\Argument\ArgumentReflectorTrait;
-use League\Container\Argument\ArgumentResolverTrait;
-use League\Container\Argument\LiteralArgument;
-use League\Container\Argument\ResolvableArgument;
-use League\Container\Exception\NotFoundException;
-use League\Container\ReflectionContainer;
+use Psr\Container\NotFoundExceptionInterface;
 use ReflectionClass;
 use ReflectionFunctionAbstract;
 use ReflectionMethod;
@@ -50,10 +46,6 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      * @use \Cake\Event\EventDispatcherTrait<TSubject>
      */
     use EventDispatcherTrait;
-
-    use ArgumentResolverTrait;
-
-    use ArgumentReflectorTrait;
 
     /**
      * The controller that this collection is associated with.
@@ -180,7 +172,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
             try {
                 $this->container->extend($class);
                 $hasDefinition = true;
-            } catch (NotFoundException) {
+            } catch (NotFoundExceptionInterface) {
                 // No definition exists yet
             }
 
@@ -245,7 +237,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
 
             // If we have a literal value for this parameter, use it
             if (array_key_exists($name, $args)) {
-                $arguments[] = new LiteralArgument($args[$name]);
+                $arguments[] = $args[$name];
                 continue;
             }
 
@@ -253,13 +245,13 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
             $type = $param->getType();
             if ($type instanceof ReflectionNamedType && !$type->isBuiltin()) {
                 // Type-hinted parameter - resolve from container
-                $arguments[] = new ResolvableArgument($type->getName());
+                $arguments[] = $type->getName();
                 continue;
             }
 
             // Check for default value
             if ($param->isDefaultValueAvailable()) {
-                $arguments[] = new LiteralArgument($param->getDefaultValue());
+                $arguments[] = $param->getDefaultValue();
                 continue;
             }
 
@@ -277,7 +269,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
             );
         }
 
-        return $this->resolveArguments($arguments);
+        return $arguments;
     }
 
     /**

--- a/src/Core/CakeContainer.php
+++ b/src/Core/CakeContainer.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Core;
+
+use Cake\Container\Container as BuiltInContainer;
+use Cake\Container\Definition\DefinitionInterface as CakeDefinitionInterface;
+use Cake\Container\Exception\ContainerException;
+use Cake\Container\Inflector\InflectorInterface as CakeInflectorInterface;
+use Cake\Container\ServiceProvider\ServiceProviderInterface as CakeServiceProviderInterface;
+use League\Container\Definition\DefinitionInterface as LeagueDefinitionInterface;
+use League\Container\Inflector\InflectorInterface as LeagueInflectorInterface;
+use League\Container\ServiceProvider\ServiceProviderInterface as LeagueServiceProviderInterface;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
+
+/**
+ * Opt-in CakePHP container implementation exposed through the core container API.
+ */
+class CakeContainer extends BuiltInContainer implements ContainerInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function add(string $id, mixed $concrete = null, bool $overwrite = false): CakeDefinitionInterface&LeagueDefinitionInterface
+    {
+        return $this->wrapDefinition(parent::add($id, $concrete, $overwrite));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addShared(string $id, mixed $concrete = null, bool $overwrite = false): CakeDefinitionInterface&LeagueDefinitionInterface
+    {
+        return $this->wrapDefinition(parent::addShared($id, $concrete, $overwrite));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addServiceProvider(mixed $provider): static
+    {
+        if ($provider instanceof LeagueServiceProviderInterface) {
+            $provider = new ContainerServiceProviderAdapter($provider, $this);
+        } elseif (!$provider instanceof CakeServiceProviderInterface) {
+            throw new ContainerException(sprintf(
+                'Service provider must implement `%s` or `%s`, got `%s` instead.',
+                CakeServiceProviderInterface::class,
+                LeagueServiceProviderInterface::class,
+                get_debug_type($provider),
+            ));
+        }
+
+        parent::addServiceProvider($provider);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function extend(string $id): CakeDefinitionInterface&LeagueDefinitionInterface
+    {
+        return $this->wrapDefinition(parent::extend($id));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delegate(PsrContainerInterface $container): static
+    {
+        parent::delegate($container);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function inflector(string $type, ?callable $callback = null): CakeInflectorInterface&LeagueInflectorInterface
+    {
+        return $this->wrapInflector(parent::inflector($type, $callback));
+    }
+
+    /**
+     * @param \Cake\Container\Definition\DefinitionInterface $definition
+     * @return \League\Container\Definition\DefinitionInterface&\Cake\Container\Definition\DefinitionInterface
+     */
+    protected function wrapDefinition(CakeDefinitionInterface $definition): CakeDefinitionInterface&LeagueDefinitionInterface
+    {
+        return new ContainerDefinitionAdapter($definition);
+    }
+
+    /**
+     * @param \Cake\Container\Inflector\InflectorInterface $inflector
+     * @return \Cake\Container\Inflector\InflectorInterface&\League\Container\Inflector\InflectorInterface
+     */
+    protected function wrapInflector(CakeInflectorInterface $inflector): CakeInflectorInterface&LeagueInflectorInterface
+    {
+        return new ContainerInflectorAdapter($inflector);
+    }
+}

--- a/src/Core/ContainerDefinitionAdapter.php
+++ b/src/Core/ContainerDefinitionAdapter.php
@@ -1,0 +1,188 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Core;
+
+use Cake\Container\ContainerAwareInterface as CakeContainerAwareInterface;
+use Cake\Container\Definition\DefinitionInterface as CakeDefinitionInterface;
+use Cake\Container\DefinitionContainerInterface as CakeDefinitionContainerInterface;
+use InvalidArgumentException;
+use League\Container\ContainerAwareInterface as LeagueContainerAwareInterface;
+use League\Container\Definition\DefinitionInterface as LeagueDefinitionInterface;
+use League\Container\DefinitionContainerInterface as LeagueDefinitionContainerInterface;
+
+class ContainerDefinitionAdapter implements CakeDefinitionInterface, LeagueDefinitionInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function __construct(protected CakeDefinitionInterface $definition)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addArgument(mixed $arg, ?string $name = null): static
+    {
+        $this->definition->addArgument($arg, $name);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addArguments(array $args): static
+    {
+        $this->definition->addArguments($args);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addMethodCall(string $method, array $args = []): static
+    {
+        $this->definition->addMethodCall($method, $args);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addMethodCalls(array $methods = []): static
+    {
+        $this->definition->addMethodCalls($methods);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addTag(string $tag): static
+    {
+        $this->definition->addTag($tag);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAlias(): string
+    {
+        return $this->definition->getAlias();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getConcrete(): mixed
+    {
+        return $this->definition->getConcrete();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getContainer(): CakeDefinitionContainerInterface&LeagueDefinitionContainerInterface
+    {
+        $container = $this->definition->getContainer();
+
+        assert($container instanceof LeagueDefinitionContainerInterface);
+
+        return $container;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTags(): array
+    {
+        return $this->definition->getTags();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasTag(string $tag): bool
+    {
+        return $this->definition->hasTag($tag);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isShared(): bool
+    {
+        return $this->definition->isShared();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function resolve(): mixed
+    {
+        return $this->definition->resolve();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function resolveNew(): mixed
+    {
+        return $this->definition->resolveNew();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setAlias(string $id): static
+    {
+        $this->definition->setAlias($id);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setConcrete(mixed $concrete): static
+    {
+        $this->definition->setConcrete($concrete);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setContainer(mixed $container): CakeContainerAwareInterface&LeagueContainerAwareInterface
+    {
+        if (!$container instanceof CakeDefinitionContainerInterface) {
+            throw new InvalidArgumentException(sprintf(
+                'Unexpected container type. Expected `%s` got `%s` instead.',
+                CakeDefinitionContainerInterface::class,
+                get_debug_type($container),
+            ));
+        }
+
+        $this->definition->setContainer($container);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setShared(bool $shared): static
+    {
+        $this->definition->setShared($shared);
+
+        return $this;
+    }
+}

--- a/src/Core/ContainerFactory.php
+++ b/src/Core/ContainerFactory.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Core;
+
+/**
+ * Creates the configured application container implementation.
+ */
+class ContainerFactory
+{
+    /**
+     * @return \Cake\Core\ContainerInterface
+     */
+    public static function create(): ContainerInterface
+    {
+        return match (Configure::read('App.container', 'league')) {
+            'cake' => new CakeContainer(),
+            default => new Container(),
+        };
+    }
+}

--- a/src/Core/ContainerInflectorAdapter.php
+++ b/src/Core/ContainerInflectorAdapter.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Core;
+
+use Cake\Container\Inflector\InflectorInterface as CakeInflectorInterface;
+use League\Container\Inflector\InflectorInterface as LeagueInflectorInterface;
+
+class ContainerInflectorAdapter implements CakeInflectorInterface, LeagueInflectorInterface
+{
+    /**
+     * @param \Cake\Container\Inflector\InflectorInterface $inflector
+     */
+    public function __construct(protected CakeInflectorInterface $inflector)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string
+    {
+        return $this->inflector->getType();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function inflect(object $object): void
+    {
+        $this->inflector->inflect($object);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function invokeMethod(string $name, array $args): static
+    {
+        $this->inflector->invokeMethod($name, $args);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function invokeMethods(array $methods): static
+    {
+        $this->inflector->invokeMethods($methods);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setProperties(array $properties): static
+    {
+        $this->inflector->setProperties($properties);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setProperty(string $property, mixed $value): static
+    {
+        $this->inflector->setProperty($property, $value);
+
+        return $this;
+    }
+}

--- a/src/Core/ContainerServiceProviderAdapter.php
+++ b/src/Core/ContainerServiceProviderAdapter.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Core;
+
+use Cake\Container\ContainerAwareInterface as CakeContainerAwareInterface;
+use Cake\Container\DefinitionContainerInterface as CakeDefinitionContainerInterface;
+use Cake\Container\ServiceProvider\BootableServiceProviderInterface as CakeBootableServiceProviderInterface;
+use Cake\Container\ServiceProvider\ServiceProviderInterface as CakeServiceProviderInterface;
+use InvalidArgumentException;
+use League\Container\DefinitionContainerInterface as LeagueDefinitionContainerInterface;
+use League\Container\ServiceProvider\BootableServiceProviderInterface as LeagueBootableServiceProviderInterface;
+use League\Container\ServiceProvider\ServiceProviderInterface as LeagueServiceProviderInterface;
+
+class ContainerServiceProviderAdapter implements CakeServiceProviderInterface, CakeBootableServiceProviderInterface
+{
+    /**
+     * @param \League\Container\ServiceProvider\ServiceProviderInterface $provider
+     * @param \Cake\Container\DefinitionContainerInterface&\Cake\Core\ContainerInterface $container
+     */
+    public function __construct(
+        protected LeagueServiceProviderInterface $provider,
+        protected CakeDefinitionContainerInterface&ContainerInterface $container,
+    ) {
+    }
+
+    /**
+     * @return void
+     */
+    public function boot(): void
+    {
+        if ($this->provider instanceof LeagueBootableServiceProviderInterface) {
+            $this->provider->boot();
+        }
+    }
+
+    /**
+     * @return \Cake\Container\DefinitionContainerInterface
+     */
+    public function getContainer(): CakeDefinitionContainerInterface
+    {
+        return $this->container;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentifier(): string
+    {
+        return $this->provider->getIdentifier();
+    }
+
+    /**
+     * @param string $id
+     * @return bool
+     */
+    public function provides(string $id): bool
+    {
+        return $this->provider->provides($id);
+    }
+
+    /**
+     * @return void
+     */
+    public function register(): void
+    {
+        $this->provider->register();
+    }
+
+    /**
+     * @param mixed $container
+     * @return \Cake\Container\ContainerAwareInterface
+     */
+    public function setContainer(mixed $container): CakeContainerAwareInterface
+    {
+        if (!$container instanceof CakeDefinitionContainerInterface && !$container instanceof LeagueDefinitionContainerInterface) {
+            throw new InvalidArgumentException(sprintf(
+                'Unexpected container type. Expected `%s` or `%s`, got `%s` instead.',
+                CakeDefinitionContainerInterface::class,
+                LeagueDefinitionContainerInterface::class,
+                get_debug_type($container),
+            ));
+        }
+
+        $this->provider->setContainer($this->container);
+
+        return $this;
+    }
+
+    /**
+     * @param string $id
+     * @return \Cake\Container\ServiceProvider\ServiceProviderInterface
+     */
+    public function setIdentifier(string $id): CakeServiceProviderInterface
+    {
+        $this->provider->setIdentifier($id);
+
+        return $this;
+    }
+}

--- a/src/Core/TestSuite/ContainerStubTrait.php
+++ b/src/Core/TestSuite/ContainerStubTrait.php
@@ -22,9 +22,9 @@ use Cake\Core\HttpApplicationInterface;
 use Cake\Event\EventInterface;
 use Cake\Routing\Router;
 use Closure;
-use League\Container\Exception\NotFoundException;
 use LogicException;
 use PHPUnit\Framework\Attributes\After;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * A set of methods used for defining container services
@@ -163,7 +163,7 @@ trait ContainerStubTrait
             if ($container->has($key)) {
                 try {
                     $container->extend($key)->setConcrete($factory);
-                } catch (NotFoundException) {
+                } catch (NotFoundExceptionInterface) {
                     $container->add($key, $factory);
                 }
             } else {

--- a/src/Error/Renderer/WebExceptionRenderer.php
+++ b/src/Error/Renderer/WebExceptionRenderer.php
@@ -20,7 +20,7 @@ use Cake\Controller\Controller;
 use Cake\Controller\ControllerFactory;
 use Cake\Core\App;
 use Cake\Core\Configure;
-use Cake\Core\Container;
+use Cake\Core\ContainerFactory;
 use Cake\Core\Exception\CakeException;
 use Cake\Core\Exception\HttpErrorCodeInterface;
 use Cake\Core\Exception\MissingPluginException;
@@ -155,7 +155,7 @@ class WebExceptionRenderer implements ExceptionRendererInterface
             $params = $request->getAttribute('params');
             $params['controller'] = 'Error';
 
-            $factory = new ControllerFactory(new Container());
+            $factory = new ControllerFactory(ContainerFactory::create());
             // Check including plugin + prefix
             $class = $factory->getControllerClass($request->withAttribute('params', $params));
 

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -20,8 +20,8 @@ namespace Cake\Http;
 use Cake\Console\CommandCollection;
 use Cake\Controller\ControllerFactory;
 use Cake\Core\ConsoleApplicationInterface;
-use Cake\Core\Container;
 use Cake\Core\ContainerApplicationInterface;
+use Cake\Core\ContainerFactory;
 use Cake\Core\ContainerInterface;
 use Cake\Core\EventAwareApplicationInterface;
 use Cake\Core\Exception\MissingPluginException;
@@ -295,7 +295,7 @@ abstract class BaseApplication implements
      */
     protected function buildContainer(): ContainerInterface
     {
-        $container = new Container();
+        $container = ContainerFactory::create();
         $this->services($container);
         foreach ($this->plugins->with('services') as $plugin) {
             $plugin->services($container);

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -21,6 +21,7 @@ use Cake\Controller\Component\FormProtectionComponent;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Controller\Exception\MissingComponentException;
+use Cake\Core\CakeContainer;
 use Cake\Core\Container;
 use Cake\Core\Exception\CakeException;
 use Cake\Event\EventManager;
@@ -115,6 +116,20 @@ class ComponentRegistryTest extends TestCase
         $controller = new Controller(new ServerRequest());
         $container = new Container();
         $container->delegate(new ReflectionContainer());
+        $components = new ComponentRegistry($controller, $container);
+
+        $container->add(ComponentRegistry::class, $components);
+
+        $component = $components->load(ConfiguredComponent::class, ['key' => 'customFlash']);
+
+        $this->assertInstanceOf(ConfiguredComponent::class, $component);
+        $this->assertSame(['key' => 'customFlash'], $component->configCopy);
+    }
+
+    public function testLoadWithBuiltInContainerAutoWiring(): void
+    {
+        $controller = new Controller(new ServerRequest());
+        $container = new CakeContainer();
         $components = new ComponentRegistry($controller, $container);
 
         $container->add(ComponentRegistry::class, $components);

--- a/tests/TestCase/Core/Attribute/ConfigureTest.php
+++ b/tests/TestCase/Core/Attribute/ConfigureTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Cake\Test\TestCase\Core\Attribute;
 
+use Cake\Core\CakeContainer;
 use Cake\Core\Configure;
 use Cake\Core\Container;
 use Cake\Test\TestCase\Core\Attribute\Configure\FakeClient;
@@ -35,5 +36,15 @@ class ConfigureTest extends TestCase
         $container->delegate(new ReflectionContainer());
         $this->expectException(TypeError::class);
         $container->get(FakeClient::class);
+    }
+
+    public function testValidConfigBuiltInContainer(): void
+    {
+        $apiKey = '987654321';
+        Configure::write('Star.apiKey', $apiKey);
+        $container = new CakeContainer();
+        $client = $container->get(FakeClient::class);
+        $this->assertInstanceOf(FakeClient::class, $client);
+        $this->assertSame($apiKey, $client->apiKey);
     }
 }

--- a/tests/TestCase/Core/ServiceProviderTest.php
+++ b/tests/TestCase/Core/ServiceProviderTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Core;
 
+use Cake\Core\CakeContainer;
 use Cake\Core\Container;
 use Cake\TestSuite\TestCase;
 use LogicException;
@@ -44,6 +45,17 @@ class ServiceProviderTest extends TestCase
         $container = new Container();
         $container->addServiceProvider(new PersonServiceProvider());
 
+        $this->assertTrue($container->has('sally'), 'Should have service');
+        $this->assertSame('sally', $container->get('sally')->name);
+    }
+
+    public function testBuiltInContainerSupportsServiceProviders(): void
+    {
+        $container = new CakeContainer();
+        $container->addServiceProvider(new PersonServiceProvider());
+
+        $this->assertTrue($container->has('boot'), 'Should have service defined in bootstrap.');
+        $this->assertSame('boot', $container->get('boot')->name);
         $this->assertTrue($container->has('sally'), 'Should have service');
         $this->assertSame('sally', $container->get('sally')->name);
     }

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -20,8 +20,10 @@ use Cake\Console\CommandRunner;
 use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Core\BasePlugin;
+use Cake\Core\CakeContainer;
 use Cake\Core\Configure;
 use Cake\Core\Container;
+use Cake\Core\ContainerFactory;
 use Cake\Core\ContainerInterface;
 use Cake\Event\EventInterface;
 use Cake\Event\EventManagerInterface;
@@ -262,6 +264,29 @@ class BaseApplicationTest extends TestCase
 
         $this->assertInstanceOf(ContainerInterface::class, $container);
         $this->assertSame($container, $app->getContainer(), 'Should return a reference');
+    }
+
+    public function testGetContainerBuiltIn(): void
+    {
+        Configure::write('App.container', 'cake');
+
+        $app = $this->app;
+        $container = $app->getContainer();
+
+        $this->assertInstanceOf(CakeContainer::class, $container);
+        $this->assertSame($container, $app->getContainer(), 'Should return a reference');
+    }
+
+    public function testContainerFactoryLegacyDefault(): void
+    {
+        $this->assertInstanceOf(Container::class, ContainerFactory::create());
+    }
+
+    public function testContainerFactoryBuiltIn(): void
+    {
+        Configure::write('App.container', 'cake');
+
+        $this->assertInstanceOf(CakeContainer::class, ContainerFactory::create());
     }
 
     public function testBuildContainerEvent(): void

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 namespace TestApp;
 
 use Cake\Console\CommandCollection;
+use Cake\Container\ReflectionContainer as CakeReflectionContainer;
+use Cake\Core\CakeContainer;
 use Cake\Core\Configure;
 use Cake\Core\ContainerInterface;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
@@ -25,7 +27,7 @@ use Cake\Http\MiddlewareQueue;
 use Cake\Routing\Exception\DuplicateNamedRouteException;
 use Cake\Routing\Middleware\RoutingMiddleware;
 use Cake\Routing\RouteBuilder;
-use League\Container\ReflectionContainer;
+use League\Container\ReflectionContainer as LeagueReflectionContainer;
 use stdClass;
 use TestApp\Command\AbortCommand;
 use TestApp\Command\DependencyCommand;
@@ -108,6 +110,10 @@ class Application extends BaseApplication
         $container->add(stdClass::class, json_decode('{"key":"value"}'));
         $container->add(DependencyCommand::class)
             ->addArgument(stdClass::class);
-        $container->delegate(new ReflectionContainer());
+        $container->delegate(
+            $container instanceof CakeContainer
+                ? new CakeReflectionContainer()
+                : new LeagueReflectionContainer(),
+        );
     }
 }


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/pull/18090

This change adds a backwards-compatible opt-in to use Cake’s "new" DI container while keeping the existing League container as the default.

The selection is controlled with `Configure::write('App.container', 'cake')`. If that value is not set, or is anything else but `cake`, it continues using the existing League container.

## What Changed

Container creation now goes through a small selection layer in `src/Core/ContainerFactory.php`.

On the builtin-container side, the actual implementation has been renamed to `src/Container/CakeContainer.php`. `src/Container/Container.php` remains as a backwards-compatible shim for the existing tests. The core-facing bridge is `src/Core/CakeContainer.php`, which lets the builtin implementation fit the existing framework contract without changing the package boundary.

To make the opt-in path actually usable, the builtin container internals were updated to satisfy the framework’s existing expectations. That includes 

- broader contract compatibility across the container interfaces in `src/Container/*`, 
- support for attribute-based resolution in `src/Container/ReflectionContainer.php`, 
- removal of League-only assumptions in `src/Controller/ComponentRegistry.php` and `src/Core/TestSuite/ContainerStubTrait.php`.

The test app service wiring in `tests/test_app/TestApp/Application.php` was also made conditional so both the legacy and opt-in container paths remain valid.