### PR TITLE
5.next: Command scanner public

### DIFF
--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -56,7 +56,6 @@ class CommandScanner
         return $this->scanDir(
             App::classPath('Command')[0],
             $appNamespace . '\Command\\',
-            '',
         );
     }
 
@@ -88,7 +87,7 @@ class CommandScanner
      * @param array<string> $hide A list of command names to hide as they are internal commands.
      * @return array The list of shell info arrays based on scanning the filesystem and inflection.
      */
-    public function scanDir(string $path, string $namespace, string $prefix, array $hide = []): array
+    public function scanDir(string $path, string $namespace, string $prefix = '', array $hide = []): array
     {
         if (!is_dir($path)) {
             return [];

--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -26,8 +26,6 @@ use ReflectionClass;
 /**
  * Used by CommandCollection and CommandTask to scan the filesystem
  * for command classes.
- *
- * @internal
  */
 class CommandScanner
 {
@@ -59,7 +57,6 @@ class CommandScanner
             App::classPath('Command')[0],
             $appNamespace . '\Command\\',
             '',
-            [],
         );
     }
 
@@ -78,7 +75,7 @@ class CommandScanner
         $namespace = str_replace('/', '\\', $plugin);
         $prefix = Inflector::underscore($plugin) . '.';
 
-        return $this->scanDir($path . 'Command', $namespace . '\Command\\', $prefix, []);
+        return $this->scanDir($path . 'Command' . DIRECTORY_SEPARATOR, $namespace . '\Command\\', $prefix);
     }
 
     /**
@@ -91,7 +88,7 @@ class CommandScanner
      * @param array<string> $hide A list of command names to hide as they are internal commands.
      * @return array The list of shell info arrays based on scanning the filesystem and inflection.
      */
