### PR TITLE
add method to mock table objects with mockery mocks

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -1109,9 +1109,10 @@ abstract class TestCase extends BaseTestCase
     /**
      * Mock a model with Mockery mocks, maintain fixtures and table association
      *
-     * @param string $alias The model to get a mock for.
+     * @template T of \Cake\ORM\Table
+     * @param string|class-string<T> $alias The alias or the FQCN of the model to get a mock for.
      * @param array<string, mixed> $options The config data for the mock's constructor.
-     * @return \Cake\ORM\Table&\Mockery\LegacyMockInterface
+     * @return (T|\Cake\ORM\Table)&\Mockery\LegacyMockInterface
      */
     public function mockModel(string $alias, array $options = []): Table&LegacyMockInterface
     {

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -39,6 +39,7 @@ use Closure;
 use Exception;
 use LogicException;
 use Mockery;
+use Mockery\MockInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use ReflectionClass;
@@ -1035,7 +1036,7 @@ abstract class TestCase extends BaseTestCase
 // phpcs:enable
 
     /**
-     * Mock a model, maintain fixtures and table association
+     * Mock a model with PHPUnit mocks, maintain fixtures and table association
      *
      * @param string $alias The model to get a mock for.
      * @param array<string> $methods The list of methods to mock
@@ -1084,6 +1085,47 @@ abstract class TestCase extends BaseTestCase
         }
 
         $mock = $builder->getMock();
+        assert($mock instanceof Table);
+
+        if (empty($options['entityClass']) && $mock->getEntityClass() === Entity::class) {
+            $parts = explode('\\', $className);
+            $entityAlias = Inflector::classify(Inflector::underscore(substr(array_pop($parts), 0, -5)));
+            $entityClass = implode('\\', array_slice($parts, 0, -1)) . '\\Entity\\' . $entityAlias;
+            if (class_exists($entityClass)) {
+                $mock->setEntityClass($entityClass);
+            }
+        }
+
+        if (stripos($mock->getTable(), 'mock') === 0) {
+            $mock->setTable(Inflector::tableize($baseClass));
+        }
+
+        $locator->set($baseClass, $mock);
+        $locator->set($alias, $mock);
+
+        return $mock;
+    }
+
+    /**
+     * Mock a model with Mockery mocks, maintain fixtures and table association
+     *
+     * @param string $alias The model to get a mock for.
+     * @param array<string, mixed> $options The config data for the mock's constructor.
+     * @return \Cake\ORM\Table|\Mockery\MockInterface
+     */
+    public function mockModel(string $alias, array $options = []): Table|MockInterface
+    {
+        $className = $this->_getTableClassName($alias, $options);
+        $connectionName = $className::defaultConnectionName();
+        $connection = ConnectionManager::get($connectionName);
+
+        $locator = $this->getTableLocator();
+
+        [, $baseClass] = pluginSplit($alias);
+        $options += ['alias' => $baseClass, 'connection' => $connection];
+        $options += $locator->getConfig($alias);
+
+        $mock = Mockery::mock(new $className($options))->makePartial();
         assert($mock instanceof Table);
 
         if (empty($options['entityClass']) && $mock->getEntityClass() === Entity::class) {

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -39,7 +39,7 @@ use Closure;
 use Exception;
 use LogicException;
 use Mockery;
-use Mockery\MockInterface;
+use Mockery\LegacyMockInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use ReflectionClass;
@@ -1111,9 +1111,9 @@ abstract class TestCase extends BaseTestCase
      *
      * @param string $alias The model to get a mock for.
      * @param array<string, mixed> $options The config data for the mock's constructor.
-     * @return \Cake\ORM\Table|\Mockery\MockInterface
+     * @return \Cake\ORM\Table&\Mockery\LegacyMockInterface
      */
-    public function mockModel(string $alias, array $options = []): Table|MockInterface
+    public function mockModel(string $alias, array $options = []): Table&LegacyMockInterface
     {
         $className = $this->_getTableClassName($alias, $options);
         $connectionName = $className::defaultConnectionName();

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -490,6 +490,119 @@ class TestCaseTest extends TestCase
     }
 
     /**
+     * Make sure the mocked objects behaves as a table object as well as a mockery object
+     */
+    public function testMockModel(): void
+    {
+        static::setAppNamespace();
+        $entity = new Entity([]);
+
+        $Posts = $this->mockModel('Posts');
+
+        $this->assertInstanceOf(PostsTable::class, $Posts);
+        $this->assertSame('posts', $Posts->getTable());
+
+        $Posts = $this->mockModel('Posts');
+        $Posts->shouldReceive('save')
+            ->once()
+            ->andReturn(false);
+        $this->assertFalse($Posts->save($entity));
+        $this->assertSame(Entity::class, $Posts->getEntityClass());
+        $this->assertInstanceOf(Connection::class, $Posts->getConnection());
+        $this->assertSame('test', $Posts->getConnection()->configName());
+
+        $Tags = $this->mockModel('Tags');
+        $this->assertSame(Tag::class, $Tags->getEntityClass());
+    }
+
+    /**
+     * Test mockModel on secondary datasource.
+     */
+    public function testMockModelSecondaryDatasource(): void
+    {
+        ConnectionManager::alias('test', 'secondary');
+
+        $post = $this->mockModel(SecondaryPostsTable::class);
+        $this->assertSame('test', $post->getConnection()->configName());
+    }
+
+    /**
+     * test mockModel() with plugin models
+     */
+    public function testMockModelWithPlugin(): void
+    {
+        static::setAppNamespace();
+        $this->loadPlugins(['TestPlugin']);
+        $TestPluginComment = $this->mockModel('TestPlugin.TestPluginComments');
+
+        $result = $this->getTableLocator()->get('TestPlugin.TestPluginComments');
+        $this->assertInstanceOf(TestPluginCommentsTable::class, $result);
+        $this->assertSame($TestPluginComment, $result);
+
+        $TestPluginComment = $this->mockModel('TestPlugin.TestPluginComments');
+
+        $this->assertInstanceOf(TestPluginCommentsTable::class, $TestPluginComment);
+        $this->assertSame(Entity::class, $TestPluginComment->getEntityClass());
+        $TestPluginComment->shouldReceive('save')
+            ->once()
+            ->andReturn(false);
+
+        $entity = new Entity([]);
+        $this->assertFalse($TestPluginComment->save($entity));
+
+        $TestPluginAuthors = $this->mockModel('TestPlugin.Authors');
+        $this->assertInstanceOf(AuthorsTable::class, $TestPluginAuthors);
+        $this->assertSame(Author::class, $TestPluginAuthors->getEntityClass());
+        $this->clearPlugins();
+    }
+
+    /**
+     * Make sure the mock behaves correctly as a table object
+     */
+    public function testMockModelTable(): void
+    {
+        $Mock = $this->mockModel(
+            'Table',
+            ['alias' => 'Comments', 'className' => Table::class],
+        );
+
+        $result = $this->getTableLocator()->get('Comments');
+        $this->assertInstanceOf(Table::class, $result);
+        $this->assertSame('Comments', $Mock->getAlias());
+
+        $Mock->shouldReceive('save')
+            ->once()
+            ->andReturn(false);
+
+        $entity = new Entity([]);
+        $this->assertFalse($Mock->save($entity));
+
+        $allMethodsStubs = $this->mockModel(
+            'Table',
+            ['alias' => 'Comments', 'className' => Table::class],
+        );
+        $result = $this->getTableLocator()->get('Comments');
+        $this->assertInstanceOf(Table::class, $result);
+        $this->assertSame('Comments', $allMethodsStubs->getAlias());
+    }
+
+    /**
+     * Test getting a table mockery model that doesn't have a preset table name sets the proper name
+     */
+    public function testMockModelSetTable(): void
+    {
+        static::setAppNamespace();
+        ConnectionManager::alias('test', 'custom_i18n_datasource');
+
+        $I18n = $this->mockModel('CustomI18n');
+        $this->assertSame('custom_i18n_table', $I18n->getTable());
+
+        $Tags = $this->mockModel('Tags');
+        $this->assertSame('tags', $Tags->getTable());
+        ConnectionManager::dropAlias('custom_i18n_datasource');
+    }
+
+    /**
      * Test loadRoutes() helper
      */
     public function testLoadRoutes(): void


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/18704

@bancer are you happy with this implementation? We don't need a full builder here as we just need to mimic what is already present for PHPUnit mocks.