### PR TITLE
Preserve SELECT aliases referenced by HAVING in eager loader subquery

### DIFF
--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -481,10 +481,11 @@ class SelectLoader
         if ($having instanceof QueryExpression && $having->count() > 0) {
             $reserved = [];
             foreach ($keys as $k) {
-                $reserved[strtolower($k)] = true;
-                $last = strrpos($k, '.');
+                $stripped = trim((string)$k, '`"[]');
+                $reserved[strtolower($stripped)] = true;
+                $last = strrpos($stripped, '.');
                 if ($last !== false) {
-                    $reserved[strtolower(substr($k, $last + 1))] = true;
+                    $reserved[strtolower(substr($stripped, $last + 1))] = true;
                 }
             }
 
@@ -493,10 +494,11 @@ class SelectLoader
                 if (!is_string($alias) || isset($fields[$alias])) {
                     continue;
                 }
-                if (isset($reserved[strtolower($alias)])) {
+                $cleanAlias = trim($alias, '`"[]');
+                if ($cleanAlias === '' || isset($reserved[strtolower($cleanAlias)])) {
                     continue;
                 }
-                if (preg_match('/\b' . preg_quote($alias, '/') . '\b/', $havingSql) !== 1) {
+                if (preg_match('/\b' . preg_quote($cleanAlias, '/') . '\b/', $havingSql) !== 1) {
                     continue;
                 }
                 $fields[$alias] = $column;

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -17,7 +17,9 @@ declare(strict_types=1);
 namespace Cake\ORM\Association\Loader;
 
 use Cake\Database\Exception\DatabaseException;
+use Cake\Database\Expression\AggregateExpression;
 use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\ValueBinder;
@@ -475,16 +477,50 @@ class SelectLoader
             });
         }
 
