### PR TITLE
#19407 SameSite cookie default applies to all session preset

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -190,8 +190,8 @@ class Session
             ));
         }
 
-        if ($name !== 'php' || empty(ini_get('session.cookie_samesite'))) {
-            $defaults['php']['ini']['session.cookie_samesite'] = 'Lax';
+        if (empty(ini_get('session.cookie_samesite'))) {
+            $defaults[$name]['ini']['session.cookie_samesite'] = 'Lax';
         }
 
         return $defaults[$name];

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -688,6 +688,59 @@ class SessionTest extends TestCase
     }
 
     /**
+     * test SameSite cookie default is applied to all presets.
+     */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function testSameSiteDefaultAppliedToAllPresets(): void
+    {
+        $_SESSION = null;
+
+        ini_set('session.cookie_samesite', '');
+        $method = new \ReflectionMethod(Session::class, '_defaultConfig');
+
+        $phpConfig = $method->invoke(null, 'php');
+        $this->assertSame('Lax', $phpConfig['ini']['session.cookie_samesite']);
+
+        $cakeConfig = $method->invoke(null, 'cake');
+        $this->assertSame('Lax', $cakeConfig['ini']['session.cookie_samesite']);
+    }
+
+    /**
+     * test SameSite cookie default is not applied when already set in php.ini.
+     */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function testSameSiteDefaultRespectsExistingIniValue(): void
+    {
+        $_SESSION = null;
+
+        ini_set('session.cookie_samesite', 'Strict');
+        $method = new \ReflectionMethod(Session::class, '_defaultConfig');
+        $config = $method->invoke(null, 'cake');
+        $this->assertArrayNotHasKey('session.cookie_samesite', $config['ini']);
+    }
+
+    /**
+     * test SameSite cookie can be overridden via user config.
+     */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function testSameSiteDefaultCanBeOverridden(): void
+    {
+        $_SESSION = null;
+
+        ini_set('session.cookie_samesite', '');
+        new Session([
+            'defaults' => 'cake',
+            'ini' => [
+                'session.cookie_samesite' => 'None',
+            ],
+        ]);
+        $this->assertSame('None', ini_get('session.cookie_samesite'));
+    }
+
+    /**
      * test setting ini properties with Session configuration after session is created before started.
      */
     #[PreserveGlobalState(false)]

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -22,6 +22,7 @@ use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use ReflectionMethod;
 use ReflectionProperty;
 use TestApp\Http\Session\TestAppLibSession;
 use TestApp\Http\Session\TestWebSession;
@@ -697,7 +698,7 @@ class SessionTest extends TestCase
         $_SESSION = null;
 
         ini_set('session.cookie_samesite', '');
-        $method = new \ReflectionMethod(Session::class, '_defaultConfig');
+        $method = new ReflectionMethod(Session::class, '_defaultConfig');
 
         $phpConfig = $method->invoke(null, 'php');
         $this->assertSame('Lax', $phpConfig['ini']['session.cookie_samesite']);
@@ -716,7 +717,7 @@ class SessionTest extends TestCase
         $_SESSION = null;
 
         ini_set('session.cookie_samesite', 'Strict');
-        $method = new \ReflectionMethod(Session::class, '_defaultConfig');
+        $method = new ReflectionMethod(Session::class, '_defaultConfig');
         $config = $method->invoke(null, 'cake');
         $this->assertArrayNotHasKey('session.cookie_samesite', $config['ini']);
     }


### PR DESCRIPTION
Fixes #19407 by applying the default SameSite cookie to all session type.