### PR TITLE
Add portable stringAgg() support to FunctionsBuilder

### DIFF
--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -19,6 +19,7 @@ namespace Cake\Database\Driver;
 use Cake\Database\Driver;
 use Cake\Database\DriverFeatureEnum;
 use Cake\Database\Expression\DistinctComparisonExpression;
+use Cake\Database\Expression\StringAggExpression;
 use Cake\Database\Query;
 use Cake\Database\Query\SelectQuery;
 use Cake\Database\Schema\MysqlSchemaDialect;
@@ -38,6 +39,7 @@ class Mysql extends Driver
     protected function _expressionTranslators(): array
     {
         return [
+            StringAggExpression::class => 'transformStringAggExpression',
             DistinctComparisonExpression::class => 'transformDistinctComparisonExpression',
         ];
     }
@@ -57,6 +59,27 @@ class Mysql extends Driver
             $expression->setOperator('<=>');
             $expression->setNot(true);
         }
+    }
+
+    /**
+     * Translates portable string aggregation to MySQL/MariaDB specific syntax.
+     *
+     * @param \Cake\Database\Expression\StringAggExpression $expression The expression to translate.
+     * @return void
+     */
+    protected function transformStringAggExpression(StringAggExpression $expression): void
+    {
+        if ($this->supports(DriverFeatureEnum::STRING_AGG)) {
+            $expression
+                ->setName('STRING_AGG')
+                ->setSyntax(StringAggExpression::SYNTAX_STANDARD);
+
+            return;
+        }
+
+        $expression
+            ->setName('GROUP_CONCAT')
+            ->setSyntax(StringAggExpression::SYNTAX_GROUP_CONCAT);
     }
 
     /**
@@ -130,6 +153,7 @@ class Mysql extends Driver
             'json' => '5.7.0',
             'cte' => '8.0.0',
             'window' => '8.0.0',
+            'string-agg' => '99.0.0',
             'intersect' => '8.0.31',
             'intersect-all' => '8.0.31',
             'check-constraints' => '8.0.16',
@@ -138,6 +162,7 @@ class Mysql extends Driver
             'json' => '10.2.7',
             'cte' => '10.2.1',
             'window' => '10.2.0',
+            'string-agg' => '10.5.0',
             'intersect' => '10.3.0',
             'intersect-all' => '10.5.0',
             'check-constraints' => '10.2.1',
@@ -283,6 +308,8 @@ class Mysql extends Driver
             DriverFeatureEnum::CTE,
             DriverFeatureEnum::JSON,
             DriverFeatureEnum::WINDOW => $versionCompare(),
+            DriverFeatureEnum::STRING_AGG => $versionCompare(),
+            DriverFeatureEnum::GROUP_CONCAT => true,
             DriverFeatureEnum::INTERSECT => $versionCompare(),
             DriverFeatureEnum::INTERSECT_ALL => $versionCompare(),
             DriverFeatureEnum::CHECK_CONSTRAINTS => $versionCompare(),

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -20,6 +20,7 @@ use Cake\Database\Driver;
 use Cake\Database\DriverFeatureEnum;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\StringAggExpression;
 use Cake\Database\Expression\StringExpression;
 use Cake\Database\PostgresCompiler;
 use Cake\Database\Query\InsertQuery;
@@ -206,6 +207,8 @@ class Postgres extends Driver
             DriverFeatureEnum::SAVEPOINT,
             DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS,
             DriverFeatureEnum::WINDOW => true,
+            DriverFeatureEnum::STRING_AGG => true,
+            DriverFeatureEnum::GROUP_CONCAT => false,
             DriverFeatureEnum::INTERSECT => true,
             DriverFeatureEnum::INTERSECT_ALL => true,
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => true,
@@ -242,9 +245,24 @@ class Postgres extends Driver
     {
         return [
             IdentifierExpression::class => '_transformIdentifierExpression',
+            StringAggExpression::class => '_transformStringAggExpression',
             FunctionExpression::class => '_transformFunctionExpression',
             StringExpression::class => '_transformStringExpression',
         ];
+    }
+
+    /**
+     * Receives a StringAggExpression and changes it so that it conforms to this
+     * SQL dialect.
+     *
+     * @param \Cake\Database\Expression\StringAggExpression $expression The expression to convert.
+     * @return void
+     */
+    protected function _transformStringAggExpression(StringAggExpression $expression): void
+    {
+        $expression
+            ->setName('STRING_AGG')
+            ->setSyntax(StringAggExpression::SYNTAX_STANDARD);
     }
 
     /**

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -19,6 +19,7 @@ namespace Cake\Database\Driver;
 use Cake\Database\Driver;
 use Cake\Database\DriverFeatureEnum;
 use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\StringAggExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\Schema\SchemaDialect;
 use Cake\Database\Schema\SqliteSchemaDialect;
@@ -101,6 +102,7 @@ class Sqlite extends Driver
      */
     protected array $featureVersions = [
         'cte' => '3.8.3',
+        'string-agg' => '3.44.0',
         'window' => '3.28.0',
     ];
 
