### PR TITLE
Add notBetween() method for NOT BETWEEN expressions

### DIFF
--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -51,15 +51,28 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
     protected mixed $_type;
 
     /**
+     * Whether this is a NOT BETWEEN expression
+     *
+     * @var bool
+     */
+    protected bool $_not = false;
+
+    /**
      * Constructor
      *
      * @param \Cake\Database\ExpressionInterface|string $field The field name to compare for values in between the range.
      * @param mixed $from The initial value of the range.
      * @param mixed $to The ending value in the comparison range.
      * @param string|null $type The data type name to bind the values with.
+     * @param bool $not Whether this is a NOT BETWEEN expression.
      */
-    public function __construct(ExpressionInterface|string $field, mixed $from, mixed $to, ?string $type = null)
-    {
+    public function __construct(
+        ExpressionInterface|string $field,
+        mixed $from,
+        mixed $to,
+        ?string $type = null,
+        bool $not = false,
+    ) {
         if ($type !== null) {
             $from = $this->_castToExpression($from, $type);
             $to = $this->_castToExpression($to, $type);
@@ -69,6 +82,7 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
         $this->_from = $from;
         $this->_to = $to;
         $this->_type = $type;
+        $this->_not = $not;
     }
 
     /**
@@ -95,7 +109,9 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
         }
         assert(is_string($field));
 
-        return sprintf('%s BETWEEN %s AND %s', $field, $parts['from'], $parts['to']);
+        $operator = $this->_not ? 'NOT BETWEEN' : 'BETWEEN';
+
+        return sprintf('%s %s %s AND %s', $field, $operator, $parts['from'], $parts['to']);
     }
 
     /**

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -457,6 +457,23 @@ class QueryExpression implements ExpressionInterface, Countable
     }
 
     /**
+     * Adds a new condition to the expression object in the form
+     * "field NOT BETWEEN from AND to".
+     *
+     * @param \Cake\Database\ExpressionInterface|string $field The field name to compare for values outside the range.
+     * @param mixed $from The initial value of the range.
+     * @param mixed $to The ending value in the comparison range.
+     * @param string|null $type the type name for $value as configured using the Type map.
+     * @return $this
+     */
+    public function notBetween(ExpressionInterface|string $field, mixed $from, mixed $to, ?string $type = null)
+    {
+        $type ??= $this->_calculateType($field);
+
+        return $this->add(new BetweenExpression($field, $from, $to, $type, true));
+    }
+
+    /**
      * Returns a new QueryExpression object containing all the conditions passed
      * and set up the conjunction to be "AND"
      *

--- a/tests/TestCase/Database/Expression/BetweenExpressionTest.php
+++ b/tests/TestCase/Database/Expression/BetweenExpressionTest.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\Expression;
+
+use Cake\Database\Expression\BetweenExpression;
+use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\ValueBinder;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Tests BetweenExpression class
+ */
+class BetweenExpressionTest extends TestCase
+{
+    /**
+     * Tests that BETWEEN expression is generated correctly
+     */
+    public function testBetween(): void
+    {
+        $expr = new BetweenExpression('age', 18, 65);
+        $this->assertEqualsSql(
+            'age BETWEEN :c0 AND :c1',
+            $expr->sql(new ValueBinder()),
+        );
+    }
+
+    /**
+     * Tests that NOT BETWEEN expression is generated correctly
+     */
+    public function testNotBetween(): void
+    {
+        $expr = new BetweenExpression('age', 18, 65, null, true);
+        $this->assertEqualsSql(
+            'age NOT BETWEEN :c0 AND :c1',
+            $expr->sql(new ValueBinder()),
+        );
+    }
+
+    /**
+     * Tests BETWEEN with an identifier expression as field
+     */
+    public function testBetweenWithIdentifierField(): void
+    {
+        $expr = new BetweenExpression(
+            new IdentifierExpression('Users.age'),
+            18,
+            65,
+        );
+        $this->assertEqualsSql(
+            'Users.age BETWEEN :c0 AND :c1',
+            $expr->sql(new ValueBinder()),
+        );
+    }
+
+    /**
+     * Tests NOT BETWEEN with an identifier expression as field
+     */
+    public function testNotBetweenWithIdentifierField(): void
+    {
+        $expr = new BetweenExpression(
+            new IdentifierExpression('Users.age'),
+            18,
+            65,
+            null,
+            true,
+        );
+        $this->assertEqualsSql(
+            'Users.age NOT BETWEEN :c0 AND :c1',
+            $expr->sql(new ValueBinder()),
+        );
+    }
+
+    /**
+     * Tests that values are properly bound with type
+     */
+    public function testBetweenWithType(): void
+    {
+        $expr = new BetweenExpression('score', 10, 100, 'integer');
+        $binder = new ValueBinder();
+        $expr->sql($binder);
+
+        $bindings = $binder->bindings();
+        $this->assertSame('integer', $bindings[':c0']['type']);
+        $this->assertSame('integer', $bindings[':c1']['type']);
+    }
+}

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -254,6 +254,32 @@ class QueryExpressionTest extends TestCase
     }
 
     /**
+     * Tests that between() generates correct SQL.
+     */
+    public function testBetween(): void
+    {
+        $expr = new QueryExpression();
+        $expr->between('age', 18, 65);
+        $this->assertEqualsSql(
+            'age BETWEEN :c0 AND :c1',
+            $expr->sql(new ValueBinder()),
+        );
+    }
+
+    /**
+     * Tests that notBetween() generates correct SQL.
+     */
+    public function testNotBetween(): void
+    {
+        $expr = new QueryExpression();
+        $expr->notBetween('age', 18, 65);
+        $this->assertEqualsSql(
+            'age NOT BETWEEN :c0 AND :c1',
+            $expr->sql(new ValueBinder()),
+        );
+    }
+
+    /**
      * Tests isDistinctFrom()
      */
     public function testIsDistinctFrom(): void


### PR DESCRIPTION
## Summary

Adds `notBetween()` to `QueryExpression` as parity with `between()`.

Updates `BetweenExpression` to support an optional negation parameter, allowing it to generate either `field BETWEEN x AND y` or `field NOT BETWEEN x AND y` syntax.

## Usage

```php
$query->where(function ($exp) {
    return $exp->notBetween('age', 18, 65);
});
// Generates: age NOT BETWEEN 18 AND 65
```

This is useful when you need to filter for values outside a specific range.

## Changes

- Added `$not` parameter to `BetweenExpression` constructor (defaults to `false` for backwards compatibility)
- Added `notBetween()` method to `QueryExpression`
- Added `BetweenExpressionTest` with tests for both BETWEEN and NOT BETWEEN
- Added tests for `between()` and `notBetween()` in `QueryExpressionTest`