### PR TITLE
Add EXCEPT and EXCEPT ALL set operations to SelectQuery

### DIFF
--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -132,6 +132,8 @@ class Mysql extends Driver
             'window' => '8.0.0',
             'intersect' => '8.0.31',
             'intersect-all' => '8.0.31',
+            'except' => '8.0.31',
+            'except-all' => '8.0.31',
             'check-constraints' => '8.0.16',
         ],
         'mariadb' => [
@@ -140,6 +142,8 @@ class Mysql extends Driver
             'window' => '10.2.0',
             'intersect' => '10.3.0',
             'intersect-all' => '10.5.0',
+            'except' => '10.3.0',
+            'except-all' => '10.5.0',
             'check-constraints' => '10.2.1',
         ],
     ];
@@ -285,6 +289,8 @@ class Mysql extends Driver
             DriverFeatureEnum::WINDOW => $versionCompare(),
             DriverFeatureEnum::INTERSECT => $versionCompare(),
             DriverFeatureEnum::INTERSECT_ALL => $versionCompare(),
+            DriverFeatureEnum::EXCEPT => $versionCompare(),
+            DriverFeatureEnum::EXCEPT_ALL => $versionCompare(),
             DriverFeatureEnum::CHECK_CONSTRAINTS => $versionCompare(),
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => true,
             DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => true,

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -208,6 +208,8 @@ class Postgres extends Driver
             DriverFeatureEnum::WINDOW => true,
             DriverFeatureEnum::INTERSECT => true,
             DriverFeatureEnum::INTERSECT_ALL => true,
+            DriverFeatureEnum::EXCEPT => true,
+            DriverFeatureEnum::EXCEPT_ALL => true,
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => true,
             DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION => false,
             DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => true,

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -206,6 +206,8 @@ class Sqlite extends Driver
             ),
             DriverFeatureEnum::INTERSECT => true,
             DriverFeatureEnum::INTERSECT_ALL => false,
+            DriverFeatureEnum::EXCEPT => true,
+            DriverFeatureEnum::EXCEPT_ALL => false,
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => false,
             DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => false,
             DriverFeatureEnum::CHECK_CONSTRAINTS => true,

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -286,6 +286,8 @@ class Sqlserver extends Driver
             DriverFeatureEnum::WINDOW => true,
             DriverFeatureEnum::INTERSECT => true,
             DriverFeatureEnum::INTERSECT_ALL => false,
+            DriverFeatureEnum::EXCEPT => true,
+            DriverFeatureEnum::EXCEPT_ALL => false,
             DriverFeatureEnum::JSON => false,
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => false,
             DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => false,

--- a/src/Database/DriverFeatureEnum.php
+++ b/src/Database/DriverFeatureEnum.php
@@ -59,7 +59,17 @@ enum DriverFeatureEnum: string
     case INTERSECT_ALL = 'intersect-all';
 
     /**
-     * Support for order by in set operations (union, intersect)
+     * Except feature support
+     */
+    case EXCEPT = 'except';
+
+    /**
+     * Except all feature support
+     */
+    case EXCEPT_ALL = 'except-all';
+
+    /**
+     * Support for order by in set operations (union, intersect, except)
      */
     case SET_OPERATIONS_ORDER_BY = 'set-operations-order-by';
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -121,6 +121,7 @@ abstract class Query implements ExpressionInterface, Stringable
         'limit' => null,
         'offset' => null,
         'union' => [],
