### PR TITLE
Add support for context-aware translation caching

### DIFF
--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -304,4 +304,15 @@ class I18n
     {
         static::$_collection = null;
     }
+
+    /**
+     * Sets the context for translation caching isolation.
+     *
+     * @param string $context The context name or identifier.
+     * @return void
+     */
+    public static function setContext(string $context): void
+    {
+        static::translators()->setContext($context);
+    }
 }

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -91,6 +91,13 @@ class TranslatorRegistry
     protected $_cacher;
 
     /**
+     * Context identifier for translations isolation.
+     *
+     * @var string
+     */
+    protected $_context = '';
+
+    /**
      * Constructor.
      *
      * @param \Cake\I18n\PackageLocator $packages The package locator.
@@ -118,6 +125,17 @@ class TranslatorRegistry
 
             return $package;
         });
+    }
+
+    /**
+     * Sets the context for translations isolation.
+     *
+     * @param string $context The context name or identifier.
+     * @return void
+     */
+    public function setContext(string $context): void
+    {
+        $this->_context = $context;
     }
 
     /**
@@ -189,17 +207,19 @@ class TranslatorRegistry
             $locale = $this->getLocale();
         }
 
-        if (isset($this->registry[$name][$locale])) {
-            return $this->registry[$name][$locale];
+        $contextKey = $this->_context ?: '_default_';
+        if (isset($this->registry[$contextKey][$name][$locale])) {
+            return $this->registry[$contextKey][$name][$locale];
         }
 
         if ($this->_cacher === null) {
-            return $this->registry[$name][$locale] = $this->_getTranslator($name, $locale);
+            return $this->registry[$contextKey][$name][$locale] = $this->_getTranslator($name, $locale);
         }
 
         // Cache keys cannot contain / if they go to file engine.
         $keyName = str_replace('/', '.', $name);
-        $key = "translations.{$keyName}.{$locale}";
+        $contextPart = $this->_context ? $this->_context . '.' : '';
+        $key = "translations.{$contextPart}{$keyName}.{$locale}";
         $translator = $this->_cacher->get($key);
 
         // PHP <8.1 does not correctly garbage collect strings created
@@ -211,7 +231,7 @@ class TranslatorRegistry
             $this->_cacher->set($key, $translator);
         }
 
-        return $this->registry[$name][$locale] = $translator;
+        return $this->registry[$contextKey][$name][$locale] = $translator;
     }
 
     /**

--- a/tests/TestCase/I18n/I18nContextTest.php
+++ b/tests/TestCase/I18n/I18nContextTest.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\I18n;
+
+use Cake\Cache\Cache;
+use Cake\I18n\I18n;
+use Cake\I18n\Package;
+use Cake\TestSuite\TestCase;
+use ReflectionProperty;
+
+/**
+ * I18nContextTest class
+ */
+class I18nContextTest extends TestCase
+{
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        I18n::clear();
+        if (Cache::getConfig('_cake_core_')) {
+            Cache::clear('_cake_core_');
+        }
+    }
+
+    /**
+     * Test that setting context works on I18n proxy and propagates to the registry.
+     *
+     * @return void
+     */
+    public function testSetContext(): void
+    {
+        I18n::setContext('tenant_123');
+        $registry = I18n::translators();
+
+        $property = new ReflectionProperty($registry, '_context');
+        $property->setAccessible(true);
+        $this->assertSame('tenant_123', $property->getValue($registry));
+    }
+
+    /**
+     * Test cache key generation when context is set.
+     *
+     * @return void
+     */
+    public function testCacheKeyWithContext(): void
+    {
+        $engine = $this->getMockBuilder('Cake\Cache\Engine\NullEngine')
+            ->onlyMethods(['get', 'set'])
+            ->getMock();
+
+        I18n::translators()->setCacher($engine);
+        I18n::setContext('my_app_context');
+
+        // The expected key pattern is: translations.{context}.{domain}.{locale}
+        $expectedKey = 'translations.my_app_context.default.en_US';
+
+        $engine->expects($this->once())
+            ->method('get')
+            ->with($expectedKey)
+            ->willReturn(null);
+
+        I18n::getTranslator('default', 'en_US');
+    }
+
+    /**
+     * Test that empty context results in legacy cache key format (backward compatibility).
+     *
+     * @return void
+     */
+    public function testCacheKeyWithoutContext(): void
+    {
+        $engine = $this->getMockBuilder('Cake\Cache\Engine\NullEngine')
+            ->onlyMethods(['get', 'set'])
+            ->getMock();
+
+        I18n::translators()->setCacher($engine);
+        I18n::setContext(''); // No context
+
+        $expectedKey = 'translations.default.en_US';
+
+        $engine->expects($this->once())
+            ->method('get')
+            ->with($expectedKey)
+            ->willReturn(null);
+
+        I18n::getTranslator('default', 'en_US');
+    }
+}


### PR DESCRIPTION
- Introduce **I18n**::**setContext**() and **TranslatorRegistry**::**setContext**().
- Update **TranslatorRegistry**::**get**() to include context in the cache key.
Add translation context support for cache isolation.
This allows isolating translation caches in multi-tenant environments (e.g., per-user or per-shop translations).

Summary: This PR introduces a "context" identifier to the I18n subsystem. It allows developers to isolate translation caches based on a dynamic identifier, which is particularly useful for multi-tenant applications.

Motivation Currently, CakePHP's I18n subsystem caches translations globally based on the domain and locale. While this works for most applications, it poses a challenge for multi-tenant systems (like SaaS platforms or Shopify apps) where:

Translations are loaded dynamically from a database or external API.
Each tenant (customer/shop) can have their own custom translations for the same keys in the same locale.
Without context isolation, the cache from one tenant could incorrectly leak to another if they share the same locale.

Changes:

Cake\I18n\I18n: Added setContext(string $context) to provide a static entry point for setting the translation context for the current request.
Cake\I18n\TranslatorRegistry:
Added $_context property and setContext() method.
Modified get() method to incorporate the context into the cache key: translations.{$context}.{$domain}.{$locale}.

Example Usage In a multi-tenant application controller or middleware:

```
// Set the context based on the current tenant ID
I18n::setContext((string)$currentCustomer->id);

// Any subsequent translation loading will use a cache key isolated to this customer
$translator = I18n::getTranslator('default');
```


This will change the cache files:
- translations.my_app_context.default.en_US
- translations.customer_A.default.en_US
- translations.customer_B.default.en_US  

Backward Compatibility: **YES** 

