### PR TITLE
Fix ambiguous column in self-referential subquery eager loading

### DIFF
--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -296,7 +296,9 @@ class SelectLoader
     protected function _addFilteringJoin(SelectQuery $query, array|string $key, SelectQuery $subquery): SelectQuery
     {
         $filter = [];
+        $joinFields = [];
         $aliasedTable = $this->sourceAlias;
+        $keyCount = count((array)$key);
 
         // When source and target use the same alias (self-referential associations
         // like a tree structure), the subquery join alias would collide with the
@@ -308,13 +310,10 @@ class SelectLoader
 
         foreach ($subquery->clause('select') as $aliasedField => $field) {
             if (is_int($aliasedField)) {
-                $filter[] = new IdentifierExpression(
-                    preg_replace(
-                        '/^' . preg_quote($this->sourceAlias, '/') . '\./',
-                        $aliasedTable . '.',
-                        $field,
-                    ),
-                );
+                $filter[] = $field;
+                if (count($joinFields) < $keyCount) {
+                    $joinFields[] = $this->_rewriteJoinIdentifier($field, $aliasedTable);
+                }
             } else {
                 $filter[$aliasedField] = $field;
             }
@@ -322,15 +321,40 @@ class SelectLoader
         $subquery->select($filter, true);
 
         if (is_array($key)) {
-            $conditions = $this->_createTupleCondition($query, $key, $filter, '=');
+            $conditions = $this->_createTupleCondition($query, $key, $joinFields, '=');
         } else {
-            $filter = current($filter);
-            $conditions = $query->expr([$key => $filter]);
+            $conditions = $query->expr([$key => $joinFields[0]]);
         }
 
         return $query->innerJoin(
             [$aliasedTable => $subquery],
             $conditions,
+        );
+    }
+
+    /**
+     * Rewrites a subquery field reference for use in the outer join condition.
+     *
+     * The subquery body must continue to reference its own internal table alias,
+     * while the outer join condition must reference the alias assigned to the
+     * derived table itself.
+     *
+     * @param mixed $field The original selected field.
+     * @param string $aliasedTable The alias assigned to the joined subquery.
+     * @return mixed
+     */
+    protected function _rewriteJoinIdentifier(mixed $field, string $aliasedTable): mixed
+    {
+        if (!is_string($field)) {
+            return $field;
+        }
+
+        return new IdentifierExpression(
+            preg_replace(
+                '/^' . preg_quote($this->sourceAlias, '/') . '\./',
+                $aliasedTable . '.' . $this->sourceAlias . '__',
+                $field,
+            ),
         );
     }
 

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -298,9 +298,23 @@ class SelectLoader
         $filter = [];
         $aliasedTable = $this->sourceAlias;
 
+        // When source and target use the same alias (self-referential associations
+        // like a tree structure), the subquery join alias would collide with the
+        // outer query's table alias, causing ambiguous column references.
+        // Use a suffixed alias to avoid the collision.
+        if ($aliasedTable === $this->targetAlias) {
+            $aliasedTable = $this->sourceAlias . '_subquery';
+        }
+
         foreach ($subquery->clause('select') as $aliasedField => $field) {
             if (is_int($aliasedField)) {
-                $filter[] = new IdentifierExpression($field);
+                $filter[] = new IdentifierExpression(
+                    preg_replace(
+                        '/^' . preg_quote($this->sourceAlias, '/') . '\./',
+                        $aliasedTable . '.',
+                        $field,
+                    ),
+                );
             } else {
                 $filter[$aliasedField] = $field;
             }

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -349,12 +349,14 @@ class SelectLoader
             return $field;
         }
 
+        $identifier = preg_replace(
+            '/^' . preg_quote($this->sourceAlias, '/') . '\./',
+            $aliasedTable . '.' . $this->sourceAlias . '__',
+            $field,
+        );
+
         return new IdentifierExpression(
-            preg_replace(
-                '/^' . preg_quote($this->sourceAlias, '/') . '\./',
-                $aliasedTable . '.' . $this->sourceAlias . '__',
-                $field,
-            ),
+            $identifier ?? $field,
         );
     }
 

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -998,6 +998,43 @@ class HasManyTest extends TestCase
     }
 
     /**
+     * Subquery strategy with a self-referential HasMany association whose source
+     * alias already ends in `_subquery`.
+     *
+     * The generated alias for the derived table must not collide with the outer
+     * table alias or SQLite will see ambiguous references.
+     */
+    public function testSubqueryWithSelfReferentialAssociationAliasAlreadyUsingSubquerySuffix(): void
+    {
+        $Categories = $this->getTableLocator()->get('Categories');
+        $Categories->hasMany('Categories_subquery', [
+            'className' => 'Categories',
+            'foreignKey' => 'parent_id',
+            'strategy' => Association::STRATEGY_SUBQUERY,
+        ]);
+
+        $Categories->Categories_subquery->hasMany('Categories_subquery', [
+            'className' => 'Categories',
+            'foreignKey' => 'parent_id',
+            'strategy' => Association::STRATEGY_SUBQUERY,
+        ]);
+
+        $result = $Categories->find()
+            ->where(['Categories.parent_id' => 0])
+            ->contain('Categories_subquery.Categories_subquery')
+            ->toArray();
+
+        $this->assertNotEmpty($result);
+        foreach ($result as $category) {
+            $this->assertIsArray($category->categories_subquery);
+            foreach ($category->categories_subquery as $childCategory) {
+                $this->assertTrue(isset($childCategory->categories_subquery));
+                $this->assertIsArray($childCategory->categories_subquery);
+            }
+        }
+    }
+
+    /**
      * Assertion method for order by clause contents.
      *
      * @param array $expected The expected join clause.

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -53,6 +53,7 @@ class HasManyTest extends TestCase
      * @var array<string>
      */
     protected array $fixtures = [
+        'core.Categories',
         'core.Comments',
         'core.Articles',
         'core.Tags',
@@ -945,6 +946,34 @@ class HasManyTest extends TestCase
         $names = array_map(fn(EntityInterface $author): string => $author->name, $result);
         sort($names);
         $this->assertSame(['garrett', 'mariano'], $names);
+    }
+
+    /**
+     * Subquery strategy with a self-referential HasMany association.
+     *
+     * When source and target alias are the same (e.g. a tree structure
+     * with parent_id), the subquery join alias must not collide with
+     * the outer query's table alias, which would cause
+     * "Column 'X.id' in SELECT is ambiguous" errors.
+     */
+    public function testSubqueryWithSelfReferentialAssociation(): void
+    {
+        $Categories = $this->getTableLocator()->get('Categories');
+        $Categories->hasMany('ChildCategories', [
+            'className' => 'Categories',
+            'foreignKey' => 'parent_id',
+            'strategy' => Association::STRATEGY_SUBQUERY,
+        ]);
+
+        $result = $Categories->find()
+            ->where(['Categories.parent_id' => 0])
+            ->contain('ChildCategories')
+            ->toArray();
+
+        $this->assertNotEmpty($result);
+        foreach ($result as $category) {
+            $this->assertIsArray($category->child_categories);
+        }
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -965,15 +965,36 @@ class HasManyTest extends TestCase
             'strategy' => Association::STRATEGY_SUBQUERY,
         ]);
 