+        'except' => [],
         'epilog' => null,
         'intersect' => [],
     ];

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -572,7 +572,7 @@ class SelectQuery extends Query implements IteratorAggregate
     /**
      * Adds a complete query to be used in conjunction with an EXCEPT operator with
      * this query. This is used to subtract the passed query from the result set of this query.
-     * You can add as many queries as you required by calling multiple times 
+     * You can add as many queries as you required by calling multiple times
      * this method with different queries.
      *
      * By default, the EXCEPT operator will remove duplicate rows, if you wish to include
@@ -610,7 +610,7 @@ class SelectQuery extends Query implements IteratorAggregate
     /**
      * Adds a complete query to be used in conjunction with the EXCEPT ALL operator with
      * this query. This is used to subtract the passed query from the result set of this query.
-     * You can add as many queries as you required by calling multiple times 
+     * You can add as many queries as you required by calling multiple times
      * this method with different queries.
      *
      * Unlike EXCEPT, EXCEPT ALL will not remove duplicate rows.

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -571,9 +571,9 @@ class SelectQuery extends Query implements IteratorAggregate
 
     /**
      * Adds a complete query to be used in conjunction with an EXCEPT operator with
-     * this query. This is used to subtract the result set returned by the passed
-     * query from the result set of this query. You can add as many queries as you
-     * required by calling multiple times this method with different queries.
+     * this query. This is used to subtract the passed query from the result set of this query.
+     * You can add as many queries as you required by calling multiple times 
+     * this method with different queries.
      *
      * By default, the EXCEPT operator will remove duplicate rows, if you wish to include
      * every row for all queries, use exceptAll().
@@ -609,9 +609,9 @@ class SelectQuery extends Query implements IteratorAggregate
 
     /**
      * Adds a complete query to be used in conjunction with the EXCEPT ALL operator with
-     * this query. This is used to subtract the result set returned by the passed
-     * query from the result set of this query. You can add as many queries as you
-     * required by calling multiple times this method with different queries.
+     * this query. This is used to subtract the passed query from the result set of this query.
+     * You can add as many queries as you required by calling multiple times 
+     * this method with different queries.
      *
      * Unlike EXCEPT, EXCEPT ALL will not remove duplicate rows.
      *

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -68,6 +68,7 @@ class SelectQuery extends Query implements IteratorAggregate
         'limit' => null,
         'offset' => null,
         'union' => [],
+        'except' => [],
         'epilog' => null,
         'intersect' => [],
     ];
@@ -560,6 +561,79 @@ class SelectQuery extends Query implements IteratorAggregate
             $this->_parts['intersect'] = [];
         }
         $this->_parts['intersect'][] = [
+            'all' => true,
+            'query' => $query,
+        ];
+        $this->_dirty();
+
+        return $this;
+    }
+
+    /**
+     * Adds a complete query to be used in conjunction with an EXCEPT operator with
+     * this query. This is used to subtract the result set returned by the passed
+     * query from the result set of this query. You can add as many queries as you
+     * required by calling multiple times this method with different queries.
+     *
+     * By default, the EXCEPT operator will remove duplicate rows, if you wish to include
+     * every row for all queries, use exceptAll().
+     *
+     * ### Examples
+     *
+     * ```
+     * $except = (new SelectQuery($conn))->select(['id', 'title'])->from(['a' => 'articles']);
+     * $query->select(['id', 'name'])->from(['d' => 'things'])->except($except);
+     * ```
+     *
+     * Will produce:
+     *
+     * `SELECT id, name FROM things d EXCEPT SELECT id, title FROM articles a`
+     *
+     * @param \Cake\Database\Query|string $query full SQL query to be used in EXCEPT operator
+     * @param bool $overwrite whether to reset the list of queries to be operated or not
+     * @return $this
+     */
+    public function except(Query|string $query, bool $overwrite = false)
+    {
+        if ($overwrite) {
+            $this->_parts['except'] = [];
+        }
+        $this->_parts['except'][] = [
+            'all' => false,
+            'query' => $query,
+        ];
+        $this->_dirty();
+
+        return $this;
+    }
+
+    /**
+     * Adds a complete query to be used in conjunction with the EXCEPT ALL operator with
+     * this query. This is used to subtract the result set returned by the passed
+     * query from the result set of this query. You can add as many queries as you
+     * required by calling multiple times this method with different queries.
+     *
+     * Unlike EXCEPT, EXCEPT ALL will not remove duplicate rows.
+     *
+     * ```
+     * $except = (new SelectQuery($conn))->select(['id', 'title'])->from(['a' => 'articles']);
+     * $query->select(['id', 'name'])->from(['d' => 'things'])->exceptAll($except);
+     * ```
+     *
+     * Will produce:
+     *
+     * `SELECT id, name FROM things d EXCEPT ALL SELECT id, title FROM articles a`
+     *
+     * @param \Cake\Database\Query|string $query full SQL query to be used in EXCEPT operator
+     * @param bool $overwrite whether to reset the list of queries to be operated or not
+     * @return $this
+     */
+    public function exceptAll(Query|string $query, bool $overwrite = false)
+    {
+        if ($overwrite) {
+            $this->_parts['except'] = [];
+        }
+        $this->_parts['except'][] = [
             'all' => true,
             'query' => $query,
         ];

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -53,7 +53,7 @@ class QueryCompiler
      */
     protected array $_selectParts = [
         'comment', 'with', 'select', 'from', 'join', 'where', 'group', 'having', 'window', 'order',
-        'limit', 'offset', 'union', 'epilog', 'intersect',
+        'limit', 'offset', 'union', 'except', 'epilog', 'intersect',
     ];
 
     /**
@@ -191,7 +191,7 @@ class QueryCompiler
         $driver = $query->getDriver();
         $select = 'SELECT%s%s %s%s';
         if (
-            ($query->clause('union') || $query->clause('intersect')) &&
+            ($query->clause('union') || $query->clause('except') || $query->clause('intersect')) &&
             $driver->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY)
         ) {
             $select = '(SELECT%s%s %s%s';
@@ -394,6 +394,21 @@ class QueryCompiler
     protected function _buildIntersectPart(array $parts, Query $query, ValueBinder $binder): string
     {
         return $this->_buildSetOperationPart('INTERSECT', $parts, $query, $binder);
+    }
+
+    /**
+     * Builds the SQL string for all the EXCEPT clauses in this query, when dealing
+     * with query objects it will also transform them using their configured SQL
+     * dialect.
+     *
+     * @param array $parts list of queries to be operated with EXCEPT
+     * @param \Cake\Database\Query $query The query that is being compiled
+     * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
+     * @return string
+     */
+    protected function _buildExceptPart(array $parts, Query $query, ValueBinder $binder): string
+    {
+        return $this->_buildSetOperationPart('EXCEPT', $parts, $query, $binder);
     }
 
     /**

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -49,7 +49,7 @@ class SqlserverCompiler extends QueryCompiler
      */
     protected array $_selectParts = [
         'comment', 'with', 'select', 'from', 'join', 'where', 'group', 'having', 'window', 'order',
-        'offset', 'limit', 'union', 'epilog', 'intersect',
+        'offset', 'limit', 'union', 'except', 'epilog', 'intersect',
     ];
 
     /**

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -222,6 +222,8 @@ class MysqlTest extends TestCase
                 'window' => '8.0.0',
                 'intersect' => '8.0.31',
                 'intersect-all' => '8.0.31',
+                'except' => '8.0.31',
+                'except-all' => '8.0.31',
             ],
             'mariadb' => [
                 'json' => '10.2.7',
@@ -229,6 +231,8 @@ class MysqlTest extends TestCase
                 'window' => '10.2.0',
                 'intersect' => '10.3.0',
                 'intersect-all' => '10.5.0',
+                'except' => '10.3.0',
+                'except-all' => '10.5.0',
             ],
         ];
         foreach ($featureVersions[$serverType] as $feature => $version) {

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -237,6 +237,8 @@ class PostgresTest extends TestCase
         $this->assertTrue($driver->supports(DriverFeatureEnum::WINDOW));
         $this->assertTrue($driver->supports(DriverFeatureEnum::INTERSECT));
         $this->assertTrue($driver->supports(DriverFeatureEnum::INTERSECT_ALL));
+        $this->assertTrue($driver->supports(DriverFeatureEnum::EXCEPT));
+        $this->assertTrue($driver->supports(DriverFeatureEnum::EXCEPT_ALL));
         $this->assertTrue($driver->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY));
 
         $this->assertFalse($driver->supports(DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -215,8 +215,10 @@ class SqliteTest extends TestCase
         $this->assertTrue($driver->supports(DriverFeatureEnum::SAVEPOINT));
         $this->assertTrue($driver->supports(DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS));
         $this->assertTrue($driver->supports(DriverFeatureEnum::INTERSECT));
+        $this->assertTrue($driver->supports(DriverFeatureEnum::EXCEPT));
 
         $this->assertFalse($driver->supports(DriverFeatureEnum::INTERSECT_ALL));
+        $this->assertFalse($driver->supports(DriverFeatureEnum::EXCEPT_ALL));
         $this->assertFalse($driver->supports(DriverFeatureEnum::JSON));
         $this->assertFalse($driver->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY));
     }

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -562,8 +562,10 @@ class SqlserverTest extends TestCase
         $this->assertTrue($driver->supports(DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS));
         $this->assertTrue($driver->supports(DriverFeatureEnum::WINDOW));
         $this->assertTrue($driver->supports(DriverFeatureEnum::INTERSECT));
+        $this->assertTrue($driver->supports(DriverFeatureEnum::EXCEPT));
 
         $this->assertFalse($driver->supports(DriverFeatureEnum::INTERSECT_ALL));
+        $this->assertFalse($driver->supports(DriverFeatureEnum::EXCEPT_ALL));
         $this->assertFalse($driver->supports(DriverFeatureEnum::JSON));
         $this->assertFalse($driver->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY));
     }

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -2820,6 +2820,170 @@ class SelectQueryTest extends TestCase
     }
 
     /**
+     * Tests that it is possible to one or multiple EXCEPT statements in a query
+     */
+    public function testExcept(): void
+    {
+        $this->skipIf(
+            !$this->connection->getDriver()->supports(DriverFeatureEnum::EXCEPT),
+            'Driver does not support EXCEPT clause.',
+        );
+
+        $except = (new SelectQuery($this->connection))
+            ->select(['id', 'comment'])
+            ->from(['c' => 'comments'])
+            ->where(['article_id' => 1]);
+        $query = new SelectQuery($this->connection);
+        $result = $query->select(['id', 'comment'])
+            ->from(['c' => 'comments'])
+            ->except($except)
+            ->execute();
+        $rows = $result->fetchAll();
+        $expectedCount = count((new SelectQuery($this->connection))
+            ->select(['id', 'comment'])
+            ->from(['c' => 'comments'])
+            ->execute()
+            ->fetchAll()) -
+            count($except->execute()->fetchAll());
+
+        $this->assertCount($expectedCount, $rows);
+        $result->closeCursor();
+
+        $except = (new SelectQuery($this->connection))
+            ->select(['foo' => 'id', 'bar' => 'comment'])
+            ->from(['c' => 'comments'])
+            ->where(['article_id' => 2])
+            ->orderBy(['foo' => 'desc']);
+        $query = new SelectQuery($this->connection);
+        $expectedCount = count((new SelectQuery($this->connection))
+            ->select(['foo' => 'id', 'bar' => 'comment'])
+            ->from(['c' => 'comments'])
+            ->execute()
+            ->fetchAll()) - count($except->execute()->fetchAll());
+        $query->select(['foo' => 'id', 'bar' => 'comment'])
+            ->from(['c' => 'comments'])
+            ->except($except);
+        $result = $query->execute();
+        $rows2 = $result->fetchAll();
+
+        $this->assertCount($expectedCount, $rows2);
+        $this->assertNotEquals($rows, $rows2);
+        $result->closeCursor();
+
+        $except = (new SelectQuery($this->connection))
+            ->select(['id', 'comment'])
+            ->where(['article_id' => 1])
+            ->from(['c' => 'comments']);
+        $query = new SelectQuery($this->connection);
+        $query->select(['id', 'comment'], true)
+            ->from(['c' => 'comments'])
+            ->except($except, true);
+        $result = $query->execute();
+        $rows3 = $result->fetchAll();
+
+        $this->assertCount(
+            count((new SelectQuery($this->connection))
+                ->select(['id', 'comment'])
+                ->from(['c' => 'comments'])
+                ->execute()
+                ->fetchAll()) - count($except->execute()->fetchAll()),
+            $rows3,
+        );
+        $this->assertEquals($rows, $rows3);
+        $result->closeCursor();
+    }
+
+    /**
+     * Tests that it is possible to run excepts with order by statements
+     */
+    public function testExceptOrderBy(): void
+    {
+        $this->skipIf(
+            !$this->connection->getDriver()->supports(DriverFeatureEnum::EXCEPT),
+            'Driver does not support EXCEPT clause.',
+        );
+        $this->skipIf(
+            !$this->connection->getDriver()->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY),
+            'Driver does not support ORDER BY on EXCEPTed queries.',
+        );
+        $except = (new SelectQuery($this->connection))
+            ->select(['id', 'comment'])
+            ->from(['c' => 'comments'])
+            ->where(['article_id' => 1])
+            ->orderBy(['c.id' => 'asc']);
+
+        $query = new SelectQuery($this->connection);
+        $result = $query->select(['id', 'comment'])
+            ->from(['c' => 'comments'])
+            ->orderBy(['c.id' => 'asc'])
+            ->except($except)
+            ->execute();
+
+        $this->assertCount(
+            count((new SelectQuery($this->connection))
+                ->select(['id', 'comment'])
+                ->from(['c' => 'comments'])
+                ->execute()
+                ->fetchAll()) -
+                count($except->execute()->fetchAll()),
+            $result->fetchAll(),
+        );
+    }
+
+    /**
+     * Tests that EXCEPT ALL can be built
+     */
+    public function testExceptAll(): void
+    {
+        $this->skipIf(
+            !$this->connection->getDriver()->supports(DriverFeatureEnum::EXCEPT_ALL),
+            'Driver does not support EXCEPT ALL clause.',
+        );
+        $except = (new SelectQuery($this->connection))
+            ->select(['id', 'comment'])
+            ->from(['c' => 'comments'])
+            ->where(['article_id' => 1]);
+        $query = new SelectQuery($this->connection);
+        $result = $query->select(['id', 'comment'])
+            ->from(['c' => 'comments'])
+            ->exceptAll($except)
+            ->execute();
+        $rows = $result->fetchAll('assoc');
+
+        $this->assertCount(
+            count((new SelectQuery($this->connection))
+                ->select(['id', 'comment'])
+                ->from(['c' => 'comments'])
+                ->execute()
+                ->fetchAll()) -
+                count($except->execute()->fetchAll()),
+            $rows,
+        );
+        $result->closeCursor();
+
+        $except = (new SelectQuery($this->connection))
+            ->select(['id', 'comment'])
+            ->from(['c' => 'comments'])
+            ->where(['article_id' => 2])
+            ->orderBy(['id' => 'desc']);
+        $query = new SelectQuery($this->connection);
+        $expectedCount = count((new SelectQuery($this->connection))
+            ->select(['id', 'comment'])
+            ->from(['c' => 'comments'])
+            ->execute()
+            ->fetchAll()) - count($except->execute()->fetchAll());
+        $query->select(['id', 'comment'], true)
+            ->from(['c' => 'comments'])
+            ->exceptAll($except, true);
+        $result = $query->execute();
+        $rows2 = $result->fetchAll();
+
+        $this->assertCount($expectedCount, $rows2);
+        $this->assertNotEquals($rows, $rows2);
+        $result->closeCursor();
+    }
+
+    /**
      * Tests stacking decorators for results and resetting the list of decorators
      */
     public function testDecorateResults(): void


### PR DESCRIPTION
## Summary
- add `except()` and `exceptAll()` to `SelectQuery`
- compile `EXCEPT` and `EXCEPT ALL` set operations across query compilers
- add driver feature flags and query/driver test coverage for supported platforms

## Notes
- support flags follow vendor documentation for each backend
- `EXCEPT ALL` is enabled for PostgreSQL and MySQL/MariaDB versions that support it
- `EXCEPT ALL` remains disabled for SQLite and SQL Server

Resolves https://github.com/cakephp/cakephp/pull/19385