### PR TITLE
refactor: replace null check with null coalescing assignment operator

### DIFF
--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -328,7 +328,7 @@ class ResultSetFactory
      */
     public function getDtoMapper(): DtoMapper
     {
-        return $this->dtoMapper ?? new DtoMapper();
+        return $this->dtoMapper ??= new DtoMapper();
     }
 
     /**

--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -328,11 +328,7 @@ class ResultSetFactory
      */
     public function getDtoMapper(): DtoMapper
     {
-        if ($this->dtoMapper === null) {
-            $this->dtoMapper = new DtoMapper();
-        }
-
-        return $this->dtoMapper;
+        return $this->dtoMapper ?? new DtoMapper();
     }
 
     /**


### PR DESCRIPTION
## Summary

Replace verbose null check with null coalescing assignment operator.

## Changes

- Refactor `getDtoMapper()` to use `??=` instead of explicit null check
- No behaviour change