@@ -199,11 +201,13 @@ class Sqlite extends Driver
             DriverFeatureEnum::JSON => false,
 
             DriverFeatureEnum::CTE,
+            DriverFeatureEnum::STRING_AGG,
             DriverFeatureEnum::WINDOW => version_compare(
                 $this->version(),
                 $this->featureVersions[$feature->value],
                 '>=',
             ),
+            DriverFeatureEnum::GROUP_CONCAT => true,
             DriverFeatureEnum::INTERSECT => true,
             DriverFeatureEnum::INTERSECT_ALL => false,
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => false,
@@ -226,9 +230,24 @@ class Sqlite extends Driver
     protected function _expressionTranslators(): array
     {
         return [
+            StringAggExpression::class => '_transformStringAggExpression',
             FunctionExpression::class => '_transformFunctionExpression',
             TupleComparison::class => '_transformTupleComparison',
         ];
+    }
+
+    /**
+     * Receives a StringAggExpression and changes it so that it conforms to this
+     * SQL dialect.
+     *
+     * @param \Cake\Database\Expression\StringAggExpression $expression The expression to convert.
+     * @return void
+     */
+    protected function _transformStringAggExpression(StringAggExpression $expression): void
+    {
+        $expression
+            ->setName($this->supports(DriverFeatureEnum::STRING_AGG) ? 'STRING_AGG' : 'GROUP_CONCAT')
+            ->setSyntax(StringAggExpression::SYNTAX_STANDARD);
     }
 
     /**

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -21,6 +21,7 @@ use Cake\Database\DriverFeatureEnum;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\OrderClauseExpression;
+use Cake\Database\Expression\StringAggExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\Expression\UnaryExpression;
 use Cake\Database\ExpressionInterface;
@@ -284,6 +285,8 @@ class Sqlserver extends Driver
             DriverFeatureEnum::SAVEPOINT,
             DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS,
             DriverFeatureEnum::WINDOW => true,
+            DriverFeatureEnum::STRING_AGG => version_compare($this->version(), '14', '>='),
+            DriverFeatureEnum::GROUP_CONCAT => false,
             DriverFeatureEnum::INTERSECT => true,
             DriverFeatureEnum::INTERSECT_ALL => false,
             DriverFeatureEnum::JSON => false,
@@ -466,9 +469,24 @@ class Sqlserver extends Driver
     protected function _expressionTranslators(): array
     {
         return [
+            StringAggExpression::class => '_transformStringAggExpression',
             FunctionExpression::class => '_transformFunctionExpression',
             TupleComparison::class => '_transformTupleComparison',
         ];
+    }
+
+    /**
+     * Receives a StringAggExpression and changes it so that it conforms to this
+     * SQL dialect.
+     *
+     * @param \Cake\Database\Expression\StringAggExpression $expression The expression to convert to TSQL.
+     * @return void
+     */
+    protected function _transformStringAggExpression(StringAggExpression $expression): void
+    {
+        $expression
+            ->setName('STRING_AGG')
+            ->setSyntax(StringAggExpression::SYNTAX_WITHIN_GROUP);
     }
 
     /**

--- a/src/Database/DriverFeatureEnum.php
+++ b/src/Database/DriverFeatureEnum.php
@@ -72,4 +72,14 @@ enum DriverFeatureEnum: string
      * Support for CHECK constraints.
      */
     case CHECK_CONSTRAINTS = 'check-constraints';
