### PR TITLE
adjust github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug Report
 description: Create a bug report
+type: bug
 labels: ["defect"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,6 @@
 name: Feature Request
 description: Create a feature request
+type: enhancement
 labels: ["enhancement"]
 body:
   - type: textarea


### PR DESCRIPTION
This makes sure the existing type field in issues is prefilled/used as well, not just the labels.