+        $Categories->ChildCategories->hasMany('ChildCategories', [
+            'className' => 'Categories',
+            'foreignKey' => 'parent_id',
+            'strategy' => Association::STRATEGY_SUBQUERY,
+        ]);
+
         $result = $Categories->find()
             ->where(['Categories.parent_id' => 0])
-            ->contain('ChildCategories')
+            ->contain('ChildCategories.ChildCategories')
             ->toArray();
 
         $this->assertNotEmpty($result);
         foreach ($result as $category) {
             $this->assertIsArray($category->child_categories);
         }
+
+        $nestedPropertyLoaded = false;
+        foreach ($result as $category) {
+            foreach ($category->child_categories as $childCategory) {
+                if (isset($childCategory->child_categories)) {
+                    $this->assertIsArray($childCategory->child_categories);
+                    $nestedPropertyLoaded = true;
+                }
+                if (!empty($childCategory->child_categories)) {
+                    $nestedPropertyLoaded = true;
+                }
+            }
+        }
+
+        $this->assertTrue($nestedPropertyLoaded);
     }
 
     /**

--- a/tests/TestCase/ORM/Query/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/Query/CompositeKeysTest.php
@@ -409,6 +409,76 @@ class CompositeKeysTest extends TestCase
     }
 
     /**
+     * Tests subquery eager loading with composite keys when the source query
+     * preserves a HAVING-referenced alias in the reduced subquery select list.
+     *
+     * The tuple join must still compare only the composite binding keys.
+     */
+    public function testHasManySubqueryCompositeKeysWithHavingAlias(): void
+    {
+        $table = $this->getTableLocator()->get('SiteAuthors');
+        $table->hasMany('SiteArticles', [
+            'propertyName' => 'articles',
+            'strategy' => 'subquery',
+            'sort' => ['SiteArticles.id' => 'asc'],
+            'foreignKey' => ['author_id', 'site_id'],
+        ]);
+
+        $query = $table->find();
+        $results = $query
+            ->select(['name_length' => $query->func()->length(['SiteAuthors.name' => 'identifier'])])
+            ->enableAutoFields()
+            ->contain('SiteArticles')
+            ->groupBy(['SiteAuthors.id', 'SiteAuthors.site_id'])
+            ->having(['name_length >' => 3], ['name_length' => 'integer'])
+            ->enableHydration(false)
+            ->toArray();
+
+        $this->assertCount(4, $results);
+        $this->assertSame(1, $results[0]['articles'][0]['id']);
+        $this->assertSame(2, $results[2]['articles'][0]['id']);
+        $this->assertSame([], $results[1]['articles']);
+        $this->assertSame([], $results[3]['articles']);
+    }
+
+    /**
+     * Tests belongsToMany subquery eager loading with composite keys when the
+     * source query preserves a HAVING-referenced alias in the reduced subquery select list.
+     *
+     * The tuple join against the junction table must ignore preserved aliases.
+     */
+    public function testBelongsToManySubqueryCompositeKeysWithHavingAlias(): void
+    {
+        $articles = $this->getTableLocator()->get('SiteArticles');
+        $tags = $this->getTableLocator()->get('SiteTags');
+        $articles->belongsToMany('SiteTags', [
+            'strategy' => 'subquery',
+            'targetTable' => $tags,
+            'propertyName' => 'tags',
+            'through' => 'SiteArticlesTags',
+            'sort' => ['SiteTags.id' => 'asc'],
+            'foreignKey' => ['article_id', 'site_id'],
+            'targetForeignKey' => ['tag_id', 'site_id'],
+        ]);
+
+        $query = $articles->find();
+        $results = $query
+            ->select(['title_length' => $query->func()->length(['SiteArticles.title' => 'identifier'])])
+            ->enableAutoFields()
+            ->contain('SiteTags')
+            ->groupBy(['SiteArticles.id', 'SiteArticles.site_id'])
+            ->having(['title_length >' => 0], ['title_length' => 'integer'])
+            ->enableHydration(false)
+            ->toArray();
+
+        $this->assertCount(4, $results);
+        $this->assertSame([1, 3], array_column($results[0]['tags'], 'id'));
+        $this->assertSame([4], array_column($results[1]['tags'], 'id'));
+        $this->assertSame([], $results[2]['tags']);
+        $this->assertSame([1], array_column($results[3]['tags'], 'id'));
+    }
+
+    /**
      * Tests loading hasOne with composite keys
      */
     #[DataProvider('strategiesProviderHasOne')]