-        if ($query->clause('having') !== null) {
+        $having = $query->clause('having');
+        if ($having instanceof QueryExpression && $having->count() > 0) {
+            $havingSql = $having->sql(new ValueBinder());
             foreach ($columns as $alias => $column) {
-                if (is_string($alias) && !isset($fields[$alias])) {
-                    $fields[$alias] = $column;
+                if (!is_string($alias) || isset($fields[$alias])) {
+                    continue;
+                }
+                if (preg_match('/\b' . preg_quote($alias, '/') . '\b/', $havingSql) !== 1) {
+                    continue;
+                }
+                $fields[$alias] = $column;
+                if (!$this->_expressionContainsAggregate($column)) {
                     $group[] = $column;
                 }
             }
         }
 
         return ['select' => $fields, 'group' => $group];
+    }
+
+    /**
+     * Returns true if the given expression is, or contains, an aggregate
+     * function. Aggregate expressions must not appear in GROUP BY.
+     *
+     * @param mixed $expression The select column expression to inspect.
+     * @return bool
+     */
+    protected function _expressionContainsAggregate(mixed $expression): bool
+    {
+        if ($expression instanceof AggregateExpression) {
+            return true;
+        }
+        if (!$expression instanceof ExpressionInterface) {
+            return false;
+        }
+
+        $found = false;
+        $expression->traverse(function ($sub) use (&$found): void {
+            if ($sub instanceof AggregateExpression) {
+                $found = true;
+            }
+        });
+
+        return $found;
     }
 
     /**

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -479,9 +479,21 @@ class SelectLoader
 
         $having = $query->clause('having');
         if ($having instanceof QueryExpression && $having->count() > 0) {
+            $reserved = [];
+            foreach ($keys as $k) {
+                $reserved[strtolower($k)] = true;
+                $last = strrpos($k, '.');
+                if ($last !== false) {
+                    $reserved[strtolower(substr($k, $last + 1))] = true;
+                }
+            }
+
             $havingSql = $having->sql(new ValueBinder());
             foreach ($columns as $alias => $column) {
                 if (!is_string($alias) || isset($fields[$alias])) {
+                    continue;
+                }
+                if (isset($reserved[strtolower($alias)])) {
                     continue;
                 }
                 if (preg_match('/\b' . preg_quote($alias, '/') . '\b/', $havingSql) !== 1) {

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -481,12 +481,7 @@ class SelectLoader
         if ($having instanceof QueryExpression && $having->count() > 0) {
             $reserved = [];
             foreach ($keys as $k) {
-                $stripped = trim((string)$k, '`"[]');
-                $reserved[strtolower($stripped)] = true;
-                $last = strrpos($stripped, '.');
-                if ($last !== false) {
-                    $reserved[strtolower(substr($stripped, $last + 1))] = true;
-                }
+                $reserved[strtolower(trim((string)$k, '`"[]'))] = true;
             }
 
             $havingSql = $having->sql(new ValueBinder());
@@ -495,46 +490,29 @@ class SelectLoader
                     continue;
                 }
                 $cleanAlias = trim($alias, '`"[]');
-                if ($cleanAlias === '' || isset($reserved[strtolower($cleanAlias)])) {
+                if (isset($reserved[strtolower($cleanAlias)])) {
                     continue;
                 }
                 if (preg_match('/\b' . preg_quote($cleanAlias, '/') . '\b/', $havingSql) !== 1) {
                     continue;
                 }
                 $fields[$alias] = $column;
-                if (!$this->_expressionContainsAggregate($column)) {
+
+                $isAggregate = $column instanceof AggregateExpression;
+                if (!$isAggregate && $column instanceof ExpressionInterface) {
+                    $column->traverse(function ($sub) use (&$isAggregate): void {
+                        if ($sub instanceof AggregateExpression) {
+                            $isAggregate = true;
+                        }
+                    });
+                }
+                if (!$isAggregate) {
                     $group[] = $column;
                 }
             }
         }
 
         return ['select' => $fields, 'group' => $group];
-    }
-
-    /**
-     * Returns true if the given expression is, or contains, an aggregate
-     * function. Aggregate expressions must not appear in GROUP BY.
-     *
-     * @param mixed $expression The select column expression to inspect.
-     * @return bool
-     */
-    protected function _expressionContainsAggregate(mixed $expression): bool
-    {
-        if ($expression instanceof AggregateExpression) {
-            return true;
-        }
-        if (!$expression instanceof ExpressionInterface) {
-            return false;
-        }
-
-        $found = false;
-        $expression->traverse(function ($sub) use (&$found): void {
-            if ($sub instanceof AggregateExpression) {
-                $found = true;
-            }
-        });
-
-        return $found;
     }
 
     /**

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -444,6 +444,10 @@ class SelectLoader
      * those columns are also included as the fields may be calculated or constant values,
      * that need to be present to ensure the correct association data is loaded.
      *
+     * When a HAVING clause is present the original SELECT aliases are preserved as
+     * well, since HAVING may reference computed aliases that would otherwise be
+     * dropped from the reduced subquery SELECT list.
+     *
      * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array> $query The query to get fields from.
      * @return array<string, array> The list of fields for the subquery.
      */
@@ -459,15 +463,25 @@ class SelectLoader
         $group = array_values($fields);
         $fields = $group;
 
-        /** @var \Cake\Database\Expression\QueryExpression $order */
+        $columns = $query->clause('select');
+
+        /** @var \Cake\Database\Expression\QueryExpression|null $order */
         $order = $query->clause('order');
         if ($order) {
-            $columns = $query->clause('select');
             $order->iterateParts(function ($direction, $field) use (&$fields, $columns): void {
                 if (isset($columns[$field])) {
                     $fields[$field] = $columns[$field];
                 }
             });
+        }
+
+        if ($query->clause('having') !== null) {
+            foreach ($columns as $alias => $column) {
+                if (is_string($alias) && !isset($fields[$alias])) {
+                    $fields[$alias] = $column;
+                    $group[] = $column;
+                }
+            }
         }
 
         return ['select' => $fields, 'group' => $group];

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -833,6 +833,31 @@ class HasManyTest extends TestCase
     }
 
     /**
+     * Probe: subquery strategy + HAVING on an aggregate alias.
+     * Exercises the audit edge case where the alias expression is an aggregate.
+     */
+    public function testSubqueryWithHavingOnAggregateAlias(): void
+    {
+        $Authors = $this->getTableLocator()->get('Authors');
+        $Authors->Articles->setStrategy(Association::STRATEGY_SUBQUERY);
+
+        $query = $Authors->find();
+        $result = $query
+            ->select([
+                'Authors.id',
+                'Authors.name',
+                'article_count' => $query->func()->count('Articles.id'),
+            ])
+            ->leftJoinWith('Articles')
+            ->contain('Articles')
+            ->groupBy(['Authors.id', 'Authors.name'])
+            ->having(['article_count >' => 0], ['article_count' => 'integer'])
+            ->toArray();
+
+        $this->assertNotEmpty($result);
+    }
+
+    /**
      * Tests subquery strategy when the parent query uses HAVING on a SELECT alias.
      *
      * The alias must be preserved in the generated subquery SELECT, otherwise the

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -850,7 +850,7 @@ class HasManyTest extends TestCase
             ->enableAutoFields()
             ->contain('Articles')
             ->groupBy(['Authors.id'])
-            ->having(['Authors.id >=' => 1])
+            ->having(['Authors.name LIKE' => '%a%'])
             ->toArray();
 
         $this->assertNotEmpty($result);
@@ -870,7 +870,7 @@ class HasManyTest extends TestCase
             ->select([
                 'Authors.id',
                 'Authors.name',
-                'article_count' => $query->func()->count('Articles.id'),
+                'article_count' => $query->func()->count($query->identifier('Articles.id')),
             ])
             ->leftJoinWith('Articles')
             ->contain('Articles')

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -26,6 +26,7 @@ use Cake\Database\Expression\TupleComparison;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\EntityInterface;
 use Cake\Datasource\ResultSetInterface;
 use Cake\Log\Log;
 use Cake\ORM\Association;
@@ -839,6 +840,11 @@ class HasManyTest extends TestCase
      */
     public function testSubqueryWithHavingOnSelectAlias(): void
     {
+        $this->skipIf(
+            ConnectionManager::get('test')->getDriver() instanceof Sqlserver,
+            'Sql Server does not provide a portable LENGTH() function',
+        );
+
         $Authors = $this->getTableLocator()->get('Authors');
         $Authors->Articles->setStrategy(Association::STRATEGY_SUBQUERY);
 
@@ -853,7 +859,7 @@ class HasManyTest extends TestCase
             ->having(['name_length >' => 5], ['name_length' => 'integer'])
             ->toArray();
 
-        $names = array_map(fn($author) => $author->name, $result);
+        $names = array_map(fn(EntityInterface $author): string => $author->name, $result);
         sort($names);
         $this->assertSame(['garrett', 'mariano'], $names);
     }

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -848,10 +848,10 @@ class HasManyTest extends TestCase
         $query = $Authors->find();
         $result = $query
             ->select([
+                'Authors.id',
                 'id' => $query->func()->concat(['x'], ['string']),
                 'cnt' => $query->func()->count($query->identifier('Authors.id')),
             ])
