### PR TITLE
Fix CS: disallow partial use statements

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -16,7 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\Cache;
 
+use Cake\Cache\Engine\ApcuEngine;
+use Cake\Cache\Engine\ArrayEngine;
+use Cake\Cache\Engine\FileEngine;
+use Cake\Cache\Engine\MemcachedEngine;
 use Cake\Cache\Engine\NullEngine;
+use Cake\Cache\Engine\RedisEngine;
 use Cake\Cache\Exception\CacheWriteException;
 use Cake\Cache\Exception\InvalidArgumentException;
 use Cake\Core\StaticConfigTrait;
@@ -120,12 +125,12 @@ class Cache
     protected static function initDsnClassMap(): array
     {
         return [
-            'array' => Engine\ArrayEngine::class,
-            'apcu' => Engine\ApcuEngine::class,
-            'file' => Engine\FileEngine::class,
-            'memcached' => Engine\MemcachedEngine::class,
-            'null' => Engine\NullEngine::class,
-            'redis' => Engine\RedisEngine::class,
+            'array' => ArrayEngine::class,
+            'apcu' => ApcuEngine::class,
+            'file' => FileEngine::class,
+            'memcached' => MemcachedEngine::class,
+            'null' => NullEngine::class,
+            'redis' => RedisEngine::class,
         ];
     }
 

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -20,6 +20,7 @@ use Cake\Cache\Cache;
 use Cake\Core\App;
 use Cake\Core\Exception\CakeException;
 use Cake\Core\Retry\CommandRetry;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Exception\MissingDriverException;
 use Cake\Database\Exception\MissingExtensionException;
 use Cake\Database\Exception\NestedTransactionRollbackException;
@@ -548,7 +549,7 @@ class Connection implements ConnectionInterface
         if ($enable === false) {
             $this->useSavePoints = false;
         } else {
-            $this->useSavePoints = $this->getWriteDriver()->supports(Enum\DriverFeature::SAVEPOINT);
+            $this->useSavePoints = $this->getWriteDriver()->supports(DriverFeature::SAVEPOINT);
         }
 
         return $this;

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -19,6 +19,7 @@ namespace Cake\Database;
 use Cake\Core\App;
 use Cake\Core\Exception\CakeException;
 use Cake\Core\Retry\CommandRetry;
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Exception\QueryException;
@@ -910,7 +911,7 @@ abstract class Driver implements LoggerAwareInterface
      * @param \Cake\Database\Enum\DriverFeature $feature Driver feature
      * @return bool
      */
-    abstract public function supports(Enum\DriverFeature $feature): bool;
+    abstract public function supports(DriverFeature $feature): bool;
 
     /**
      * Transforms the passed query to this Driver's dialect and returns an instance

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database;
 
+use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Exception\DatabaseException;
 use Closure;
 use Countable;
@@ -192,7 +193,7 @@ class QueryCompiler
         $select = 'SELECT%s%s %s%s';
         if (
             ($query->clause('union') || $query->clause('intersect')) &&
-            $driver->supports(Enum\DriverFeature::SET_OPERATIONS_ORDER_BY)
+            $driver->supports(DriverFeature::SET_OPERATIONS_ORDER_BY)
         ) {
             $select = '(SELECT%s%s %s%s';
         }
@@ -359,7 +360,7 @@ class QueryCompiler
         $setOperationsOrderBy = $query
             ->getConnection()
             ->getDriver($query->getConnectionRole())
-            ->supports(Enum\DriverFeature::SET_OPERATIONS_ORDER_BY);
+            ->supports(DriverFeature::SET_OPERATIONS_ORDER_BY);
 
         $parts = array_map(function (array $p) use ($binder, $setOperationsOrderBy) {
             /** @var \Cake\Database\Expression\IdentifierExpression $expr */
