### PR TITLE
fix: use continue instead of return when skipping closure in `updateCounterCache`

### DIFF
--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -218,8 +218,8 @@ class CounterCacheBehavior extends Behavior
 
             foreach ($settings as $field => $config) {
                 if ($config instanceof Closure) {
-                    // Cannot update counter cache which use a closure
-                    return;
+                    // Skip counter cache fields that use a closure
+                    continue;
                 }
 
                 if (is_int($field)) {

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -655,6 +655,27 @@ class CounterCacheBehaviorTest extends TestCase
         $this->assertSame(1, $user->get('post_count'));
     }
 
+    public function testUpdateCounterCacheSkipsClosureButContinues(): void
+    {
+        $this->post->belongsTo('Users');
+        $this->post->addBehavior('CounterCache', [
+            'Users' => [
+                'posts_published' => function (): void {
+                    // Should be skipped
+                },
+                'post_count',
+            ],
+        ]);
+
+        $this->user->updateAll(['post_count' => 0], []);
+        $this->post->getBehavior('CounterCache')->updateCounterCache('Users');
+
+        $user = $this->_getUser(1);
+        // With "return": post_count stays 0 (buggy behavior)
+        // With "continue": post_count becomes 2 (correct behavior)
+        $this->assertSame(2, $user->get('post_count'));
+    }
+
     /**
      * Get a new Entity
      */


### PR DESCRIPTION
## Problem
When `updateCounterCache()` encounters a Closure field, it calls `return`,
which exits the entire method. This causes subsequent non-closure fields
to be skipped unintentionally.

## Fix
Replace `return` with `continue` so that only the Closure field is skipped
and the remaining fields are still processed.

## Test
Added `testUpdateCounterCacheSkipsClosureButContinues` to verify that
non-closure fields are processed even when a Closure field precedes them.

## Tests Results
<img width="639" height="352" alt="スクリーンショット 2026-04-04 17 43 10" src="https://github.com/user-attachments/assets/bca1147e-8cba-44eb-85fa-ec1d2f53f34f" />

<img width="827" height="269" alt="スクリーンショット 2026-04-04 17 48 37" src="https://github.com/user-attachments/assets/6b19823f-7db9-4196-a1f9-fd21f9bcccd7" />