--- a/tests/TestCase/ORM/Query/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/Query/CompositeKeysTest.php
@@ -336,6 +336,79 @@ class CompositeKeysTest extends TestCase
     }
 
     /**
+     * Tests subquery eager loading with composite keys when the source query
+     * preserves an ORDER BY alias in the reduced subquery select list.
+     *
+     * The join tuple must only use the composite binding key fields, not the
+     * additional ORDER BY alias that is kept for deterministic limiting.
+     */
+    public function testHasManySubqueryCompositeKeysWithOrderAlias(): void
+    {
+        $table = $this->getTableLocator()->get('SiteAuthors');
+        $table->hasMany('SiteArticles', [
+            'propertyName' => 'articles',
+            'strategy' => 'subquery',
+            'sort' => ['SiteArticles.id' => 'asc'],
+            'foreignKey' => ['author_id', 'site_id'],
+        ]);
+
+        $query = $table->find();
+        $results = $query
+            ->select(['sort_key' => 'SiteAuthors.name'])
+            ->enableAutoFields()
+            ->contain('SiteArticles')
+            ->orderBy(['sort_key' => 'ASC'])
+            ->limit(2)
+            ->enableHydration(false)
+            ->toArray();
+
+        $this->assertSame([4, 3], array_column($results, 'id'));
+        $this->assertSame([1, 2], array_column($results, 'site_id'));
+        $this->assertSame([], $results[0]['articles']);
+        $this->assertCount(1, $results[1]['articles']);
+        $this->assertSame(2, $results[1]['articles'][0]['id']);
+    }
+
+    /**
+     * Tests belongsToMany subquery eager loading with composite keys when the
+     * source query preserves an ORDER BY alias in the reduced subquery select list.
+     *
+     * The tuple join against the junction table must ignore preserved aliases and
+     * compare only the composite foreign key pair.
+     */
+    public function testBelongsToManySubqueryCompositeKeysWithOrderAlias(): void
+    {
+        $articles = $this->getTableLocator()->get('SiteArticles');
+        $tags = $this->getTableLocator()->get('SiteTags');
+        $articles->belongsToMany('SiteTags', [
+            'strategy' => 'subquery',
+            'targetTable' => $tags,
+            'propertyName' => 'tags',
+            'through' => 'SiteArticlesTags',
+            'sort' => ['SiteTags.id' => 'asc'],
+            'foreignKey' => ['article_id', 'site_id'],
+            'targetForeignKey' => ['tag_id', 'site_id'],
+        ]);
+
+        $query = $articles->find();
+        $results = $query
+            ->select(['sort_key' => 'SiteArticles.title'])
+            ->enableAutoFields()
+            ->contain('SiteTags')
+            ->orderBy(['sort_key' => 'ASC'])
+            ->limit(2)
+            ->enableHydration(false)
+            ->toArray();
+
+        $this->assertSame([1, 4], array_column($results, 'id'));
+        $this->assertSame([1, 1], array_column($results, 'site_id'));
+        $this->assertCount(2, $results[0]['tags']);
+        $this->assertCount(1, $results[1]['tags']);
+        $this->assertSame([1, 3], array_column($results[0]['tags'], 'id'));
+        $this->assertSame([1], array_column($results[1]['tags'], 'id'));
+    }
+
+    /**
      * Tests loading hasOne with composite keys
      */
     #[DataProvider('strategiesProviderHasOne')]

