### PR TITLE
Fix pagination sort merge with prefixed default order

### DIFF
--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -618,9 +618,19 @@ class NumericPaginator implements PaginatorInterface
 
                 // Merge with existing order - existing order comes AFTER our resolved order
                 $existingOrder = isset($options['order']) && is_array($options['order']) ? $options['order'] : [];
+                $modelAlias = $object->getAlias();
                 // Only keep fields from existing order that aren't already in our resolved order
+                // Account for prefixed vs unprefixed field names (e.g., 'modified' vs 'Alerts.modified')
                 foreach ($existingOrder as $field => $dir) {
-                    if (!isset($order[$field])) {
+                    // Check if this field (or its unprefixed version) is already in $order
+                    $alreadyInOrder = isset($order[$field]);
+                    if (!$alreadyInOrder && str_contains($field, '.')) {
+                        [$alias, $fieldName] = explode('.', $field, 2);
+                        if ($alias === $modelAlias && isset($order[$fieldName])) {
+                            $alreadyInOrder = true;
+                        }
+                    }
+                    if (!$alreadyInOrder) {
                         $order[$field] = $dir;
                     }
                 }

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -1045,6 +1045,38 @@ trait PaginatorTestTrait
     }
 
     /**
+     * Test that unprefixed sortableFields work correctly with prefixed default order.
+     *
+     * When controller sets prefixed order like `['Articles.modified' => 'DESC']`
+     * and sortableFields uses unprefixed names like `['modified']`, sort toggling
+     * should work correctly without duplicating the field in the order array.
+     */
+    public function testValidateSortUnprefixedFieldsWithPrefixedDefaultOrder(): void
+    {
+        $model = $this->mockAliasHasFieldModel();
+
+        // Controller has prefixed default order but unprefixed sortableFields
+        $options = [
+            'sort' => 'created',
+            'direction' => 'asc',
+            'order' => [
+                'model.created' => 'DESC',
+            ],
+            'sortableFields' => ['created'],
+        ];
+
+        $result = $this->Paginator->validateSort($model, $options);
+
+        // The sort should work - unprefixed 'created' from sortableFields should
+        // be recognized as matching 'model.created' from default order
+        $expected = [
+            'model.created' => 'asc',
+        ];
+        $this->assertEquals($expected, $result['order']);
+        $this->assertEquals('created', $result['sort']);
+    }
+
+    /**
      * @return array
      */
     public static function checkLimitProvider(): array

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -1072,8 +1072,8 @@ trait PaginatorTestTrait
         $expected = [
             'model.created' => 'asc',
         ];
-        $this->assertEquals($expected, $result['order']);
-        $this->assertEquals('created', $result['sort']);
+        $this->assertSame($expected, $result['order']);
+        $this->assertSame('created', $result['sort']);
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes an issue where pagination sort toggling doesn't work correctly when:
- `sortableFields` uses unprefixed field names (e.g., `'modified'`)
- The default `order` configuration uses prefixed names (e.g., `'Articles.modified' => 'DESC'`)

This is a common pattern when sorting on joined tables where the prefix is required for the SQL to be valid.

### Problem

When clicking a sort link, the first click works correctly. However, subsequent clicks (to toggle direction) would lose the sort parameters because the merge logic didn't recognize that `'modified'` and `'Articles.modified'` refer to the same field.

### Solution

The fix normalizes field names during the merge by checking if a prefixed field from the default order (e.g., `'Model.field'`) matches an unprefixed field already present in the resolved order array. When the alias matches the model's alias, the fields are considered duplicates and the prefixed version is skipped.

The PR fixes:                                                                                                                         
  - Controller order: ['Articles.modified' => 'DESC'] (prefixed for valid SQL (other joined model also as this field)                                                                        
  - Controller sortableFields: ['modified'] (unprefixed)                                                                                
  - Template: $this->Paginator->sort('modified') (unprefixed)     

### Example

```php
// Controller configuration
$this->paginate($query, [
    'order' => ['Articles.modified' => 'DESC'],  // Prefixed for join clarity
    'sortableFields' => ['modified', 'title'],   // Unprefixed for simplicity
]);

// Template
<?= $this->Paginator->sort('modified', 'Modified Date') ?>
```

Also `'sortableFields' => ['Articles.modified', 'Articles.title'],` would be valid though.

Before this fix, clicking the sort link twice would result in the sort being lost. Now it correctly toggles between ASC and DESC.
