### PR TITLE
Add inOrNull() convenience method and fix TypeMap propagation

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,7 +51,7 @@ parameters:
 		-
 			message: '#^Unsafe usage of new static\(\)\.$#'
 			identifier: new.static
-			count: 8
+			count: 9
 			path: src/Database/Expression/QueryExpression.php
 
 		-

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -397,6 +397,28 @@ class QueryExpression implements ExpressionInterface, Countable
 
     /**
      * Adds a new condition to the expression object in the form
+     * "(field IN (value1, value2) OR field IS NULL".
+     *
+     * @param \Cake\Database\ExpressionInterface|string $field Database field to be compared against value
+     * @param \Cake\Database\ExpressionInterface|array|string $values the value to be bound to $field for comparison
+     * @param string|null $type the type name for $value as configured using the Type map.
+     * @return $this
+     */
+    public function inOrNull(
+        ExpressionInterface|string $field,
+        ExpressionInterface|array|string $values,
+        ?string $type = null,
+    ) {
+        $or = new static([], $this->getTypeMap(), 'OR');
+        $or
+            ->in($field, $values, $type)
+            ->isNull($field);
+
+        return $this->add($or);
+    }
+
+    /**
+     * Adds a new condition to the expression object in the form
      * "(field NOT IN (value1, value2) OR field IS NULL".
      *
      * @param \Cake\Database\ExpressionInterface|string $field Database field to be compared against value
@@ -409,7 +431,7 @@ class QueryExpression implements ExpressionInterface, Countable
         ExpressionInterface|array|string $values,
         ?string $type = null,
     ) {
-        $or = new static([], [], 'OR');
+        $or = new static([], $this->getTypeMap(), 'OR');
         $or
             ->notIn($field, $values, $type)
             ->isNull($field);

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -200,7 +200,7 @@ class QueryExpressionTest extends TestCase
     {
         return [
             ['eq'], ['notEq'], ['gt'], ['lt'], ['gte'], ['lte'], ['like'],
-            ['notLike'], ['in'], ['notIn'], ['isDistinctFrom'], ['isNotDistinctFrom'],
+            ['notLike'], ['in'], ['notIn'], ['inOrNull'], ['notInOrNull'], ['isDistinctFrom'], ['isNotDistinctFrom'],
         ];
     }
 
@@ -238,6 +238,19 @@ class QueryExpressionTest extends TestCase
 
         $expr = new QueryExpression(['OR' => []]);
         $this->assertCount(0, $expr);
+    }
+
+    /**
+     * Tests that both conditions are generated for inOrNull().
+     */
+    public function testInOrNull(): void
+    {
+        $expr = new QueryExpression();
+        $expr->inOrNull('test', ['one', 'two']);
+        $this->assertEqualsSql(
+            '(test IN (:c0,:c1) OR (test) IS NULL)',
+            $expr->sql(new ValueBinder()),
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds `inOrNull()` as complement to existing `notInOrNull()` for the common pattern of `(field IN (...) OR field IS NULL)`.

Also fixes both `inOrNull()` and `notInOrNull()` methods to properly pass the TypeMap to the nested OR expression, ensuring type inference works correctly when no explicit type is provided.

## Usage

```php
$query->where(function ($exp) {
    return $exp->inOrNull('status', ['active', 'pending']);
});
// Generates: (status IN ('active', 'pending') OR status IS NULL)
```

This is useful when you need to include NULL values alongside specific values, which is a common pattern when filtering optional/nullable fields.