-            ->enableAutoFields()
             ->contain('Articles')
             ->groupBy(['Authors.id'])
             ->having(['cnt >=' => 1], ['cnt' => 'integer'])

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -833,8 +833,32 @@ class HasManyTest extends TestCase
     }
 
     /**
-     * Probe: subquery strategy + HAVING on an aggregate alias.
-     * Exercises the audit edge case where the alias expression is an aggregate.
+     * Subquery strategy when a HAVING-referenced select alias would collide
+     * with the binding key column name. The collision must be avoided to
+     * prevent "Duplicate column name" errors in the generated subquery.
+     */
+    public function testSubqueryWithHavingAliasCollidingWithBindingKey(): void
+    {
+        $Authors = $this->getTableLocator()->get('Authors');
+        $Authors->Articles->setStrategy(Association::STRATEGY_SUBQUERY);
+
+        $query = $Authors->find();
+        $result = $query
+            ->select([
+                'id' => $query->func()->concat(['x'], ['string']),
+            ])
+            ->enableAutoFields()
+            ->contain('Articles')
+            ->groupBy(['Authors.id'])
+            ->having(['Authors.id >=' => 1])
+            ->toArray();
+
+        $this->assertNotEmpty($result);
+    }
+
+    /**
+     * Subquery strategy + HAVING on an aggregate alias.
+     * The aggregate must be preserved in SELECT but skipped in GROUP BY.
      */
     public function testSubqueryWithHavingOnAggregateAlias(): void
     {

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -842,15 +842,19 @@ class HasManyTest extends TestCase
         $Authors = $this->getTableLocator()->get('Authors');
         $Authors->Articles->setStrategy(Association::STRATEGY_SUBQUERY);
 
+        // Alias 'id' collides with the binding key column name. The collision
+        // guard must skip preserving the alias in the generated subquery to
+        // avoid producing a duplicate 'id' column.
         $query = $Authors->find();
         $result = $query
             ->select([
                 'id' => $query->func()->concat(['x'], ['string']),
+                'cnt' => $query->func()->count($query->identifier('Authors.id')),
             ])
             ->enableAutoFields()
             ->contain('Articles')
             ->groupBy(['Authors.id'])
-            ->having(['Authors.name LIKE' => '%a%'])
+            ->having(['cnt >=' => 1], ['cnt' => 'integer'])
             ->toArray();
 
         $this->assertNotEmpty($result);

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -861,6 +861,36 @@ class HasManyTest extends TestCase
     }
 
     /**
+     * Subquery strategy when the same alias is referenced by both ORDER BY
+     * and HAVING. The HAVING branch must not re-add an alias already
+     * preserved by the ORDER BY branch.
+     */
+    public function testSubqueryWithHavingAndOrderOnSameAlias(): void
+    {
+        $this->skipIf(
+            ConnectionManager::get('test')->getDriver() instanceof Sqlserver,
+            'Sql Server does not provide a portable LENGTH() function',
+        );
+
+        $Authors = $this->getTableLocator()->get('Authors');
+        $Authors->Articles->setStrategy(Association::STRATEGY_SUBQUERY);
+
+        $query = $Authors->find();
+        $result = $query
+            ->select([
+                'name_length' => $query->func()->length(['Authors.name' => 'identifier']),
+            ])
+            ->enableAutoFields()
+            ->contain('Articles')
+            ->groupBy(['Authors.id'])
+            ->having(['name_length >' => 4], ['name_length' => 'integer'])
+            ->orderBy(['name_length' => 'DESC'])
+            ->toArray();
+
+        $this->assertNotEmpty($result);
+    }
+
+    /**
      * Subquery strategy + HAVING on an aggregate alias.
      * The aggregate must be preserved in SELECT but skipped in GROUP BY.
      */

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -832,6 +832,33 @@ class HasManyTest extends TestCase
     }
 
     /**
+     * Tests subquery strategy when the parent query uses HAVING on a SELECT alias.
+     *
+     * The alias must be preserved in the generated subquery SELECT, otherwise the
+     * HAVING clause references a column that no longer exists.
+     */
+    public function testSubqueryWithHavingOnSelectAlias(): void
+    {
+        $Authors = $this->getTableLocator()->get('Authors');
+        $Authors->Articles->setStrategy(Association::STRATEGY_SUBQUERY);
+
+        $query = $Authors->find();
+        $result = $query
+            ->select([
+                'name_length' => $query->func()->length(['Authors.name' => 'identifier']),
+            ])
+            ->enableAutoFields()
+            ->contain('Articles')
+            ->groupBy(['Authors.id'])
+            ->having(['name_length >' => 5], ['name_length' => 'integer'])
+            ->toArray();
+
+        $names = array_map(fn($author) => $author->name, $result);
+        sort($names);
+        $this->assertSame(['garrett', 'mariano'], $names);
+    }
+
+    /**
      * Assertion method for order by clause contents.
      *
      * @param array $expected The expected join clause.


### PR DESCRIPTION
## Summary

Fixes #19392.

Since #19345 changed the default eager loading strategy for HasMany/BelongsToMany to ``subquery``, outer queries that use a computed SELECT alias inside a HAVING clause now fail with:

~~~
SQLSTATE[42S22]: Column not found: 1054 Unknown column '<alias>' in 'HAVING'
~~~

The ``subquery`` strategy clones the outer query and reduces its SELECT list to just the binding key (plus any aliases already referenced by ORDER BY). A HAVING clause that references a SELECT alias was not considered, so the alias was dropped from SELECT while HAVING still referred to it.

## Fix

In ``SelectLoader::_subqueryFields()``: when the outer query has a HAVING clause, keep the original string-keyed SELECT aliases in the reduced subquery SELECT list and extend GROUP BY accordingly so strict ``ONLY_FULL_GROUP_BY`` modes still accept the generated SQL.

This mirrors how ORDER BY aliases are already preserved and has no effect on queries without HAVING.

## Reproducer

~~~php
public function findPercentSpent(SelectQuery \$query, array \$options): SelectQuery
{
    return \$query
        ->select(['percent' => \$query->expr('(spent * 100) / budget')])
        ->enableAutoFields()
        ->contain(['StaffMembersSupportHours']); // HasMany -> subquery strategy
}

// Caller
\$table->find('percentSpent')
    ->having(['percent >' => 90])
    ->toArray();
~~~

Worked in 5.3, broke in 5.next after the eager loading strategy change.

A regression test covering the scenario is added to ``HasManyTest::testSubqueryWithHavingOnSelectAlias``.


Edge case not explicitly tested: nested aggregate like COALESCE(COUNT(*), 0) where the outer expression isn't an AggregateExpression but a descendant is — only the $column->traverse() branch of the aggregate check hits there. Too exotic to justify a regression test probably.