### PR TITLE
Add integration test for check constraints and array schema

### DIFF
--- a/tests/TestCase/TestSuite/Fixture/SchemaLoaderTest.php
+++ b/tests/TestCase/TestSuite/Fixture/SchemaLoaderTest.php
@@ -17,6 +17,8 @@ namespace Cake\Test\TestCase\TestSuite\Fixture;
 
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
+use Cake\Database\Schema\CheckConstraint;
+use Cake\Database\Schema\ForeignKey;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\ConnectionHelper;
@@ -135,9 +137,23 @@ class SchemaLoaderTest extends TestCase
         $this->loader->loadInternalFile(__DIR__ . '/test_schema.php', 'test_schema_loader');
 
         $connection = ConnectionManager::get('test_schema_loader');
-        $tables = $connection->getSchemaCollection()->listTables();
+        /** @var \Cake\Database\Schema\Collection $schema */
+        $schema = $connection->getSchemaCollection();
+        $tables = $schema->listTables();
         $this->assertContains('schema_generator', $tables);
         $this->assertContains('schema_generator_comment', $tables);
+
+        $table = $schema->describe('schema_generator');
+
+        $constraint = $table->constraint('checked_relation_id');
+        assert($constraint instanceof CheckConstraint);
+        $this->assertEquals('checked_relation_id', $constraint->getName());
+        $this->assertEquals('relation_id > 1', $constraint->getExpression());
+
+        $key = $table->constraint('relation_fk');
+        assert($key instanceof ForeignKey);
+        $this->assertEquals('relation_fk', $key->getName());
+        $this->assertEquals(['relation_id'], $key->getColumns());
     }
 
     protected function createSchemaFile(string $tableName): string

--- a/tests/TestCase/TestSuite/Fixture/test_schema.php
+++ b/tests/TestCase/TestSuite/Fixture/test_schema.php
@@ -27,6 +27,10 @@ return [
                 'columns' => ['relation_id'],
                 'references' => ['schema_generator_comment', 'id'],
             ],
+            'checked_relation_id' => [
+                'type' => 'check',
+                'expression' => 'relation_id > 1',
+            ],
         ],
         'indexes' => [
             'title_idx' => [


### PR DESCRIPTION
Recently I was playing with check constraints, I hit an error that indicated that check constraints were not supported by array schema. The source of my problem was an old version of CakePHP, but I wrote up this test and figured it was useful to have as an integration test.