@@ -475,7 +476,7 @@ class QueryCompiler
      */
     protected function buildOptimizerHintPart(array $parts, Query $query, ValueBinder $binder): string
     {
-        if ($parts === [] || !$query->getDriver()->supports(Enum\DriverFeature::OPTIMIZER_HINT_COMMENT)) {
+        if ($parts === [] || !$query->getDriver()->supports(DriverFeature::OPTIMIZER_HINT_COMMENT)) {
             return '';
         }
 

--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -16,6 +16,21 @@ declare(strict_types=1);
  */
 namespace Cake\Database;
 
+use Cake\Database\Type\BinaryType;
+use Cake\Database\Type\BinaryUuidType;
+use Cake\Database\Type\BoolType;
+use Cake\Database\Type\DateTimeFractionalType;
+use Cake\Database\Type\DateTimeTimezoneType;
+use Cake\Database\Type\DateTimeType;
+use Cake\Database\Type\DateType;
+use Cake\Database\Type\DecimalType;
+use Cake\Database\Type\FloatType;
+use Cake\Database\Type\IntegerType;
+use Cake\Database\Type\JsonType;
+use Cake\Database\Type\StringType;
+use Cake\Database\Type\TimeType;
+use Cake\Database\Type\UuidType;
+
 /**
  * Factory for building database type classes.
  */
@@ -30,38 +45,38 @@ class TypeFactory
      * @phpstan-var array<string, class-string<\Cake\Database\TypeInterface>>
      */
     protected static array $types = [
-        'biginteger' => Type\IntegerType::class,
-        'binary' => Type\BinaryType::class,
-        'binaryuuid' => Type\BinaryUuidType::class,
-        'varbinary' => Type\BinaryType::class,
-        'boolean' => Type\BoolType::class,
-        'char' => Type\StringType::class,
-        'cidr' => Type\StringType::class,
-        'citext' => Type\StringType::class,
-        'date' => Type\DateType::class,
-        'datetime' => Type\DateTimeType::class,
-        'datetimefractional' => Type\DateTimeFractionalType::class,
-        'decimal' => Type\DecimalType::class,
-        'float' => Type\FloatType::class,
-        'geometry' => Type\StringType::class,
-        'integer' => Type\IntegerType::class,
-        'inet' => Type\StringType::class,
-        'json' => Type\JsonType::class,
-        'linestring' => Type\StringType::class,
-        'macaddr' => Type\StringType::class,
-        'nativeuuid' => Type\UuidType::class,
-        'point' => Type\StringType::class,
-        'polygon' => Type\StringType::class,
-        'smallinteger' => Type\IntegerType::class,
-        'string' => Type\StringType::class,
-        'text' => Type\StringType::class,
-        'time' => Type\TimeType::class,
-        'timestamp' => Type\DateTimeType::class,
-        'timestampfractional' => Type\DateTimeFractionalType::class,
-        'timestamptimezone' => Type\DateTimeTimezoneType::class,
-        'tinyinteger' => Type\IntegerType::class,
-        'uuid' => Type\UuidType::class,
-        'year' => Type\IntegerType::class,
+        'biginteger' => IntegerType::class,
+        'binary' => BinaryType::class,
+        'binaryuuid' => BinaryUuidType::class,
+        'varbinary' => BinaryType::class,
+        'boolean' => BoolType::class,
+        'char' => StringType::class,
+        'cidr' => StringType::class,
+        'citext' => StringType::class,
+        'date' => DateType::class,
+        'datetime' => DateTimeType::class,
+        'datetimefractional' => DateTimeFractionalType::class,
+        'decimal' => DecimalType::class,
+        'float' => FloatType::class,
+        'geometry' => StringType::class,
+        'integer' => IntegerType::class,
+        'inet' => StringType::class,
+        'json' => JsonType::class,
+        'linestring' => StringType::class,
+        'macaddr' => StringType::class,
+        'nativeuuid' => UuidType::class,
+        'point' => StringType::class,
+        'polygon' => StringType::class,
+        'smallinteger' => IntegerType::class,
+        'string' => StringType::class,
+        'text' => StringType::class,
+        'time' => TimeType::class,
+        'timestamp' => DateTimeType::class,
+        'timestampfractional' => DateTimeFractionalType::class,
+        'timestamptimezone' => DateTimeTimezoneType::class,
+        'tinyinteger' => IntegerType::class,
+        'uuid' => UuidType::class,
+        'year' => IntegerType::class,
     ];
 
     /**

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -17,6 +17,9 @@ namespace Cake\Log;
 
 use Cake\Core\StaticConfigTrait;
 use Cake\Log\Engine\BaseLog;
+use Cake\Log\Engine\ConsoleLog;
+use Cake\Log\Engine\FileLog;
+use Cake\Log\Engine\SyslogLog;
 use Closure;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
@@ -167,9 +170,9 @@ class Log
     protected static function initDsnClassMap(): array
     {
         return [
-            'console' => Engine\ConsoleLog::class,
-            'file' => Engine\FileLog::class,
-            'syslog' => Engine\SyslogLog::class,
+            'console' => ConsoleLog::class,
+            'file' => FileLog::class,
+            'syslog' => SyslogLog::class,
         ];
     }
 

--- a/src/Mailer/TransportFactory.php
+++ b/src/Mailer/TransportFactory.php
@@ -17,6 +17,9 @@ declare(strict_types=1);
 namespace Cake\Mailer;
 
 use Cake\Core\StaticConfigTrait;
+use Cake\Mailer\Transport\DebugTransport;
+use Cake\Mailer\Transport\MailTransport;
+use Cake\Mailer\Transport\SmtpTransport;
 use InvalidArgumentException;
 
 /**
@@ -41,9 +44,9 @@ class TransportFactory
     protected static function initDsnClassMap(): array
     {
         return [
-            'debug' => Transport\DebugTransport::class,
-            'mail' => Transport\MailTransport::class,
-            'smtp' => Transport\SmtpTransport::class,
+            'debug' => DebugTransport::class,
+            'mail' => MailTransport::class,
+            'smtp' => SmtpTransport::class,
         ];
     }
 

--- a/tests/TestCase/Container/Argument/ArgumentResolverTest.php
+++ b/tests/TestCase/Container/Argument/ArgumentResolverTest.php
@@ -5,7 +5,7 @@ namespace Cake\Test\TestCase\Container\Argument;
 
 use Cake\Container\Argument\ArgumentResolverInterface;
 use Cake\Container\Argument\ArgumentResolverTrait;
-use Cake\Container\Argument\Literal;
+use Cake\Container\Argument\Literal\StringArgument;
 use Cake\Container\Container;
 use Cake\Container\ContainerAwareTrait;
 use Cake\Test\TestCase\Container\Asset\Baz;
@@ -71,12 +71,12 @@ class ArgumentResolverTest extends TestCase
             ->expects($this->once())
             ->method('get')
             ->with(self::equalTo('alias1'))
-            ->willReturn(new Literal\StringArgument('value1'));
+            ->willReturn(new StringArgument('value1'));
 
         /** @var Container $container */
         $resolver->setContainer($container);
 
-        $args = $resolver->resolveArguments(['alias1', new Literal\StringArgument('value2')]);
+        $args = $resolver->resolveArguments(['alias1', new StringArgument('value2')]);
 
         self::assertSame('value1', $args[0]);
         self::assertSame('value2', $args[1]);

--- a/tests/TestCase/Container/Argument/TypedArgumentTest.php
+++ b/tests/TestCase/Container/Argument/TypedArgumentTest.php
@@ -3,7 +3,13 @@ declare(strict_types=1);
 
 namespace Cake\Test\TestCase\Container\Argument;
 
-use Cake\Container\Argument\Literal;
+use Cake\Container\Argument\Literal\ArrayArgument;
+use Cake\Container\Argument\Literal\BooleanArgument;
+use Cake\Container\Argument\Literal\CallableArgument;
+use Cake\Container\Argument\Literal\FloatArgument;
+use Cake\Container\Argument\Literal\IntegerArgument;
+use Cake\Container\Argument\Literal\ObjectArgument;
+use Cake\Container\Argument\Literal\StringArgument;
 use Cake\Container\Argument\LiteralArgument;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -13,15 +19,15 @@ class TypedArgumentTest extends TestCase
     public function testLiteralArgumentSetsAndGetsArgument(): void
     {
         $arguments = [
-            Literal\ArrayArgument::class => [],
-            Literal\BooleanArgument::class => true,
-            Literal\CallableArgument::class => function (): void {
+            ArrayArgument::class => [],
+            BooleanArgument::class => true,
+            CallableArgument::class => function (): void {
             },
-            Literal\FloatArgument::class => 1.23,
-            Literal\IntegerArgument::class => 1,
-            Literal\ObjectArgument::class => new class {
+            FloatArgument::class => 1.23,
+            IntegerArgument::class => 1,
+            ObjectArgument::class => new class {
             },
-            Literal\StringArgument::class => 'string',
+            StringArgument::class => 'string',
         ];
 
         foreach ($arguments as $type => $expected) {

--- a/tests/TestCase/Container/Definition/DefinitionTest.php
+++ b/tests/TestCase/Container/Definition/DefinitionTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Cake\Test\TestCase\Container\Definition;
 
-use Cake\Container\Argument\Literal;
+use Cake\Container\Argument\Literal\StringArgument;
 use Cake\Container\Argument\ResolvableArgument;
 use Cake\Container\Container;
 use Cake\Container\Definition\Definition;
@@ -29,7 +29,7 @@ class DefinitionTest extends TestCase
     public function testDefinitionResolvesClosureReturningRawArgument(): void
     {
         $definition = new Definition('callable', function () {
-            return new Literal\StringArgument('hello world');
+            return new StringArgument('hello world');
         });
 
         $actual = $definition->resolve();
@@ -144,7 +144,7 @@ class DefinitionTest extends TestCase
 
     public function testDefinitionCanGetConcrete(): void
     {
-        $concrete = new Literal\StringArgument(Foo::class);
+        $concrete = new StringArgument(Foo::class);
         $definition = new Definition('class', $concrete);
         self::assertSame($concrete, $definition->getConcrete());
     }
@@ -152,7 +152,7 @@ class DefinitionTest extends TestCase
     public function testDefinitionCanSetConcrete(): void
     {
         $definition = new Definition('class');
-        $concrete = new Literal\StringArgument(Foo::class);
+        $concrete = new StringArgument(Foo::class);
         $definition->setConcrete($concrete);
         self::assertSame($concrete, $definition->getConcrete());
     }

--- a/tests/TestCase/Container/ReflectionContainerTest.php
+++ b/tests/TestCase/Container/ReflectionContainerTest.php
@@ -156,9 +156,9 @@ class ReflectionContainerTest extends TestCase
     public function testCallReflectsOnStaticMethodArguments(): void
     {
         $container = new ReflectionContainer();
-        $container->call('Cake\Test\TestCase\Container\Asset\Foo::staticSetBar');
-        self::assertInstanceOf(Bar::class, Asset\Foo::$staticBar);
-        self::assertEquals('hello world', Asset\Foo::$staticHello);
+        $container->call('Cake\Test\TestCase\Container\Foo::staticSetBar');
+        self::assertInstanceOf(Bar::class, Foo::$staticBar);
+        self::assertEquals('hello world', Foo::$staticHello);
     }
 
     public function testCallThrowsWhenArgumentCannotBeResolved(): void

--- a/tests/TestCase/Container/ReflectionContainerTest.php
+++ b/tests/TestCase/Container/ReflectionContainerTest.php
@@ -156,7 +156,7 @@ class ReflectionContainerTest extends TestCase
     public function testCallReflectsOnStaticMethodArguments(): void
     {
         $container = new ReflectionContainer();
-        $container->call('Cake\Test\TestCase\Container\Foo::staticSetBar');
+        $container->call('Cake\Test\TestCase\Container\Asset\Foo::staticSetBar');
         self::assertInstanceOf(Bar::class, Foo::$staticBar);
         self::assertEquals('hello world', Foo::$staticHello);
     }

--- a/tests/TestCase/Database/QueryCompilerTest.php
+++ b/tests/TestCase/Database/QueryCompilerTest.php
@@ -18,6 +18,10 @@ use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Enum\DriverFeature;
 use Cake\Database\Query;
+use Cake\Database\Query\DeleteQuery;
+use Cake\Database\Query\InsertQuery;
+use Cake\Database\Query\SelectQuery;
+use Cake\Database\Query\UpdateQuery;
 use Cake\Database\QueryCompiler;
 use Cake\Database\StatementInterface;
 use Cake\Database\ValueBinder;
@@ -60,10 +64,10 @@ class QueryCompilerTest extends TestCase
     protected function newQuery(string $type): Query
     {
         return match ($type) {
-            Query::TYPE_SELECT => new Query\SelectQuery($this->connection),
-            Query::TYPE_INSERT => new Query\InsertQuery($this->connection),
-            Query::TYPE_UPDATE => new Query\UpdateQuery($this->connection),
-            Query::TYPE_DELETE => new Query\DeleteQuery($this->connection),
+            Query::TYPE_SELECT => new SelectQuery($this->connection),
+            Query::TYPE_INSERT => new InsertQuery($this->connection),
+            Query::TYPE_UPDATE => new UpdateQuery($this->connection),
+            Query::TYPE_DELETE => new DeleteQuery($this->connection),
         };
     }
 

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -758,7 +758,7 @@ class ClientTest extends TestCase
     {
         $url = 'http://cakephp.org';
 
-        $adapter = Mockery::mock(Client\Adapter\Stream::class);
+        $adapter = Mockery::mock(Stream::class);
 
         $redirect = new Response([
             'HTTP/1.0 301',
@@ -950,7 +950,7 @@ class ClientTest extends TestCase
      */
     public function testRedirectDifferentSubDomains(): void
     {
-        $adapter = Mockery::mock(Client\Adapter\Stream::class);
+        $adapter = Mockery::mock(Stream::class);
 
         $url = 'http://auth.example.org';
 


### PR DESCRIPTION
## Summary

Replaces partial namespace references (e.g. `Engine\FileEngine::class`) with fully imported class names to satisfy `SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.PartialUse`.

Fixes 69 existing CS errors across 13 files in `src/` and `tests/`.

Overall I think this is cleaner and probably easier to review.