### PR TITLE
6.0 - Entity props with hooks

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -43,7 +43,7 @@
   </file>
   <file src="src/Datasource/EntityTrait.php">
     <UnsupportedPropertyReferenceUsage>
-      <code><![CDATA[$value = &$this->fields[$field]]]></code>
+      <code><![CDATA[$value = &$this->dynamicFields[$field]]]></code>
     </UnsupportedPropertyReferenceUsage>
   </file>
   <file src="src/ORM/Query/SelectQuery.php">

--- a/rector.php
+++ b/rector.php
@@ -119,6 +119,7 @@ return RectorConfig::configure()
         \Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictSetUpRector::class,
         \Rector\TypeDeclaration\Rector\While_\WhileNullableToInstanceofRector::class,
         \Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector::class,
+        \Rector\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector::class,
 
         // Manual - only appliable for part of the code
         \Rector\CodeQuality\Rector\Equal\UseIdenticalOverEqualWithSameTypeRector::class,

--- a/rector.php
+++ b/rector.php
@@ -122,6 +122,7 @@ return RectorConfig::configure()
         \Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictSetUpRector::class,
         \Rector\TypeDeclaration\Rector\While_\WhileNullableToInstanceofRector::class,
         \Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector::class,
+        \Rector\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector::class,
 
         // Manual - only appliable for part of the code
         \Rector\CodeQuality\Rector\Equal\UseIdenticalOverEqualWithSameTypeRector::class,

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -154,7 +154,7 @@ trait EntityTrait
     /**
      * List of properties that are not treated as fields.
      *
-     * @var array<string>
+     * @var list<string>
      */
     protected static array $restrictedProperties = [
         'dynamicFields',
@@ -164,6 +164,7 @@ trait EntityTrait
         'hidden',
         'virtual',
         'dirty',
+        'accessors',
         'new',
         'errors',
         'invalid',

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -325,7 +325,7 @@ trait EntityTrait
 
             if ($options['asOriginal'] || $this->isModified($name, $value)) {
                 $this->setDirty($name, true);
-            } else {
+            } elseif ($value !== null && !$this->propertyExists($name)) {
                 continue;
             }
 
@@ -561,21 +561,9 @@ trait EntityTrait
      */
     public function has(array|string $field): bool
     {
-        foreach ((array)$field as $prop) {
-            $exists = $this->propertyExists($prop);
-            if ($exists) {
-                try {
-                    // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
-                    @$this->{$prop};
-                } catch (Error) {
-                    return false;
-                }
-            } elseif (!array_key_exists($prop, $this->dynamicFields) && !static::accessor($prop, 'get')) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all((array)$field, function ($prop) {
+            return !(!in_array($prop, $this->propertyFields) && !static::accessor($prop, 'get'));
+        });
     }
 
     /**
@@ -624,16 +612,13 @@ trait EntityTrait
      */
     public function unset(array|string $field): static
     {
-        $field = (array)$field;
-        foreach ($field as $p) {
-            unset($this->dynamicFields[$p], $this->dirty[$p]);
+        foreach ((array)$field as $p) {
+            unset($this->dynamicFields[$p], $this->dirty[$p], $this->{$p});
 
             $pos = array_search($p, $this->propertyFields, true);
             if ($pos !== false) {
                 unset($this->propertyFields[$pos]);
             }
-
-            unset($this->{$p});
         }
 
         return $this;

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -33,6 +33,13 @@ use InvalidArgumentException;
 trait EntityTrait
 {
     /**
+     * Hold values fields which do not have corresponding class properties.
+     *
+     * @var array<array-key, mixed>
+     */
+    protected array $dynamicFields = [];
+
+    /**
      * Holds field names for initialized properties
      *
      * @var array<string>
@@ -145,25 +152,22 @@ trait EntityTrait
      */
     protected bool $requireFieldPresence = false;
 
-    /**
-     * List of fields that can be dynamically set in this entity.
-     *
-     * @var list<string>
-     */
-    protected array $allowedDynamicFields = [
-        '_joinData',
-        '_matchingData',
-        '_locale',
-        '_translations',
-        '_i18n',
+    protected array $restrictedProperties = [
+        'propertyFields',
+        'original',
+        'originalFields',
+        'hidden',
+        'virtual',
+        'dirty',
+        'new',
+        'errors',
+        'invalid',
+        'patchable',
+        'registryAlias',
+        'hasBeenVisited',
+        'requireFieldPresence',
+        'dynamicFields',
     ];
-
-    /**
-     * Dynamically set field values.
-     *
-     * @var array<array-key, mixed>
-     */
-    protected array $dynamicFields = [];
 
     /**
      * Magic getter to access fields that have been set in this entity
@@ -303,12 +307,7 @@ trait EntityTrait
      */
     public function patch(array $values, array $options = []): static
     {
-        $options += [
-            'setter' => true,
-            'guard' => true,
-            'asOriginal' => false,
-            'allowDynamic' => static::class === Entity::class ? true : false,
-        ];
+        $options += ['setter' => true, 'guard' => true, 'asOriginal' => false];
 
         if ($options['asOriginal'] === true) {
             $this->setOriginalField(array_keys($values));
@@ -350,18 +349,14 @@ trait EntityTrait
                 $this->propertyFields[] = $name;
             }
 
-            if ($options['allowDynamic']) {
-                $propExists = property_exists($this, $name);
+            $propExists = $this->propertyExists($name);
+            if ($propExists) {
+                $this->{$name} = $value;
 
-                if (!$propExists) {
-                    $this->allowedDynamicFields[] = $name;
-                    $this->dynamicFields[$name] = $value;
-
-                    continue;
-                }
+                continue;
             }
 
-            $this->{$name} = $value;
+            $this->dynamicFields[$name] = $value;
         }
 
         return $this;
@@ -381,21 +376,18 @@ trait EntityTrait
      */
     protected function isModified(string $field, mixed $value): bool
     {
-        if (
-            in_array($field, $this->allowedDynamicFields, true)
-            && !property_exists($this, $field)
-        ) {
-            if (!array_key_exists($field, $this->dynamicFields)) {
-                return true;
-            }
-
-            $existing = $this->dynamicFields[$field];
-        } else {
+        if ($this->propertyExists($field)) {
             try {
                 $existing = $this->{$field};
             } catch (Error) {
                 return true;
             }
+        } else {
+            if (!array_key_exists($field, $this->dynamicFields)) {
+                return true;
+            }
+
+            $existing = $this->dynamicFields[$field] ?? null;
         }
 
         if (($value === null || is_scalar($value)) && $existing === $value) {
@@ -447,14 +439,12 @@ trait EntityTrait
         $value = null;
         $fieldIsPresent = false;
 
-        if (property_exists($this, $field)) {
+        if ($this->propertyExists($field)) {
             $fieldIsPresent = true;
             $value = $this->{$field} ?? null;
-        } elseif (in_array($field, $this->allowedDynamicFields, true)) {
+        } elseif (array_key_exists($field, $this->dynamicFields)) {
             $fieldIsPresent = true;
-            if (array_key_exists($field, $this->dynamicFields)) {
-                $value = &$this->dynamicFields[$field];
-            }
+            $value = &$this->dynamicFields[$field];
         }
 
         $method = static::accessor($field, 'get');
@@ -544,24 +534,16 @@ trait EntityTrait
     }
 
     /**
-     * Returns whether this entity contains a field named $field and is initialized.
+     * Returns whether this entity contains a field named $field.
      *
      * It will return `true` even for fields set to `null`.
      *
      * ### Example:
      *
      * ```
-     * class MyEntity extends Entity
-     * {
-     *    protected $id;
-     *    protected $name;
-     *    protected $first_name;
-     * }
-     *
-     * $entity = new MyEntity(['id' => 1, 'name' => null]);
+     * $entity = new Entity(['id' => 1, 'name' => null]);
      * $entity->has('id'); // true
      * $entity->has('name'); // true
-     * $entity->has('first_name'); // false
      * $entity->has('last_name'); // false
      * ```
      *
@@ -580,17 +562,16 @@ trait EntityTrait
     public function has(array|string $field): bool
     {
         foreach ((array)$field as $prop) {
-            $exists = property_exists($this, $prop);
-            if (!$exists) {
-                if (!array_key_exists($prop, $this->dynamicFields) && !static::accessor($prop, 'get')) {
-                    return false;
-                }
-            } else {
+            $exists = $this->propertyExists($prop);
+            if ($exists) {
                 try {
-                    $this->{$prop};
+                    // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+                    @$this->{$prop};
                 } catch (Error) {
                     return false;
                 }
+            } elseif (!array_key_exists($prop, $this->dynamicFields) && !static::accessor($prop, 'get')) {
+                return false;
             }
         }
 
@@ -1502,6 +1483,17 @@ trait EntityTrait
     }
 
     /**
+     * Checks if a property exists and is not restricted.
+     *
+     * @param string $field The field name to check.
+     * @return bool
+     */
+    protected function propertyExists(string $field): bool
+    {
+        return !in_array($field, $this->restrictedProperties) && property_exists($this, $field);
+    }
+
+    /**
      * Returns an array that can be used to describe the internal state of this
      * object.
      *
@@ -1523,7 +1515,6 @@ trait EntityTrait
             '[new]' => $this->isNew(),
             '[patchable]' => $this->patchable,
             '[dirty]' => $this->dirty,
-            '[allowedDynamic]' => $this->allowedDynamicFields,
             '[original]' => $this->original,
             '[originalFields]' => $this->originalFields,
             '[virtual]' => $this->virtual,

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -151,7 +151,12 @@ trait EntityTrait
      */
     protected bool $requireFieldPresence = false;
 
-    protected array $restrictedProperties = [
+    /**
+     * List of properties that are not treated as fields.
+     *
+     * @var array<string>
+     */
+    protected static array $restrictedProperties = [
         'propertyFields',
         'original',
         'originalFields',
@@ -1474,7 +1479,7 @@ trait EntityTrait
      */
     protected function propertyExists(string $field): bool
     {
-        return !in_array($field, $this->restrictedProperties) && property_exists($this, $field);
+        return !in_array($field, static::$restrictedProperties) && property_exists($this, $field);
     }
 
     /**

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -159,28 +159,28 @@ trait EntityTrait
     protected bool $requireFieldPresence = false;
 
     /**
-     * List of properties that are not treated as fields.
+     * Map of properties that are not treated as fields.
      *
-     * @var array<string, string>
+     * @var array<string, true>
      */
     protected static array $restrictedProperties = [
-        'dynamicFields' => 'dynamicFields',
-        'propertyFields' => 'propertyFields',
-        'reflectionCache' => 'reflectionCache',
-        'original' => 'original',
-        'originalFields' => 'originalFields',
-        'hidden' => 'hidden',
-        'virtual' => 'virtual',
-        'dirty' => 'dirty',
-        'accessors' => 'accessors',
-        'new' => 'new',
-        'errors' => 'errors',
-        'invalid' => 'invalid',
-        'patchable' => 'patchable',
-        'registryAlias' => 'registryAlias',
-        'hasBeenVisited' => 'hasBeenVisited',
-        'requireFieldPresence' => 'requireFieldPresence',
-        'restrictedProperties' => 'restrictedProperties',
+        'dynamicFields' => true,
+        'propertyFields' => true,
+        'reflectionCache' => true,
+        'original' => true,
+        'originalFields' => true,
+        'hidden' => true,
+        'virtual' => true,
+        'dirty' => true,
+        'accessors' => true,
+        'new' => true,
+        'errors' => true,
+        'invalid' => true,
+        'patchable' => true,
+        'registryAlias' => true,
+        'hasBeenVisited' => true,
+        'requireFieldPresence' => true,
+        'restrictedProperties' => true,
     ];
 
     /**

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -99,7 +99,7 @@ trait EntityTrait
     /**
      * Per-class cache of ReflectionProperty instances for concrete field properties.
      *
-     * @var array<class-string, array<string, \ReflectionProperty|null>>
+     * @var array<class-string, array<string, \ReflectionProperty|false>>
      */
     protected static array $reflectionCache = [];
 
@@ -349,7 +349,7 @@ trait EntityTrait
 
             if ($asOriginal || $this->isModified($name, $value)) {
                 $this->setDirty($name, true);
-            } elseif ($isDynamic || $ref === null || $value !== null) {
+            } elseif ($isDynamic || !$ref || $value !== null) {
                 continue;
             }
 
@@ -365,25 +365,25 @@ trait EntityTrait
                 !array_key_exists($name, $this->original) &&
                 ($isDynamic || isset($this->assignedProps[$name]))
             ) {
-                $existing = $isDynamic ? $this->dynamicFields[$name] : $ref?->getRawValue($this);
+                $existing = $isDynamic ? $this->dynamicFields[$name] : $ref->getRawValue($this);
                 if ($value !== $existing) {
                     $this->original[$name] = $existing;
                 }
             }
 
             if ($useSetter) {
-                if ($ref !== null) {
+                if ($ref) {
                     $this->{$name} = $value;
                 } else {
                     $this->dynamicFields[$name] = $value;
                 }
-            } elseif ($ref !== null) {
+            } elseif ($ref) {
                 $ref->setRawValue($this, $value);
             } else {
                 $this->dynamicFields[$name] = $value;
             }
 
-            if ($ref !== null) {
+            if ($ref) {
                 $this->assignedProps[$name] = true;
             }
         }
@@ -409,7 +409,7 @@ trait EntityTrait
             $existing = $this->dynamicFields[$field];
         } else {
             $ref = static::getReflectionProperty($field);
-            if ($ref === null || !$ref->isInitialized($this)) {
+            if (!$ref || !$ref->isInitialized($this)) {
                 return true;
             }
             $existing = $ref->getRawValue($this);
@@ -1488,19 +1488,21 @@ trait EntityTrait
      */
     protected function propertyExists(string $field): bool
     {
-        return static::getReflectionProperty($field) !== null;
+        return (bool)static::getReflectionProperty($field);
     }
 
     /**
      * Get cached ReflectionProperty for a concrete field property.
      *
-     * Returns null if the property doesn't exist, is a restricted
-     * (infrastructure) property, or is static.
+     * Returns false if the property doesn't exist, is a restricted
+     * (infrastructure) property, or is static. Using false as the
+     * negative-cache sentinel allows isset() to serve both cache hit
+     * types with a single lookup.
      *
      * @param string $field The field name.
-     * @return \ReflectionProperty|null
+     * @return \ReflectionProperty|false
      */
-    protected static function getReflectionProperty(string $field): ?ReflectionProperty
+    protected static function getReflectionProperty(string $field): ReflectionProperty|false
     {
         $class = static::class;
 
@@ -1508,20 +1510,13 @@ trait EntityTrait
             return static::$reflectionCache[$class][$field];
         }
 
-        if (isset(static::$reflectionCache[$class]) && array_key_exists($field, static::$reflectionCache[$class])) {
-            return null;
-        }
-
         if (isset(static::$restrictedProperties[$field]) || !property_exists(static::class, $field)) {
-            static::$reflectionCache[$class][$field] = null;
-
-            return null;
+            return static::$reflectionCache[$class][$field] = false;
         }
 
         $ref = new ReflectionProperty(static::class, $field);
-        static::$reflectionCache[$class][$field] = $ref->isStatic() ? null : $ref;
 
-        return static::$reflectionCache[$class][$field];
+        return static::$reflectionCache[$class][$field] = $ref->isStatic() ? false : $ref;
     }
 
     /**
@@ -1544,7 +1539,7 @@ trait EntityTrait
 
         $ref = static::getReflectionProperty($field);
 
-        if ($ref === null) {
+        if (!$ref) {
             $this->dynamicFields[$field] = $value;
 
             return;
@@ -1569,7 +1564,7 @@ trait EntityTrait
 
         $ref = static::getReflectionProperty($field);
 
-        if ($ref === null) {
+        if (!$ref) {
             return null;
         }
 

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -157,6 +157,7 @@ trait EntityTrait
      * @var array<string>
      */
     protected static array $restrictedProperties = [
+        'dynamicFields',
         'propertyFields',
         'original',
         'originalFields',
@@ -170,7 +171,7 @@ trait EntityTrait
         'registryAlias',
         'hasBeenVisited',
         'requireFieldPresence',
-        'dynamicFields',
+        'restrictedProperties',
     ];
 
     /**

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -20,8 +20,8 @@ use Cake\Collection\Collection;
 use Cake\Datasource\Exception\MissingPropertyException;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
-use Error;
 use InvalidArgumentException;
+use ReflectionProperty;
 
 /**
  * An entity represents a single result row from a repository. It exposes the
@@ -92,6 +92,13 @@ trait EntityTrait
     protected static array $accessors = [];
 
     /**
+     * Per-class cache of ReflectionProperty instances for concrete field properties.
+     *
+     * @var array<class-string, array<string, \ReflectionProperty|null>>
+     */
+    protected static array $reflectionCache = [];
+
+    /**
      * Indicates whether this entity is yet to be persisted.
      * Entities default to assuming they are new. You can use Table::persisted()
      * to set the new flag on an entity based on records in the database.
@@ -159,6 +166,7 @@ trait EntityTrait
     protected static array $restrictedProperties = [
         'dynamicFields' => 'dynamicFields',
         'propertyFields' => 'propertyFields',
+        'reflectionCache' => 'reflectionCache',
         'original' => 'original',
         'originalFields' => 'originalFields',
         'hidden' => 'hidden',
@@ -347,19 +355,27 @@ trait EntityTrait
             if (
                 $this->isOriginalField($name) &&
                 !array_key_exists($name, $this->original) &&
-                isset($this->propertyFields[$name]) &&
-                $value !== ($this->{$name} ?? null)
+                isset($this->propertyFields[$name])
             ) {
-                $this->original[$name] = $this->{$name} ?? null;
+                $existing = $this->getRawValue($name);
+                if ($value !== $existing) {
+                    $this->original[$name] = $existing;
+                }
             }
 
             if (!isset($this->propertyFields[$name])) {
                 $this->propertyFields[$name] = $name;
             }
 
-            $propExists = $this->propertyExists($name);
-            if ($propExists) {
-                $this->{$name} = $value;
+            if ($options['setter']) {
+                $propExists = $this->propertyExists($name);
+                if ($propExists) {
+                    $this->{$name} = $value;
+
+                    continue;
+                }
+            } else {
+                $this->setRawValue($name, $value);
 
                 continue;
             }
@@ -384,16 +400,12 @@ trait EntityTrait
      */
     protected function isModified(string $field, mixed $value): bool
     {
-        if ($this->propertyExists($field)) {
-            try {
-                $existing = $this->{$field};
-            } catch (Error $error) {
-                if (str_ends_with($error->getMessage(), 'must not be accessed before initialization')) {
-                    return true;
-                }
-
-                throw $error;
+        $ref = static::getReflectionProperty($field);
+        if ($ref !== null) {
+            if (!$ref->isInitialized($this)) {
+                return true;
             }
+            $existing = $ref->getRawValue($this);
         } else {
             if (!array_key_exists($field, $this->dynamicFields)) {
                 return true;
@@ -537,7 +549,7 @@ trait EntityTrait
                 !array_key_exists($key, $originals) &&
                 $this->isOriginalField($key)
             ) {
-                $originals[$key] = $this->{$key};
+                $originals[$key] = $this->getRawValue($key);
             }
         }
 
@@ -1072,7 +1084,7 @@ trait EntityTrait
         $this->hasBeenVisited = true;
         try {
             foreach ($this->propertyFields as $field) {
-                $value = $this->{$field};
+                $value = $this->getRawValue($field);
 
                 if ($this->readHasErrors($value)) {
                     return true;
@@ -1100,7 +1112,7 @@ trait EntityTrait
         $diff = array_diff($this->propertyFields, array_keys($this->errors));
         $values = [];
         foreach ($diff as $field) {
-            $values[$field] = $this->{$field};
+            $values[$field] = $this->getRawValue($field);
         }
 
         $this->hasBeenVisited = true;
@@ -1475,7 +1487,90 @@ trait EntityTrait
      */
     protected function propertyExists(string $field): bool
     {
-        return !isset(static::$restrictedProperties[$field]) && property_exists($this, $field);
+        return static::getReflectionProperty($field) !== null;
+    }
+
+    /**
+     * Get cached ReflectionProperty for a concrete field property.
+     *
+     * Returns null if the property doesn't exist, is a restricted
+     * (infrastructure) property, or is static.
+     *
+     * @param string $field The field name.
+     * @return \ReflectionProperty|null
+     */
+    protected static function getReflectionProperty(string $field): ?ReflectionProperty
+    {
+        $class = static::class;
+
+        if (!isset(static::$reflectionCache[$class])) {
+            static::$reflectionCache[$class] = [];
+        }
+
+        if (!array_key_exists($field, static::$reflectionCache[$class])) {
+            if (isset(static::$restrictedProperties[$field]) || !property_exists(static::class, $field)) {
+                static::$reflectionCache[$class][$field] = null;
+            } else {
+                $ref = new ReflectionProperty(static::class, $field);
+                static::$reflectionCache[$class][$field] = $ref->isStatic() ? null : $ref;
+            }
+        }
+
+        return static::$reflectionCache[$class][$field];
+    }
+
+    /**
+     * Set a property's raw value, bypassing any property hooks.
+     *
+     * Uses ReflectionProperty::setRawValue() to avoid triggering `set` hooks.
+     * Falls back to $dynamicFields for fields without a concrete property.
+     *
+     * @param string $field The field name.
+     * @param mixed $value The value to set.
+     * @return void
+     */
+    protected function setRawValue(string $field, mixed $value): void
+    {
+        $ref = static::getReflectionProperty($field);
+
+        if ($ref === null) {
+            $this->dynamicFields[$field] = $value;
+
+            return;
+        }
+
+        $ref->setRawValue($this, $value);
+    }
+
+    /**
+     * Get a property's raw value, bypassing any property `get` hooks.
+     *
+     * Falls back to $dynamicFields for fields without a concrete property.
+     *
+     * @param string $field The field name.
+     * @return mixed
+     */
+    protected function getRawValue(string $field): mixed
+    {
+        $ref = static::getReflectionProperty($field);
+
+        if ($ref === null) {
+            return $this->dynamicFields[$field] ?? null;
+        }
+
+        return $ref->getRawValue($this);
+    }
+
+    /**
+     * Clear the reflection cache.
+     *
+     * Useful for testing where entity classes may be dynamically defined.
+     *
+     * @return void
+     */
+    public static function clearReflectionCache(): void
+    {
+        static::$reflectionCache = [];
     }
 
     /**
@@ -1488,7 +1583,7 @@ trait EntityTrait
     {
         $fields = [];
         foreach ($this->propertyFields as $field) {
-            $fields[$field] = $this->{$field};
+            $fields[$field] = $this->getRawValue($field);
         }
         $fields += $this->dynamicFields;
 

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -327,6 +327,8 @@ trait EntityTrait
             $this->setOriginalField(array_keys($values));
         }
 
+        $useSetter = $options['setter'];
+
         foreach ($values as $name => $value) {
             $name = (string)$name;
             if ($name === '') {
@@ -337,15 +339,17 @@ trait EntityTrait
                 continue;
             }
 
+            $isDynamic = array_key_exists($name, $this->dynamicFields);
+            $ref = $isDynamic ? null : static::getReflectionProperty($name);
+
+
             if ($asOriginal || $this->isModified($name, $value)) {
                 $this->setDirty($name, true);
-            } elseif (!$this->propertyExists($name)) {
-                continue;
-            } elseif ($value !== null) {
+            } elseif ($isDynamic || $ref === null || $value !== null) {
                 continue;
             }
 
-            if ($options['setter']) {
+            if ($useSetter) {
                 $setter = static::accessor($name, 'set');
                 if ($setter) {
                     $value = $this->{$setter}($value);
@@ -357,7 +361,7 @@ trait EntityTrait
                 !array_key_exists($name, $this->original) &&
                 isset($this->propertyFields[$name])
             ) {
-                $existing = $this->getRawValue($name);
+                $existing = $isDynamic ? $this->dynamicFields[$name] : $ref?->getRawValue($this);
                 if ($value !== $existing) {
                     $this->original[$name] = $existing;
                 }
@@ -367,20 +371,17 @@ trait EntityTrait
                 $this->propertyFields[$name] = $name;
             }
 
-            if ($options['setter']) {
-                $propExists = $this->propertyExists($name);
-                if ($propExists) {
+            if ($useSetter) {
+                if ($ref !== null) {
                     $this->{$name} = $value;
-
-                    continue;
+                } else {
+                    $this->dynamicFields[$name] = $value;
                 }
+            } elseif ($ref !== null) {
+                $ref->setRawValue($this, $value);
             } else {
-                $this->setRawValue($name, $value);
-
-                continue;
+                $this->dynamicFields[$name] = $value;
             }
-
-            $this->dynamicFields[$name] = $value;
         }
 
         return $this;
@@ -400,18 +401,14 @@ trait EntityTrait
      */
     protected function isModified(string $field, mixed $value): bool
     {
-        $ref = static::getReflectionProperty($field);
-        if ($ref !== null) {
-            if (!$ref->isInitialized($this)) {
+        if (array_key_exists($field, $this->dynamicFields)) {
+            $existing = $this->dynamicFields[$field];
+        } else {
+            $ref = static::getReflectionProperty($field);
+            if ($ref === null || !$ref->isInitialized($this)) {
                 return true;
             }
             $existing = $ref->getRawValue($this);
-        } else {
-            if (!array_key_exists($field, $this->dynamicFields)) {
-                return true;
-            }
-
-            $existing = $this->dynamicFields[$field] ?? null;
         }
 
         if (($value === null || is_scalar($value)) && $existing === $value) {
@@ -463,12 +460,12 @@ trait EntityTrait
         $value = null;
         $fieldIsPresent = false;
 
-        if ($this->propertyExists($field)) {
-            $fieldIsPresent = true;
-            $value = $this->{$field} ?? null;
-        } elseif (array_key_exists($field, $this->dynamicFields)) {
+        if (array_key_exists($field, $this->dynamicFields)) {
             $fieldIsPresent = true;
             $value = &$this->dynamicFields[$field];
+        } elseif ($this->propertyExists($field)) {
+            $fieldIsPresent = true;
+            $value = $this->{$field} ?? null;
         }
 
         $method = static::accessor($field, 'get');
@@ -1503,18 +1500,22 @@ trait EntityTrait
     {
         $class = static::class;
 
-        if (!isset(static::$reflectionCache[$class])) {
-            static::$reflectionCache[$class] = [];
+        if (isset(static::$reflectionCache[$class][$field])) {
+            return static::$reflectionCache[$class][$field];
         }
 
-        if (!array_key_exists($field, static::$reflectionCache[$class])) {
-            if (isset(static::$restrictedProperties[$field]) || !property_exists(static::class, $field)) {
-                static::$reflectionCache[$class][$field] = null;
-            } else {
-                $ref = new ReflectionProperty(static::class, $field);
-                static::$reflectionCache[$class][$field] = $ref->isStatic() ? null : $ref;
-            }
+        if (isset(static::$reflectionCache[$class]) && array_key_exists($field, static::$reflectionCache[$class])) {
+            return null;
         }
+
+        if (isset(static::$restrictedProperties[$field]) || !property_exists(static::class, $field)) {
+            static::$reflectionCache[$class][$field] = null;
+
+            return null;
+        }
+
+        $ref = new ReflectionProperty(static::class, $field);
+        static::$reflectionCache[$class][$field] = $ref->isStatic() ? null : $ref;
 
         return static::$reflectionCache[$class][$field];
     }
@@ -1531,6 +1532,12 @@ trait EntityTrait
      */
     protected function setRawValue(string $field, mixed $value): void
     {
+        if (array_key_exists($field, $this->dynamicFields)) {
+            $this->dynamicFields[$field] = $value;
+
+            return;
+        }
+
         $ref = static::getReflectionProperty($field);
 
         if ($ref === null) {
@@ -1552,10 +1559,14 @@ trait EntityTrait
      */
     protected function getRawValue(string $field): mixed
     {
+        if (array_key_exists($field, $this->dynamicFields)) {
+            return $this->dynamicFields[$field];
+        }
+
         $ref = static::getReflectionProperty($field);
 
         if ($ref === null) {
-            return $this->dynamicFields[$field] ?? null;
+            return null;
         }
 
         return $ref->getRawValue($this);

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -21,6 +21,7 @@ use Cake\Datasource\Exception\MissingPropertyException;
 use Cake\ORM\Entity;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
+use Error;
 use InvalidArgumentException;
 
 /**
@@ -32,11 +33,11 @@ use InvalidArgumentException;
 trait EntityTrait
 {
     /**
-     * Holds all fields and their values for this entity.
+     * Holds field names for initialized properties
      *
-     * @var array<string, mixed>
+     * @var array<string>
      */
-    protected array $fields = [];
+    protected array $propertyFields = [];
 
     /**
      * Holds all fields that have been changed and their original values for this entity.
@@ -143,6 +144,26 @@ trait EntityTrait
      * @var bool
      */
     protected bool $requireFieldPresence = false;
+
+    /**
+     * List of fields that can be dynamically set in this entity.
+     *
+     * @var list<string>
+     */
+    protected array $allowedDynamicFields = [
+        '_joinData',
+        '_matchingData',
+        '_locale',
+        '_translations',
+        '_i18n',
+    ];
+
+    /**
+     * Dynamically set field values.
+     *
+     * @var array<array-key, mixed>
+     */
+    protected array $dynamicFields = [];
 
     /**
      * Magic getter to access fields that have been set in this entity
@@ -282,7 +303,12 @@ trait EntityTrait
      */
     public function patch(array $values, array $options = []): static
     {
-        $options += ['setter' => true, 'guard' => true, 'asOriginal' => false];
+        $options += [
+            'setter' => true,
+            'guard' => true,
+            'asOriginal' => false,
+            'allowDynamic' => static::class === Entity::class ? true : false,
+        ];
 
         if ($options['asOriginal'] === true) {
             $this->setOriginalField(array_keys($values));
@@ -314,13 +340,28 @@ trait EntityTrait
             if (
                 $this->isOriginalField($name) &&
                 !array_key_exists($name, $this->original) &&
-                array_key_exists($name, $this->fields) &&
-                $value !== $this->fields[$name]
+                in_array($name, $this->propertyFields, true) &&
+                $value !== ($this->{$name} ?? null)
             ) {
-                $this->original[$name] = $this->fields[$name];
+                $this->original[$name] = $this->{$name} ?? null;
             }
 
-            $this->fields[$name] = $value;
+            if (!in_array($name, $this->propertyFields, true)) {
+                $this->propertyFields[] = $name;
+            }
+
+            if ($options['allowDynamic']) {
+                $propExists = property_exists($this, $name);
+
+                if (!$propExists) {
+                    $this->allowedDynamicFields[] = $name;
+                    $this->dynamicFields[$name] = $value;
+
+                    continue;
+                }
+            }
+
+            $this->{$name} = $value;
         }
 
         return $this;
@@ -340,11 +381,22 @@ trait EntityTrait
      */
     protected function isModified(string $field, mixed $value): bool
     {
-        if (!array_key_exists($field, $this->fields)) {
-            return true;
-        }
+        if (
+            in_array($field, $this->allowedDynamicFields, true)
+            && !property_exists($this, $field)
+        ) {
+            if (!array_key_exists($field, $this->dynamicFields)) {
+                return true;
+            }
 
-        $existing = $this->fields[$field] ?? null;
+            $existing = $this->dynamicFields[$field];
+        } else {
+            try {
+                $existing = $this->{$field};
+            } catch (Error) {
+                return true;
+            }
+        }
 
         if (($value === null || is_scalar($value)) && $existing === $value) {
             return false;
@@ -394,9 +446,15 @@ trait EntityTrait
 
         $value = null;
         $fieldIsPresent = false;
-        if (array_key_exists($field, $this->fields)) {
+
+        if (property_exists($this, $field)) {
             $fieldIsPresent = true;
-            $value = &$this->fields[$field];
+            $value = $this->{$field} ?? null;
+        } elseif (in_array($field, $this->allowedDynamicFields, true)) {
+            $fieldIsPresent = true;
+            if (array_key_exists($field, $this->dynamicFields)) {
+                $value = &$this->dynamicFields[$field];
+            }
         }
 
         $method = static::accessor($field, 'get');
@@ -473,12 +531,12 @@ trait EntityTrait
     {
         $originals = $this->original;
         $originalKeys = array_keys($originals);
-        foreach ($this->fields as $key => $value) {
+        foreach ($this->propertyFields as $key) {
             if (
                 !in_array($key, $originalKeys, true) &&
                 $this->isOriginalField($key)
             ) {
-                $originals[$key] = $value;
+                $originals[$key] = $this->{$key};
             }
         }
 
@@ -486,16 +544,24 @@ trait EntityTrait
     }
 
     /**
-     * Returns whether this entity contains a field named $field.
+     * Returns whether this entity contains a field named $field and is initialized.
      *
      * It will return `true` even for fields set to `null`.
      *
      * ### Example:
      *
      * ```
-     * $entity = new Entity(['id' => 1, 'name' => null]);
+     * class MyEntity extends Entity
+     * {
+     *    protected $id;
+     *    protected $name;
+     *    protected $first_name;
+     * }
+     *
+     * $entity = new MyEntity(['id' => 1, 'name' => null]);
      * $entity->has('id'); // true
      * $entity->has('name'); // true
+     * $entity->has('first_name'); // false
      * $entity->has('last_name'); // false
      * ```
      *
@@ -513,9 +579,22 @@ trait EntityTrait
      */
     public function has(array|string $field): bool
     {
-        return array_all((array)$field, function ($prop) {
-            return !(!array_key_exists($prop, $this->fields) && !static::accessor($prop, 'get'));
-        });
+        foreach ((array)$field as $prop) {
+            $exists = property_exists($this, $prop);
+            if (!$exists) {
+                if (!array_key_exists($prop, $this->dynamicFields) && !static::accessor($prop, 'get')) {
+                    return false;
+                }
+            } else {
+                try {
+                    $this->{$prop};
+                } catch (Error) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -540,10 +619,8 @@ trait EntityTrait
         $value = $this->get($field);
         if (
             $value === null ||
-            (
-                $value === [] ||
-                $value === ''
-            )
+            $value === [] ||
+            $value === ''
         ) {
             return false;
         }
@@ -568,7 +645,14 @@ trait EntityTrait
     {
         $field = (array)$field;
         foreach ($field as $p) {
-            unset($this->fields[$p], $this->dirty[$p]);
+            unset($this->dynamicFields[$p], $this->dirty[$p]);
+
+            $pos = array_search($p, $this->propertyFields, true);
+            if ($pos !== false) {
+                unset($this->propertyFields[$pos]);
+            }
+
+            unset($this->{$p});
         }
 
         return $this;
@@ -647,8 +731,7 @@ trait EntityTrait
      */
     public function getVisible(): array
     {
-        $fields = array_keys($this->fields);
-        $fields = array_merge($fields, $this->virtual);
+        $fields = array_merge($this->propertyFields, $this->virtual);
 
         return array_diff($fields, $this->hidden);
     }
@@ -964,7 +1047,7 @@ trait EntityTrait
         $this->errors = [];
         $this->invalid = [];
         $this->original = [];
-        $this->setOriginalField(array_keys($this->fields), false);
+        $this->setOriginalField($this->propertyFields, false);
     }
 
     /**
@@ -979,7 +1062,7 @@ trait EntityTrait
     public function setNew(bool $new): static
     {
         if ($new) {
-            foreach ($this->fields as $k => $p) {
+            foreach ($this->propertyFields as $k) {
                 $this->dirty[$k] = true;
             }
         }
@@ -1022,8 +1105,10 @@ trait EntityTrait
 
         $this->hasBeenVisited = true;
         try {
-            foreach ($this->fields as $field) {
-                if ($this->readHasErrors($field)) {
+            foreach ($this->propertyFields as $field) {
+                $value = $this->{$field};
+
+                if ($this->readHasErrors($value)) {
                     return true;
                 }
             }
@@ -1046,11 +1131,15 @@ trait EntityTrait
             return [];
         }
 
-        $diff = array_diff_key($this->fields, $this->errors);
+        $diff = array_diff_key($this->propertyFields, array_keys($this->errors));
+        $values = [];
+        foreach ($diff as $field) {
+            $values[$field] = $this->{$field};
+        }
 
         $this->hasBeenVisited = true;
         try {
-            $errors = $this->errors + new Collection($diff)
+            $errors = $this->errors + new Collection($values)
                 ->filter(function ($value) {
                     return is_array($value) || $value instanceof EntityInterface;
                 })
@@ -1420,15 +1509,21 @@ trait EntityTrait
      */
     public function __debugInfo(): array
     {
-        $fields = $this->fields;
+        $fields = [];
+        foreach ($this->propertyFields as $field) {
+            $fields[$field] = $this->{$field};
+        }
+        $fields += $this->dynamicFields;
+
         foreach ($this->virtual as $field) {
-            $fields[$field] = $this->$field;
+            $fields[$field] = $this->{$field};
         }
 
         return $fields + [
             '[new]' => $this->isNew(),
             '[patchable]' => $this->patchable,
             '[dirty]' => $this->dirty,
+            '[allowedDynamic]' => $this->allowedDynamicFields,
             '[original]' => $this->original,
             '[originalFields]' => $this->originalFields,
             '[virtual]' => $this->virtual,

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -324,7 +324,7 @@ trait EntityTrait
 
             if ($options['asOriginal'] || $this->isModified($name, $value)) {
                 $this->setDirty($name, true);
-            } else {
+            } elseif ($value !== null && !$this->propertyExists($name)) {
                 continue;
             }
 
@@ -560,21 +560,9 @@ trait EntityTrait
      */
     public function has(array|string $field): bool
     {
-        foreach ((array)$field as $prop) {
-            $exists = $this->propertyExists($prop);
-            if ($exists) {
-                try {
-                    // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
-                    @$this->{$prop};
-                } catch (Error) {
-                    return false;
-                }
-            } elseif (!array_key_exists($prop, $this->dynamicFields) && !static::accessor($prop, 'get')) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all((array)$field, function ($prop) {
+            return !(!in_array($prop, $this->propertyFields) && !static::accessor($prop, 'get'));
+        });
     }
 
     /**
@@ -623,16 +611,13 @@ trait EntityTrait
      */
     public function unset(array|string $field): static
     {
-        $field = (array)$field;
-        foreach ($field as $p) {
-            unset($this->dynamicFields[$p], $this->dirty[$p]);
+        foreach ((array)$field as $p) {
+            unset($this->dynamicFields[$p], $this->dirty[$p], $this->{$p});
 
             $pos = array_search($p, $this->propertyFields, true);
             if ($pos !== false) {
                 unset($this->propertyFields[$pos]);
             }
-
-            unset($this->{$p});
         }
 
         return $this;

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -154,25 +154,25 @@ trait EntityTrait
     /**
      * List of properties that are not treated as fields.
      *
-     * @var list<string>
+     * @var array<string, string>
      */
     protected static array $restrictedProperties = [
-        'dynamicFields',
-        'propertyFields',
-        'original',
-        'originalFields',
-        'hidden',
-        'virtual',
-        'dirty',
-        'accessors',
-        'new',
-        'errors',
-        'invalid',
-        'patchable',
-        'registryAlias',
-        'hasBeenVisited',
-        'requireFieldPresence',
-        'restrictedProperties',
+        'dynamicFields' => 'dynamicFields',
+        'propertyFields' => 'propertyFields',
+        'original' => 'original',
+        'originalFields' => 'originalFields',
+        'hidden' => 'hidden',
+        'virtual' => 'virtual',
+        'dirty' => 'dirty',
+        'accessors' => 'accessors',
+        'new' => 'new',
+        'errors' => 'errors',
+        'invalid' => 'invalid',
+        'patchable' => 'patchable',
+        'registryAlias' => 'registryAlias',
+        'hasBeenVisited' => 'hasBeenVisited',
+        'requireFieldPresence' => 'requireFieldPresence',
+        'restrictedProperties' => 'restrictedProperties',
     ];
 
     /**
@@ -1473,7 +1473,7 @@ trait EntityTrait
      */
     protected function propertyExists(string $field): bool
     {
-        return !in_array($field, static::$restrictedProperties, true) && property_exists($this, $field);
+        return !isset(static::$restrictedProperties[$field]) && property_exists($this, $field);
     }
 
     /**

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -152,7 +152,12 @@ trait EntityTrait
      */
     protected bool $requireFieldPresence = false;
 
-    protected array $restrictedProperties = [
+    /**
+     * List of properties that are not treated as fields.
+     *
+     * @var array<string>
+     */
+    protected static array $restrictedProperties = [
         'propertyFields',
         'original',
         'originalFields',
@@ -1475,7 +1480,7 @@ trait EntityTrait
      */
     protected function propertyExists(string $field): bool
     {
-        return !in_array($field, $this->restrictedProperties) && property_exists($this, $field);
+        return !in_array($field, static::$restrictedProperties) && property_exists($this, $field);
     }
 
     /**

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -618,7 +618,10 @@ trait EntityTrait
     public function unset(array|string $field): static
     {
         foreach ((array)$field as $p) {
-            unset($this->dynamicFields[$p], $this->dirty[$p], $this->{$p});
+            unset($this->dynamicFields[$p], $this->dirty[$p]);
+            if ($this->propertyExists($p)) {
+                unset($this->{$p});
+            }
 
             $pos = array_search($p, $this->propertyFields, true);
             if ($pos !== false) {
@@ -1102,7 +1105,7 @@ trait EntityTrait
             return [];
         }
 
-        $diff = array_diff_key($this->propertyFields, array_keys($this->errors));
+        $diff = array_diff($this->propertyFields, array_keys($this->errors));
         $values = [];
         foreach ($diff as $field) {
             $values[$field] = $this->{$field};
@@ -1480,7 +1483,7 @@ trait EntityTrait
      */
     protected function propertyExists(string $field): bool
     {
-        return !in_array($field, static::$restrictedProperties) && property_exists($this, $field);
+        return !in_array($field, static::$restrictedProperties, true) && property_exists($this, $field);
     }
 
     /**

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -55,7 +55,7 @@ trait EntityTrait
     /**
      * Holds all fields that have been initially set on instantiation, or after marking as clean
      *
-     * @var array<string>
+     * @var array<string, string>
      */
     protected array $originalFields = [];
 
@@ -306,16 +306,16 @@ trait EntityTrait
      * ```
      *
      * @param array<string, mixed> $values Map of fields with their respective values.
-     * @param array<string, mixed> $options Options to be used for setting the field. Allowed option
-     * keys are `setter`, `guard` and `asOriginal`
+     * @param array{setter?: bool, guard?: bool, asOriginal?: bool} $options Options to be used for setting the field.
      * @return $this
      * @throws \InvalidArgumentException
      */
     public function patch(array $values, array $options = []): static
     {
         $options += ['setter' => true, 'guard' => true, 'asOriginal' => false];
+        $asOriginal = $options['asOriginal'];
 
-        if ($options['asOriginal'] === true) {
+        if ($asOriginal) {
             $this->setOriginalField(array_keys($values));
         }
 
@@ -325,11 +325,11 @@ trait EntityTrait
                 throw new InvalidArgumentException('Cannot set an empty field');
             }
 
-            if ($options['guard'] === true && !$this->isPatchable($name)) {
+            if ($options['guard'] && !$this->isPatchable($name)) {
                 continue;
             }
 
-            if ($options['asOriginal'] || $this->isModified($name, $value)) {
+            if ($asOriginal || $this->isModified($name, $value)) {
                 $this->setDirty($name, true);
             } elseif (!$this->propertyExists($name)) {
                 continue;
@@ -637,14 +637,14 @@ trait EntityTrait
      */
     public function setHidden(array $fields, bool $merge = false): static
     {
-        if ($merge === false) {
-            $this->hidden = $fields;
+        if ($merge) {
+            $fields = array_merge($this->hidden, $fields);
+            $this->hidden = array_unique($fields);
 
             return $this;
         }
 
-        $fields = array_merge($this->hidden, $fields);
-        $this->hidden = array_unique($fields);
+        $this->hidden = $fields;
 
         return $this;
     }
@@ -668,14 +668,14 @@ trait EntityTrait
      */
     public function setVirtual(array $fields, bool $merge = false): static
     {
-        if ($merge === false) {
-            $this->virtual = $fields;
+        if ($merge) {
+            $fields = array_merge($this->virtual, $fields);
+            $this->virtual = array_unique($fields);
 
             return $this;
         }
 
-        $fields = array_merge($this->virtual, $fields);
-        $this->virtual = array_unique($fields);
+        $this->virtual = $fields;
 
         return $this;
     }
@@ -916,7 +916,7 @@ trait EntityTrait
      */
     public function isOriginalField(string $name): bool
     {
-        return in_array($name, $this->originalFields, true);
+        return isset($this->originalFields[$name]);
     }
 
     /**
@@ -927,7 +927,7 @@ trait EntityTrait
      */
     public function getOriginalFields(): array
     {
-        return $this->originalFields;
+        return array_values($this->originalFields);
     }
 
     /**
@@ -940,19 +940,16 @@ trait EntityTrait
      */
     protected function setOriginalField(string|array $field, bool $merge = true): static
     {
-        if (!$merge) {
-            $this->originalFields = (array)$field;
+        $field = (array)$field;
+        $field = array_combine($field, $field);
+
+        if ($merge) {
+            $this->originalFields += $field;
 
             return $this;
         }
 
-        $fields = (array)$field;
-        foreach ($fields as $field) {
-            $field = (string)$field;
-            if (!$this->isOriginalField($field)) {
-                $this->originalFields[] = $field;
-            }
-        }
+        $this->originalFields = $field;
 
         return $this;
     }
@@ -967,16 +964,15 @@ trait EntityTrait
      */
     public function setDirty(string $field, bool $isDirty = true): static
     {
-        if ($isDirty === false) {
-            $this->setOriginalField($field);
-
-            unset($this->dirty[$field], $this->original[$field]);
+        if ($isDirty) {
+            $this->dirty[$field] = true;
+            unset($this->errors[$field], $this->invalid[$field]);
 
             return $this;
         }
 
-        $this->dirty[$field] = true;
-        unset($this->errors[$field], $this->invalid[$field]);
+        $this->setOriginalField($field);
+        unset($this->dirty[$field], $this->original[$field]);
 
         return $this;
     }
@@ -1017,7 +1013,7 @@ trait EntityTrait
         $this->errors = [];
         $this->invalid = [];
         $this->original = [];
-        $this->setOriginalField(array_values($this->propertyFields), false);
+        $this->setOriginalField($this->propertyFields, false);
     }
 
     /**
@@ -1069,7 +1065,7 @@ trait EntityTrait
             return true;
         }
 
-        if ($includeNested === false) {
+        if (!$includeNested) {
             return false;
         }
 
@@ -1505,7 +1501,7 @@ trait EntityTrait
             '[patchable]' => $this->patchable,
             '[dirty]' => $this->dirty,
             '[original]' => $this->original,
-            '[originalFields]' => $this->originalFields,
+            '[originalFields]' => array_values($this->originalFields),
             '[virtual]' => $this->virtual,
             '[hasErrors]' => $this->hasErrors(),
             '[errors]' => $this->errors,

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -158,6 +158,7 @@ trait EntityTrait
      * @var array<string>
      */
     protected static array $restrictedProperties = [
+        'dynamicFields',
         'propertyFields',
         'original',
         'originalFields',
@@ -171,7 +172,7 @@ trait EntityTrait
         'registryAlias',
         'hasBeenVisited',
         'requireFieldPresence',
-        'dynamicFields',
+        'restrictedProperties',
     ];
 
     /**

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -20,6 +20,7 @@ use Cake\Collection\Collection;
 use Cake\Datasource\Exception\MissingPropertyException;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
+use Error;
 use InvalidArgumentException;
 use ReflectionProperty;
 
@@ -39,11 +40,15 @@ trait EntityTrait
     protected array $dynamicFields = [];
 
     /**
-     * Holds field names for initialized properties
+     * Tracks field names that have been routed into declared class properties
+     * through the entity API (set()/patch()/hydration).
      *
-     * @var array<string, string>
+     * Fields stored in $dynamicFields are tracked by that array's keys, this
+     * map only covers values living inside declared properties.
+     *
+     * @var array<string, true>
      */
-    protected array $propertyFields = [];
+    protected array $assignedProps = [];
 
     /**
      * Holds all fields that have been changed and their original values for this entity.
@@ -165,8 +170,8 @@ trait EntityTrait
      */
     protected static array $restrictedProperties = [
         'dynamicFields' => true,
-        'propertyFields' => true,
         'reflectionCache' => true,
+        'assignedProps' => true,
         'original' => true,
         'originalFields' => true,
         'hidden' => true,
@@ -358,16 +363,12 @@ trait EntityTrait
             if (
                 $this->isOriginalField($name) &&
                 !array_key_exists($name, $this->original) &&
-                isset($this->propertyFields[$name])
+                ($isDynamic || isset($this->assignedProps[$name]))
             ) {
                 $existing = $isDynamic ? $this->dynamicFields[$name] : $ref?->getRawValue($this);
                 if ($value !== $existing) {
                     $this->original[$name] = $existing;
                 }
-            }
-
-            if (!isset($this->propertyFields[$name])) {
-                $this->propertyFields[$name] = $name;
             }
 
             if ($useSetter) {
@@ -380,6 +381,10 @@ trait EntityTrait
                 $ref->setRawValue($this, $value);
             } else {
                 $this->dynamicFields[$name] = $value;
+            }
+
+            if ($ref !== null) {
+                $this->assignedProps[$name] = true;
             }
         }
 
@@ -540,7 +545,7 @@ trait EntityTrait
     public function getOriginalValues(): array
     {
         $originals = $this->original;
-        foreach ($this->propertyFields as $key) {
+        foreach ($this->initializedFieldNames() as $key) {
             if (
                 !array_key_exists($key, $originals) &&
                 $this->isOriginalField($key)
@@ -581,7 +586,9 @@ trait EntityTrait
     public function has(array|string $field): bool
     {
         return array_all((array)$field, function ($prop) {
-            return !(!isset($this->propertyFields[$prop]) && !static::accessor($prop, 'get'));
+            return array_key_exists($prop, $this->dynamicFields)
+                || isset($this->assignedProps[$prop])
+                || static::accessor($prop, 'get');
         });
     }
 
@@ -625,12 +632,10 @@ trait EntityTrait
     public function unset(array|string $field): static
     {
         foreach ((array)$field as $p) {
-            unset($this->dynamicFields[$p], $this->dirty[$p]);
+            unset($this->dynamicFields[$p], $this->dirty[$p], $this->assignedProps[$p]);
             if ($this->propertyExists($p)) {
                 unset($this->{$p});
             }
-
-            unset($this->propertyFields[$p]);
         }
 
         return $this;
@@ -709,7 +714,7 @@ trait EntityTrait
      */
     public function getVisible(): array
     {
-        $fields = array_merge($this->propertyFields, $this->virtual);
+        $fields = array_merge($this->initializedFieldNames(), $this->virtual);
 
         return array_values(array_diff($fields, $this->hidden));
     }
@@ -1021,7 +1026,7 @@ trait EntityTrait
         $this->errors = [];
         $this->invalid = [];
         $this->original = [];
-        $this->setOriginalField($this->propertyFields, false);
+        $this->setOriginalField($this->initializedFieldNames(), false);
     }
 
     /**
@@ -1036,7 +1041,7 @@ trait EntityTrait
     public function setNew(bool $new): static
     {
         if ($new) {
-            foreach ($this->propertyFields as $k) {
+            foreach ($this->initializedFieldNames() as $k) {
                 $this->dirty[$k] = true;
             }
         }
@@ -1079,7 +1084,7 @@ trait EntityTrait
 
         $this->hasBeenVisited = true;
         try {
-            foreach ($this->propertyFields as $field) {
+            foreach ($this->initializedFieldNames() as $field) {
                 $value = $this->getRawValue($field);
 
                 if ($this->readHasErrors($value)) {
@@ -1105,7 +1110,7 @@ trait EntityTrait
             return [];
         }
 
-        $diff = array_diff($this->propertyFields, array_keys($this->errors));
+        $diff = array_diff($this->initializedFieldNames(), array_keys($this->errors));
         $values = [];
         foreach ($diff as $field) {
             $values[$field] = $this->getRawValue($field);
@@ -1568,7 +1573,35 @@ trait EntityTrait
             return null;
         }
 
-        return $ref->getRawValue($this);
+        try {
+            return $ref->getRawValue($this);
+        } catch (Error) {
+            // Virtual properties without backing storage cannot be read raw.
+            // Fall back to the hooked read.
+            return $this->{$field};
+        }
+    }
+
+    /**
+     * Names of all fields that currently hold a value assigned through the
+     * entity API.
+     *
+     * @return list<string>
+     */
+    protected function initializedFieldNames(): array
+    {
+        /** @var list<string> $names */
+        $names = [];
+
+        foreach ($this->dynamicFields as $name => $_) {
+            $names[] = (string)$name;
+        }
+
+        foreach ($this->assignedProps as $name => $_) {
+            $names[] = $name;
+        }
+
+        return $names;
     }
 
     /**
@@ -1592,7 +1625,7 @@ trait EntityTrait
     public function __debugInfo(): array
     {
         $fields = [];
-        foreach ($this->propertyFields as $field) {
+        foreach ($this->initializedFieldNames() as $field) {
             $fields[$field] = $this->getRawValue($field);
         }
         $fields += $this->dynamicFields;

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -365,6 +365,7 @@ trait EntityTrait
                 !array_key_exists($name, $this->original) &&
                 ($isDynamic || isset($this->assignedProps[$name]))
             ) {
+                /** @phpstan-ignore-next-line method.nonObject */
                 $existing = $isDynamic ? $this->dynamicFields[$name] : $ref->getRawValue($this);
                 if ($value !== $existing) {
                     $this->original[$name] = $existing;

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -18,7 +18,6 @@ namespace Cake\Datasource;
 
 use Cake\Collection\Collection;
 use Cake\Datasource\Exception\MissingPropertyException;
-use Cake\ORM\Entity;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Error;
@@ -816,7 +815,7 @@ trait EntityTrait
             return static::$accessors[$class][$type][$property] = '';
         }
 
-        if (static::class === Entity::class) {
+        if (static::class === self::class) {
             return '';
         }
 

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -331,7 +331,9 @@ trait EntityTrait
 
             if ($options['asOriginal'] || $this->isModified($name, $value)) {
                 $this->setDirty($name, true);
-            } elseif ($value !== null && !$this->propertyExists($name)) {
+            } elseif (!$this->propertyExists($name)) {
+                continue;
+            } elseif ($value !== null) {
                 continue;
             }
 

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -592,15 +592,8 @@ trait EntityTrait
     public function hasValue(string $field): bool
     {
         $value = $this->get($field);
-        if (
-            $value === null ||
-            $value === [] ||
-            $value === ''
-        ) {
-            return false;
-        }
 
-        return true;
+        return !in_array($value, [null, [], ''], true);
     }
 
     /**

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -385,8 +385,12 @@ trait EntityTrait
         if ($this->propertyExists($field)) {
             try {
                 $existing = $this->{$field};
-            } catch (Error) {
-                return true;
+            } catch (Error $error) {
+                if (str_ends_with($error->getMessage(), 'must not be accessed before initialization')) {
+                    return true;
+                }
+
+                throw $error;
             }
         } else {
             if (!array_key_exists($field, $this->dynamicFields)) {

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -41,7 +41,7 @@ trait EntityTrait
     /**
      * Holds field names for initialized properties
      *
-     * @var array<string>
+     * @var array<string, string>
      */
     protected array $propertyFields = [];
 
@@ -345,14 +345,14 @@ trait EntityTrait
             if (
                 $this->isOriginalField($name) &&
                 !array_key_exists($name, $this->original) &&
-                in_array($name, $this->propertyFields, true) &&
+                isset($this->propertyFields[$name]) &&
                 $value !== ($this->{$name} ?? null)
             ) {
                 $this->original[$name] = $this->{$name} ?? null;
             }
 
-            if (!in_array($name, $this->propertyFields, true)) {
-                $this->propertyFields[] = $name;
+            if (!isset($this->propertyFields[$name])) {
+                $this->propertyFields[$name] = $name;
             }
 
             $propExists = $this->propertyExists($name);
@@ -526,10 +526,9 @@ trait EntityTrait
     public function getOriginalValues(): array
     {
         $originals = $this->original;
-        $originalKeys = array_keys($originals);
         foreach ($this->propertyFields as $key) {
             if (
-                !in_array($key, $originalKeys, true) &&
+                !array_key_exists($key, $originals) &&
                 $this->isOriginalField($key)
             ) {
                 $originals[$key] = $this->{$key};
@@ -568,7 +567,7 @@ trait EntityTrait
     public function has(array|string $field): bool
     {
         return array_all((array)$field, function ($prop) {
-            return !(!in_array($prop, $this->propertyFields) && !static::accessor($prop, 'get'));
+            return !(!isset($this->propertyFields[$prop]) && !static::accessor($prop, 'get'));
         });
     }
 
@@ -617,10 +616,7 @@ trait EntityTrait
                 unset($this->{$p});
             }
 
-            $pos = array_search($p, $this->propertyFields, true);
-            if ($pos !== false) {
-                unset($this->propertyFields[$pos]);
-            }
+            unset($this->propertyFields[$p]);
         }
 
         return $this;
@@ -701,7 +697,7 @@ trait EntityTrait
     {
         $fields = array_merge($this->propertyFields, $this->virtual);
 
-        return array_diff($fields, $this->hidden);
+        return array_values(array_diff($fields, $this->hidden));
     }
 
     /**
@@ -1015,7 +1011,7 @@ trait EntityTrait
         $this->errors = [];
         $this->invalid = [];
         $this->original = [];
-        $this->setOriginalField($this->propertyFields, false);
+        $this->setOriginalField(array_values($this->propertyFields), false);
     }
 
     /**

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -20,6 +20,7 @@ use Cake\Collection\Collection;
 use Cake\Datasource\Exception\MissingPropertyException;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
+use Error;
 use InvalidArgumentException;
 
 /**
@@ -31,11 +32,11 @@ use InvalidArgumentException;
 trait EntityTrait
 {
     /**
-     * Holds all fields and their values for this entity.
+     * Holds field names for initialized properties
      *
-     * @var array<string, mixed>
+     * @var array<string>
      */
-    protected array $fields = [];
+    protected array $propertyFields = [];
 
     /**
      * Holds all fields that have been changed and their original values for this entity.
@@ -142,6 +143,26 @@ trait EntityTrait
      * @var bool
      */
     protected bool $requireFieldPresence = false;
+
+    /**
+     * List of fields that can be dynamically set in this entity.
+     *
+     * @var list<string>
+     */
+    protected array $allowedDynamicFields = [
+        '_joinData',
+        '_matchingData',
+        '_locale',
+        '_translations',
+        '_i18n',
+    ];
+
+    /**
+     * Dynamically set field values.
+     *
+     * @var array<array-key, mixed>
+     */
+    protected array $dynamicFields = [];
 
     /**
      * Magic getter to access fields that have been set in this entity
@@ -281,7 +302,12 @@ trait EntityTrait
      */
     public function patch(array $values, array $options = []): static
     {
-        $options += ['setter' => true, 'guard' => true, 'asOriginal' => false];
+        $options += [
+            'setter' => true,
+            'guard' => true,
+            'asOriginal' => false,
+            'allowDynamic' => static::class === Entity::class ? true : false,
+        ];
 
         if ($options['asOriginal'] === true) {
             $this->setOriginalField(array_keys($values));
@@ -313,13 +339,28 @@ trait EntityTrait
             if (
                 $this->isOriginalField($name) &&
                 !array_key_exists($name, $this->original) &&
-                array_key_exists($name, $this->fields) &&
-                $value !== $this->fields[$name]
+                in_array($name, $this->propertyFields, true) &&
+                $value !== ($this->{$name} ?? null)
             ) {
-                $this->original[$name] = $this->fields[$name];
+                $this->original[$name] = $this->{$name} ?? null;
             }
 
-            $this->fields[$name] = $value;
+            if (!in_array($name, $this->propertyFields, true)) {
+                $this->propertyFields[] = $name;
+            }
+
+            if ($options['allowDynamic']) {
+                $propExists = property_exists($this, $name);
+
+                if (!$propExists) {
+                    $this->allowedDynamicFields[] = $name;
+                    $this->dynamicFields[$name] = $value;
+
+                    continue;
+                }
+            }
+
+            $this->{$name} = $value;
         }
 
         return $this;
@@ -339,11 +380,22 @@ trait EntityTrait
      */
     protected function isModified(string $field, mixed $value): bool
     {
-        if (!array_key_exists($field, $this->fields)) {
-            return true;
-        }
+        if (
+            in_array($field, $this->allowedDynamicFields, true)
+            && !property_exists($this, $field)
+        ) {
+            if (!array_key_exists($field, $this->dynamicFields)) {
+                return true;
+            }
 
-        $existing = $this->fields[$field] ?? null;
+            $existing = $this->dynamicFields[$field];
+        } else {
+            try {
+                $existing = $this->{$field};
+            } catch (Error) {
+                return true;
+            }
+        }
 
         if (($value === null || is_scalar($value)) && $existing === $value) {
             return false;
@@ -393,9 +445,15 @@ trait EntityTrait
 
         $value = null;
         $fieldIsPresent = false;
-        if (array_key_exists($field, $this->fields)) {
+
+        if (property_exists($this, $field)) {
             $fieldIsPresent = true;
-            $value = &$this->fields[$field];
+            $value = $this->{$field} ?? null;
+        } elseif (in_array($field, $this->allowedDynamicFields, true)) {
+            $fieldIsPresent = true;
+            if (array_key_exists($field, $this->dynamicFields)) {
+                $value = &$this->dynamicFields[$field];
+            }
         }
 
         $method = static::accessor($field, 'get');
@@ -472,12 +530,12 @@ trait EntityTrait
     {
         $originals = $this->original;
         $originalKeys = array_keys($originals);
-        foreach ($this->fields as $key => $value) {
+        foreach ($this->propertyFields as $key) {
             if (
                 !in_array($key, $originalKeys, true) &&
                 $this->isOriginalField($key)
             ) {
-                $originals[$key] = $value;
+                $originals[$key] = $this->{$key};
             }
         }
 
@@ -485,16 +543,24 @@ trait EntityTrait
     }
 
     /**
-     * Returns whether this entity contains a field named $field.
+     * Returns whether this entity contains a field named $field and is initialized.
      *
      * It will return `true` even for fields set to `null`.
      *
      * ### Example:
      *
      * ```
-     * $entity = new Entity(['id' => 1, 'name' => null]);
+     * class MyEntity extends Entity
+     * {
+     *    protected $id;
+     *    protected $name;
+     *    protected $first_name;
+     * }
+     *
+     * $entity = new MyEntity(['id' => 1, 'name' => null]);
      * $entity->has('id'); // true
      * $entity->has('name'); // true
+     * $entity->has('first_name'); // false
      * $entity->has('last_name'); // false
      * ```
      *
@@ -512,9 +578,22 @@ trait EntityTrait
      */
     public function has(array|string $field): bool
     {
-        return array_all((array)$field, function ($prop) {
-            return !(!array_key_exists($prop, $this->fields) && !static::accessor($prop, 'get'));
-        });
+        foreach ((array)$field as $prop) {
+            $exists = property_exists($this, $prop);
+            if (!$exists) {
+                if (!array_key_exists($prop, $this->dynamicFields) && !static::accessor($prop, 'get')) {
+                    return false;
+                }
+            } else {
+                try {
+                    $this->{$prop};
+                } catch (Error) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -539,10 +618,8 @@ trait EntityTrait
         $value = $this->get($field);
         if (
             $value === null ||
-            (
-                $value === [] ||
-                $value === ''
-            )
+            $value === [] ||
+            $value === ''
         ) {
             return false;
         }
@@ -567,7 +644,14 @@ trait EntityTrait
     {
         $field = (array)$field;
         foreach ($field as $p) {
-            unset($this->fields[$p], $this->dirty[$p]);
+            unset($this->dynamicFields[$p], $this->dirty[$p]);
+
+            $pos = array_search($p, $this->propertyFields, true);
+            if ($pos !== false) {
+                unset($this->propertyFields[$pos]);
+            }
+
+            unset($this->{$p});
         }
 
         return $this;
@@ -646,8 +730,7 @@ trait EntityTrait
      */
     public function getVisible(): array
     {
-        $fields = array_keys($this->fields);
-        $fields = array_merge($fields, $this->virtual);
+        $fields = array_merge($this->propertyFields, $this->virtual);
 
         return array_diff($fields, $this->hidden);
     }
@@ -963,7 +1046,7 @@ trait EntityTrait
         $this->errors = [];
         $this->invalid = [];
         $this->original = [];
-        $this->setOriginalField(array_keys($this->fields), false);
+        $this->setOriginalField($this->propertyFields, false);
     }
 
     /**
@@ -978,7 +1061,7 @@ trait EntityTrait
     public function setNew(bool $new): static
     {
         if ($new) {
-            foreach ($this->fields as $k => $p) {
+            foreach ($this->propertyFields as $k) {
                 $this->dirty[$k] = true;
             }
         }
@@ -1021,8 +1104,10 @@ trait EntityTrait
 
         $this->hasBeenVisited = true;
         try {
-            foreach ($this->fields as $field) {
-                if ($this->readHasErrors($field)) {
+            foreach ($this->propertyFields as $field) {
+                $value = $this->{$field};
+
+                if ($this->readHasErrors($value)) {
                     return true;
                 }
             }
@@ -1045,11 +1130,15 @@ trait EntityTrait
             return [];
         }
 
-        $diff = array_diff_key($this->fields, $this->errors);
+        $diff = array_diff_key($this->propertyFields, array_keys($this->errors));
+        $values = [];
+        foreach ($diff as $field) {
+            $values[$field] = $this->{$field};
+        }
 
         $this->hasBeenVisited = true;
         try {
-            $errors = $this->errors + new Collection($diff)
+            $errors = $this->errors + new Collection($values)
                 ->filter(function ($value) {
                     return is_array($value) || $value instanceof EntityInterface;
                 })
@@ -1419,15 +1508,21 @@ trait EntityTrait
      */
     public function __debugInfo(): array
     {
-        $fields = $this->fields;
+        $fields = [];
+        foreach ($this->propertyFields as $field) {
+            $fields[$field] = $this->{$field};
+        }
+        $fields += $this->dynamicFields;
+
         foreach ($this->virtual as $field) {
-            $fields[$field] = $this->$field;
+            $fields[$field] = $this->{$field};
         }
 
         return $fields + [
             '[new]' => $this->isNew(),
             '[patchable]' => $this->patchable,
             '[dirty]' => $this->dirty,
+            '[allowedDynamic]' => $this->allowedDynamicFields,
             '[original]' => $this->original,
             '[originalFields]' => $this->originalFields,
             '[virtual]' => $this->virtual,

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -32,6 +32,13 @@ use InvalidArgumentException;
 trait EntityTrait
 {
     /**
+     * Hold values fields which do not have corresponding class properties.
+     *
+     * @var array<array-key, mixed>
+     */
+    protected array $dynamicFields = [];
+
+    /**
      * Holds field names for initialized properties
      *
      * @var array<string>
@@ -144,25 +151,22 @@ trait EntityTrait
      */
     protected bool $requireFieldPresence = false;
 
-    /**
-     * List of fields that can be dynamically set in this entity.
-     *
-     * @var list<string>
-     */
-    protected array $allowedDynamicFields = [
-        '_joinData',
-        '_matchingData',
-        '_locale',
-        '_translations',
-        '_i18n',
+    protected array $restrictedProperties = [
+        'propertyFields',
+        'original',
+        'originalFields',
+        'hidden',
+        'virtual',
+        'dirty',
+        'new',
+        'errors',
+        'invalid',
+        'patchable',
+        'registryAlias',
+        'hasBeenVisited',
+        'requireFieldPresence',
+        'dynamicFields',
     ];
-
-    /**
-     * Dynamically set field values.
-     *
-     * @var array<array-key, mixed>
-     */
-    protected array $dynamicFields = [];
 
     /**
      * Magic getter to access fields that have been set in this entity
@@ -302,12 +306,7 @@ trait EntityTrait
      */
     public function patch(array $values, array $options = []): static
     {
-        $options += [
-            'setter' => true,
-            'guard' => true,
-            'asOriginal' => false,
-            'allowDynamic' => static::class === Entity::class ? true : false,
-        ];
+        $options += ['setter' => true, 'guard' => true, 'asOriginal' => false];
 
         if ($options['asOriginal'] === true) {
             $this->setOriginalField(array_keys($values));
@@ -349,18 +348,14 @@ trait EntityTrait
                 $this->propertyFields[] = $name;
             }
 
-            if ($options['allowDynamic']) {
-                $propExists = property_exists($this, $name);
+            $propExists = $this->propertyExists($name);
+            if ($propExists) {
+                $this->{$name} = $value;
 
-                if (!$propExists) {
-                    $this->allowedDynamicFields[] = $name;
-                    $this->dynamicFields[$name] = $value;
-
-                    continue;
-                }
+                continue;
             }
 
-            $this->{$name} = $value;
+            $this->dynamicFields[$name] = $value;
         }
 
         return $this;
@@ -380,21 +375,18 @@ trait EntityTrait
      */
     protected function isModified(string $field, mixed $value): bool
     {
-        if (
-            in_array($field, $this->allowedDynamicFields, true)
-            && !property_exists($this, $field)
-        ) {
-            if (!array_key_exists($field, $this->dynamicFields)) {
-                return true;
-            }
-
-            $existing = $this->dynamicFields[$field];
-        } else {
+        if ($this->propertyExists($field)) {
             try {
                 $existing = $this->{$field};
             } catch (Error) {
                 return true;
             }
+        } else {
+            if (!array_key_exists($field, $this->dynamicFields)) {
+                return true;
+            }
+
+            $existing = $this->dynamicFields[$field] ?? null;
         }
 
         if (($value === null || is_scalar($value)) && $existing === $value) {
@@ -446,14 +438,12 @@ trait EntityTrait
         $value = null;
         $fieldIsPresent = false;
 
-        if (property_exists($this, $field)) {
+        if ($this->propertyExists($field)) {
             $fieldIsPresent = true;
             $value = $this->{$field} ?? null;
-        } elseif (in_array($field, $this->allowedDynamicFields, true)) {
+        } elseif (array_key_exists($field, $this->dynamicFields)) {
             $fieldIsPresent = true;
-            if (array_key_exists($field, $this->dynamicFields)) {
-                $value = &$this->dynamicFields[$field];
-            }
+            $value = &$this->dynamicFields[$field];
         }
 
         $method = static::accessor($field, 'get');
@@ -543,24 +533,16 @@ trait EntityTrait
     }
 
     /**
-     * Returns whether this entity contains a field named $field and is initialized.
+     * Returns whether this entity contains a field named $field.
      *
      * It will return `true` even for fields set to `null`.
      *
      * ### Example:
      *
      * ```
-     * class MyEntity extends Entity
-     * {
-     *    protected $id;
-     *    protected $name;
-     *    protected $first_name;
-     * }
-     *
-     * $entity = new MyEntity(['id' => 1, 'name' => null]);
+     * $entity = new Entity(['id' => 1, 'name' => null]);
      * $entity->has('id'); // true
      * $entity->has('name'); // true
-     * $entity->has('first_name'); // false
      * $entity->has('last_name'); // false
      * ```
      *
@@ -579,17 +561,16 @@ trait EntityTrait
     public function has(array|string $field): bool
     {
         foreach ((array)$field as $prop) {
-            $exists = property_exists($this, $prop);
-            if (!$exists) {
-                if (!array_key_exists($prop, $this->dynamicFields) && !static::accessor($prop, 'get')) {
-                    return false;
-                }
-            } else {
+            $exists = $this->propertyExists($prop);
+            if ($exists) {
                 try {
-                    $this->{$prop};
+                    // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+                    @$this->{$prop};
                 } catch (Error) {
                     return false;
                 }
+            } elseif (!array_key_exists($prop, $this->dynamicFields) && !static::accessor($prop, 'get')) {
+                return false;
             }
         }
 
@@ -1501,6 +1482,17 @@ trait EntityTrait
     }
 
     /**
+     * Checks if a property exists and is not restricted.
+     *
+     * @param string $field The field name to check.
+     * @return bool
+     */
+    protected function propertyExists(string $field): bool
+    {
+        return !in_array($field, $this->restrictedProperties) && property_exists($this, $field);
+    }
+
+    /**
      * Returns an array that can be used to describe the internal state of this
      * object.
      *
@@ -1522,7 +1514,6 @@ trait EntityTrait
             '[new]' => $this->isNew(),
             '[patchable]' => $this->patchable,
             '[dirty]' => $this->dirty,
-            '[allowedDynamic]' => $this->allowedDynamicFields,
             '[original]' => $this->original,
             '[originalFields]' => $this->originalFields,
             '[virtual]' => $this->virtual,

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -342,7 +342,6 @@ trait EntityTrait
             $isDynamic = array_key_exists($name, $this->dynamicFields);
             $ref = $isDynamic ? null : static::getReflectionProperty($name);
 
-
             if ($asOriginal || $this->isModified($name, $value)) {
                 $this->setDirty($name, true);
             } elseif ($isDynamic || $ref === null || $value !== null) {

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -66,9 +66,6 @@ class Entity implements EntityInterface, InvalidPropertyInterface
         }
 
         if ($properties) {
-            // Remember the original field names here.
-            $this->setOriginalField(array_keys($properties));
-
             $this->patch($properties, [
                 'asOriginal' => true,
                 'setter' => $options['useSetters'],

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -55,7 +55,6 @@ class Entity implements EntityInterface, InvalidPropertyInterface
             'markNew' => null,
             'guard' => false,
             'source' => null,
-            'allowDynamic' => true,
         ];
 
         if ($options['source'] !== null) {
@@ -67,14 +66,13 @@ class Entity implements EntityInterface, InvalidPropertyInterface
         }
 
         if ($properties) {
-            //Remember the original field names here.
+            // Remember the original field names here.
             $this->setOriginalField(array_keys($properties));
 
             $this->patch($properties, [
                 'asOriginal' => true,
                 'setter' => $options['useSetters'],
                 'guard' => $options['guard'],
-                'allowDynamic' => $options['allowDynamic'],
             ]);
         }
 

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -66,6 +66,22 @@ class Entity implements EntityInterface, InvalidPropertyInterface
         }
 
         if ($properties) {
+            if ($options['markClean'] && !$options['useSetters'] && !$options['guard']) {
+                $this->setOriginalField(array_keys($properties));
+
+                foreach ($properties as $field => $value) {
+                    $rp = static::getReflectionProperty($field);
+                    if ($rp) {
+                        $rp->setRawValue($this, $value);
+                        $this->assignedProps[$field] = true;
+                    } else {
+                        $this->dynamicFields[$field] = $value;
+                    }
+                }
+
+                return;
+            }
+
             $this->patch($properties, [
                 'asOriginal' => true,
                 'setter' => $options['useSetters'],

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -55,6 +55,7 @@ class Entity implements EntityInterface, InvalidPropertyInterface
             'markNew' => null,
             'guard' => false,
             'source' => null,
+            'allowDynamic' => true,
         ];
 
         if ($options['source'] !== null) {
@@ -69,16 +70,11 @@ class Entity implements EntityInterface, InvalidPropertyInterface
             //Remember the original field names here.
             $this->setOriginalField(array_keys($properties));
 
-            if ($options['markClean'] && !$options['useSetters']) {
-                $this->fields = $properties;
-
-                return;
-            }
-
             $this->patch($properties, [
                 'asOriginal' => true,
                 'setter' => $options['useSetters'],
                 'guard' => $options['guard'],
+                'allowDynamic' => $options['allowDynamic'],
             ]);
         }
 

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -191,8 +191,6 @@ class EntityTest extends TestCase
     public function testSetOneParamWithSetter(): void
     {
         $entity = new class extends Entity {
-            protected string $name;
-
             protected function _setName(?string $name): string
             {
                 return 'Dr. ' . $name;
@@ -208,9 +206,6 @@ class EntityTest extends TestCase
     public function testMultipleWithSetter(): void
     {
         $entity = new class extends Entity {
-            protected string $name;
-            protected array $stuff;
-
             protected function _setName(?string $name): string
             {
                 return 'Dr. ' . $name;
@@ -233,9 +228,6 @@ class EntityTest extends TestCase
     public function testBypassSetters(): void
     {
         $entity = new class extends Entity {
-            protected string $name;
-            protected array $stuff;
-
             protected function _setName(?string $name): string
             {
                 throw new Exception('_setName should not have been called');
@@ -251,11 +243,11 @@ class EntityTest extends TestCase
         $entity->set('name', 'Jones', ['setter' => false]);
         $this->assertSame('Jones', $entity->name);
 
-        $entity->set('stuff', ['Thing'], ['setter' => false]);
-        $this->assertSame(['Thing'], $entity->stuff);
+        $entity->set('stuff', 'Thing', ['setter' => false]);
+        $this->assertSame('Thing', $entity->stuff);
 
-        $entity->patch(['name' => 'foo', 'stuff' => ['bar']], ['setter' => false]);
-        $this->assertSame(['bar'], $entity->stuff);
+        $entity->patch(['name' => 'foo', 'stuff' => 'bar'], ['setter' => false]);
+        $this->assertSame('bar', $entity->stuff);
     }
 
     /**
@@ -267,11 +259,11 @@ class EntityTest extends TestCase
 
         $entity
             ->shouldReceive('patch')
-            ->with(['a' => 'b', 'c' => 'd'], ['setter' => true, 'guard' => false, 'asOriginal' => true, 'allowDynamic' => true])
+            ->with(['a' => 'b', 'c' => 'd'], ['setter' => true, 'guard' => false, 'asOriginal' => true])
             ->once();
 
         $entity->shouldReceive('patch')
-            ->with(['foo' => 'bar'], ['setter' => false, 'guard' => false, 'asOriginal' => true, 'allowDynamic' => true])
+            ->with(['foo' => 'bar'], ['setter' => false, 'guard' => false, 'asOriginal' => true])
             ->once();
 
         $entity->__construct(['a' => 'b', 'c' => 'd']);
@@ -288,7 +280,7 @@ class EntityTest extends TestCase
 
         $entity
             ->shouldReceive('patch')
-            ->with(['foo' => 'bar'], ['setter' => true, 'guard' => true, 'asOriginal' => true, 'allowDynamic' => true])
+            ->with(['foo' => 'bar'], ['setter' => true, 'guard' => true, 'asOriginal' => true])
             ->once();
 
         $entity->__construct(['foo' => 'bar'], ['guard' => true]);
@@ -350,8 +342,6 @@ class EntityTest extends TestCase
     public function testGetCustomGetters(): void
     {
         $entity = new class extends Entity {
-            protected string $name;
-
             protected function _getName(string $name): string
             {
                 return 'Dr. ' . $name;
@@ -368,8 +358,6 @@ class EntityTest extends TestCase
     public function testGetCustomGettersAfterSet(): void
     {
         $entity = new class extends Entity {
-            protected string $name;
-
             protected function _getName(string $name): string
             {
                 return 'Dr. ' . $name;
@@ -390,8 +378,6 @@ class EntityTest extends TestCase
     public function testGetCacheClearedByUnset(): void
     {
         $entity = new class extends Entity {
-            protected string $name;
-
             protected function _getName(?string $name): string
             {
                 return 'Dr. ' . $name;
@@ -438,8 +424,6 @@ class EntityTest extends TestCase
     public function testMagicSetWithSetter(): void
     {
         $entity = new class extends Entity {
-            protected string $name;
-
             protected function _setName(?string $name): string
             {
                 return 'Dr. ' . $name;
@@ -455,8 +439,6 @@ class EntityTest extends TestCase
     public function testMagicSetWithSetterTitleCase(): void
     {
         $entity = new class extends Entity {
-            protected string $Name;
-
             protected function _setName(?string $name): string
             {
                 return 'Dr. ' . $name;
@@ -472,8 +454,6 @@ class EntityTest extends TestCase
     public function testMagicGetWithGetter(): void
     {
         $entity = new class extends Entity {
-            protected string $name;
-
             protected function _getName(string $name): string
             {
                 return 'Dr. ' . $name;
@@ -489,8 +469,6 @@ class EntityTest extends TestCase
     public function testMagicGetWithGetterTitleCase(): void
     {
         $entity = new class extends Entity {
-            protected string $Name;
-
             protected function _getName(string $name): string
             {
                 return 'Dr. ' . $name;
@@ -516,12 +494,7 @@ class EntityTest extends TestCase
      */
     public function testHas(): void
     {
-        $entity = new class (['id' => 1]) extends Entity {
-            protected $id;
-            protected $name;
-            protected $foo;
-            protected ?string $typed;
-        };
+        $entity = new Entity(['id' => 1]);
         $entity->name = 'Juan';
         $entity->foo = null;
         $this->assertTrue($entity->has('id'));
@@ -639,18 +612,19 @@ class EntityTest extends TestCase
      */
     public function testSetArrayAccess(): void
     {
-        $entity = Mockery::mock(Entity::class)->makePartial();
-        $entity->shouldReceive('set')
-            ->with('foo', 1)
-            ->once()
-            ->andReturnSelf();
-        $entity->shouldReceive('set')
-            ->with('bar', 2)
-            ->once()
-            ->andReturnSelf();
+        $entity = Mockery::spy(Entity::class)->makePartial();
+        $entity->setPatchable('*', true);
 
         $entity['foo'] = 1;
         $entity['bar'] = 2;
+
+        $entity->shouldHaveReceived('set')
+            ->with('foo', 1)
+            ->once();
+
+        $entity->shouldHaveReceived('set')
+            ->with('bar', 2)
+            ->once();
     }
 
     /**
@@ -673,9 +647,6 @@ class EntityTest extends TestCase
     public function testMethodCache(): void
     {
         $entity = new class extends Entity {
-            protected string $foo;
-            protected string $bar;
-
             protected function _setFoo(?string $name): string
             {
                 return 'Dr. ' . $name;
@@ -687,8 +658,6 @@ class EntityTest extends TestCase
             }
         };
         $entity2 = new class extends Entity {
-            protected string $bar;
-
             protected function _setBar(?string $name): string
             {
                 return 'DrDr. ' . $name;
@@ -707,8 +676,6 @@ class EntityTest extends TestCase
     public function testSetGetLongPropertyNames(): void
     {
         $entity = new class extends Entity {
-            protected string $very_long_property;
-
             protected function _setVeryLongProperty(?string $name): string
             {
                 return 'Dr. ' . $name;
@@ -1042,23 +1009,10 @@ class EntityTest extends TestCase
     public function testToArrayRecursive(): void
     {
         $data = ['id' => 1, 'name' => 'James', 'age' => 20, 'phones' => ['123', '457']];
-        $user = new class ($data) extends Entity {
-            protected $id;
-            protected $name;
-            protected $age;
-            protected $phones;
-            protected $comments;
-            protected $profile;
-        };
+        $user = new Extending($data);
         $comments = [
-            new class (['user_id' => 1, 'body' => 'Comment 1']) extends Entity {
-                protected $user_id;
-                protected $body;
-            },
-            new class (['user_id' => 1, 'body' => 'Comment 2']) extends Entity {
-                protected $user_id;
-                protected $body;
-            },
+            new NonExtending(['user_id' => 1, 'body' => 'Comment 1']),
+            new NonExtending(['user_id' => 1, 'body' => 'Comment 2']),
         ];
         $user->comments = $comments;
         $user->profile = new Entity(['email' => 'mark@example.com']);
@@ -1105,9 +1059,6 @@ class EntityTest extends TestCase
     public function testToArrayWithAccessor(): void
     {
         $entity = new class extends Entity {
-            protected string $name;
-            protected string $email;
-
             protected function _getName(?string $name): string
             {
                 return 'Jose';
@@ -1176,9 +1127,6 @@ class EntityTest extends TestCase
     public function testToArrayVirtualProperties(): void
     {
         $entity = new class extends Entity {
-            protected string $name;
-            protected string $email;
-
             protected function _getName(?string $name): string
             {
                 return 'Jose';
@@ -1217,25 +1165,21 @@ class EntityTest extends TestCase
      */
     public function testSetVirtualWithMerge(): void
     {
-        $data = ['virt' => 'sauce', 'name' => 'mark', 'id' => 1];
-        $entity = new class ($data) extends Entity {
-            protected $virt;
-            protected $name;
-            protected $id;
-        };
-        $entity->setVirtual(['virt']);
+        $data = ['virtual' => 'sauce', 'name' => 'mark', 'id' => 1];
+        $entity = new Entity($data);
+        $entity->setVirtual(['virtual']);
 
         $result = $entity->getVirtual();
-        $this->assertSame(['virt'], $result);
+        $this->assertSame(['virtual'], $result);
 
         $entity->setVirtual(['name'], true);
 
         $result = $entity->getVirtual();
-        $this->assertSame(['virt', 'name'], $result);
+        $this->assertSame(['virtual', 'name'], $result);
 
         $entity->setVirtual(['name'], true);
         $result = $entity->getVirtual();
-        $this->assertSame(['virt', 'name'], $result);
+        $this->assertSame(['virtual', 'name'], $result);
     }
 
     /**
@@ -1334,18 +1278,12 @@ class EntityTest extends TestCase
     {
         $user = new Entity();
         $owner = new NonExtending();
-        $author = new class ([
+        $author = new Extending([
             'foo' => 'bar',
             'thing' => 'baz',
             'user' => $user,
             'owner' => $owner,
-        ]) extends Entity {
-            protected $foo;
-            protected $thing;
-            protected $user;
-            protected $owner;
-            protected $multiple;
-        };
+        ]);
         $author->setError('thing', ['this is a mistake']);
         $user->setErrors(['a' => ['error1'], 'b' => ['error2']]);
         $owner->setErrors(['c' => ['error3'], 'd' => ['error4']]);
@@ -1635,7 +1573,6 @@ class EntityTest extends TestCase
             '[new]' => true,
             '[patchable]' => ['*' => true, 'id' => false, 'name' => true],
             '[dirty]' => ['somethingElse' => true, 'foo' => true],
-            '[allowedDynamic]' => ['_joinData', '_matchingData', '_locale', '_translations', '_i18n', 'foo', 'somethingElse'],
             '[original]' => [],
             '[originalFields]' => ['foo'],
             '[virtual]' => ['baz'],

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -191,6 +191,8 @@ class EntityTest extends TestCase
     public function testSetOneParamWithSetter(): void
     {
         $entity = new class extends Entity {
+            protected string $name;
+
             protected function _setName(?string $name): string
             {
                 return 'Dr. ' . $name;
@@ -206,6 +208,9 @@ class EntityTest extends TestCase
     public function testMultipleWithSetter(): void
     {
         $entity = new class extends Entity {
+            protected string $name;
+            protected array $stuff;
+
             protected function _setName(?string $name): string
             {
                 return 'Dr. ' . $name;
@@ -228,6 +233,9 @@ class EntityTest extends TestCase
     public function testBypassSetters(): void
     {
         $entity = new class extends Entity {
+            protected string $name;
+            protected array $stuff;
+
             protected function _setName(?string $name): string
             {
                 throw new Exception('_setName should not have been called');
@@ -243,11 +251,11 @@ class EntityTest extends TestCase
         $entity->set('name', 'Jones', ['setter' => false]);
         $this->assertSame('Jones', $entity->name);
 
-        $entity->set('stuff', 'Thing', ['setter' => false]);
-        $this->assertSame('Thing', $entity->stuff);
+        $entity->set('stuff', ['Thing'], ['setter' => false]);
+        $this->assertSame(['Thing'], $entity->stuff);
 
-        $entity->patch(['name' => 'foo', 'stuff' => 'bar'], ['setter' => false]);
-        $this->assertSame('bar', $entity->stuff);
+        $entity->patch(['name' => 'foo', 'stuff' => ['bar']], ['setter' => false]);
+        $this->assertSame(['bar'], $entity->stuff);
     }
 
     /**
@@ -259,11 +267,11 @@ class EntityTest extends TestCase
 
         $entity
             ->shouldReceive('patch')
-            ->with(['a' => 'b', 'c' => 'd'], ['setter' => true, 'guard' => false, 'asOriginal' => true])
+            ->with(['a' => 'b', 'c' => 'd'], ['setter' => true, 'guard' => false, 'asOriginal' => true, 'allowDynamic' => true])
             ->once();
 
         $entity->shouldReceive('patch')
-            ->with(['foo' => 'bar'], ['setter' => false, 'guard' => false, 'asOriginal' => true])
+            ->with(['foo' => 'bar'], ['setter' => false, 'guard' => false, 'asOriginal' => true, 'allowDynamic' => true])
             ->once();
 
         $entity->__construct(['a' => 'b', 'c' => 'd']);
@@ -280,7 +288,7 @@ class EntityTest extends TestCase
 
         $entity
             ->shouldReceive('patch')
-            ->with(['foo' => 'bar'], ['setter' => true, 'guard' => true, 'asOriginal' => true])
+            ->with(['foo' => 'bar'], ['setter' => true, 'guard' => true, 'asOriginal' => true, 'allowDynamic' => true])
             ->once();
 
         $entity->__construct(['foo' => 'bar'], ['guard' => true]);
@@ -342,6 +350,8 @@ class EntityTest extends TestCase
     public function testGetCustomGetters(): void
     {
         $entity = new class extends Entity {
+            protected string $name;
+
             protected function _getName(string $name): string
             {
                 return 'Dr. ' . $name;
@@ -358,6 +368,8 @@ class EntityTest extends TestCase
     public function testGetCustomGettersAfterSet(): void
     {
         $entity = new class extends Entity {
+            protected string $name;
+
             protected function _getName(string $name): string
             {
                 return 'Dr. ' . $name;
@@ -378,6 +390,8 @@ class EntityTest extends TestCase
     public function testGetCacheClearedByUnset(): void
     {
         $entity = new class extends Entity {
+            protected string $name;
+
             protected function _getName(?string $name): string
             {
                 return 'Dr. ' . $name;
@@ -424,6 +438,8 @@ class EntityTest extends TestCase
     public function testMagicSetWithSetter(): void
     {
         $entity = new class extends Entity {
+            protected string $name;
+
             protected function _setName(?string $name): string
             {
                 return 'Dr. ' . $name;
@@ -439,6 +455,8 @@ class EntityTest extends TestCase
     public function testMagicSetWithSetterTitleCase(): void
     {
         $entity = new class extends Entity {
+            protected string $Name;
+
             protected function _setName(?string $name): string
             {
                 return 'Dr. ' . $name;
@@ -454,6 +472,8 @@ class EntityTest extends TestCase
     public function testMagicGetWithGetter(): void
     {
         $entity = new class extends Entity {
+            protected string $name;
+
             protected function _getName(string $name): string
             {
                 return 'Dr. ' . $name;
@@ -469,6 +489,8 @@ class EntityTest extends TestCase
     public function testMagicGetWithGetterTitleCase(): void
     {
         $entity = new class extends Entity {
+            protected string $Name;
+
             protected function _getName(string $name): string
             {
                 return 'Dr. ' . $name;
@@ -494,7 +516,12 @@ class EntityTest extends TestCase
      */
     public function testHas(): void
     {
-        $entity = new Entity(['id' => 1]);
+        $entity = new class (['id' => 1]) extends Entity {
+            protected $id;
+            protected $name;
+            protected $foo;
+            protected ?string $typed;
+        };
         $entity->name = 'Juan';
         $entity->foo = null;
         $this->assertTrue($entity->has('id'));
@@ -612,19 +639,18 @@ class EntityTest extends TestCase
      */
     public function testSetArrayAccess(): void
     {
-        $entity = Mockery::spy(Entity::class)->makePartial();
-        $entity->setPatchable('*', true);
+        $entity = Mockery::mock(Entity::class)->makePartial();
+        $entity->shouldReceive('set')
+            ->with('foo', 1)
+            ->once()
+            ->andReturnSelf();
+        $entity->shouldReceive('set')
+            ->with('bar', 2)
+            ->once()
+            ->andReturnSelf();
 
         $entity['foo'] = 1;
         $entity['bar'] = 2;
-
-        $entity->shouldHaveReceived('set')
-            ->with('foo', 1)
-            ->once();
-
-        $entity->shouldHaveReceived('set')
-            ->with('bar', 2)
-            ->once();
     }
 
     /**
@@ -647,6 +673,9 @@ class EntityTest extends TestCase
     public function testMethodCache(): void
     {
         $entity = new class extends Entity {
+            protected string $foo;
+            protected string $bar;
+
             protected function _setFoo(?string $name): string
             {
                 return 'Dr. ' . $name;
@@ -658,6 +687,8 @@ class EntityTest extends TestCase
             }
         };
         $entity2 = new class extends Entity {
+            protected string $bar;
+
             protected function _setBar(?string $name): string
             {
                 return 'DrDr. ' . $name;
@@ -676,6 +707,8 @@ class EntityTest extends TestCase
     public function testSetGetLongPropertyNames(): void
     {
         $entity = new class extends Entity {
+            protected string $very_long_property;
+
             protected function _setVeryLongProperty(?string $name): string
             {
                 return 'Dr. ' . $name;
@@ -1009,10 +1042,23 @@ class EntityTest extends TestCase
     public function testToArrayRecursive(): void
     {
         $data = ['id' => 1, 'name' => 'James', 'age' => 20, 'phones' => ['123', '457']];
-        $user = new Extending($data);
+        $user = new class ($data) extends Entity {
+            protected $id;
+            protected $name;
+            protected $age;
+            protected $phones;
+            protected $comments;
+            protected $profile;
+        };
         $comments = [
-            new NonExtending(['user_id' => 1, 'body' => 'Comment 1']),
-            new NonExtending(['user_id' => 1, 'body' => 'Comment 2']),
+            new class (['user_id' => 1, 'body' => 'Comment 1']) extends Entity {
+                protected $user_id;
+                protected $body;
+            },
+            new class (['user_id' => 1, 'body' => 'Comment 2']) extends Entity {
+                protected $user_id;
+                protected $body;
+            },
         ];
         $user->comments = $comments;
         $user->profile = new Entity(['email' => 'mark@example.com']);
@@ -1059,6 +1105,9 @@ class EntityTest extends TestCase
     public function testToArrayWithAccessor(): void
     {
         $entity = new class extends Entity {
+            protected string $name;
+            protected string $email;
+
             protected function _getName(?string $name): string
             {
                 return 'Jose';
@@ -1127,6 +1176,9 @@ class EntityTest extends TestCase
     public function testToArrayVirtualProperties(): void
     {
         $entity = new class extends Entity {
+            protected string $name;
+            protected string $email;
+
             protected function _getName(?string $name): string
             {
                 return 'Jose';
@@ -1165,21 +1217,25 @@ class EntityTest extends TestCase
      */
     public function testSetVirtualWithMerge(): void
     {
-        $data = ['virtual' => 'sauce', 'name' => 'mark', 'id' => 1];
-        $entity = new Entity($data);
-        $entity->setVirtual(['virtual']);
+        $data = ['virt' => 'sauce', 'name' => 'mark', 'id' => 1];
+        $entity = new class ($data) extends Entity {
+            protected $virt;
+            protected $name;
+            protected $id;
+        };
+        $entity->setVirtual(['virt']);
 
         $result = $entity->getVirtual();
-        $this->assertSame(['virtual'], $result);
+        $this->assertSame(['virt'], $result);
 
         $entity->setVirtual(['name'], true);
 
         $result = $entity->getVirtual();
-        $this->assertSame(['virtual', 'name'], $result);
+        $this->assertSame(['virt', 'name'], $result);
 
         $entity->setVirtual(['name'], true);
         $result = $entity->getVirtual();
-        $this->assertSame(['virtual', 'name'], $result);
+        $this->assertSame(['virt', 'name'], $result);
     }
 
     /**
@@ -1278,12 +1334,18 @@ class EntityTest extends TestCase
     {
         $user = new Entity();
         $owner = new NonExtending();
-        $author = new Extending([
+        $author = new class ([
             'foo' => 'bar',
             'thing' => 'baz',
             'user' => $user,
             'owner' => $owner,
-        ]);
+        ]) extends Entity {
+            protected $foo;
+            protected $thing;
+            protected $user;
+            protected $owner;
+            protected $multiple;
+        };
         $author->setError('thing', ['this is a mistake']);
         $user->setErrors(['a' => ['error1'], 'b' => ['error2']]);
         $owner->setErrors(['c' => ['error3'], 'd' => ['error4']]);
@@ -1573,6 +1635,7 @@ class EntityTest extends TestCase
             '[new]' => true,
             '[patchable]' => ['*' => true, 'id' => false, 'name' => true],
             '[dirty]' => ['somethingElse' => true, 'foo' => true],
+            '[allowedDynamic]' => ['_joinData', '_matchingData', '_locale', '_translations', '_i18n', 'foo', 'somethingElse'],
             '[original]' => [],
             '[originalFields]' => ['foo'],
             '[virtual]' => ['baz'],

--- a/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
+++ b/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
@@ -1940,4 +1940,76 @@ class EntityWithConcretePropertiesTest extends TestCase
 
         $this->assertArrayHasKey('reflectionCache', $restricted);
     }
+
+    /**
+     * Tests that restricted properties cannot be get, set, checked, or unset
+     * via entity methods.
+     */
+    public function testRestrictedPropertiesCannotBeAccessedViaEntityMethods(): void
+    {
+        $entity = new class (['id' => 1, 'title' => 'test']) extends Entity {
+            protected int $id;
+            protected string $title;
+        };
+
+        foreach (['accessors', 'dirty'] as $name) {
+            $this->assertNull($entity->get($name), "get('{$name}') should return null");
+            $this->assertFalse($entity->has($name), "has('{$name}') should return false");
+            $this->assertFalse($entity->isDirty($name), "isDirty('{$name}') should return false");
+            $this->assertNull($entity->extract([$name])[$name], "extract(['{$name}']) should return null");
+        }
+    }
+
+    /**
+     * Tests that set() on restricted property names stores them as dynamic
+     * fields and does not corrupt internal state.
+     */
+    public function testSetRestrictedPropertyNameDoesNotCorruptState(): void
+    {
+        $entity = new class (['id' => 1, 'title' => 'test']) extends Entity {
+            protected int $id;
+            protected string $title;
+        };
+
+        // Setting a field named 'dirty' should not overwrite the internal $dirty array
+        $entity->set('dirty', 'some value');
+        $this->assertSame('some value', $entity->get('dirty'));
+        // Internal dirty tracking still works
+        $this->assertTrue($entity->isDirty('dirty'));
+        $this->assertTrue($entity->isDirty('id'));
+
+        // Setting 'errors' should not overwrite internal $errors array
+        $entity->set('errors', 'some error data');
+        $this->assertSame('some error data', $entity->get('errors'));
+        $this->assertSame([], $entity->getErrors());
+
+        // Setting 'new' should not change isNew()
+        $entity->set('new', false);
+        $this->assertTrue($entity->isNew());
+        $this->assertFalse($entity->get('new'));
+    }
+
+    /**
+     * Tests that unset() on restricted property names does not corrupt internal state.
+     */
+    public function testUnsetRestrictedPropertyNameDoesNotCorruptState(): void
+    {
+        $entity = new class (['id' => 1]) extends Entity {
+            protected int $id;
+        };
+
+        // Set then unset a field named after a restricted property
+        $entity->set('dirty', 'value');
+        $this->assertTrue($entity->has('dirty'));
+
+        $entity->unset('dirty');
+        $this->assertFalse($entity->has('dirty'));
+
+        // Internal dirty tracking still works
+        $this->assertTrue($entity->isDirty('id'));
+
+        // Unsetting 'errors' when it was never set as a field should be harmless
+        $entity->unset('errors');
+        $this->assertSame([], $entity->getErrors());
+    }
 }

--- a/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
+++ b/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
@@ -1,0 +1,1740 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         6.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\ORM;
+
+use Cake\Datasource\Exception\MissingPropertyException;
+use Cake\ORM\Entity;
+use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use Mockery;
+use stdClass;
+use TestApp\Model\Entity\UserWithProps;
+
+/**
+ * Entity with concrete properties test case.
+ */
+// phpcs:ignoreFile - PHPCS barfs on this file for some reason
+class EntityWithConcretePropertiesTest extends TestCase
+{
+    /**
+     * Tests setting a single property in an entity without custom setters
+     */
+    public function testSetOneParamNoSetters(): void
+    {
+        $entity = new class extends Entity {
+            protected $id;
+            protected $foo;
+        };
+
+        $this->assertNull($entity->getOriginal('foo'));
+        $entity->set('foo', 'bar', ['asOriginal' => true]);
+        $this->assertSame('bar', $entity->foo);
+        $this->assertSame('bar', $entity->getOriginal('foo'));
+
+        $entity->set('foo', 'baz');
+        $this->assertSame('baz', $entity->foo);
+        $this->assertSame('bar', $entity->getOriginal('foo'));
+
+        $entity->set('id', 1, ['asOriginal' => true]);
+        $this->assertSame(1, $entity->id);
+        $this->assertSame(1, $entity->getOriginal('id'));
+        $this->assertSame('bar', $entity->getOriginal('foo'));
+    }
+
+    /**
+     * Tests patching entity without custom setters
+     */
+    public function testPatchPropertiesNoSetters(): void
+    {
+        $entity = new class extends Entity {
+            protected $id;
+            protected $foo;
+            protected $thing;
+        };
+        $entity->setPatchable('*', true);
+
+        $entity->patch(['foo' => 'bar', 'id' => 1], ['asOriginal' => true]);
+        $this->assertSame('bar', $entity->foo);
+        $this->assertSame(1, $entity->id);
+
+        $entity->patch(['foo' => 'baz', 'id' => 2, 'thing' => 3]);
+        $this->assertSame('baz', $entity->foo);
+        $this->assertSame(2, $entity->id);
+        $this->assertSame(3, $entity->thing);
+        $this->assertSame('bar', $entity->getOriginal('foo'));
+        $this->assertSame(1, $entity->getOriginal('id'));
+    }
+
+    /**
+     * Test that getOriginal() retains falsey values.
+     */
+    public function testGetOriginal(): void
+    {
+        $entity = new class (['false' => false, 'null' => null, 'zero' => 0, 'empty' => ''], ['markNew' => true], ) extends Entity {
+            protected $false;
+            protected $null;
+            protected $zero;
+            protected $empty;
+        };
+
+        $this->assertNull($entity->getOriginal('null'));
+        $this->assertFalse($entity->getOriginal('false'));
+        $this->assertSame(0, $entity->getOriginal('zero'));
+        $this->assertSame('', $entity->getOriginal('empty'));
+
+        $entity->patch(['false' => 'y', 'null' => 'y', 'zero' => 'y', 'empty' => '']);
+        $this->assertNull($entity->getOriginal('null'));
+        $this->assertFalse($entity->getOriginal('false'));
+        $this->assertSame(0, $entity->getOriginal('zero'));
+        $this->assertSame('', $entity->getOriginal('empty'));
+    }
+
+    /**
+     * Test that getOriginal throws an exception for fields without original value
+     * when called with second parameter "false"
+     */
+    public function testGetOriginalFallback(): void
+    {
+        $entity = new class (['foo' => 'foo', 'bar' => 'bar'], ['markNew' => true], ) extends Entity {
+            protected $foo;
+            protected $bar;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot retrieve original value for field `baz`');
+        $entity->getOriginal('baz', false);
+    }
+
+    /**
+     * Test extractOriginal()
+     */
+    public function testExtractOriginal(): void
+    {
+        $entity = new class (['id' => 1, 'title' => 'original', 'body' => 'no', 'null' => null,], ['markNew' => true]) extends Entity {
+            protected $id;
+            protected $title;
+            protected $body;
+            protected $null;
+        };
+        $entity->set('body', 'updated body');
+        $result = $entity->extractOriginal(['id', 'title', 'body', 'null', 'undefined']);
+        $expected = [
+            'id' => 1,
+            'title' => 'original',
+            'body' => 'no',
+            'null' => null,
+        ];
+        $this->assertEquals($expected, $result);
+
+        $result = $entity->extractOriginalChanged(['id', 'title', 'body', 'null', 'undefined']);
+        $expected = [
+            'body' => 'no',
+        ];
+        $this->assertEquals($expected, $result);
+
+        $entity->set('null', 'not null');
+        $result = $entity->extractOriginalChanged(['id', 'title', 'body', 'null', 'undefined']);
+        $expected = [
+            'null' => null,
+            'body' => 'no',
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test that all original values are returned properly
+     */
+    public function testExtractOriginalValues(): void
+    {
+        $entity = new class (['id' => 1, 'title' => 'original', 'body' => 'no', 'null' => null,], ['markNew' => true]) extends Entity {
+            protected $id;
+            protected $title;
+            protected $body;
+            protected $null;
+        };
+        $entity->set('body', 'updated body');
+        $result = $entity->getOriginalValues();
+        $expected = [
+            'id' => 1,
+            'title' => 'original',
+            'body' => 'no',
+            'null' => null,
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Tests setting a single property using a setter function
+     */
+    public function testSetOneParamWithSetter(): void
+    {
+        $entity = new class extends Entity {
+            protected ?string $name {
+                set(?string $name) {
+                    $this->name = 'Dr. ' . $name;
+                }
+            }
+        };
+        $entity->set('name', 'Jones');
+        $this->assertSame('Dr. Jones', $entity->name);
+    }
+
+    /**
+     * Tests patching entity with multiple properties using a setter function
+     */
+    public function testPatchWithSetter(): void
+    {
+        $entity = new class extends Entity {
+            protected ?string $name {
+                set(?string $name) {
+                    $this->name = 'Dr. ' . $name;
+                }
+            }
+
+            protected ?array $stuff {
+                set(?array $stuff) {
+                    $this->stuff = ['c', 'd'];
+                }
+            }
+        };
+
+        $entity->setPatchable('*', true);
+        $entity->patch(['name' => 'Jones', 'stuff' => ['a', 'b']]);
+        $this->assertSame('Dr. Jones', $entity->name);
+        $this->assertEquals(['c', 'd'], $entity->stuff);
+    }
+
+    /**
+     * Tests getting properties with no custom getters
+     */
+    public function testGetNoGetters(): void
+    {
+        $entity = new class (['id' => 1, 'foo' => 'bar']) extends Entity {
+            protected $id;
+            protected $foo;
+        };
+        $this->assertSame(1, $entity->get('id'));
+        $this->assertSame('bar', $entity->get('foo'));
+    }
+
+    /**
+     * Test that accessing missing property via magic getter throws exception
+     */
+    public function testMissingPropertyException(): void
+    {
+        $this->expectException(MissingPropertyException::class);
+        $this->expectExceptionMessage('Property `not_present` does not exist for the entity');
+
+        $entity = new class (['is_present' => null]) extends Entity {
+            protected bool $requireFieldPresence = true;
+        };
+        $entity->not_present;
+    }
+
+    public function testNoMissingPropertyException(): void
+    {
+        $entity = new Entity();
+        $this->assertNull($entity->get('not_present'));
+
+        $entity = new class (['is_present' => null]) extends Entity {
+            protected ?bool $is_present;
+        };
+        $this->assertNull($entity->get('is_present'));
+
+        $entity = new class extends Entity {
+            protected array $_virtual = [
+                'bonus',
+            ];
+
+            protected $bonus {
+                get => 'bonus';
+            }
+        };
+        $this->assertSame('bonus', $entity->get('bonus'));
+    }
+
+    /**
+     * Tests get with custom getter
+     */
+    public function testGetCustomGetters(): void
+    {
+        $entity = new class extends Entity {
+            protected $name {
+                get => 'Dr. ' . $this->name;
+            }
+        };
+        $entity->set('name', 'Jones');
+        $this->assertSame('Dr. Jones', $entity->get('name'));
+    }
+
+    /**
+     * Tests get with custom getter
+     */
+    public function testGetCustomGettersAfterSet(): void
+    {
+        $entity = new class extends Entity {
+            protected $name {
+                get => 'Dr. ' . $this->name;
+            }
+        };
+        $entity->set('name', 'Jones');
+        $this->assertSame('Dr. Jones', $entity->get('name'));
+
+        $entity->set('name', 'Mark');
+        $this->assertSame('Dr. Mark', $entity->get('name'));
+    }
+
+    /**
+     * Test getting camelcased virtual fields.
+     */
+    public function testGetCamelCasedProperties(): void
+    {
+        $entity = new class extends Entity {
+            protected $list_id_name {
+                get => 'A name';
+            }
+        };
+        $entity->setVirtual(['list_id_name']);
+        $this->assertSame('A name', $entity->list_id_name);
+    }
+
+    /**
+     * Test magic property setting with no custom setter
+     */
+    public function testMagicSet(): void
+    {
+        $entity = new class extends Entity {
+            protected $name;
+        };
+        $entity->name = 'Jones';
+        $this->assertSame('Jones', $entity->name);
+        $entity->name = 'George';
+        $this->assertSame('George', $entity->name);
+    }
+
+    /**
+     * Tests magic set with custom setter function
+     */
+    public function testMagicSetWithSetter(): void
+    {
+        $entity = new class extends Entity {
+            protected ?string $name {
+                set(?string $name) {
+                    $this->name = 'Dr. ' . $name;
+                }
+            }
+        };
+        $entity->name = 'Jones';
+        $this->assertSame('Dr. Jones', $entity->name);
+    }
+
+    /**
+     * Tests magic set with custom setter function using a Title cased property
+     */
+    public function testMagicSetWithSetterTitleCase(): void
+    {
+        $entity = new class extends Entity {
+            protected ?string $Name {
+                set(?string $name) {
+                    $this->Name = 'Dr. ' . $name;
+                }
+            }
+        };
+        $entity->Name = 'Jones';
+        $this->assertSame('Dr. Jones', $entity->Name);
+    }
+
+    /**
+     * Tests the magic getter with a custom getter function
+     */
+    public function testMagicGetWithGetter(): void
+    {
+        $entity = new class extends Entity {
+            protected $name {
+                get => 'Dr. ' . $this->name;
+            }
+        };
+        $entity->set('name', 'Jones');
+        $this->assertSame('Dr. Jones', $entity->name);
+    }
+
+    /**
+     * Tests magic get with custom getter function using a Title cased property
+     */
+    public function testMagicGetWithGetterTitleCase(): void
+    {
+        $entity = new class extends Entity {
+            protected $Name {
+                get => 'Dr. ' . $this->Name;
+            }
+        };
+        $entity->set('Name', 'Jones');
+        $this->assertSame('Dr. Jones', $entity->Name);
+    }
+
+    /**
+     * Test indirectly modifying internal properties
+     */
+    public function testIndirectModificationFailure(): void
+    {
+        $entity = new class extends Entity {
+            protected $things;
+        };
+        $entity->things = ['a', 'b'];
+        $entity->things[] = 'c';
+        $this->assertEquals(['a', 'b'], $entity->things);
+
+        $entity->things = array_merge($entity->things, ['c']);
+        $this->assertEquals(['a', 'b', 'c'], $entity->things);
+    }
+
+    /**
+     * Tests has() method
+     */
+    public function testHas(): void
+    {
+        $entity = new class (['id' => 1]) extends Entity {
+            protected $id;
+            protected $name;
+            protected $foo;
+            protected ?string $typed;
+        };
+        $entity->name = 'Juan';
+        $entity->foo = null;
+        $this->assertTrue($entity->has('id'));
+        $this->assertTrue($entity->has('name'));
+        $this->assertTrue($entity->has('foo'));
+        $this->assertFalse($entity->has('typed'));
+        $this->assertFalse($entity->has('last_name'));
+
+        $entity->typed = null;
+        $this->assertTrue($entity->has('typed'));
+
+        $this->assertTrue($entity->has(['id']));
+        $this->assertTrue($entity->has(['id', 'name']));
+        $this->assertTrue($entity->has(['id', 'foo']));
+        $this->assertFalse($entity->has(['id', 'nope']));
+
+        $entity->foo = null;
+        $this->assertTrue($entity->has('foo'));
+    }
+
+    /**
+     * Tests unset one property at a time
+     */
+    public function testUnset(): void
+    {
+        $entity = new class (['id' => 1, 'name' => 'bar']) extends Entity {
+            protected $id;
+            protected string $name = 'admad';
+        };
+        $entity->unset('id');
+        // Untyped properties are implicitly initialized to null, so they will still be "present" after unsetting.
+        $this->assertTrue($entity->has('id'));
+        $this->assertTrue($entity->has('name'));
+        $entity->unset('name');
+        $this->assertFalse($entity->has('name'));
+
+        $this->assertSame([], $entity->toArray());
+    }
+
+    /**
+     * Unsetting a property should not mark it as dirty.
+     */
+    public function testUnsetMakesClean(): void
+    {
+        $entity = new class (['id' => 1, 'name' => 'bar']) extends Entity {
+            protected $id;
+            protected $name;
+        };
+        $this->assertTrue($entity->isDirty('name'));
+        $entity->unset('name');
+        $this->assertFalse($entity->isDirty('name'), 'Removed properties are not dirty.');
+    }
+
+    /**
+     * Tests the magic __isset() method
+     */
+    public function testMagicIsset(): void
+    {
+        $entity = new class (['id' => 1, 'name' => 'Juan', 'foo' => null]) extends Entity {
+            protected $id;
+            protected $name;
+            protected $foo;
+        };
+        $this->assertTrue(isset($entity->id));
+        $this->assertTrue(isset($entity->name));
+        $this->assertFalse(isset($entity->foo));
+        $this->assertFalse(isset($entity->thing));
+    }
+
+    /**
+     * Tests the magic __unset() method
+     */
+    public function testMagicUnset(): void
+    {
+        $entity = $this->getMockBuilder(Entity::class)
+            ->onlyMethods(['unset'])
+            ->getMock();
+        $entity->expects($this->once())
+            ->method('unset')
+            ->with('foo');
+        unset($entity->foo);
+    }
+
+    /**
+     * Tests isset with array access
+     */
+    public function testIssetArrayPatchable(): void
+    {
+        $entity = new class (['id' => 1, 'name' => 'Juan', 'foo' => null]) extends Entity {
+            protected $id;
+            protected $name;
+            protected $foo;
+        };
+        $this->assertArrayHasKey('id', $entity);
+        $this->assertArrayHasKey('name', $entity);
+        $this->assertArrayNotHasKey('foo', $entity);
+    }
+
+    /**
+     * Tests get property with array access
+     */
+    public function testGetArrayPatchable(): void
+    {
+        $entity = $this->getMockBuilder(Entity::class)
+            ->onlyMethods(['get'])
+            ->getMock();
+        $entity->expects($this->exactly(2))
+            ->method('get')
+            ->with(
+                ...self::withConsecutive(['foo'], ['bar']),
+            )
+            ->willReturn('worked', 'worked too');
+
+        $this->assertSame('worked', $entity['foo']);
+        $this->assertSame('worked too', $entity['bar']);
+    }
+
+    /**
+     * Tests set with array access
+     */
+    public function testSetArrayPatchable(): void
+    {
+        $entity = $this->getMockBuilder(Entity::class)
+            ->onlyMethods(['set'])
+            ->getMock();
+        $entity->setPatchable('*', true);
+
+        $entity->expects($this->exactly(2))
+            ->method('set')
+            ->with(
+                ...self::withConsecutive(['foo', 1], ['bar', 2]),
+            )
+            ->willReturnSelf();
+
+        $entity['foo'] = 1;
+        $entity['bar'] = 2;
+    }
+
+    /**
+     * Tests unset with array access
+     */
+    public function testUnsetArrayPatchable(): void
+    {
+        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
+        $entity = $this->getMockBuilder(Entity::class)
+            ->onlyMethods(['unset'])
+            ->getMock();
+        $entity->expects($this->once())
+            ->method('unset')
+            ->with('foo');
+        unset($entity['foo']);
+    }
+
+    /**
+     * Tests serializing an entity as JSON
+     */
+    public function testJsonSerialize(): void
+    {
+        $data = ['name' => 'James', 'age' => 20, 'phones' => ['123', '457']];
+        $entity = new class ($data) extends Entity {
+            protected $name;
+            protected $age;
+            protected $phones;
+        };
+        $this->assertEquals(json_encode($data), json_encode($entity));
+    }
+
+    /**
+     * Tests serializing an entity as PHP
+     */
+    public function testPhpSerialize(): void
+    {
+        $data = ['username' => 'james', 'password' => 'mypass', 'articles' => ['123', '457']];
+        $entity = new UserWithProps($data);
+        $copy = unserialize(serialize($entity));
+        $this->assertInstanceOf(Entity::class, $copy);
+        $this->assertEquals($data, $copy->toArray());
+    }
+
+    /**
+     * Tests that jsonSerialize is called recursively for contained entities
+     */
+    public function testJsonSerializeRecursive(): void
+    {
+        $phone = $this->getMockBuilder(Entity::class)
+            ->onlyMethods(['jsonSerialize'])
+            ->getMock();
+        $phone->expects($this->once())->method('jsonSerialize')->willReturn(['something']);
+        $data = ['name' => 'James', 'age' => 20, 'phone' => $phone];
+        $entity = new class ($data) extends Entity {
+            protected $name;
+            protected $age;
+            protected $phone;
+        };
+        $expected = ['name' => 'James', 'age' => 20, 'phone' => ['something']];
+        $this->assertEquals(json_encode($expected), json_encode($entity));
+    }
+
+    /**
+     * Tests the extract method
+     */
+    public function testExtract(): void
+    {
+        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3,]) extends Entity {
+            protected $id;
+            protected $title;
+            protected $author_id;
+        };
+        $expected = ['author_id' => 3, 'title' => 'Foo',];
+        $this->assertEquals($expected, $entity->extract(['author_id', 'title']));
+
+        $expected = ['id' => 1];
+        $this->assertEquals($expected, $entity->extract(['id']));
+
+        $expected = [];
+        $this->assertEquals($expected, $entity->extract([]));
+
+        $expected = ['craziness' => null];
+        $entity = new Entity();
+        $this->assertEquals($expected, $entity->extract(['craziness']));
+    }
+
+    public function testExtractNonExistent(): void
+    {
+        $entity = new class extends Entity {};
+        $this->assertSame(['craziness' => null], $entity->extract(['craziness']));
+    }
+
+    /**
+     * Tests isDirty() method on a newly created object
+     */
+    public function testIsDirty(): void
+    {
+        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3,]) extends Entity {
+            protected $id;
+            protected $title;
+            protected $author_id;
+            protected ?bool $is_approved = null;
+        };
+        $this->assertTrue($entity->isDirty('id'));
+        $this->assertTrue($entity->isDirty('title'));
+        $this->assertTrue($entity->isDirty('author_id'));
+        $this->assertFalse($entity->isDirty('is_approved'));
+
+        $this->assertTrue($entity->isDirty());
+
+        $entity->setDirty('id', false);
+        $this->assertFalse($entity->isDirty('id'));
+        $this->assertTrue($entity->isDirty('title'));
+
+        $entity->setDirty('title', false);
+        $this->assertFalse($entity->isDirty('title'));
+        $this->assertTrue($entity->isDirty(), 'should be dirty, one field left');
+
+        $entity->setDirty('author_id', false);
+        $this->assertFalse($entity->isDirty(), 'all fields are clean.');
+
+        $entity->is_approved = true;
+        $this->assertTrue($entity->isDirty('is_approved'));
+
+        $entity2 = new class (['id' => 1, 'title' => 'Foo',], ['markClean' => true]) extends Entity {
+            protected $id;
+            protected $title;
+            protected ?bool $is_approved = null;
+        };
+        $this->assertFalse($entity2->isDirty());
+        $this->assertFalse($entity2->isDirty('title'));
+
+        $entity2->is_approved = true;
+        $this->assertTrue($entity2->isDirty('is_approved'));
+
+        $this->assertTrue($entity2->isDirty());
+
+        $entity2->title = 'bar';
+        $this->assertTrue($entity2->isDirty('title'));
+
+        $entity = new Entity(['title' => 'foo']);
+        $this->assertTrue($entity->isDirty('title'));
+    }
+
+    /**
+     * Test setDirty().
+     */
+    public function testSetDirty(): void
+    {
+        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3,], ['markClean' => true]) extends Entity {
+            protected $id;
+            protected $title;
+            protected $author_id;
+        };
+
+        $this->assertFalse($entity->isDirty());
+        $this->assertSame($entity, $entity->setDirty('title'));
+        $this->assertSame($entity, $entity->setDirty('id', false));
+
+        $entity->setErrors(['title' => ['badness']]);
+        $entity->setDirty('title', true);
+        $this->assertEmpty($entity->getErrors(), 'Making a field dirty clears errors.');
+    }
+
+    /**
+     * Tests dirty() when altering properties values and adding new ones
+     */
+    public function testDirtyChangingProperties(): void
+    {
+        $entity = new class (['title' => 'Foo']) extends Entity {
+            protected string $title;
+            protected string $something;
+        };
+
+        $entity->setDirty('title', false);
+        $this->assertFalse($entity->isDirty('title'));
+
+        $entity->set('title', 'Foo');
+        $this->assertFalse($entity->isDirty('title'));
+
+        $entity->set('title', 'Bar');
+        $this->assertTrue($entity->isDirty('title'));
+
+        $entity->set('something', 'else');
+        $this->assertTrue($entity->isDirty('something'));
+    }
+
+    /**
+     * Tests extract only dirty properties
+     */
+    public function testExtractDirty(): void
+    {
+        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3,]) extends Entity {
+            protected $id;
+            protected $title;
+            protected $author_id;
+        };
+        $entity->setDirty('id', false);
+        $entity->setDirty('title', false);
+        $expected = ['author_id' => 3];
+        $result = $entity->extract(['id', 'title', 'author_id'], true);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Tests the getDirty method
+     */
+    public function testGetDirty(): void
+    {
+        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3,]) extends Entity {
+            protected $id;
+            protected $title;
+            protected $author_id;
+        };
+
+        $expected = [
+            'id',
+            'title',
+            'author_id',
+        ];
+        $this->assertSame($expected, $entity->getDirty());
+    }
+
+    /**
+     * Tests the clean method
+     */
+    public function testClean(): void
+    {
+        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3,]) extends Entity {
+            protected $id;
+            protected $title;
+            protected $author_id;
+        };
+        $this->assertTrue($entity->isDirty('id'));
+        $this->assertTrue($entity->isDirty('title'));
+        $this->assertTrue($entity->isDirty('author_id'));
+
+        $entity->clean();
+        $this->assertFalse($entity->isDirty('id'));
+        $this->assertFalse($entity->isDirty('title'));
+        $this->assertFalse($entity->isDirty('author_id'));
+    }
+
+    /**
+     * Tests the isNew method
+     */
+    public function testIsNew(): void
+    {
+        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3,]) extends Entity {
+            protected $id;
+            protected $title;
+            protected $author_id;
+        };
+        $this->assertTrue($entity->isNew());
+
+        $entity->setNew(true);
+        $this->assertTrue($entity->isNew());
+
+        $entity->setNew(false);
+        $this->assertFalse($entity->isNew());
+    }
+
+    /**
+     * Tests the constructor when passing the markClean option
+     */
+    public function testConstructorWithClean(): void
+    {
+        $mock = Mockery::mock(Entity::class)->makePartial();
+        $mock->shouldReceive('clean')->never();
+        $mock->__construct();
+
+        $entity = new class extends Entity {
+            protected $id;
+        };
+
+        $mock = Mockery::mock($entity::class)->makePartial();
+        $mock->shouldReceive('clean')->once();
+        $mock->__construct([], ['markClean' => true]);
+
+        $mock = Mockery::mock($entity::class)->makePartial();
+        $mock->shouldReceive('clean')->once();
+        $mock->__construct(['id' => 1], ['markClean' => true]);
+    }
+
+    /**
+     * Tests the constructor when passing the markClean option
+     */
+    public function testConstructorWithMarkNew(): void
+    {
+        $mock = Mockery::mock(Entity::class)->makePartial();
+        $mock->shouldReceive('setNew')->never();
+        $mock->__construct();
+
+        $mock = Mockery::mock(Entity::class)->makePartial();
+        $mock->shouldReceive('setNew')->once();
+        $mock->__construct([], ['markNew' => true]);
+    }
+
+    public function testConstructorWithDynamicField(): void
+    {
+        $entiy = new Entity(['foo' => 'bar']);
+        $this->assertSame('bar', $entiy->foo);
+    }
+
+    /**
+     * Test toArray method.
+     */
+    public function testToArray(): void
+    {
+        $data = ['name' => 'James', 'age' => 20, 'phones' => ['123', '457']];
+        $entity = new class ($data) extends Entity {
+            protected $name;
+            protected $age;
+            protected $phones;
+        };
+
+        $this->assertEquals($data, $entity->toArray());
+    }
+
+    /**
+     * Test toArray recursive.
+     */
+    public function testToArrayRecursive(): void
+    {
+        $data = ['id' => 1, 'name' => 'James', 'age' => 20, 'phones' => ['123', '457']];
+        $user = new class ($data) extends Entity {
+            protected $id;
+            protected $name;
+            protected $age;
+            protected $phones;
+            protected $comments;
+            protected $profile;
+        };
+        $comments = [
+            new class (['user_id' => 1, 'body' => 'Comment 1']) extends Entity {
+            protected $user_id;
+            protected $body;
+            },
+            new class (['user_id' => 1, 'body' => 'Comment 2']) extends Entity {
+            protected $user_id;
+            protected $body;
+            },
+        ];
+        $user->comments = $comments;
+        $user->profile = new class (['email' => 'mark@example.com']) extends Entity {
+            protected $email;
+        };
+
+        $expected = [
+            'id' => 1,
+            'name' => 'James',
+            'age' => 20,
+            'phones' => ['123', '457'],
+            'profile' => ['email' => 'mark@example.com'],
+            'comments' => [
+                ['user_id' => 1, 'body' => 'Comment 1'],
+                ['user_id' => 1, 'body' => 'Comment 2'],
+            ],
+        ];
+        $this->assertEquals($expected, $user->toArray());
+    }
+
+    /**
+     * Tests that an entity with entities and other misc types can be properly toArray'd
+     */
+    public function testToArrayMixed(): void
+    {
+        $test = new class (['id' => 1, 'foo' => [new class (['hi' => 'test']) extends Entity {
+            protected $hi;
+        },
+            'notentity' => 1,
+        ],
+        ]) extends Entity {
+            protected $id;
+            protected $foo;
+        };
+        $expected = [
+            'id' => 1,
+            'foo' => [
+                ['hi' => 'test'],
+                'notentity' => 1,
+            ],
+        ];
+        $this->assertEquals($expected, $test->toArray());
+    }
+
+    /**
+     * Test that get accessors are called when converting to arrays.
+     */
+    public function testToArrayWithPatchableor(): void
+    {
+        $entity = new class extends Entity {
+            protected $name {
+                get => 'Mr. ' . $this->name;
+            }
+            protected $email;
+        };
+        $entity->setPatchable('*', true);
+        $entity->patch(['name' => 'Mark', 'email' => 'mark@example.com']);
+        $expected = ['name' => 'Mr. Mark', 'email' => 'mark@example.com'];
+        $this->assertEquals($expected, $entity->toArray());
+    }
+
+    /**
+     * Test that toArray respects hidden properties.
+     */
+    public function testToArrayHiddenProperties(): void
+    {
+        $data = ['secret' => 'sauce', 'name' => 'mark', 'id' => 1];
+        $entity = new class ($data) extends Entity {
+            protected $secret;
+            protected $name;
+            protected $id;
+        };
+        $entity->setHidden(['secret']);
+        $this->assertEquals(['name' => 'mark', 'id' => 1], $entity->toArray());
+    }
+
+    /**
+     * Tests setting hidden properties.
+     */
+    public function testSetHidden(): void
+    {
+        $data = ['secret' => 'sauce', 'name' => 'mark', 'id' => 1];
+        $entity = new class ($data) extends Entity {
+            protected $secret;
+            protected $name;
+            protected $id;
+        };
+        $entity->setHidden(['secret']);
+
+        $result = $entity->getHidden();
+        $this->assertSame(['secret'], $result);
+
+        $entity->setHidden(['name']);
+
+        $result = $entity->getHidden();
+        $this->assertSame(['name'], $result);
+    }
+
+    /**
+     * Tests setting hidden properties with merging.
+     */
+    public function testSetHiddenWithMerge(): void
+    {
+        $data = ['secret' => 'sauce', 'name' => 'mark', 'id' => 1];
+        $entity = new class ($data) extends Entity {
+            protected $secret;
+            protected $name;
+            protected $id;
+        };
+        $entity->setHidden(['secret'], true);
+
+        $result = $entity->getHidden();
+        $this->assertSame(['secret'], $result);
+
+        $entity->setHidden(['name'], true);
+
+        $result = $entity->getHidden();
+        $this->assertSame(['secret', 'name'], $result);
+
+        $entity->setHidden(['name'], true);
+        $result = $entity->getHidden();
+        $this->assertSame(['secret', 'name'], $result);
+    }
+
+    /**
+     * Test toArray includes 'virtual' properties.
+     */
+    public function testToArrayVirtualProperties(): void
+    {
+        $entity = new class extends Entity {
+            protected $name {
+                get => 'Jose';
+            }
+            protected $email;
+        };
+        $entity->setPatchable('*', true);
+        $entity->patch(['email' => 'mark@example.com']);
+
+        $entity->setVirtual(['name']);
+        $expected = ['name' => 'Jose', 'email' => 'mark@example.com'];
+        $this->assertEquals($expected, $entity->toArray());
+
+        $this->assertEquals(['name'], $entity->getVirtual());
+
+        $entity->setHidden(['name']);
+        $expected = ['email' => 'mark@example.com'];
+        $this->assertEquals($expected, $entity->toArray());
+        $this->assertEquals(['name'], $entity->getHidden());
+    }
+
+    /**
+     * Tests the getVisible() method
+     */
+    public function testGetVisible(): void
+    {
+        $entity = new class extends Entity {
+            protected $foo;
+            protected $bar;
+        };
+        $entity->foo = 'foo';
+        $entity->bar = 'bar';
+
+        $expected = $entity->getVisible();
+        $this->assertSame(['foo', 'bar'], $expected);
+    }
+
+    /**
+     * Tests setting virtual properties with merging.
+     */
+    public function testSetVirtualWithMerge(): void
+    {
+        $data = ['virt' => 'sauce', 'name' => 'mark', 'id' => 1];
+        $entity = new class ($data) extends Entity {
+            protected $virt;
+            protected $name;
+            protected $id;
+        };
+        $entity->setVirtual(['virt']);
+
+        $result = $entity->getVirtual();
+        $this->assertSame(['virt'], $result);
+
+        $entity->setVirtual(['name'], true);
+
+        $result = $entity->getVirtual();
+        $this->assertSame(['virt', 'name'], $result);
+
+        $entity->setVirtual(['name'], true);
+        $result = $entity->getVirtual();
+        $this->assertSame(['virt', 'name'], $result);
+    }
+
+    /**
+     * Tests error getters and setters
+     */
+    public function testGetErrorAndSetError(): void
+    {
+        $entity = new Entity();
+        $this->assertEmpty($entity->getErrors());
+
+        $entity->setError('foo', 'bar');
+        $this->assertEquals(['bar'], $entity->getError('foo'));
+
+        $expected = [
+            'foo' => ['bar'],
+        ];
+        $result = $entity->getErrors();
+        $this->assertEquals($expected, $result);
+
+        $indexedErrors = [2 => ['foo' => 'bar']];
+        $entity = new Entity();
+        $entity->setError('indexes', $indexedErrors);
+
+        $expectedIndexed = [
+            'indexes' => ['2' => ['foo' => 'bar']],
+        ];
+        $result = $entity->getErrors();
+        $this->assertEquals($expectedIndexed, $result);
+    }
+
+    /**
+     * Tests reading errors from nested validator
+     */
+    public function testGetErrorNested(): void
+    {
+        $entity = new Entity();
+        $entity->setError('options', ['subpages' => ['_empty' => 'required']]);
+
+        $expected = [
+            'subpages' => ['_empty' => 'required'],
+        ];
+        // $this->assertEquals($expected, $entity->getError('options'));
+
+        $expected = ['_empty' => 'required'];
+        $this->assertEquals($expected, $entity->getError('options.subpages'));
+    }
+
+    /**
+     * Tests that it is possible to get errors for nested entities
+     */
+    public function testErrorsDeep(): void
+    {
+        $user = new Entity();
+        $owner = new Entity();
+        $author = new class (['foo' => 'bar', 'thing' => 'baz', 'user' => $user, 'owner' => $owner,]) extends Entity {
+            protected $foo;
+            protected $thing;
+            protected $user;
+            protected $owner;
+            protected $multiple;
+        };
+        $author->setError('thing', ['this is a mistake']);
+        $user->setErrors(['a' => ['error1'], 'b' => ['error2']]);
+        $owner->setErrors(['c' => ['error3'], 'd' => ['error4']]);
+
+        $expected = ['a' => ['error1'], 'b' => ['error2']];
+        $this->assertEquals($expected, $author->getError('user'));
+
+        $expected = ['c' => ['error3'], 'd' => ['error4']];
+        $this->assertEquals($expected, $author->getError('owner'));
+
+        $author->set('multiple', [$user, $owner]);
+        $expected = [
+            ['a' => ['error1'], 'b' => ['error2']],
+            ['c' => ['error3'], 'd' => ['error4']],
+        ];
+        $this->assertEquals($expected, $author->getError('multiple'));
+
+        $expected = [
+            'thing' => $author->getError('thing'),
+            'user' => $author->getError('user'),
+            'owner' => $author->getError('owner'),
+            'multiple' => $author->getError('multiple'),
+        ];
+        $this->assertEquals($expected, $author->getErrors());
+    }
+
+    /**
+     * Tests that check if hasErrors() works
+     */
+    public function testHasErrors(): void
+    {
+        $entity = new class extends Entity {
+            protected $nested;
+        };
+        $hasErrors = $entity->hasErrors();
+        $this->assertFalse($hasErrors);
+
+        $nestedEntity = new class extends Entity {
+            protected $description;
+        };
+        $entity->patch(['nested' => $nestedEntity]);
+        $hasErrors = $entity->hasErrors();
+        $this->assertFalse($hasErrors);
+
+        $nestedEntity->setError('description', 'oops');
+        $hasErrors = $entity->hasErrors();
+        $this->assertTrue($hasErrors);
+
+        $hasErrors = $entity->hasErrors(false);
+        $this->assertFalse($hasErrors);
+
+        $entity->clean();
+        $hasErrors = $entity->hasErrors();
+        $this->assertTrue($hasErrors);
+        $hasErrors = $entity->hasErrors(false);
+        $this->assertFalse($hasErrors);
+
+        $nestedEntity->clean();
+        $hasErrors = $entity->hasErrors();
+        $this->assertFalse($hasErrors);
+
+        $entity->setError('foo', []);
+        $this->assertFalse($entity->hasErrors());
+    }
+
+    /**
+     * Test that errors can be read with a path.
+     */
+    public function testErrorPathReading(): void
+    {
+        $assoc = new Entity();
+        $assoc2 = new Entity();
+        $entity = new class (['field' => 'value', 'one' => $assoc, 'many' => [$assoc2],]) extends Entity {
+            protected $field;
+            protected $one;
+            protected $many;
+        };
+        $entity->setError('wrong', 'Bad stuff');
+        $assoc->setError('nope', 'Terrible things');
+        $assoc2->setError('nope', 'Terrible things');
+
+        $this->assertEquals(['Bad stuff'], $entity->getError('wrong'));
+        $this->assertEquals(['Terrible things'], $entity->getError('many.0.nope'));
+        $this->assertEquals(['Terrible things'], $entity->getError('one.nope'));
+        $this->assertEquals(['nope' => ['Terrible things']], $entity->getError('one'));
+        $this->assertEquals([0 => ['nope' => ['Terrible things']]], $entity->getError('many'));
+        $this->assertEquals(['nope' => ['Terrible things']], $entity->getError('many.0'));
+
+        $this->assertEquals([], $entity->getError('many.0.mistake'));
+        $this->assertEquals([], $entity->getError('one.mistake'));
+        $this->assertEquals([], $entity->getError('one.1.mistake'));
+        $this->assertEquals([], $entity->getError('many.1.nope'));
+    }
+
+    /**
+     * Tests that changing the value of a property will remove errors
+     * stored for it
+     */
+    public function testDirtyRemovesError(): void
+    {
+        $entity = new class ((['a' => 'b'])) extends Entity {
+            protected $a;
+        };
+        $entity->setError('a', 'is not good');
+        $entity->set('a', 'c');
+        $this->assertEmpty($entity->getError('a'));
+
+        $entity->setError('a', 'is not good');
+        $entity->setDirty('a', true);
+        $this->assertEmpty($entity->getError('a'));
+    }
+
+    /**
+     * Tests that marking an entity as clean will remove errors too
+     */
+    public function testCleanRemovesErrors(): void
+    {
+        $entity = new class ((['a' => 'b'])) extends Entity {
+            protected $a;
+        };
+        $entity->setError('a', 'is not good');
+        $entity->clean();
+        $this->assertEmpty($entity->getErrors());
+    }
+
+    /**
+     * Tests getPatchable() method
+     */
+    public function testGetPatchable(): void
+    {
+        $entity = new Entity();
+        $entity->setPatchable('*', false);
+        $entity->setPatchable('bar', true);
+
+        $accessible = $entity->getPatchable();
+        $expected = [
+            '*' => false,
+            'bar' => true,
+        ];
+        $this->assertSame($expected, $accessible);
+    }
+
+    /**
+     * Tests isPatchable() and setPatchable() methods
+     */
+    public function testIsPatchable(): void
+    {
+        $entity = new Entity();
+        $entity->setPatchable('*', false);
+        $this->assertFalse($entity->isPatchable('foo'));
+        $this->assertFalse($entity->isPatchable('bar'));
+
+        $this->assertSame($entity, $entity->setPatchable('foo', true));
+        $this->assertTrue($entity->isPatchable('foo'));
+        $this->assertFalse($entity->isPatchable('bar'));
+
+        $this->assertSame($entity, $entity->setPatchable('bar', true));
+        $this->assertTrue($entity->isPatchable('foo'));
+        $this->assertTrue($entity->isPatchable('bar'));
+
+        $this->assertSame($entity, $entity->setPatchable('foo', false));
+        $this->assertFalse($entity->isPatchable('foo'));
+        $this->assertTrue($entity->isPatchable('bar'));
+
+        $this->assertSame($entity, $entity->setPatchable('bar', false));
+        $this->assertFalse($entity->isPatchable('foo'));
+        $this->assertFalse($entity->isPatchable('bar'));
+    }
+
+    /**
+     * Tests that an array can be used to set
+     */
+    public function testPatchableAsArray(): void
+    {
+        $entity = new Entity();
+        $entity->setPatchable(['foo', 'bar', 'baz'], true);
+        $this->assertTrue($entity->isPatchable('foo'));
+        $this->assertTrue($entity->isPatchable('bar'));
+        $this->assertTrue($entity->isPatchable('baz'));
+
+        $entity->setPatchable('foo', false);
+        $this->assertFalse($entity->isPatchable('foo'));
+        $this->assertTrue($entity->isPatchable('bar'));
+        $this->assertTrue($entity->isPatchable('baz'));
+
+        $entity->setPatchable(['foo', 'bar', 'baz'], false);
+        $this->assertFalse($entity->isPatchable('foo'));
+        $this->assertFalse($entity->isPatchable('bar'));
+        $this->assertFalse($entity->isPatchable('baz'));
+    }
+
+    /**
+     * Tests that a wildcard can be used for setting accessible properties
+     */
+    public function testPatchableWildcard(): void
+    {
+        $entity = new Entity();
+        $entity->setPatchable(['foo', 'bar', 'baz'], true);
+        $this->assertTrue($entity->isPatchable('foo'));
+        $this->assertTrue($entity->isPatchable('bar'));
+        $this->assertTrue($entity->isPatchable('baz'));
+
+        $entity->setPatchable('*', false);
+        $this->assertFalse($entity->isPatchable('foo'));
+        $this->assertFalse($entity->isPatchable('bar'));
+        $this->assertFalse($entity->isPatchable('baz'));
+        $this->assertFalse($entity->isPatchable('newOne'));
+
+        $entity->setPatchable('*', true);
+        $this->assertTrue($entity->isPatchable('foo'));
+        $this->assertTrue($entity->isPatchable('bar'));
+        $this->assertTrue($entity->isPatchable('baz'));
+        $this->assertTrue($entity->isPatchable('newOne2'));
+    }
+
+    /**
+     * Tests that only accessible properties can be set
+     */
+    public function testSetWithPatchable(): void
+    {
+        $entity = new class (['foo' => 1, 'bar' => 2]) extends Entity {
+            protected $foo;
+            protected $bar;
+        };
+        $options = ['guard' => true];
+        $entity->setPatchable('*', false);
+        $entity->setPatchable('foo', true);
+        $entity->set('bar', 3, $options);
+        $entity->set('foo', 4, $options);
+        $this->assertSame(2, $entity->get('bar'));
+        $this->assertSame(4, $entity->get('foo'));
+
+        $entity->setPatchable('bar', true);
+        $entity->set('bar', 3, $options);
+        $this->assertSame(3, $entity->get('bar'));
+    }
+
+    /**
+     * Tests that only accessible properties can be set
+     */
+    public function testSetWithPatchableWithArray(): void
+    {
+        $entity = new class (['foo' => 1, 'bar' => 2]) extends Entity {
+            protected $foo;
+            protected $bar;
+        };
+        $options = ['guard' => true];
+        $entity->setPatchable('*', false);
+        $entity->setPatchable('foo', true);
+        $entity->patch(['bar' => 3, 'foo' => 4], $options);
+        $this->assertSame(2, $entity->get('bar'));
+        $this->assertSame(4, $entity->get('foo'));
+
+        $entity->setPatchable('bar', true);
+        $entity->patch(['bar' => 3, 'foo' => 5], $options);
+        $this->assertSame(3, $entity->get('bar'));
+        $this->assertSame(5, $entity->get('foo'));
+    }
+
+    /**
+     * Test that accessible() and single property setting works.
+     */
+    public function testSetWithPatchableSingleProperty(): void
+    {
+        $entity = new class (['foo' => 1, 'bar' => 2]) extends Entity {
+            protected $foo;
+            protected $bar;
+            protected $title;
+            protected $body;
+        };
+        $entity->setPatchable('*', false);
+        $entity->setPatchable('title', true);
+
+        $entity->patch(['title' => 'test', 'body' => 'Nope']);
+        $this->assertSame('test', $entity->title);
+        $this->assertNull($entity->body);
+
+        $entity->body = 'Yep';
+        $this->assertSame('Yep', $entity->body, 'Single set should bypass guards.');
+
+        $entity->set('body', 'Yes');
+        $this->assertSame('Yes', $entity->body, 'Single set should bypass guards.');
+    }
+
+    /**
+     * Tests __debugInfo
+     */
+    public function testDebugInfo(): void
+    {
+        $entity = new class (['foo' => 'bar'], ['markClean' => true]) extends Entity {
+            protected $foo;
+            protected $somethingElse;
+            protected $baz {
+                get => 'baz';
+            }
+        };
+        $entity->somethingElse = 'value';
+        $entity->setPatchable('id', false);
+        $entity->setPatchable('name', true);
+        $entity->setVirtual(['baz']);
+        $entity->setDirty('foo', true);
+        $entity->setError('foo', ['An error']);
+        $entity->setInvalidField('foo', 'a value');
+        $entity->setSource('foos');
+        $result = $entity->__debugInfo();
+        $expected = [
+            'foo' => 'bar',
+            'somethingElse' => 'value',
+            'baz' => 'baz',
+            '[new]' => true,
+            '[patchable]' => ['*' => true, 'id' => false, 'name' => true],
+            '[dirty]' => ['somethingElse' => true, 'foo' => true],
+            '[original]' => [],
+            '[originalFields]' => ['foo'],
+            '[virtual]' => ['baz'],
+            '[hasErrors]' => true,
+            '[errors]' => ['foo' => ['An error']],
+            '[invalid]' => ['foo' => 'a value'],
+            '[repository]' => 'foos',
+        ];
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test the source getter
+     */
+    public function testGetAndSetSource(): void
+    {
+        $entity = new Entity();
+        $this->assertSame('', $entity->getSource());
+        $entity->setSource('foos');
+        $this->assertSame('foos', $entity->getSource());
+    }
+
+    /**
+     * Provides empty values
+     *
+     * @return array
+     */
+    public function emptyNamesProvider(): array
+    {
+        return [[''], [null]];
+    }
+
+    /**
+     * Tests that trying to get an empty property name throws exception
+     */
+    public function testEmptyProperties(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $entity = new Entity();
+        $entity->get('');
+    }
+
+    /**
+     * Provides empty values
+     */
+    public function testIsDirtyFromClone(): void
+    {
+        $entity = new class (['a' => 1, 'b' => 2], ['markNew' => false, 'markClean' => true], ) extends Entity {
+            protected $a;
+            protected $b;
+        };
+
+        $this->assertFalse($entity->isNew());
+        $this->assertFalse($entity->isDirty());
+
+        $cloned = clone $entity;
+        $cloned->setNew(true);
+
+        $this->assertTrue($cloned->isDirty());
+        $this->assertTrue($cloned->isDirty('a'));
+        $this->assertTrue($cloned->isDirty('b'));
+    }
+
+    /**
+     * Tests getInvalid and setInvalid
+     */
+    public function testGetSetInvalid(): void
+    {
+        $entity = new Entity();
+        $return = $entity->setInvalid([
+            'title' => 'albert',
+            'body' => 'einstein',
+        ]);
+        $this->assertSame($entity, $return);
+        $this->assertSame([
+            'title' => 'albert',
+            'body' => 'einstein',
+        ], $entity->getInvalid());
+
+        $set = $entity->setInvalid([
+            'title' => 'nikola',
+            'body' => 'tesla',
+        ]);
+        $this->assertSame([
+            'title' => 'albert',
+            'body' => 'einstein',
+        ], $set->getInvalid());
+
+        $overwrite = $entity->setInvalid([
+            'title' => 'nikola',
+            'body' => 'tesla',
+        ], true);
+        $this->assertSame($entity, $overwrite);
+        $this->assertSame([
+            'title' => 'nikola',
+            'body' => 'tesla',
+        ], $entity->getInvalid());
+    }
+
+    /**
+     * Tests getInvalidField
+     */
+    public function testGetSetInvalidField(): void
+    {
+        $entity = new Entity();
+        $return = $entity->setInvalidField('title', 'albert');
+        $this->assertSame($entity, $return);
+        $this->assertSame('albert', $entity->getInvalidField('title'));
+
+        $overwrite = $entity->setInvalidField('title', 'nikola');
+        $this->assertSame($entity, $overwrite);
+        $this->assertSame('nikola', $entity->getInvalidField('title'));
+    }
+
+    /**
+     * Tests getInvalidFieldNull
+     */
+    public function testGetInvalidFieldNull(): void
+    {
+        $entity = new Entity();
+        $this->assertNull($entity->getInvalidField('foo'));
+    }
+
+    /**
+     * Test hasValue()
+     */
+    public function testHasValue(): void
+    {
+        $entity = new class (['array' => ['foo' => 'bar'], 'emptyArray' => [], 'object' => new stdClass(), 'string' => 'string', 'stringZero' => '0', 'emptyString' => '', 'intZero' => 0, 'intNotZero' => 1, 'floatZero' => 0.0, 'floatNonZero' => 1.5, 'null' => null, 'true' => true, 'false' => false,]) extends Entity {
+            protected $array;
+            protected $emptyArray;
+            protected $object;
+            protected $string;
+            protected $stringZero;
+            protected $emptyString;
+            protected $intZero;
+            protected $intNotZero;
+            protected $floatZero;
+            protected $floatNonZero;
+            protected $null;
+        };
+
+        $this->assertTrue($entity->hasValue('array'));
+        $this->assertFalse($entity->hasValue('emptyArray'));
+        $this->assertTrue($entity->hasValue('object'));
+        $this->assertTrue($entity->hasValue('string'));
+        $this->assertTrue($entity->hasValue('stringZero'));
+        $this->assertFalse($entity->hasValue('emptyString'));
+        $this->assertTrue($entity->hasValue('intZero'));
+        $this->assertTrue($entity->hasValue('intNotZero'));
+        $this->assertTrue($entity->hasValue('floatZero'));
+        $this->assertTrue($entity->hasValue('floatNonZero'));
+        $this->assertFalse($entity->hasValue('null'));
+        $this->assertTrue($entity->hasValue('true'));
+        $this->assertTrue($entity->hasValue('false'));
+    }
+
+    /**
+     * Test isOriginalField()
+     */
+    public function testIsOriginalField(): void
+    {
+        $entity = new class (['foo' => null]) extends Entity {
+            protected $foo;
+        };
+        $return = $entity->isOriginalField('foo');
+        $this->assertSame(true, $return);
+
+        $entity = new class extends Entity {
+            protected $foo;
+        };
+        $entity->set('foo', null);
+        $return = $entity->isOriginalField('foo');
+        $this->assertSame(false, $return);
+
+        $return = $entity->isOriginalField('bar');
+        $this->assertSame(false, $return);
+    }
+
+    /**
+     * Test getOriginalFields()
+     */
+    public function testGetOriginalFields(): void
+    {
+        $entity = new class (['foo' => 'foo', 'bar' => 'bar']) extends Entity {
+            protected $foo;
+            protected $bar;
+            protected $baz;
+        };
+        $entity->set('baz', 'baz');
+        $return = $entity->getOriginalFields();
+        $this->assertEquals(['foo', 'bar'], $return);
+
+        $entity = new class extends Entity {
+            protected $foo;
+            protected $bar;
+            protected $baz;
+        };
+        $entity->set('foo', 'foo');
+        $entity->set('bar', 'bar');
+        $entity->set('baz', 'baz');
+        $return = $entity->getOriginalFields();
+        $this->assertEquals([], $return);
+    }
+
+    /**
+     * Test setOriginalField() inside EntityInterface::setDirty()
+     */
+    public function testSetOriginalFieldInSetDirty(): void
+    {
+        $entity = new class extends Entity {
+            protected $foo;
+        };
+        $entity->set('foo', 'bar');
+
+        $return = $entity->isOriginalField('foo');
+        $this->assertSame(false, $return);
+
+        $entity->setDirty('foo', false);
+
+        $return = $entity->isOriginalField('foo');
+        $this->assertSame(true, $return);
+    }
+
+    /**
+     * Test setOriginalField() inside EntityInterface::clean()
+     */
+    public function testSetOriginalFieldInClean(): void
+    {
+        $entity = new class extends Entity {
+            protected $foo;
+        };
+        $entity->set('foo', 'bar');
+
+        $return = $entity->isOriginalField('foo');
+        $this->assertSame(false, $return);
+
+        $entity->clean();
+
+        $return = $entity->isOriginalField('foo');
+        $this->assertSame(true, $return);
+    }
+
+    /**
+     * Test infinite recursion in getErrors and hasErrors
+     * See https://github.com/cakephp/cakephp/issues/17318
+     */
+    public function testGetErrorsRecursionError(): void
+    {
+        $entity = new class extends Entity {
+            protected $child;
+        };
+        $secondEntity = new class extends Entity {
+            protected $parent;
+        };
+
+        $entity->set('child', $secondEntity);
+        $secondEntity->set('parent', $entity);
+
+        $expectedErrors = ['name' => ['_required' => 'Must be present.']];
+        $secondEntity->setErrors($expectedErrors);
+
+        $this->assertEquals(['child' => $expectedErrors], $entity->getErrors());
+    }
+
+    /**
+     * Test infinite recursion in getErrors and hasErrors
+     * See https://github.com/cakephp/cakephp/issues/17318
+     */
+    public function testHasErrorsRecursionError(): void
+    {
+        $entity = new class extends Entity {
+            protected $child;
+        };
+        $secondEntity = new class extends Entity {
+            protected $parent;
+        };
+
+        $entity->set('child', $secondEntity);
+        $secondEntity->set('parent', $entity);
+
+        $this->assertFalse($entity->hasErrors());
+    }
+}

--- a/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
+++ b/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
@@ -53,6 +53,10 @@ class EntityWithConcretePropertiesTest extends TestCase
         $this->assertSame(1, $entity->id);
         $this->assertSame(1, $entity->getOriginal('id'));
         $this->assertSame('bar', $entity->getOriginal('foo'));
+
+        // Test setting restricted properties does not cause issues.
+        $entity->set('virtual', 'value');
+        $this->assertSame('value', $entity->virtual);
     }
 
     /**

--- a/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
+++ b/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
@@ -16,11 +16,13 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM;
 
+use Cake\Datasource\EntityTrait;
 use Cake\Datasource\Exception\MissingPropertyException;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Mockery;
+use ReflectionClass;
 use stdClass;
 use TestApp\Model\Entity\UserWithProps;
 
@@ -1669,5 +1671,27 @@ class EntityWithConcretePropertiesTest extends TestCase
         $secondEntity->set('parent', $entity);
 
         $this->assertFalse($entity->hasErrors());
+    }
+
+    /**
+     * Test that EntityTrait::$restrictedProperties list matches the list of
+     * properties declared in the trait.
+     */
+    public function testRestrictedPropertiesMatchesTraitProperties(): void
+    {
+        $reflectedTrait = new ReflectionClass(EntityTrait::class);
+        $properties = [];
+        foreach ($reflectedTrait->getProperties() as $property) {
+            $properties[] = $property->getName();
+        }
+
+        $reflectedEntity = new ReflectionClass(Entity::class);
+        $restrictedProperty = $reflectedEntity->getProperty('restrictedProperties');
+        $restrictedProperties = $restrictedProperty->getValue();
+
+        sort($properties);
+        sort($restrictedProperties);
+
+        $this->assertSame($properties, $restrictedProperties);
     }
 }

--- a/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
+++ b/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
@@ -782,8 +782,8 @@ class EntityWithConcretePropertiesTest extends TestCase
 
     public function testConstructorWithDynamicField(): void
     {
-        $entiy = new Entity(['foo' => 'bar']);
-        $this->assertSame('bar', $entiy->foo);
+        $entity = new Entity(['foo' => 'bar']);
+        $this->assertSame('bar', $entity->foo);
     }
 
     /**
@@ -871,7 +871,7 @@ class EntityWithConcretePropertiesTest extends TestCase
     /**
      * Test that get accessors are called when converting to arrays.
      */
-    public function testToArrayWithPatchableor(): void
+    public function testToArrayWithPatchable(): void
     {
         $entity = new class extends Entity {
             protected $name {

--- a/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
+++ b/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
@@ -1694,4 +1694,250 @@ class EntityWithConcretePropertiesTest extends TestCase
 
         $this->assertSame($properties, $restrictedProperties);
     }
+
+    /**
+     * Tests getReflectionProperty returns a ReflectionProperty for concrete fields
+     */
+    public function testGetReflectionProperty(): void
+    {
+        $entity = new class extends Entity {
+            protected int $id;
+            protected string $title;
+        };
+
+        $ref = new ReflectionClass($entity);
+        $method = $ref->getMethod('getReflectionProperty');
+
+        $this->assertInstanceOf(\ReflectionProperty::class, $method->invoke(null, 'id'));
+        $this->assertInstanceOf(\ReflectionProperty::class, $method->invoke(null, 'title'));
+        $this->assertNull($method->invoke(null, 'nonexistent'));
+        // Restricted properties should return null
+        $this->assertNull($method->invoke(null, 'dirty'));
+        $this->assertNull($method->invoke(null, 'reflectionCache'));
+    }
+
+    /**
+     * Tests setRawValue bypasses property hooks
+     */
+    public function testSetRawValueBypassesHooks(): void
+    {
+        $entity = new class extends Entity {
+            protected string $title {
+                set(string $value) {
+                    $this->title = strtolower($value);
+                }
+            }
+        };
+
+        // Via set() (hooks fire)
+        $entity->set('title', 'HELLO');
+        $this->assertSame('hello', $entity->title);
+
+        // Via raw value (hooks bypassed) - simulate hydration
+        $ref = new ReflectionClass($entity);
+        $method = $ref->getMethod('setRawValue');
+        $method->invoke($entity, 'title', 'WORLD');
+        $this->assertSame('WORLD', $entity->title);
+    }
+
+    /**
+     * Tests getRawValue bypasses property get hooks
+     */
+    public function testGetRawValueBypassesGetHooks(): void
+    {
+        $entity = new class extends Entity {
+            protected string $title {
+                get => strtoupper($this->title);
+            }
+        };
+
+        // Set raw value first
+        $ref = new ReflectionClass($entity);
+        $setMethod = $ref->getMethod('setRawValue');
+        $setMethod->invoke($entity, 'title', 'hello');
+
+        // get() goes through hooks
+        $this->assertSame('HELLO', $entity->get('title'));
+
+        // getRawValue() bypasses hooks
+        $getMethod = $ref->getMethod('getRawValue');
+        $this->assertSame('hello', $getMethod->invoke($entity, 'title'));
+    }
+
+    /**
+     * Tests that ORM-style hydration (useSetters=false) bypasses property hooks
+     */
+    public function testHydrationBypassesPropertyHooks(): void
+    {
+        $entity = new class (['title' => 'HELLO'], [
+            'useSetters' => false,
+            'markClean' => true,
+            'markNew' => false,
+        ]) extends Entity {
+            protected string $title {
+                set(string $value) {
+                    $this->title = strtolower($value);
+                }
+            }
+        };
+
+        // Value should NOT have been lowercased during hydration
+        $this->assertSame('HELLO', $entity->title);
+        $this->assertFalse($entity->isDirty('title'));
+
+        // Application writes should trigger hooks
+        $entity->title = 'WORLD';
+        $this->assertSame('world', $entity->title);
+        $this->assertTrue($entity->isDirty('title'));
+    }
+
+    /**
+     * Tests that useSetters=true (default) fires property hooks
+     */
+    public function testConstructorWithSettersFiresHooks(): void
+    {
+        $entity = new class (['title' => 'HELLO'], [
+            'useSetters' => true,
+        ]) extends Entity {
+            protected string $title {
+                set(string $value) {
+                    $this->title = strtolower($value);
+                }
+            }
+        };
+
+        // Hook should have fired
+        $this->assertSame('hello', $entity->title);
+    }
+
+    /**
+     * Tests isModified with property hooks uses raw values
+     */
+    public function testIsModifiedUsesRawValues(): void
+    {
+        $entity = new class extends Entity {
+            protected string $title {
+                get => strtoupper($this->title);
+            }
+        };
+
+        $entity->set('title', 'hello', ['asOriginal' => true]);
+        $entity->clean();
+
+        // Setting same raw value should not mark as dirty
+        $entity->set('title', 'hello');
+        $this->assertFalse($entity->isDirty('title'));
+
+        // Setting different value should mark as dirty
+        $entity->set('title', 'world');
+        $this->assertTrue($entity->isDirty('title'));
+    }
+
+    /**
+     * Tests combined get/set hooks work correctly
+     */
+    public function testCombinedHooks(): void
+    {
+        $entity = new class extends Entity {
+            protected string $email {
+                get => $this->email;
+                set(string $value) {
+                    $this->email = strtolower(trim($value));
+                }
+            }
+        };
+
+        $entity->set('email', '  FOO@BAR.COM  ');
+        $this->assertSame('foo@bar.com', $entity->email);
+        $this->assertSame('foo@bar.com', $entity->get('email'));
+    }
+
+    /**
+     * Tests virtual computed property via get hook
+     */
+    public function testVirtualPropertyGetHook(): void
+    {
+        $entity = new class (['title' => 'Hello', 'author_name' => 'World'], [
+            'useSetters' => false,
+        ]) extends Entity {
+            protected string $title;
+            protected string $author_name;
+
+            protected string $full_title {
+                get => $this->title . ' by ' . $this->author_name;
+            }
+        };
+
+        $entity->setVirtual(['full_title']);
+        $this->assertSame('Hello by World', $entity->get('full_title'));
+    }
+
+    /**
+     * Tests clearReflectionCache works
+     */
+    public function testClearReflectionCache(): void
+    {
+        $entity = new class extends Entity {
+            protected string $title;
+        };
+
+        // Access a property to populate cache
+        $entity->set('title', 'hello');
+
+        // Clear should not cause errors
+        $entity::clearReflectionCache();
+
+        // Should still work after clearing
+        $entity->set('title', 'world');
+        $this->assertSame('world', $entity->title);
+    }
+
+    /**
+     * Tests dynamic fields work with getRawValue/setRawValue
+     */
+    public function testRawValueWithDynamicFields(): void
+    {
+        $entity = new class extends Entity {
+            protected int $id;
+        };
+
+        $ref = new ReflectionClass($entity);
+        $setMethod = $ref->getMethod('setRawValue');
+        $getMethod = $ref->getMethod('getRawValue');
+
+        // Dynamic field (no property)
+        $setMethod->invoke($entity, 'dynamic_field', 'value');
+        $this->assertSame('value', $getMethod->invoke($entity, 'dynamic_field'));
+    }
+
+    /**
+     * Tests getOriginalValues uses raw values (bypasses get hooks)
+     */
+    public function testGetOriginalValuesBypassesGetHooks(): void
+    {
+        $entity = new class extends Entity {
+            protected string $title {
+                get => strtoupper($this->title);
+            }
+        };
+
+        $entity->set('title', 'hello', ['asOriginal' => true]);
+        $entity->clean();
+
+        $originals = $entity->getOriginalValues();
+        // Should return raw value, not hooked value
+        $this->assertSame('hello', $originals['title']);
+    }
+
+    /**
+     * Tests restricted properties includes reflectionCache
+     */
+    public function testReflectionCacheIsRestricted(): void
+    {
+        $ref = new ReflectionClass(Entity::class);
+        $prop = $ref->getProperty('restrictedProperties');
+        $restricted = $prop->getValue();
+
+        $this->assertArrayHasKey('reflectionCache', $restricted);
+    }
 }

--- a/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
+++ b/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
@@ -1710,10 +1710,10 @@ class EntityWithConcretePropertiesTest extends TestCase
 
         $this->assertInstanceOf(\ReflectionProperty::class, $method->invoke(null, 'id'));
         $this->assertInstanceOf(\ReflectionProperty::class, $method->invoke(null, 'title'));
-        $this->assertNull($method->invoke(null, 'nonexistent'));
-        // Restricted properties should return null
-        $this->assertNull($method->invoke(null, 'dirty'));
-        $this->assertNull($method->invoke(null, 'reflectionCache'));
+        $this->assertFalse($method->invoke(null, 'nonexistent'));
+        // Restricted properties should return false
+        $this->assertFalse($method->invoke(null, 'dirty'));
+        $this->assertFalse($method->invoke(null, 'reflectionCache'));
     }
 
     /**

--- a/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
+++ b/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
@@ -1674,7 +1674,7 @@ class EntityWithConcretePropertiesTest extends TestCase
     }
 
     /**
-     * Test that EntityTrait::$restrictedProperties list matches the list of
+     * Test that Entity::$restrictedProperties list matches the list of
      * properties declared in the trait.
      */
     public function testRestrictedPropertiesMatchesTraitProperties(): void
@@ -1682,15 +1682,15 @@ class EntityWithConcretePropertiesTest extends TestCase
         $reflectedTrait = new ReflectionClass(EntityTrait::class);
         $properties = [];
         foreach ($reflectedTrait->getProperties() as $property) {
-            $properties[] = $property->getName();
+            $properties[$property->getName()] = true;
         }
 
         $reflectedEntity = new ReflectionClass(Entity::class);
         $restrictedProperty = $reflectedEntity->getProperty('restrictedProperties');
         $restrictedProperties = $restrictedProperty->getValue();
 
-        sort($properties);
-        sort($restrictedProperties);
+        ksort($properties);
+        ksort($restrictedProperties);
 
         $this->assertSame($properties, $restrictedProperties);
     }

--- a/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
+++ b/tests/TestCase/ORM/EntityWithConcretePropertiesTest.php
@@ -36,8 +36,8 @@ class EntityWithConcretePropertiesTest extends TestCase
     public function testSetOneParamNoSetters(): void
     {
         $entity = new class extends Entity {
-            protected $id;
-            protected $foo;
+            protected int $id;
+            protected string $foo;
         };
 
         $this->assertNull($entity->getOriginal('foo'));
@@ -61,9 +61,9 @@ class EntityWithConcretePropertiesTest extends TestCase
     public function testPatchPropertiesNoSetters(): void
     {
         $entity = new class extends Entity {
-            protected $id;
-            protected $foo;
-            protected $thing;
+            protected int $id;
+            protected string $foo;
+            protected int $thing;
         };
         $entity->setPatchable('*', true);
 
@@ -85,10 +85,10 @@ class EntityWithConcretePropertiesTest extends TestCase
     public function testGetOriginal(): void
     {
         $entity = new class (['false' => false, 'null' => null, 'zero' => 0, 'empty' => ''], ['markNew' => true], ) extends Entity {
-            protected $false;
-            protected $null;
-            protected $zero;
-            protected $empty;
+            protected bool|string $false;
+            protected ?string $null;
+            protected int|string $zero;
+            protected string $empty;
         };
 
         $this->assertNull($entity->getOriginal('null'));
@@ -110,8 +110,8 @@ class EntityWithConcretePropertiesTest extends TestCase
     public function testGetOriginalFallback(): void
     {
         $entity = new class (['foo' => 'foo', 'bar' => 'bar'], ['markNew' => true], ) extends Entity {
-            protected $foo;
-            protected $bar;
+            protected string $foo;
+            protected string $bar;
         };
 
         $this->expectException(InvalidArgumentException::class);
@@ -124,11 +124,12 @@ class EntityWithConcretePropertiesTest extends TestCase
      */
     public function testExtractOriginal(): void
     {
-        $entity = new class (['id' => 1, 'title' => 'original', 'body' => 'no', 'null' => null,], ['markNew' => true]) extends Entity {
-            protected $id;
-            protected $title;
-            protected $body;
-            protected $null;
+        $entity = new class (['id' => 1, 'title' => 'original', 'body' => 'no', 'null' => null], ['markNew' => true]) extends Entity {
+            protected int $id;
+            protected string $title;
+            protected string $body;
+            protected ?string $null;
+            protected $extra;
         };
         $entity->set('body', 'updated body');
         $result = $entity->extractOriginal(['id', 'title', 'body', 'null', 'undefined']);
@@ -160,11 +161,12 @@ class EntityWithConcretePropertiesTest extends TestCase
      */
     public function testExtractOriginalValues(): void
     {
-        $entity = new class (['id' => 1, 'title' => 'original', 'body' => 'no', 'null' => null,], ['markNew' => true]) extends Entity {
-            protected $id;
-            protected $title;
-            protected $body;
-            protected $null;
+        $entity = new class (['id' => 1, 'title' => 'original', 'body' => 'no', 'null' => null], ['markNew' => true]) extends Entity {
+            protected int $id;
+            protected string $title;
+            protected string $body;
+            protected ?string $null;
+            protected $extra;
         };
         $entity->set('body', 'updated body');
         $result = $entity->getOriginalValues();
@@ -224,8 +226,8 @@ class EntityWithConcretePropertiesTest extends TestCase
     public function testGetNoGetters(): void
     {
         $entity = new class (['id' => 1, 'foo' => 'bar']) extends Entity {
-            protected $id;
-            protected $foo;
+            protected int $id;
+            protected string $foo;
         };
         $this->assertSame(1, $entity->get('id'));
         $this->assertSame('bar', $entity->get('foo'));
@@ -256,7 +258,7 @@ class EntityWithConcretePropertiesTest extends TestCase
         $this->assertNull($entity->get('is_present'));
 
         $entity = new class extends Entity {
-            protected array $_virtual = [
+            protected array $virtual = [
                 'bonus',
             ];
 
@@ -318,7 +320,7 @@ class EntityWithConcretePropertiesTest extends TestCase
     public function testMagicSet(): void
     {
         $entity = new class extends Entity {
-            protected $name;
+            protected string $name;
         };
         $entity->name = 'Jones';
         $this->assertSame('Jones', $entity->name);
@@ -392,7 +394,7 @@ class EntityWithConcretePropertiesTest extends TestCase
     public function testIndirectModificationFailure(): void
     {
         $entity = new class extends Entity {
-            protected $things;
+            protected array $things;
         };
         $entity->things = ['a', 'b'];
         $entity->things[] = 'c';
@@ -428,9 +430,6 @@ class EntityWithConcretePropertiesTest extends TestCase
         $this->assertTrue($entity->has(['id', 'name']));
         $this->assertTrue($entity->has(['id', 'foo']));
         $this->assertFalse($entity->has(['id', 'nope']));
-
-        $entity->foo = null;
-        $this->assertTrue($entity->has('foo'));
     }
 
     /**
@@ -439,12 +438,11 @@ class EntityWithConcretePropertiesTest extends TestCase
     public function testUnset(): void
     {
         $entity = new class (['id' => 1, 'name' => 'bar']) extends Entity {
-            protected $id;
+            protected int $id;
             protected string $name = 'admad';
         };
         $entity->unset('id');
-        // Untyped properties are implicitly initialized to null, so they will still be "present" after unsetting.
-        $this->assertTrue($entity->has('id'));
+        $this->assertFalse($entity->has('id'));
         $this->assertTrue($entity->has('name'));
         $entity->unset('name');
         $this->assertFalse($entity->has('name'));
@@ -472,9 +470,9 @@ class EntityWithConcretePropertiesTest extends TestCase
     public function testMagicIsset(): void
     {
         $entity = new class (['id' => 1, 'name' => 'Juan', 'foo' => null]) extends Entity {
-            protected $id;
-            protected $name;
-            protected $foo;
+            protected int $id;
+            protected string $name;
+            protected ?string $foo;
         };
         $this->assertTrue(isset($entity->id));
         $this->assertTrue(isset($entity->name));
@@ -483,87 +481,18 @@ class EntityWithConcretePropertiesTest extends TestCase
     }
 
     /**
-     * Tests the magic __unset() method
-     */
-    public function testMagicUnset(): void
-    {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->onlyMethods(['unset'])
-            ->getMock();
-        $entity->expects($this->once())
-            ->method('unset')
-            ->with('foo');
-        unset($entity->foo);
-    }
-
-    /**
      * Tests isset with array access
      */
     public function testIssetArrayPatchable(): void
     {
         $entity = new class (['id' => 1, 'name' => 'Juan', 'foo' => null]) extends Entity {
-            protected $id;
-            protected $name;
-            protected $foo;
+            protected int $id;
+            protected string $name;
+            protected ?string $foo;
         };
         $this->assertArrayHasKey('id', $entity);
         $this->assertArrayHasKey('name', $entity);
         $this->assertArrayNotHasKey('foo', $entity);
-    }
-
-    /**
-     * Tests get property with array access
-     */
-    public function testGetArrayPatchable(): void
-    {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->onlyMethods(['get'])
-            ->getMock();
-        $entity->expects($this->exactly(2))
-            ->method('get')
-            ->with(
-                ...self::withConsecutive(['foo'], ['bar']),
-            )
-            ->willReturn('worked', 'worked too');
-
-        $this->assertSame('worked', $entity['foo']);
-        $this->assertSame('worked too', $entity['bar']);
-    }
-
-    /**
-     * Tests set with array access
-     */
-    public function testSetArrayPatchable(): void
-    {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->onlyMethods(['set'])
-            ->getMock();
-        $entity->setPatchable('*', true);
-
-        $entity->expects($this->exactly(2))
-            ->method('set')
-            ->with(
-                ...self::withConsecutive(['foo', 1], ['bar', 2]),
-            )
-            ->willReturnSelf();
-
-        $entity['foo'] = 1;
-        $entity['bar'] = 2;
-    }
-
-    /**
-     * Tests unset with array access
-     */
-    public function testUnsetArrayPatchable(): void
-    {
-        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
-        $entity = $this->getMockBuilder(Entity::class)
-            ->onlyMethods(['unset'])
-            ->getMock();
-        $entity->expects($this->once())
-            ->method('unset')
-            ->with('foo');
-        unset($entity['foo']);
     }
 
     /**
@@ -573,9 +502,9 @@ class EntityWithConcretePropertiesTest extends TestCase
     {
         $data = ['name' => 'James', 'age' => 20, 'phones' => ['123', '457']];
         $entity = new class ($data) extends Entity {
-            protected $name;
-            protected $age;
-            protected $phones;
+            protected string $name;
+            protected int $age;
+            protected array $phones;
         };
         $this->assertEquals(json_encode($data), json_encode($entity));
     }
@@ -603,9 +532,9 @@ class EntityWithConcretePropertiesTest extends TestCase
         $phone->expects($this->once())->method('jsonSerialize')->willReturn(['something']);
         $data = ['name' => 'James', 'age' => 20, 'phone' => $phone];
         $entity = new class ($data) extends Entity {
-            protected $name;
-            protected $age;
-            protected $phone;
+            protected string $name;
+            protected int $age;
+            protected Entity $phone;
         };
         $expected = ['name' => 'James', 'age' => 20, 'phone' => ['something']];
         $this->assertEquals(json_encode($expected), json_encode($entity));
@@ -616,12 +545,12 @@ class EntityWithConcretePropertiesTest extends TestCase
      */
     public function testExtract(): void
     {
-        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3,]) extends Entity {
-            protected $id;
-            protected $title;
-            protected $author_id;
+        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3]) extends Entity {
+            protected int $id;
+            protected string $title;
+            protected int $author_id;
         };
-        $expected = ['author_id' => 3, 'title' => 'Foo',];
+        $expected = ['author_id' => 3, 'title' => 'Foo'];
         $this->assertEquals($expected, $entity->extract(['author_id', 'title']));
 
         $expected = ['id' => 1];
@@ -646,10 +575,10 @@ class EntityWithConcretePropertiesTest extends TestCase
      */
     public function testIsDirty(): void
     {
-        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3,]) extends Entity {
-            protected $id;
-            protected $title;
-            protected $author_id;
+        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3]) extends Entity {
+            protected int $id;
+            protected string $title;
+            protected int $author_id;
             protected ?bool $is_approved = null;
         };
         $this->assertTrue($entity->isDirty('id'));
@@ -673,9 +602,9 @@ class EntityWithConcretePropertiesTest extends TestCase
         $entity->is_approved = true;
         $this->assertTrue($entity->isDirty('is_approved'));
 
-        $entity2 = new class (['id' => 1, 'title' => 'Foo',], ['markClean' => true]) extends Entity {
-            protected $id;
-            protected $title;
+        $entity2 = new class (['id' => 1, 'title' => 'Foo'], ['markClean' => true]) extends Entity {
+            protected int $id;
+            protected string $title;
             protected ?bool $is_approved = null;
         };
         $this->assertFalse($entity2->isDirty());
@@ -698,10 +627,10 @@ class EntityWithConcretePropertiesTest extends TestCase
      */
     public function testSetDirty(): void
     {
-        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3,], ['markClean' => true]) extends Entity {
-            protected $id;
-            protected $title;
-            protected $author_id;
+        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3], ['markClean' => true]) extends Entity {
+            protected int $id;
+            protected string $title;
+            protected int $author_id;
         };
 
         $this->assertFalse($entity->isDirty());
@@ -741,7 +670,7 @@ class EntityWithConcretePropertiesTest extends TestCase
      */
     public function testExtractDirty(): void
     {
-        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3,]) extends Entity {
+        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3]) extends Entity {
             protected $id;
             protected $title;
             protected $author_id;
@@ -758,7 +687,7 @@ class EntityWithConcretePropertiesTest extends TestCase
      */
     public function testGetDirty(): void
     {
-        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3,]) extends Entity {
+        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3]) extends Entity {
             protected $id;
             protected $title;
             protected $author_id;
@@ -777,7 +706,7 @@ class EntityWithConcretePropertiesTest extends TestCase
      */
     public function testClean(): void
     {
-        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3,]) extends Entity {
+        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3]) extends Entity {
             protected $id;
             protected $title;
             protected $author_id;
@@ -797,7 +726,7 @@ class EntityWithConcretePropertiesTest extends TestCase
      */
     public function testIsNew(): void
     {
-        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3,]) extends Entity {
+        $entity = new class (['id' => 1, 'title' => 'Foo', 'author_id' => 3]) extends Entity {
             protected $id;
             protected $title;
             protected $author_id;
@@ -1135,7 +1064,7 @@ class EntityWithConcretePropertiesTest extends TestCase
     {
         $user = new Entity();
         $owner = new Entity();
-        $author = new class (['foo' => 'bar', 'thing' => 'baz', 'user' => $user, 'owner' => $owner,]) extends Entity {
+        $author = new class (['foo' => 'bar', 'thing' => 'baz', 'user' => $user, 'owner' => $owner]) extends Entity {
             protected $foo;
             protected $thing;
             protected $user;
@@ -1214,7 +1143,7 @@ class EntityWithConcretePropertiesTest extends TestCase
     {
         $assoc = new Entity();
         $assoc2 = new Entity();
-        $entity = new class (['field' => 'value', 'one' => $assoc, 'many' => [$assoc2],]) extends Entity {
+        $entity = new class (['field' => 'value', 'one' => $assoc, 'many' => [$assoc2]]) extends Entity {
             protected $field;
             protected $one;
             protected $many;
@@ -1582,7 +1511,7 @@ class EntityWithConcretePropertiesTest extends TestCase
      */
     public function testHasValue(): void
     {
-        $entity = new class (['array' => ['foo' => 'bar'], 'emptyArray' => [], 'object' => new stdClass(), 'string' => 'string', 'stringZero' => '0', 'emptyString' => '', 'intZero' => 0, 'intNotZero' => 1, 'floatZero' => 0.0, 'floatNonZero' => 1.5, 'null' => null, 'true' => true, 'false' => false,]) extends Entity {
+        $entity = new class (['array' => ['foo' => 'bar'], 'emptyArray' => [], 'object' => new stdClass(), 'string' => 'string', 'stringZero' => '0', 'emptyString' => '', 'intZero' => 0, 'intNotZero' => 1, 'floatZero' => 0.0, 'floatNonZero' => 1.5, 'null' => null, 'true' => true, 'false' => false]) extends Entity {
             protected $array;
             protected $emptyArray;
             protected $object;

--- a/tests/test_app/TestApp/Model/Entity/UserWithProps.php
+++ b/tests/test_app/TestApp/Model/Entity/UserWithProps.php
@@ -11,11 +11,6 @@ class UserWithProps extends Entity
     protected string $name;
     protected ?string $username;
     protected ?string $password;
-    protected $created;
-    protected $updated;
-    protected $odd;
 
-    protected $article;
-    protected $articles;
-    protected $comments;
+    protected ?array $articles;
 }

--- a/tests/test_app/TestApp/Model/Entity/UserWithProps.php
+++ b/tests/test_app/TestApp/Model/Entity/UserWithProps.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Entity;
+
+use Cake\ORM\Entity;
+
+class UserWithProps extends Entity
+{
+    protected int $id;
+    protected string $name;
+    protected ?string $username;
+    protected ?string $password;
+    protected $created;
+    protected $updated;
+    protected $odd;
+
+    protected $article;
+    protected $articles;
+    protected $comments;
+}


### PR DESCRIPTION
Refs #19380, enhanced version of #19313. The key difference between the 2 PRs is the use of reflection to support use of hooked properties with asymmetric visibility.

This  implementation allows having clean entity classes like:

```php
class User extends Entity
{
    public protected(set) int $id;
    public protected(set) ?string $email;
    public protected(set) bool $is_active = false;
    public protected(set) ?string $first_name;
    public protected(set) ?string $last_name;

    public protected(set) ?string $first_name {
        set(?string $value) {
            $this->first_name = $value ? trim(ucwords($value)) : null;
        }
    }

    public protected(set) ?string $password {
        set(?string $value) {
            $this->password = $value ? password_hash($value, PASSWORD_DEFAULT) : null;
        }
    }

    public string $full_name {
        get => $this->first_name . ' ' . $this->last_name;
    }
}
```

### Advantages
- ~~No docblock required for entity properties.~~  Docblock would not be required for "get" since it's public but would be for using assignment like `$entity->foo = 'val';` since the `set` hook is protected.
- Using actual typed properties gives you proper type enforcement.
- With asymmetric visibility reading the property directly reads the value instead of going through magic `__get()`. Writing a value still goes through magic `__set()` to ensure features like dirty tracking etc. continue to work.
  Properties can also be declared without asymmetric visibility as `protected string $foo`.
- Storing the values using properties instead of a fields array is more memory efficient.

### Why is reflection needed
- Our current entity implementation skips the use of setter (`_setFoo()`) when the entity is constructed (from the data fetched from db). PHP's set hook can be skipped only through reflection.
-  The current `hasValue()` differentiates between "field not set" vs "value set to null", which is not possible for properties without using `ReflectedProperty::isInitialized()`.

### What about the overhead of reflection
- Currently an in memory cached of reflected properties is maintained through a static property.
- The reflection data can be be further cached using the `PhpEngine` cache engine, which can be opcache optimized. (This is yet to be added). This would make any overhead added by use of reflection negligible and the benefits achieved greatly out weight it.

P.S.  Full backwards compatibility is maintained with 5.x, so the new usage with properties become opt-in for those upgrading. 