+
+    /**
+     * String aggregation via STRING_AGG support.
+     */
+    case STRING_AGG = 'string-agg';
+
+    /**
+     * String aggregation via GROUP_CONCAT support.
+     */
+    case GROUP_CONCAT = 'group-concat';
 }

--- a/src/Database/Expression/StringAggExpression.php
+++ b/src/Database/Expression/StringAggExpression.php
@@ -55,7 +55,7 @@ class StringAggExpression extends AggregateExpression
      */
     public function __construct(array $params = [], array $types = [], ExpressionInterface|array|string|null $orderBy = null)
     {
-        parent::__construct('STRING_AGG', $params, $types, 'string');
+        parent::__construct('STRING_AGG', $params, $types);
         if ($orderBy !== null) {
             $this->setAggregateOrderBy($orderBy);
         }

--- a/src/Database/Expression/StringAggExpression.php
+++ b/src/Database/Expression/StringAggExpression.php
@@ -1,0 +1,205 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+use Cake\Database\ExpressionInterface;
+use Cake\Database\Query;
+use Cake\Database\ValueBinder;
+use Closure;
+use InvalidArgumentException;
+
+/**
+ * Portable string aggregation expression that can render as STRING_AGG or
+ * GROUP_CONCAT depending on the driver dialect.
+ */
+class StringAggExpression extends AggregateExpression
+{
+    public const SYNTAX_STANDARD = 'standard';
+    public const SYNTAX_WITHIN_GROUP = 'within-group';
+    public const SYNTAX_GROUP_CONCAT = 'group-concat';
+
+    /**
+     * Aggregate-local ORDER BY clause.
+     *
+     * @var \Cake\Database\Expression\OrderByExpression|null
+     */
+    protected ?OrderByExpression $aggregateOrderBy = null;
+
+    /**
+     * SQL syntax variant to render.
+     *
+     * @var string
+     */
+    protected string $syntax = self::SYNTAX_STANDARD;
+
+    /**
+     * Constructor.
+     *
+     * @param array $params Function arguments, value first and separator second.
+     * @param array<string, string>|array<string|null> $types Types for function arguments.
+     * @param \Cake\Database\ExpressionInterface|array|string|null $orderBy Aggregate-local ordering.
+     */
+    public function __construct(array $params = [], array $types = [], ExpressionInterface|array|string|null $orderBy = null)
+    {
+        parent::__construct('STRING_AGG', $params, $types, 'string');
+        if ($orderBy !== null) {
+            $this->setAggregateOrderBy($orderBy);
+        }
+    }
+
+    /**
+     * Sets aggregate-local ordering.
+     *
+     * @param \Cake\Database\ExpressionInterface|array|string $fields The sort columns.
+     * @return $this
+     */
+    public function setAggregateOrderBy(ExpressionInterface|array|string $fields)
+    {
+        $this->aggregateOrderBy ??= new OrderByExpression();
+        $this->aggregateOrderBy->add($fields);
+
+        return $this;
+    }
+
+    /**
+     * Sets the SQL syntax variant.
+     *
+     * @param string $syntax The syntax variant.
+     * @return $this
+     */
+    public function setSyntax(string $syntax)
+    {
+        $allowed = [
+            static::SYNTAX_STANDARD,
+            static::SYNTAX_WITHIN_GROUP,
+            static::SYNTAX_GROUP_CONCAT,
+        ];
+        if (!in_array($syntax, $allowed, true)) {
+            throw new InvalidArgumentException(sprintf('Unsupported string aggregation syntax `%s`.', $syntax));
+        }
+
+        $this->syntax = $syntax;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function sql(ValueBinder $binder): string
+    {
+        $parts = array_map(fn($part) => $this->stringifyPart($part, $binder), $this->_conditions);
+        [$value, $separator] = $parts + [null, null];
+
+        $sql = match ($this->syntax) {
+            static::SYNTAX_GROUP_CONCAT => $this->_name . sprintf(
+                '(%s%s SEPARATOR %s)',
+                $value,
+                $this->aggregateOrderBy ? ' ' . $this->aggregateOrderBy->sql($binder) : '',
+                $separator,
+            ),
+            static::SYNTAX_WITHIN_GROUP => $this->_name . sprintf(
+                '(%s, %s)%s',
+                $value,
+                $separator,
+                $this->aggregateOrderBy ? ' WITHIN GROUP (' . $this->aggregateOrderBy->sql($binder) . ')' : '',
+            ),
+            default => $this->_name . sprintf(
+                '(%s, %s%s)',
+                $value,
+                $separator,
+                $this->aggregateOrderBy ? ' ' . $this->aggregateOrderBy->sql($binder) : '',
+            ),
+        };
+
+        if ($this->filter !== null) {
+            $sql .= ' FILTER (WHERE ' . $this->filter->sql($binder) . ')';
+        }
+        if ($this->window !== null) {
+            if ($this->window->isNamedOnly()) {
+                $sql .= ' OVER ' . $this->window->sql($binder);
+            } else {
+                $sql .= ' OVER (' . $this->window->sql($binder) . ')';
+            }
+        }
+
+        return $sql;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function traverse(Closure $callback)
+    {
+        parent::traverse($callback);
+        if ($this->aggregateOrderBy !== null) {
+            $callback($this->aggregateOrderBy);
+            $this->aggregateOrderBy->traverse($callback);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function count(): int
+    {
+        $count = parent::count();
+        if ($this->aggregateOrderBy !== null) {
+            $count += 1;
+        }
+
+        return $count;
+    }
+
+    /**
+     * Clone this object and its subtree of expressions.
+     */
+    public function __clone()
+    {
+        parent::__clone();
+        if ($this->aggregateOrderBy !== null) {
+            $this->aggregateOrderBy = clone $this->aggregateOrderBy;
+        }
+    }
+
+    /**
+     * Converts a function argument into SQL.
+     *
+     * @param mixed $part Function argument.
+     * @param \Cake\Database\ValueBinder $binder Value binder.
+     * @return string
+     */
+    protected function stringifyPart(mixed $part, ValueBinder $binder): string
+    {
+        if ($part instanceof Query) {
+            return sprintf('(%s)', $part->sql($binder));
+        }
+        if ($part instanceof ExpressionInterface) {
+            return $part->sql($binder);
+        }
+        if (is_array($part)) {
+            $placeholder = $binder->placeholder('param');
+            $binder->bind($placeholder, $part['value'], $part['type']);
+
+            return $placeholder;
+        }
+
+        return (string)$part;
+    }
+}

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -18,6 +18,7 @@ namespace Cake\Database;
 
 use Cake\Database\Expression\AggregateExpression;
 use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\StringAggExpression;
 use InvalidArgumentException;
 
 /**
@@ -100,6 +101,27 @@ class FunctionsBuilder
     public function count(ExpressionInterface|string $expression, array $types = []): AggregateExpression
     {
         return $this->aggregate('COUNT', $this->toLiteralParam($expression), $types, 'integer');
+    }
+
+    /**
+     * Returns an AggregateExpression representing a portable string aggregation call.
+     *
+     * @param \Cake\Database\ExpressionInterface|string $expression The value to aggregate.
+     * @param string $separator The separator inserted between values.
+     * @param \Cake\Database\ExpressionInterface|array|string|null $orderBy Aggregate-local ordering.
+     * @param array $types List of types to bind to the arguments.
+     * @return \Cake\Database\Expression\StringAggExpression
+     */
+    public function stringAgg(
+        ExpressionInterface|string $expression,
+        string $separator,
+        ExpressionInterface|array|string|null $orderBy = null,
+        array $types = [],
+    ): StringAggExpression {
+        $params = $this->toLiteralParam($expression);
+        $params[] = $separator;
+
+        return new StringAggExpression($params, $types, $orderBy);
     }
 
     /**

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -26,6 +26,7 @@ use Mockery;
 use PDO;
 use Pdo\Mysql as PdoMysql;
 use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionClass;
 
 /**
  * Tests MySQL driver
@@ -262,7 +263,6 @@ class MysqlTest extends TestCase
         $driver->shouldReceive('connect')->andReturnNull();
         $driver->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
         $driver->shouldReceive('version')->andReturn('8.4.0');
-        $driver->shouldReceive('isMariadb')->andReturn(false);
 
         $connection = new Connection(['driver' => $driver, 'log' => false]);
         $query = new SelectQuery($connection);
@@ -271,7 +271,7 @@ class MysqlTest extends TestCase
         ])->from('authors');
 
         $this->assertSame(
-            'SELECT GROUP_CONCAT(name ORDER BY sort_order DESC SEPARATOR :c0) AS names FROM authors',
+            'SELECT (GROUP_CONCAT(name ORDER BY sort_order DESC SEPARATOR :param0)) AS names FROM authors',
             $query->sql(),
         );
     }
@@ -285,11 +285,13 @@ class MysqlTest extends TestCase
             ->makePartial()
             ->shouldAllowMockingProtectedMethods();
         $driver->__construct([]);
+        $reflection = new ReflectionClass($driver);
+        $serverType = $reflection->getProperty('serverType');
+        $serverType->setValue($driver, 'mariadb');
         $driver->shouldReceive('enabled')->andReturn(true);
         $driver->shouldReceive('connect')->andReturnNull();
         $driver->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
         $driver->shouldReceive('version')->andReturn('10.5.0');
-        $driver->shouldReceive('isMariadb')->andReturn(true);
 
         $connection = new Connection(['driver' => $driver, 'log' => false]);
         $query = new SelectQuery($connection);
@@ -298,7 +300,7 @@ class MysqlTest extends TestCase
         ])->from('authors');
 
         $this->assertSame(
-            'SELECT STRING_AGG(name, :c0 ORDER BY sort_order DESC) AS names FROM authors',
+            'SELECT (STRING_AGG(name, :param0 ORDER BY sort_order DESC)) AS names FROM authors',
             $query->sql(),
         );
     }

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -16,8 +16,10 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Driver;
 
+use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Query\SelectQuery;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Mockery;
@@ -220,6 +222,7 @@ class MysqlTest extends TestCase
                 'json' => '5.7.0',
                 'cte' => '8.0.0',
                 'window' => '8.0.0',
+                'string-agg' => '99.0.0',
                 'intersect' => '8.0.31',
                 'intersect-all' => '8.0.31',
             ],
@@ -227,6 +230,7 @@ class MysqlTest extends TestCase
                 'json' => '10.2.7',
                 'cte' => '10.2.1',
                 'window' => '10.2.0',
+                'string-agg' => '10.5.0',
                 'intersect' => '10.3.0',
                 'intersect-all' => '10.5.0',
             ],
@@ -240,8 +244,63 @@ class MysqlTest extends TestCase
 
         $this->assertTrue($driver->supports(DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));
         $this->assertTrue($driver->supports(DriverFeatureEnum::SAVEPOINT));
+        $this->assertTrue($driver->supports(DriverFeatureEnum::GROUP_CONCAT));
 
         $this->assertFalse($driver->supports(DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS));
+    }
+
+    /**
+     * Tests string aggregation translation for MySQL.
+     */
+    public function testStringAggTranslationForMysql(): void
+    {
+        $driver = Mockery::mock(Mysql::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct([]);
+        $driver->shouldReceive('enabled')->andReturn(true);
+        $driver->shouldReceive('connect')->andReturnNull();
+        $driver->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
+        $driver->shouldReceive('version')->andReturn('8.4.0');
+        $driver->shouldReceive('isMariadb')->andReturn(false);
+
+        $connection = new Connection(['driver' => $driver, 'log' => false]);
+        $query = new SelectQuery($connection);
+        $query->select([
+            'names' => $query->func()->stringAgg('name', ',', ['sort_order' => 'DESC']),
+        ])->from('authors');
+
+        $this->assertSame(
+            'SELECT GROUP_CONCAT(name ORDER BY sort_order DESC SEPARATOR :c0) AS names FROM authors',
+            $query->sql(),
+        );
+    }
+
+    /**
+     * Tests string aggregation translation for MariaDB.
+     */
+    public function testStringAggTranslationForMariadb(): void
+    {
+        $driver = Mockery::mock(Mysql::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct([]);
+        $driver->shouldReceive('enabled')->andReturn(true);
+        $driver->shouldReceive('connect')->andReturnNull();
+        $driver->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
+        $driver->shouldReceive('version')->andReturn('10.5.0');
+        $driver->shouldReceive('isMariadb')->andReturn(true);
+
+        $connection = new Connection(['driver' => $driver, 'log' => false]);
+        $query = new SelectQuery($connection);
+        $query->select([
+            'names' => $query->func()->stringAgg('name', ',', ['sort_order' => 'DESC']),
+        ])->from('authors');
+
+        $this->assertSame(
+            'SELECT STRING_AGG(name, :c0 ORDER BY sort_order DESC) AS names FROM authors',
+            $query->sql(),
+        );
     }
 
     /**

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -223,6 +223,32 @@ class PostgresTest extends TestCase
     }
 
     /**
+     * Tests string aggregation translation.
+     */
+    public function testStringAggTranslation(): void
+    {
+        $driver = Mockery::mock(Postgres::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct([]);
+        $driver->shouldReceive('enabled')->andReturn(true);
+        $driver->shouldReceive('connect')->andReturnNull();
+        $driver->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
+        $driver->shouldReceive('version')->andReturn('16.0');
+
+        $connection = new Connection(['driver' => $driver, 'log' => false]);
+        $query = new SelectQuery($connection);
+        $query->select([
+            'names' => $query->func()->stringAgg('name', ',', ['sort_order' => 'DESC']),
+        ])->from('authors');
+
+        $this->assertSame(
+            'SELECT (STRING_AGG(name, :param0 ORDER BY sort_order DESC)) AS "names" FROM authors',
+            $query->sql(),
+        );
+    }
+
+    /**
      * Tests driver-specific feature support check.
      */
     public function testSupports(): void
@@ -235,6 +261,8 @@ class PostgresTest extends TestCase
         $this->assertTrue($driver->supports(DriverFeatureEnum::SAVEPOINT));
         $this->assertTrue($driver->supports(DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS));
         $this->assertTrue($driver->supports(DriverFeatureEnum::WINDOW));
+        $this->assertTrue($driver->supports(DriverFeatureEnum::STRING_AGG));
+        $this->assertFalse($driver->supports(DriverFeatureEnum::GROUP_CONCAT));
         $this->assertTrue($driver->supports(DriverFeatureEnum::INTERSECT));
         $this->assertTrue($driver->supports(DriverFeatureEnum::INTERSECT_ALL));
         $this->assertTrue($driver->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY));

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Query\SelectQuery;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Mockery;
@@ -202,6 +203,7 @@ class SqliteTest extends TestCase
 
         $featureVersions = [
             'cte' => '3.8.3',
+            'string-agg' => '3.44.0',
             'window' => '3.28.0',
         ];
         foreach ($featureVersions as $feature => $version) {
@@ -214,11 +216,38 @@ class SqliteTest extends TestCase
         $this->assertTrue($driver->supports(DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));
         $this->assertTrue($driver->supports(DriverFeatureEnum::SAVEPOINT));
         $this->assertTrue($driver->supports(DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS));
+        $this->assertTrue($driver->supports(DriverFeatureEnum::GROUP_CONCAT));
         $this->assertTrue($driver->supports(DriverFeatureEnum::INTERSECT));
 
         $this->assertFalse($driver->supports(DriverFeatureEnum::INTERSECT_ALL));
         $this->assertFalse($driver->supports(DriverFeatureEnum::JSON));
         $this->assertFalse($driver->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY));
+    }
+
+    /**
+     * Tests string aggregation translation.
+     */
+    public function testStringAggTranslation(): void
+    {
+        $driver = Mockery::mock(Sqlite::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct([]);
+        $driver->shouldReceive('enabled')->andReturn(true);
+        $driver->shouldReceive('connect')->andReturnNull();
+        $driver->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
+        $driver->shouldReceive('version')->andReturn('3.43.0');
+
+        $connection = new Connection(['driver' => $driver, 'log' => false]);
+        $query = new SelectQuery($connection);
+        $query->select([
+            'names' => $query->func()->stringAgg('name', ',', ['sort_order' => 'DESC']),
+        ])->from('authors');
+
+        $this->assertSame(
+            'SELECT (GROUP_CONCAT(name, :param0 ORDER BY sort_order DESC)) AS names FROM authors',
+            $query->sql(),
+        );
     }
 
     /**

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -532,6 +532,32 @@ class SqlserverTest extends TestCase
         $this->assertSame($expected, $query->sql());
     }
 
+    /**
+     * Tests string aggregation translation.
+     */
+    public function testStringAggTranslation(): void
+    {
+        $driver = Mockery::mock(Sqlserver::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+        $driver->__construct([]);
+        $driver->shouldReceive('version')->andReturn('16');
+        $driver->shouldReceive('enabled')->andReturn(true);
+        $driver->shouldReceive('connect')->andReturnNull();
+        $driver->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
+
+        $connection = new Connection(['driver' => $driver, 'log' => false]);
+        $query = new SelectQuery($connection);
+        $query->select([
+            'names' => $query->func()->stringAgg('name', ',', ['sort_order' => 'DESC']),
+        ])->from('authors');
+
+        $this->assertSame(
+            'SELECT (STRING_AGG(name, :param0) WITHIN GROUP (ORDER BY sort_order DESC)) AS names FROM authors',
+            $query->sql(),
+        );
+    }
+
     public function testExceedingMaxParameters(): void
     {
         $connection = ConnectionManager::get('test');
@@ -561,6 +587,8 @@ class SqlserverTest extends TestCase
         $this->assertTrue($driver->supports(DriverFeatureEnum::SAVEPOINT));
         $this->assertTrue($driver->supports(DriverFeatureEnum::TRUNCATE_WITH_CONSTRAINTS));
         $this->assertTrue($driver->supports(DriverFeatureEnum::WINDOW));
+        $this->assertTrue($driver->supports(DriverFeatureEnum::STRING_AGG));
+        $this->assertFalse($driver->supports(DriverFeatureEnum::GROUP_CONCAT));
         $this->assertTrue($driver->supports(DriverFeatureEnum::INTERSECT));
 
         $this->assertFalse($driver->supports(DriverFeatureEnum::INTERSECT_ALL));

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Database;
 use Cake\Database\Expression\AggregateExpression;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\StringAggExpression;
 use Cake\Database\FunctionsBuilder;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
@@ -132,6 +133,20 @@ class FunctionsBuilderTest extends TestCase
         $this->assertInstanceOf(AggregateExpression::class, $function);
         $this->assertSame('COUNT(*)', $function->sql(new ValueBinder()));
         $this->assertSame('integer', $function->getReturnType());
+    }
+
+    /**
+     * Tests generating a portable STRING_AGG() function
+     */
+    public function testStringAgg(): void
+    {
+        $function = $this->functions->stringAgg('name', ',');
+        $this->assertInstanceOf(StringAggExpression::class, $function);
+        $this->assertSame('STRING_AGG(name, :param0)', $function->sql(new ValueBinder()));
+        $this->assertSame('string', $function->getReturnType());
+
+        $function = $this->functions->stringAgg('name', ',', ['sort_order' => 'DESC']);
+        $this->assertSame('STRING_AGG(name, :param0 ORDER BY sort_order DESC)', $function->sql(new ValueBinder()));
     }
 
     /**


### PR DESCRIPTION
## Summary
- add `FunctionsBuilder::stringAgg()` for portable string aggregation
- translate the expression to native `STRING_AGG` or `GROUP_CONCAT` per driver
- add driver feature flags plus builder and driver SQL generation tests

## Notes
- MySQL always translates to `GROUP_CONCAT`
- MariaDB 10.5+ and SQLite 3.44+ advertise native `STRING_AGG` support
- SQL Server uses `WITHIN GROUP (ORDER BY ...)` syntax when aggregate ordering is provided

Resolves https://github.com/cakephp/cakephp/issues/19365