-    protected function scanDir(string $path, string $namespace, string $prefix, array $hide): array
+    public function scanDir(string $path, string $namespace, string $prefix, array $hide = []): array
     {
         if (!is_dir($path)) {
             return [];

--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -24,8 +24,10 @@ use Cake\Utility\Inflector;
 use ReflectionClass;
 
 /**
- * Used by CommandCollection and CommandTask to scan the filesystem
- * for command classes.
+ * Scans the filesystem for command classes.
+ *
+ * Used internally by CommandCollection, but can also be used directly
+ * (e.g. via `scanDir()`) to discover commands in custom directories.
  */
 class CommandScanner
 {
@@ -70,11 +72,10 @@ class CommandScanner
         if (!Plugin::isLoaded($plugin)) {
             return [];
         }
-        $path = Plugin::classPath($plugin);
         $namespace = str_replace('/', '\\', $plugin);
         $prefix = Inflector::underscore($plugin) . '.';
 
-        return $this->scanDir($path . 'Command' . DIRECTORY_SEPARATOR, $namespace . '\Command\\', $prefix);
+        return $this->scanDir(App::classPath('Command', $plugin)[0], $namespace . '\Command\\', $prefix);
     }
 
     /**
@@ -92,6 +93,9 @@ class CommandScanner
         if (!is_dir($path)) {
             return [];
         }
+        // Normalize to a single trailing separator so `file` paths are
+        // correct regardless of how callers pass the directory.
+        $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 
         // This ensures `Command` class is not added to the list.
         $hide[] = '';

--- a/tests/TestCase/Console/CommandScannerTest.php
+++ b/tests/TestCase/Console/CommandScannerTest.php
@@ -19,19 +19,151 @@ class CommandScannerTest extends TestCase
      */
     public function testScanCore(): void
     {
-        $commandScanner = Mockery::mock(CommandScanner::class . '[scanDir]');
-        $commandScanner
-            ->shouldReceive('scanDir')
-            ->once()
-            ->with(
-                CAKE . 'Command' . DIRECTORY_SEPARATOR,
-                'Cake\\Command\\',
-                '',
-                ['command_list'],
-            )
-            ->andReturn([]);
+        $dir = ROOT . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Command' . DIRECTORY_SEPARATOR;
 
-        $commandScanner->scanCore();
+        $expected = [
+            [
+                'file' => $dir . 'CacheClearCommand.php',
+                'fullName' => 'cache clear',
+                'name' => 'cache clear',
+                'class' => 'Cake\Command\CacheClearCommand',
+            ],
+            [
+                'file' => $dir . 'CacheClearGroupCommand.php',
+                'fullName' => 'cache clear_group',
+                'name' => 'cache clear_group',
+                'class' => 'Cake\Command\CacheClearGroupCommand',
+            ],
+            [
+                'file' => $dir . 'CacheClearallCommand.php',
+                'fullName' => 'cache clear_all',
+                'name' => 'cache clear_all',
+                'class' => 'Cake\Command\CacheClearallCommand',
+            ],
+            [
+                'file' => $dir . 'CacheListCommand.php',
+                'fullName' => 'cache list',
+                'name' => 'cache list',
+                'class' => 'Cake\Command\CacheListCommand',
+            ],
+            [
+                'file' => $dir . 'CompletionCommand.php',
+                'fullName' => 'completion',
+                'name' => 'completion',
+                'class' => 'Cake\Command\CompletionCommand',
+            ],
+            [
+                'file' => $dir . 'CounterCacheCommand.php',
+                'fullName' => 'counter_cache',
+                'name' => 'counter_cache',
+                'class' => 'Cake\Command\CounterCacheCommand',
+            ],
+            [
+                'file' => $dir . 'I18nCommand.php',
+                'fullName' => 'i18n',
+                'name' => 'i18n',
+                'class' => 'Cake\Command\I18nCommand',
+            ],
+            [
+                'file' => $dir . 'I18nExtractCommand.php',
+                'fullName' => 'i18n extract',
+                'name' => 'i18n extract',
+                'class' => 'Cake\Command\I18nExtractCommand',
+            ],
+            [
+                'file' => $dir . 'I18nInitCommand.php',
+                'fullName' => 'i18n init',
+                'name' => 'i18n init',
+                'class' => 'Cake\Command\I18nInitCommand',
+            ],
+            [
+                'file' => $dir . 'PluginAssetsCopyCommand.php',
+                'fullName' => 'plugin assets copy',
+                'name' => 'plugin assets copy',
+                'class' => 'Cake\Command\PluginAssetsCopyCommand',
+            ],
+            [
+                'file' => $dir . 'PluginAssetsRemoveCommand.php',
+                'fullName' => 'plugin assets remove',
+                'name' => 'plugin assets remove',
+                'class' => 'Cake\Command\PluginAssetsRemoveCommand',
+            ],
+            [
+                'file' => $dir . 'PluginAssetsSymlinkCommand.php',
+                'fullName' => 'plugin assets symlink',
+                'name' => 'plugin assets symlink',
+                'class' => 'Cake\Command\PluginAssetsSymlinkCommand',
+            ],
+            [
+                'file' => $dir . 'PluginListCommand.php',
+                'fullName' => 'plugin list',
+                'name' => 'plugin list',
+                'class' => 'Cake\Command\PluginListCommand',
+            ],
+            [
+                'file' => $dir . 'PluginLoadCommand.php',
+                'fullName' => 'plugin load',
+                'name' => 'plugin load',
+                'class' => 'Cake\Command\PluginLoadCommand',
+            ],
+            [
+                'file' => $dir . 'PluginLoadedCommand.php',
+                'fullName' => 'plugin loaded',
+                'name' => 'plugin loaded',
+                'class' => 'Cake\Command\PluginLoadedCommand',
+            ],
+            [
+                'file' => $dir . 'PluginUnloadCommand.php',
+                'fullName' => 'plugin unload',
+                'name' => 'plugin unload',
+                'class' => 'Cake\Command\PluginUnloadCommand',
+            ],
+            [
+                'file' => $dir . 'RoutesCheckCommand.php',
+                'fullName' => 'routes check',
+                'name' => 'routes check',
+                'class' => 'Cake\Command\RoutesCheckCommand',
+            ],
+            [
+                'file' => $dir . 'RoutesCommand.php',
+                'fullName' => 'routes',
+                'name' => 'routes',
+                'class' => 'Cake\Command\RoutesCommand',
+            ],
+            [
+                'file' => $dir . 'RoutesGenerateCommand.php',
+                'fullName' => 'routes generate',
+                'name' => 'routes generate',
+                'class' => 'Cake\Command\RoutesGenerateCommand',
+            ],
+            [
+                'file' => $dir . 'SchemacacheBuildCommand.php',
+                'fullName' => 'schema_cache build',
+                'name' => 'schema_cache build',
+                'class' => 'Cake\Command\SchemacacheBuildCommand',
+            ],
+            [
+                'file' => $dir . 'SchemacacheClearCommand.php',
+                'fullName' => 'schema_cache clear',
+                'name' => 'schema_cache clear',
+                'class' => 'Cake\Command\SchemacacheClearCommand',
+            ],
+            [
+                'file' => $dir . 'ServerCommand.php',
+                'fullName' => 'server',
+                'name' => 'server',
+                'class' => 'Cake\Command\ServerCommand',
+            ],
+            [
+                'file' => $dir . 'VersionCommand.php',
+                'fullName' => 'version',
+                'name' => 'version',
+                'class' => 'Cake\Command\VersionCommand',
+            ],
+        ];
+        $commandScanner = new CommandScanner();
+        $result = $commandScanner->scanCore();
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Console/CommandScannerTest.php
+++ b/tests/TestCase/Console/CommandScannerTest.php
@@ -62,7 +62,7 @@ class CommandScannerTest extends TestCase
 
         $expected = [
             [
-                'file' => Plugin::classPath('Company/TestPluginThree') . 'Command/CompanyCommand.php',
+                'file' => Plugin::classPath('Company/TestPluginThree') . 'Command' . DIRECTORY_SEPARATOR . 'CompanyCommand.php',
                 'fullName' => 'company/test_plugin_three.company',
                 'name' => 'company',
                 'class' => 'Company\TestPluginThree\Command\CompanyCommand',

--- a/tests/TestCase/Console/CommandScannerTest.php
+++ b/tests/TestCase/Console/CommandScannerTest.php
@@ -19,143 +19,143 @@ class CommandScannerTest extends TestCase
      */
     public function testScanCore(): void
     {
-        $dir = ROOT . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Command' . DIRECTORY_SEPARATOR;
+        $commandDir = ROOT . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Command' . DIRECTORY_SEPARATOR;
 
         $expected = [
             [
-                'file' => $dir . 'CacheClearCommand.php',
+                'file' => $commandDir . 'CacheClearCommand.php',
                 'fullName' => 'cache clear',
                 'name' => 'cache clear',
                 'class' => 'Cake\Command\CacheClearCommand',
             ],
             [
-                'file' => $dir . 'CacheClearGroupCommand.php',
+                'file' => $commandDir . 'CacheClearGroupCommand.php',
                 'fullName' => 'cache clear_group',
                 'name' => 'cache clear_group',
                 'class' => 'Cake\Command\CacheClearGroupCommand',
             ],
             [
-                'file' => $dir . 'CacheClearallCommand.php',
+                'file' => $commandDir . 'CacheClearallCommand.php',
                 'fullName' => 'cache clear_all',
                 'name' => 'cache clear_all',
                 'class' => 'Cake\Command\CacheClearallCommand',
             ],
             [
-                'file' => $dir . 'CacheListCommand.php',
+                'file' => $commandDir . 'CacheListCommand.php',
                 'fullName' => 'cache list',
                 'name' => 'cache list',
                 'class' => 'Cake\Command\CacheListCommand',
             ],
             [
-                'file' => $dir . 'CompletionCommand.php',
+                'file' => $commandDir . 'CompletionCommand.php',
                 'fullName' => 'completion',
                 'name' => 'completion',
                 'class' => 'Cake\Command\CompletionCommand',
             ],
             [
-                'file' => $dir . 'CounterCacheCommand.php',
+                'file' => $commandDir . 'CounterCacheCommand.php',
                 'fullName' => 'counter_cache',
                 'name' => 'counter_cache',
                 'class' => 'Cake\Command\CounterCacheCommand',
             ],
             [
-                'file' => $dir . 'I18nCommand.php',
+                'file' => $commandDir . 'I18nCommand.php',
                 'fullName' => 'i18n',
                 'name' => 'i18n',
                 'class' => 'Cake\Command\I18nCommand',
             ],
             [
-                'file' => $dir . 'I18nExtractCommand.php',
+                'file' => $commandDir . 'I18nExtractCommand.php',
                 'fullName' => 'i18n extract',
                 'name' => 'i18n extract',
                 'class' => 'Cake\Command\I18nExtractCommand',
             ],
             [
-                'file' => $dir . 'I18nInitCommand.php',
+                'file' => $commandDir . 'I18nInitCommand.php',
                 'fullName' => 'i18n init',
                 'name' => 'i18n init',
                 'class' => 'Cake\Command\I18nInitCommand',
             ],
             [
-                'file' => $dir . 'PluginAssetsCopyCommand.php',
+                'file' => $commandDir . 'PluginAssetsCopyCommand.php',
                 'fullName' => 'plugin assets copy',
                 'name' => 'plugin assets copy',
                 'class' => 'Cake\Command\PluginAssetsCopyCommand',
             ],
             [
-                'file' => $dir . 'PluginAssetsRemoveCommand.php',
+                'file' => $commandDir . 'PluginAssetsRemoveCommand.php',
                 'fullName' => 'plugin assets remove',
                 'name' => 'plugin assets remove',
                 'class' => 'Cake\Command\PluginAssetsRemoveCommand',
             ],
             [
-                'file' => $dir . 'PluginAssetsSymlinkCommand.php',
+                'file' => $commandDir . 'PluginAssetsSymlinkCommand.php',
                 'fullName' => 'plugin assets symlink',
                 'name' => 'plugin assets symlink',
                 'class' => 'Cake\Command\PluginAssetsSymlinkCommand',
             ],
             [
-                'file' => $dir . 'PluginListCommand.php',
+                'file' => $commandDir . 'PluginListCommand.php',
                 'fullName' => 'plugin list',
                 'name' => 'plugin list',
                 'class' => 'Cake\Command\PluginListCommand',
             ],
             [
-                'file' => $dir . 'PluginLoadCommand.php',
+                'file' => $commandDir . 'PluginLoadCommand.php',
                 'fullName' => 'plugin load',
                 'name' => 'plugin load',
                 'class' => 'Cake\Command\PluginLoadCommand',
             ],
             [
-                'file' => $dir . 'PluginLoadedCommand.php',
+                'file' => $commandDir . 'PluginLoadedCommand.php',
                 'fullName' => 'plugin loaded',
                 'name' => 'plugin loaded',
                 'class' => 'Cake\Command\PluginLoadedCommand',
             ],
             [
-                'file' => $dir . 'PluginUnloadCommand.php',
+                'file' => $commandDir . 'PluginUnloadCommand.php',
                 'fullName' => 'plugin unload',
                 'name' => 'plugin unload',
                 'class' => 'Cake\Command\PluginUnloadCommand',
             ],
             [
-                'file' => $dir . 'RoutesCheckCommand.php',
+                'file' => $commandDir . 'RoutesCheckCommand.php',
                 'fullName' => 'routes check',
                 'name' => 'routes check',
                 'class' => 'Cake\Command\RoutesCheckCommand',
             ],
             [
-                'file' => $dir . 'RoutesCommand.php',
+                'file' => $commandDir . 'RoutesCommand.php',
                 'fullName' => 'routes',
                 'name' => 'routes',
                 'class' => 'Cake\Command\RoutesCommand',
             ],
             [
-                'file' => $dir . 'RoutesGenerateCommand.php',
+                'file' => $commandDir . 'RoutesGenerateCommand.php',
                 'fullName' => 'routes generate',
                 'name' => 'routes generate',
                 'class' => 'Cake\Command\RoutesGenerateCommand',
             ],
             [
-                'file' => $dir . 'SchemacacheBuildCommand.php',
+                'file' => $commandDir . 'SchemacacheBuildCommand.php',
                 'fullName' => 'schema_cache build',
                 'name' => 'schema_cache build',
                 'class' => 'Cake\Command\SchemacacheBuildCommand',
             ],
             [
-                'file' => $dir . 'SchemacacheClearCommand.php',
+                'file' => $commandDir . 'SchemacacheClearCommand.php',
                 'fullName' => 'schema_cache clear',
                 'name' => 'schema_cache clear',
                 'class' => 'Cake\Command\SchemacacheClearCommand',
             ],
             [
-                'file' => $dir . 'ServerCommand.php',
+                'file' => $commandDir . 'ServerCommand.php',
                 'fullName' => 'server',
                 'name' => 'server',
                 'class' => 'Cake\Command\ServerCommand',
             ],
             [
-                'file' => $dir . 'VersionCommand.php',
+                'file' => $commandDir . 'VersionCommand.php',
                 'fullName' => 'version',
                 'name' => 'version',
                 'class' => 'Cake\Command\VersionCommand',
@@ -178,7 +178,6 @@ class CommandScannerTest extends TestCase
             ->with(
                 App::classPath('Command')[0],
                 'App\\Command\\',
-                '',
             )
             ->andReturn([]);
 

--- a/tests/TestCase/Console/CommandScannerTest.php
+++ b/tests/TestCase/Console/CommandScannerTest.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
 namespace Cake\Test\TestCase\Console;
 
 use Cake\Console\CommandScanner;
@@ -14,6 +27,15 @@ use Mockery;
  */
 class CommandScannerTest extends TestCase
 {
+    /**
+     * @inheritDoc
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->clearPlugins();
+    }
+
     /**
      * Test scanning commands from the core.
      */
@@ -171,7 +193,8 @@ class CommandScannerTest extends TestCase
      */
     public function testScanApp(): void
     {
-        $commandScanner = Mockery::mock(CommandScanner::class . '[scanDir]');
+        /** @var \Cake\Console\CommandScanner&\Mockery\MockInterface $commandScanner */
+        $commandScanner = Mockery::mock(CommandScanner::class)->makePartial();
         $commandScanner
             ->shouldReceive('scanDir')
             ->once()
@@ -205,9 +228,9 @@ class CommandScannerTest extends TestCase
     }
 
     /**
-     * Test scanning commands from a no existing plugin.
+     * Test scanning commands from a non-existent plugin.
      */
-    public function testScanPluginNoExistingPlugin(): void
+    public function testScanPluginNonExistentPlugin(): void
     {
         $commandScanner = new CommandScanner();
         $this->assertEmpty($commandScanner->scanPlugin('NonExistentPlugin'));

--- a/tests/TestCase/Console/CommandScannerTest.php
+++ b/tests/TestCase/Console/CommandScannerTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Console;
+
+use Cake\Console\CommandScanner;
+use Cake\Core\App;
+use Cake\Core\Plugin;
+use Cake\TestSuite\TestCase;
+use Mockery;
+
+/**
+ * Test case for the CommandScanner
+ */
+class CommandScannerTest extends TestCase
+{
+    /**
+     * Test scanning commands from the core.
+     */
+    public function testScanCore(): void
+    {
+        $commandScanner = Mockery::mock(CommandScanner::class . '[scanDir]');
+        $commandScanner
+            ->shouldReceive('scanDir')
+            ->once()
+            ->with(
+                CAKE . 'Command' . DIRECTORY_SEPARATOR,
+                'Cake\\Command\\',
+                '',
+                ['command_list'],
+            )
+            ->andReturn([]);
+
+        $commandScanner->scanCore();
+    }
+
+    /**
+     * Test scanning commands from the app.
+     */
+    public function testScanApp(): void
+    {
+        $commandScanner = Mockery::mock(CommandScanner::class . '[scanDir]');
+        $commandScanner
+            ->shouldReceive('scanDir')
+            ->once()
+            ->with(
+                App::classPath('Command')[0],
+                'App\\Command\\',
+                '',
+            )
+            ->andReturn([]);
+
+        $commandScanner->scanApp();
+    }
+
+    /**
+     * Test scanning commands from a plugin.
+     */
+    public function testScanPlugin(): void
+    {
+        $this->loadPlugins(['Company/TestPluginThree']);
+
+        $expected = [
+            [
+                'file' => Plugin::classPath('Company/TestPluginThree') . 'Command/CompanyCommand.php',
+                'fullName' => 'company/test_plugin_three.company',
+                'name' => 'company',
+                'class' => 'Company\TestPluginThree\Command\CompanyCommand',
+            ],
+        ];
+        $commandScanner = new CommandScanner();
+        $result = $commandScanner->scanPlugin('Company/TestPluginThree');
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test scanning commands from a no existing plugin.
+     */
+    public function testScanPluginNoExistingPlugin(): void
+    {
+        $commandScanner = new CommandScanner();
+        $this->assertEmpty($commandScanner->scanPlugin('NonExistentPlugin'));
+    }
+}

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/Command/AbstractCompanyCommand.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/Command/AbstractCompanyCommand.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Company\TestPluginThree\Command;
+
+use Cake\Command\Command;
+
+abstract class AbstractCompanyCommand extends Command
+{
+}


### PR DESCRIPTION
This PR:

1. makes `CommandScanner` no longer internal (this may require rewriting the class description);
2. makes `scanDir()` method public;
3. fixes [this line](https://github.com/cakephp/cakephp/blob/ca1c22c8c6757a1f28c1f731ff55072a1a333317/src/Console/CommandScanner.php#L81)
It seems to me that currently this:
```php
$commandScanner->scanPlugin('Company/TestPluginThree')
```
produces this (see the `file` key):
```php
[
  (int) 0 => [
    'file' => '/home/mirko/PhpstormProjects/cakephp/tests/test_app/Plugin/Company/TestPluginThree/src/CommandCompanyCommand.php',
    'fullName' => 'company/test_plugin_three.company',
    'name' => 'company',
    'class' => 'Company\TestPluginThree\Command\CompanyCommand'
  ]
]
```
4. adds tests. It can and perhaps should be extended further, although I believe the `testScanPlugin()` method reasonably covers the `scanDir()` method.

### Why make it non-internal and the method public?

I think I read a long time ago that we don't want to recursively scan (subdirectories) for commands. I'm going from memory.

I find this understandable, both because it would be unnecessarily complex and especially because it would then easily include plugins.

This PR doesn't do that, but it allows for a reasonable implementation of a particular directory, without breaking anything.

My problem: My app is growing in terms of commands. I need to reorganize them into subdirectories and namespaces. For example, I could move all the "maintenance" commands (which only work for cronjobs) to `src/Command/Maintenance`. I could move them to a plugin, but I'd also like to avoid having to manage a separate plugin.

Currently, instead of declaring them individually (which is difficult to maintain), I've easily solved it like this:

```php
public function console(CommandCollection $commands): CommandCollection
    {
        $commands = parent::console($commands);

        $scanner = new class extends CommandScanner {
            /** @phpstan-ignore-next-line */
            public function scanDir(string $path, string $namespace, string $prefix, array $hide = []): array
            {
                return parent::scanDir($path, $namespace, $prefix, $hide);
            }
        };

        $maintenanceCommands = $scanner->scanDir(
            ROOT . '/src/Command/Maintenance/',
            'App\\Command\\Maintenance\\',
            'maintenance_',
        );

        $commands->addMany(array_column($maintenanceCommands, 'class', 'fullName'));

        return $commands;
    }
```

This obviously already works like this.
But I don't see why it can't be made easier.

Obviously, this is a draft, both because I'm not sure of the validity of my code and because I would expect it to be sufficient to say that the `Application::console()` method can be used to independently implement a filesystem scan of any subdirectories (it's not difficult at all).

Thanks as always for any comments.

#### Miscellaneous notes:
1) the `AbstractCompanyCommand` class is simply used to verify that it is excluded from the scan;
2) I used mocks where I thought they might be useful. We can do without them, but testing the scan results of the app, and especially the core, becomes tricky and variable if other commands are added.