### PR TITLE
refactor: Replace callable with Closure where appropriate

### DIFF
--- a/src/AttributeResolver/AttributeCollection.php
+++ b/src/AttributeResolver/AttributeCollection.php
@@ -18,6 +18,7 @@ namespace Cake\AttributeResolver;
 
 use Cake\AttributeResolver\Enum\AttributeTargetType;
 use Cake\AttributeResolver\ValueObject\AttributeInfo;
+use Closure;
 use Countable;
 use IteratorAggregate;
 use Traversable;
@@ -236,10 +237,10 @@ class AttributeCollection implements IteratorAggregate, Countable
     /**
      * Filter with a callback. Triggers full hydration.
      *
-     * @param callable $callback Callback to filter elements
+     * @param \Closure $callback Closure to filter elements
      * @return static
      */
-    public function filter(callable $callback): static
+    public function filter(Closure $callback): static
     {
         $matchingIds = [];
         foreach ($this->getActiveIds() as $id) {

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -24,6 +24,7 @@ use Cake\Http\Exception\InvalidCsrfTokenException;
 use Cake\Http\Response;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
+use Closure;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -79,9 +80,9 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      *
      * CSRF protection token check will be skipped if the callback returns `true`.
      *
-     * @var callable|null
+     * @var \Closure|null
      */
-    protected $skipCheckCallback;
+    protected ?Closure $skipCheckCallback = null;
 
     /**
      * @var int
@@ -175,10 +176,10 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      * The callback will receive request instance as argument and must return
      * `true` if you want to skip token check for the current request.
      *
-     * @param callable $callback A callable.
+     * @param \Closure $callback A closure.
      * @return $this
      */
-    public function skipCheckCallback(callable $callback): static
+    public function skipCheckCallback(Closure $callback): static
     {
         $this->skipCheckCallback = $callback;
 

--- a/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
@@ -23,6 +23,7 @@ use Cake\Http\ServerRequest;
 use Cake\Http\Session;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
+use Closure;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -68,9 +69,9 @@ class SessionCsrfProtectionMiddleware implements MiddlewareInterface
      *
      * CSRF protection token check will be skipped if the callback returns `true`.
      *
-     * @var callable|null
+     * @var \Closure|null
      */
-    protected $skipCheckCallback;
+    protected ?Closure $skipCheckCallback = null;
 
     /**
      * @var int
@@ -140,10 +141,10 @@ class SessionCsrfProtectionMiddleware implements MiddlewareInterface
      * The callback will receive request instance as argument and must return
      * `true` if you want to skip token check for the current request.
      *
-     * @param callable $callback A callable.
+     * @param \Closure $callback A closure.
      * @return $this
      */
-    public function skipCheckCallback(callable $callback): static
+    public function skipCheckCallback(Closure $callback): static
     {
         $this->skipCheckCallback = $callback;
 

--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -20,6 +20,7 @@ use Cake\Collection\Collection;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\ResultSetInterface;
 use Cake\ORM\Query\SelectQuery;
+use Closure;
 use InvalidArgumentException;
 use SplFixedArray;
 
@@ -257,10 +258,10 @@ class ResultSetFactory
     protected ?DtoMapper $dtoMapper = null;
 
     /**
-     * Cached DTO hydrator callables by class name.
+     * Cached DTO hydrator closures by class name.
      * Avoids method_exists() check on every row.
      *
-     * @var array<class-string, callable(array): object>
+     * @var array<class-string, \Closure(array): object>
      */
     protected static array $dtoHydrators = [];
 
@@ -281,15 +282,15 @@ class ResultSetFactory
     }
 
     /**
-     * Get a cached hydrator callable for a DTO class.
+     * Get a cached hydrator closure for a DTO class.
      *
      * The hydrator is determined once per class and cached to avoid
      * method_exists() checks on every row.
      *
      * @param class-string $dtoClass DTO class name
-     * @return callable(array): object
+     * @return \Closure(array): object
      */
-    public function getDtoHydrator(string $dtoClass): callable
+    public function getDtoHydrator(string $dtoClass): Closure
     {
         if (!isset(static::$dtoHydrators[$dtoClass])) {
             // Check for array style static factory method (cakephp-dto style)

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1546,11 +1546,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Handles the logic executing of a worker inside a transaction.
      *
-     * @param callable $worker The worker that will run inside the transaction.
+     * @param \Closure $worker The worker that will run inside the transaction.
      * @param bool $atomic Whether to execute the worker inside a database transaction.
      * @return mixed
      */
-    protected function executeTransaction(callable $worker, bool $atomic = true): mixed
+    protected function executeTransaction(Closure $worker, bool $atomic = true): mixed
     {
         if ($atomic) {
             return $this->getConnection()->transactional($worker(...));

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -104,10 +104,10 @@ abstract class TestCase extends BaseTestCase
      * Helper method for tests that needs to use error_reporting()
      *
      * @param int $errorLevel value of error_reporting() that needs to use
-     * @param callable $callable callable function that will receive asserts
+     * @param \Closure $callable Closure that will receive asserts
      * @return void
      */
-    public function withErrorReporting(int $errorLevel, callable $callable): void
+    public function withErrorReporting(int $errorLevel, Closure $callable): void
     {
         $default = error_reporting();
         error_reporting($errorLevel);

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -32,6 +32,7 @@ use Cake\Utility\Inflector;
 use Cake\View\Exception\MissingElementException;
 use Cake\View\Exception\MissingLayoutException;
 use Cake\View\Exception\MissingTemplateException;
+use Closure;
 use Generator;
 use InvalidArgumentException;
 use LogicException;
@@ -708,12 +709,12 @@ class View implements EventDispatcherInterface
      * This method will attempt to read the cache first. If the cache
      * is empty, the $block will be run and the output stored.
      *
-     * @param callable $block The block of code that you want to cache the output of.
+     * @param \Closure $block The block of code that you want to cache the output of.
      * @param array<string, mixed> $options The options defining the cache key etc.
      * @return string The rendered content.
      * @throws \InvalidArgumentException When $options is lacking a 'key' option.
      */
-    public function cache(callable $block, array $options = []): string
+    public function cache(Closure $block, array $options = []): string
     {
         $options += ['key' => '', 'config' => $this->elementCache];
         if (empty($options['key'])) {


### PR DESCRIPTION
## Summary

Replace `callable` type hints with `Closure` for parameters and return types where only anonymous functions are actually used. Using `Closure` is more type-safe as it explicitly declares that only anonymous functions are accepted, rather than any callable type (arrays, strings, invokable objects).

### Changed methods:

| File | Method | Change |
|------|--------|--------|
| `CsrfProtectionMiddleware` | `skipCheckCallback($callback)` | `callable` → `Closure` |
| `SessionCsrfProtectionMiddleware` | `skipCheckCallback($callback)` | `callable` → `Closure` |
| `View` | `cache($block)` | `callable` → `Closure` |
| `TestCase` | `withErrorReporting($callable)` | `callable` → `Closure` |
| `Table` | `executeTransaction($worker)` | `callable` → `Closure` |
| `AttributeCollection` | `filter($callback)` | `callable` → `Closure` |
| `ResultSetFactory` | `getDtoHydrator()` return type | `callable` → `Closure` |

### Not changed (intentionally)

- **Collection methods** (`filter`, `map`, `reduce`, etc.) - mirrors PHP's `array_*` functions, users may pass `'strlen'`, `'is_string'`, etc.
- **Container classes** - DI container needs to accept `['Class', 'method']` arrays
- **Hash methods** - same as Collection
- **Event system** - listeners can be various callable types
- **I18n loaders** - may be class methods
- **RulesChecker** - rules might be invokable objects