--- a/tests/TestCase/ORM/Query/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/Query/CompositeKeysTest.php
@@ -344,6 +344,11 @@ class CompositeKeysTest extends TestCase
      */
     public function testHasManySubqueryCompositeKeysWithOrderAlias(): void
     {
+        $this->skipIf(
+            $this->connection->getDriver() instanceof Sqlserver,
+            'SQL Server does not support ORDER BY on fields not included in GROUP BY',
+        );
+
         $table = $this->getTableLocator()->get('SiteAuthors');
         $table->hasMany('SiteArticles', [
             'propertyName' => 'articles',
@@ -378,6 +383,11 @@ class CompositeKeysTest extends TestCase
      */
     public function testBelongsToManySubqueryCompositeKeysWithOrderAlias(): void
     {
+        $this->skipIf(
+            $this->connection->getDriver() instanceof Sqlserver,
+            'SQL Server does not support ORDER BY on fields not included in GROUP BY',
+        );
+
         $articles = $this->getTableLocator()->get('SiteArticles');
         $tags = $this->getTableLocator()->get('SiteTags');
         $articles->belongsToMany('SiteTags', [
@@ -416,6 +426,11 @@ class CompositeKeysTest extends TestCase
      */
     public function testHasManySubqueryCompositeKeysWithHavingAlias(): void
     {
+        $this->skipIf(
+            $this->connection->getDriver() instanceof Sqlserver,
+            'Sql Server does not provide a portable LENGTH() function',
+        );
+
         $table = $this->getTableLocator()->get('SiteAuthors');
         $table->hasMany('SiteArticles', [
             'propertyName' => 'articles',
@@ -453,6 +468,11 @@ class CompositeKeysTest extends TestCase
      */
     public function testBelongsToManySubqueryCompositeKeysWithHavingAlias(): void
     {
+        $this->skipIf(
+            $this->connection->getDriver() instanceof Sqlserver,
+            'Sql Server does not provide a portable LENGTH() function',
+        );
+
         $articles = $this->getTableLocator()->get('SiteArticles');
         $tags = $this->getTableLocator()->get('SiteTags');
         $articles->belongsToMany('SiteTags', [

--- a/tests/TestCase/ORM/Query/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/Query/CompositeKeysTest.php
@@ -435,10 +435,14 @@ class CompositeKeysTest extends TestCase
             ->toArray();
 
         $this->assertCount(4, $results);
-        $this->assertSame(1, $results[0]['articles'][0]['id']);
-        $this->assertSame(2, $results[2]['articles'][0]['id']);
-        $this->assertSame([], $results[1]['articles']);
-        $this->assertSame([], $results[3]['articles']);
+        $indexed = [];
+        foreach ($results as $row) {
+            $indexed[$row['id'] . ';' . $row['site_id']] = array_column($row['articles'], 'id');
+        }
+        $this->assertSame([1], $indexed['1;1']);
+        $this->assertSame([], $indexed['2;2']);
+        $this->assertSame([2], $indexed['3;2']);
+        $this->assertSame([], $indexed['4;1']);
     }
 
     /**
@@ -472,10 +476,14 @@ class CompositeKeysTest extends TestCase
             ->toArray();
 
         $this->assertCount(4, $results);
-        $this->assertSame([1, 3], array_column($results[0]['tags'], 'id'));
-        $this->assertSame([4], array_column($results[1]['tags'], 'id'));
-        $this->assertSame([], $results[2]['tags']);
-        $this->assertSame([1], array_column($results[3]['tags'], 'id'));
+        $indexed = [];
+        foreach ($results as $row) {
+            $indexed[$row['id'] . ';' . $row['site_id']] = array_column($row['tags'], 'id');
+        }
+        $this->assertSame([1, 3], $indexed['1;1']);
+        $this->assertSame([4], $indexed['2;2']);
+        $this->assertSame([], $indexed['3;2']);
+        $this->assertSame([1], $indexed['4;1']);
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #19395.

Since #19345 changed the default eager loading strategy for HasMany/BelongsToMany to `subquery`, self-referential associations (e.g. a tree structure with `parent_id` pointing to the same table) fail with:

```
SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'X.id' in SELECT is ambiguous
```

The `subquery` strategy in `SelectLoader::_addFilteringJoin()` joins the subquery using `$this->sourceAlias`. For self-referential associations, the source and target alias are identical, so the outer query's table and the joined subquery share the same alias — making all column references ambiguous.

## Fix

When `sourceAlias === targetAlias` (self-referential association), use a suffixed alias (`{sourceAlias}_subquery`) for the inner join and update the filter identifier expressions to reference the new alias.

A regression test using the `Categories` table (which has `parent_id`) is included.