### PR TITLE
Add support for IS DISTINCT FROM / IS NOT DISTINCT FROM`

### DIFF
--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -38,7 +38,7 @@ class Mysql extends Driver
     protected function _expressionTranslators(): array
     {
         return [
-            DistinctComparisonExpression::class => '_transformDistinctComparisonExpression',
+            DistinctComparisonExpression::class => 'transformDistinctComparisonExpression',
         ];
     }
 
@@ -48,7 +48,7 @@ class Mysql extends Driver
      * @param \Cake\Database\Expression\DistinctComparisonExpression $expression The expression to translate.
      * @return void
      */
-    protected function _transformDistinctComparisonExpression(DistinctComparisonExpression $expression): void
+    protected function transformDistinctComparisonExpression(DistinctComparisonExpression $expression): void
     {
         $operator = strtoupper($expression->getOperator());
         if ($operator === 'IS NOT DISTINCT FROM') {
@@ -363,3 +363,4 @@ class Mysql extends Driver
         return PHP_VERSION_ID < 80400 ? PDO::MYSQL_ATTR_USE_BUFFERED_QUERY : PdoMysql::ATTR_USE_BUFFERED_QUERY;
     }
 }
+

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -18,6 +18,7 @@ namespace Cake\Database\Driver;
 
 use Cake\Database\Driver;
 use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Expression\DistinctComparisonExpression;
 use Cake\Database\Query;
 use Cake\Database\Query\SelectQuery;
 use Cake\Database\Schema\MysqlSchemaDialect;
@@ -31,6 +32,33 @@ use Pdo\Mysql as PdoMysql;
  */
 class Mysql extends Driver
 {
+    /**
+     * @inheritDoc
+     */
+    protected function _expressionTranslators(): array
+    {
+        return [
+            DistinctComparisonExpression::class => '_transformDistinctComparisonExpression',
+        ];
+    }
+
+    /**
+     * Translates IS [NOT] DISTINCT FROM into MySQL-specific syntax.
+     *
+     * @param \Cake\Database\Expression\DistinctComparisonExpression $expression The expression to translate.
+     * @return void
+     */
+    protected function _transformDistinctComparisonExpression(DistinctComparisonExpression $expression): void
+    {
+        $operator = strtoupper($expression->getOperator());
+        if ($operator === 'IS NOT DISTINCT FROM') {
+            $expression->setOperator('<=>');
+        } elseif ($operator === 'IS DISTINCT FROM') {
+            $expression->setOperator('<=>');
+            $expression->setNot(true);
+        }
+    }
+
     /**
      * @inheritDoc
      */

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -363,4 +363,3 @@ class Mysql extends Driver
         return PHP_VERSION_ID < 80400 ? PDO::MYSQL_ATTR_USE_BUFFERED_QUERY : PdoMysql::ATTR_USE_BUFFERED_QUERY;
     }
 }
-

--- a/src/Database/Expression/DistinctComparisonExpression.php
+++ b/src/Database/Expression/DistinctComparisonExpression.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         5.1.0
+ * @since         5.4.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Database\Expression;
@@ -30,7 +30,7 @@ class DistinctComparisonExpression extends ComparisonExpression
      *
      * @var bool
      */
-    protected bool $_isNot = false;
+    protected bool $isNot = false;
 
     /**
      * Sets whether to wrap the expression in `NOT (...)`
@@ -40,7 +40,7 @@ class DistinctComparisonExpression extends ComparisonExpression
      */
     public function setNot(bool $not)
     {
-        $this->_isNot = $not;
+        $this->isNot = $not;
 
         return $this;
     }
@@ -69,6 +69,7 @@ class DistinctComparisonExpression extends ComparisonExpression
         /** @var string $field */
         $sql = sprintf($template, $field, $this->_operator, $value);
 
-        return $this->_isNot ? "NOT ({$sql})" : $sql;
+        return $this->isNot ? "NOT ({$sql})" : $sql;
     }
 }
+

--- a/src/Database/Expression/DistinctComparisonExpression.php
+++ b/src/Database/Expression/DistinctComparisonExpression.php
@@ -72,4 +72,3 @@ class DistinctComparisonExpression extends ComparisonExpression
         return $this->isNot ? "NOT ({$sql})" : $sql;
     }
 }
-

--- a/src/Database/Expression/DistinctComparisonExpression.php
+++ b/src/Database/Expression/DistinctComparisonExpression.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+use Cake\Database\ExpressionInterface;
+use Cake\Database\ValueBinder;
+
+/**
+ * A Comparison is a type of query expression that represents `IS DISTINCT FROM`
+ * or `IS NOT DISTINCT FROM` operations.
+ */
+class DistinctComparisonExpression extends ComparisonExpression
+{
+    /**
+     * Whether to wrap the expression in `NOT (...)`
+     *
+     * @var bool
+     */
+    protected bool $_isNot = false;
+
+    /**
+     * Sets whether to wrap the expression in `NOT (...)`
+     *
+     * @param bool $not Whether to wrap the expression in `NOT (...)`
+     * @return $this
+     */
+    public function setNot(bool $not)
+    {
+        $this->_isNot = $not;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function sql(ValueBinder $binder): string
+    {
+        $field = $this->_field;
+
+        if ($field instanceof ExpressionInterface) {
+            $field = $field->sql($binder);
+        }
+
+        if ($this->_value instanceof IdentifierExpression) {
+            $template = '%s %s %s';
+            $value = $this->_value->sql($binder);
+        } elseif ($this->_value instanceof ExpressionInterface) {
+            $template = '%s %s (%s)';
+            $value = $this->_value->sql($binder);
+        } else {
+            [$template, $value] = $this->_stringExpression($binder);
+        }
+
+        /** @var string $field */
+        $sql = sprintf($template, $field, $this->_operator, $value);
+
+        return $this->_isNot ? "NOT ({$sql})" : $sql;
+    }
+}

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -260,6 +260,36 @@ class QueryExpression implements ExpressionInterface, Countable
     }
 
     /**
+     * Adds a new condition to the expression object in the form "field IS DISTINCT FROM value".
+     *
+     * @param \Cake\Database\ExpressionInterface|string $field Database field to be compared against value
+     * @param mixed $value The value to be bound to $field for comparison
+     * @param string|null $type the type name for $value as configured using the Type map.
+     * @return $this
+     */
+    public function isDistinctFrom(ExpressionInterface|string $field, mixed $value, ?string $type = null)
+    {
+        $type ??= $this->_calculateType($field);
+
+        return $this->add(new DistinctComparisonExpression($field, $value, $type, 'IS DISTINCT FROM'));
+    }
+
+    /**
+     * Adds a new condition to the expression object in the form "field IS NOT DISTINCT FROM value".
+     *
+     * @param \Cake\Database\ExpressionInterface|string $field Database field to be compared against value
+     * @param mixed $value The value to be bound to $field for comparison
+     * @param string|null $type the type name for $value as configured using the Type map.
+     * @return $this
+     */
+    public function isNotDistinctFrom(ExpressionInterface|string $field, mixed $value, ?string $type = null)
+    {
+        $type ??= $this->_calculateType($field);
+
+        return $this->add(new DistinctComparisonExpression($field, $value, $type, 'IS NOT DISTINCT FROM'));
+    }
+
+    /**
      * Adds a new condition to the expression object in the form "field LIKE value".
      *
      * @param \Cake\Database\ExpressionInterface|string $field Database field to be compared against value
@@ -690,12 +720,18 @@ class QueryExpression implements ExpressionInterface, Countable
         // like `CONCAT(first_name, ' ', last_name) IN`.
         if ($spaces > 1) {
             $parts = explode(' ', $expression);
-            if (preg_match('/(is not|not \w+)$/i', $expression)) {
-                $last = array_pop($parts);
-                $second = array_pop($parts);
-                $parts[] = "{$second} {$last}";
+            if (preg_match('/is not distinct from$/i', $expression)) {
+                $operator = implode(' ', array_slice($parts, -4));
+                $parts = array_slice($parts, 0, -4);
+            } elseif (preg_match('/is distinct from$/i', $expression)) {
+                $operator = implode(' ', array_slice($parts, -3));
+                $parts = array_slice($parts, 0, -3);
+            } elseif (preg_match('/(is not|not \w+)$/i', $expression)) {
+                $operator = implode(' ', array_slice($parts, -2));
+                $parts = array_slice($parts, 0, -2);
+            } else {
+                $operator = array_pop($parts);
             }
-            $operator = array_pop($parts);
             $expression = implode(' ', $parts);
         } elseif ($spaces === 1) {
             $parts = explode(' ', $expression, 2);
@@ -743,11 +779,18 @@ class QueryExpression implements ExpressionInterface, Countable
             $operator = '!=';
         }
 
-        if ($value === null && $this->_conjunction !== ',') {
+        if (in_array($operator, ['IS DISTINCT FROM', 'IS NOT DISTINCT FROM'], true)) {
+            return new DistinctComparisonExpression($expression, $value, $type, $operator);
+        }
+
+        if (
+            $value === null &&
+            $this->_conjunction !== ','
+        ) {
             throw new InvalidArgumentException(
                 sprintf(
                     'Expression `%s` has invalid `null` value.'
-                    . ' If `null` is a valid value, operator (IS, IS NOT) is missing.',
+                    . ' If `null` is a valid value, operator (IS, IS NOT, IS DISTINCT FROM, IS NOT DISTINCT FROM) is missing.',
                     $expression,
                 ),
             );

--- a/tests/TestCase/Database/Expression/DistinctComparisonExpressionTest.php
+++ b/tests/TestCase/Database/Expression/DistinctComparisonExpressionTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\Expression;
+
+use Cake\Database\Expression\DistinctComparisonExpression;
+use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ValueBinder;
+use Cake\TestSuite\TestCase;
+
+class DistinctComparisonExpressionTest extends TestCase
+{
+    public function testSqlWithIdentifierValue(): void
+    {
+        $expr = new DistinctComparisonExpression(
+            new IdentifierExpression('field'),
+            new IdentifierExpression('other_field'),
+            null,
+            'IS DISTINCT FROM',
+        );
+
+        $this->assertEqualsSql('field IS DISTINCT FROM other_field', $expr->sql(new ValueBinder()));
+    }
+
+    public function testSqlWithExpressionValue(): void
+    {
+        $expr = new DistinctComparisonExpression(
+            new IdentifierExpression('field'),
+            new QueryExpression(['other_field' => 'value']),
+            null,
+            'IS DISTINCT FROM',
+        );
+
+        $this->assertEqualsSql('field IS DISTINCT FROM (other_field = :c0)', $expr->sql(new ValueBinder()));
+    }
+
+    public function testSqlWithNotFlag(): void
+    {
+        $expr = new DistinctComparisonExpression(
+            new IdentifierExpression('field'),
+            'value',
+            null,
+            'IS DISTINCT FROM',
+        );
+        $expr->setNot(true);
+
+        $this->assertEqualsSql('NOT (field IS DISTINCT FROM :c0)', $expr->sql(new ValueBinder()));
+    }
+}

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -200,7 +200,7 @@ class QueryExpressionTest extends TestCase
     {
         return [
             ['eq'], ['notEq'], ['gt'], ['lt'], ['gte'], ['lte'], ['like'],
-            ['notLike'], ['in'], ['notIn'],
+            ['notLike'], ['in'], ['notIn'], ['isDistinctFrom'], ['isNotDistinctFrom'],
         ];
     }
 
@@ -249,6 +249,82 @@ class QueryExpressionTest extends TestCase
         $expr->notInOrNull('test', ['one', 'two']);
         $this->assertEqualsSql(
             '(test NOT IN (:c0,:c1) OR (test) IS NULL)',
+            $expr->sql(new ValueBinder()),
+        );
+    }
+
+    /**
+     * Tests isDistinctFrom()
+     */
+    public function testIsDistinctFrom(): void
+    {
+        $expr = new QueryExpression();
+        $expr->isDistinctFrom('deleted_at', '2021-01-01');
+        $this->assertEqualsSql(
+            'deleted_at IS DISTINCT FROM :c0',
+            $expr->sql(new ValueBinder()),
+        );
+
+        $expr = new QueryExpression();
+        $expr->isDistinctFrom('deleted_at', null);
+        $this->assertEqualsSql(
+            'deleted_at IS DISTINCT FROM :c0',
+            $expr->sql(new ValueBinder()),
+        );
+    }
+
+    /**
+     * Tests isNotDistinctFrom()
+     */
+    public function testIsNotDistinctFrom(): void
+    {
+        $expr = new QueryExpression();
+        $expr->isNotDistinctFrom('deleted_at', '2021-01-01');
+        $this->assertEqualsSql(
+            'deleted_at IS NOT DISTINCT FROM :c0',
+            $expr->sql(new ValueBinder()),
+        );
+
+        $expr = new QueryExpression();
+        $expr->isNotDistinctFrom('deleted_at', null);
+        $this->assertEqualsSql(
+            'deleted_at IS NOT DISTINCT FROM :c0',
+            $expr->sql(new ValueBinder()),
+        );
+    }
+
+    /**
+     * Tests parsing IS DISTINCT FROM in array conditions
+     */
+    public function testParseIsDistinctFrom(): void
+    {
+        $expr = new QueryExpression(['deleted_at IS DISTINCT FROM' => '2021-01-01']);
+        $this->assertEqualsSql(
+            'deleted_at IS DISTINCT FROM :c0',
+            $expr->sql(new ValueBinder()),
+        );
+
+        $expr = new QueryExpression(['deleted_at IS DISTINCT FROM' => null]);
+        $this->assertEqualsSql(
+            'deleted_at IS DISTINCT FROM :c0',
+            $expr->sql(new ValueBinder()),
+        );
+    }
+
+    /**
+     * Tests parsing IS NOT DISTINCT FROM in array conditions
+     */
+    public function testParseIsNotDistinctFrom(): void
+    {
+        $expr = new QueryExpression(['deleted_at IS NOT DISTINCT FROM' => '2021-01-01']);
+        $this->assertEqualsSql(
+            'deleted_at IS NOT DISTINCT FROM :c0',
+            $expr->sql(new ValueBinder()),
+        );
+
+        $expr = new QueryExpression(['deleted_at IS NOT DISTINCT FROM' => null]);
+        $this->assertEqualsSql(
+            'deleted_at IS NOT DISTINCT FROM :c0',
             $expr->sql(new ValueBinder()),
         );
     }

--- a/tests/TestCase/Database/NullSafeComparisonTest.php
+++ b/tests/TestCase/Database/NullSafeComparisonTest.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Database;
+
+use Cake\Database\Connection;
+use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
+use Cake\Database\Driver\Sqlite;
+use Cake\Database\Driver\Sqlserver;
+use Cake\Database\Expression\QueryExpression;
+use Cake\Database\Query\SelectQuery;
+use Cake\Database\QueryCompiler;
+use Cake\Database\ValueBinder;
+use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class NullSafeComparisonTest extends TestCase
+{
+    public static function dialectProvider(): array
+    {
+        return [
+            'PostgreSQL' => [Postgres::class, 'col IS DISTINCT FROM :c0', 'col IS NOT DISTINCT FROM :c0'],
+            'SQLite' => [Sqlite::class, 'col IS DISTINCT FROM :c0', 'col IS NOT DISTINCT FROM :c0'],
+            'SQLServer' => [Sqlserver::class, 'col IS DISTINCT FROM :c0', 'col IS NOT DISTINCT FROM :c0'],
+            'MySQL' => [Mysql::class, 'NOT (col <=> :c0)', 'col <=> :c0'],
+        ];
+    }
+
+    #[DataProvider('dialectProvider')]
+    public function testNullSafeComparisonSql(string $driverClass, string $expectedDistinct, string $expectedNotDistinct): void
+    {
+        $driver = $this->getMockBuilder($driverClass)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['connect', 'enabled', 'newCompiler', 'version', 'getRole', 'supports', 'isAutoQuotingEnabled'])
+            ->getMock();
+        $driver->method('enabled')->willReturn(true);
+        $driver->method('newCompiler')->willReturn(new QueryCompiler());
+        $driver->method('version')->willReturn('8.0.0');
+        $driver->method('getRole')->willReturn('write');
+        $driver->method('supports')->willReturn(true);
+        $driver->method('isAutoQuotingEnabled')->willReturn(false);
+
+        $connection = $this->getMockBuilder(Connection::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getDriver', 'selectQuery', 'role', 'configName'])
+            ->getMock();
+        $connection->method('role')->willReturn('write');
+        $connection->method('configName')->willReturn('test');
+        $connection->method('getDriver')->willReturn($driver);
+        $connection->method('selectQuery')->willReturnCallback(function () use ($connection) {
+            return new SelectQuery($connection);
+        });
+
+        $binder = new ValueBinder();
+
+        // IS DISTINCT FROM
+        $expr = new QueryExpression(['col IS DISTINCT FROM' => 'val']);
+        if ($driver instanceof Mysql) {
+            $query = $connection->selectQuery();
+            $query->where($expr);
+            $sql = $driver->compileQuery($query, $binder);
+            $this->assertStringContainsString($expectedDistinct, $sql);
+        } else {
+            $this->assertEqualsSql($expectedDistinct, $expr->sql($binder));
+        }
+
+        $binder = new ValueBinder();
+        // IS NOT DISTINCT FROM
+        $expr = new QueryExpression(['col IS NOT DISTINCT FROM' => 'val']);
+        if ($driver instanceof Mysql) {
+            $query = $connection->selectQuery();
+            $query->where($expr);
+            $sql = $driver->compileQuery($query, $binder);
+            $this->assertStringContainsString($expectedNotDistinct, $sql);
+        } else {
+            $this->assertEqualsSql($expectedNotDistinct, $expr->sql($binder));
+        }
+    }
+}

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -3486,7 +3486,7 @@ class SelectQueryTest extends TestCase
     public function testIsNullInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expression `name` has invalid `null` value. If `null` is a valid value, operator (IS, IS NOT) is missing.');
+        $this->expectExceptionMessage('Expression `name` has invalid `null` value. If `null` is a valid value, operator (IS, IS NOT, IS DISTINCT FROM, IS NOT DISTINCT FROM) is missing.');
 
         (new SelectQuery($this->connection))
             ->select(['name'])


### PR DESCRIPTION
## Summary

This PR adds first-class support for the SQL null-safe comparison operators:

- IS DISTINCT FROM
- IS NOT DISTINCT FROM

to the CakePHP ORM query builder and expression system.

These operators provide consistent and predictable semantics when comparing values that may contain NULL, and are part of the SQL standard.

---

## Motivation

Currently, CakePHP ORM does not provide a direct way to express null-safe comparisons in a database-agnostic way.

Developers must rely on:
- database-specific syntax (eg <=> in MySQL), or
- verbose manual conditions involving IS NULL / IS NOT NULL

This PR introduces a unified, expressive, and portable API for these comparisons.

---

## Features

### Fluent API

```php
$exp->isDistinctFrom('Articles.deleted_at', $value);
$exp->isNotDistinctFrom('Articles.deleted_at', $value);
```

### Array condition parsing

```php
->where(['Articles.deleted_at IS DISTINCT FROM' => $value])
->where(['Articles.deleted_at IS NOT DISTINCT FROM' => $value])
```

---

## Implementation details

### New expression

A dedicated expression class (DistinctComparisonExpression) was introduced (extending ComparisonExpression) to represent these operators in a database-agnostic way.

---

### SQL generation per dialect

PostgreSQL / SQLite / SQL Server:
- Native syntax

MySQL:
- IS NOT DISTINCT FROM → <=>  
- IS DISTINCT FROM → NOT (<=>)

---

## Backwards compatibility

Fully additive. No breaking changes.

---
