### PR TITLE
Allow customizing translation cache key (context) to support advanced…

### DIFF
--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -312,4 +312,15 @@ class I18n
     {
         static::$_collection = null;
     }
+
+    /**
+     * Sets the context for translation caching isolation.
+     *
+     * @param string $context The context name or identifier.
+     * @return void
+     */
+    public static function setContext(string $context): void
+    {
+        static::translators()->setContext($context);
+    }
 }

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -95,6 +95,13 @@ class TranslatorRegistry
     protected $_cacher;
 
     /**
+     * Context identifier for translations isolation.
+     *
+     * @var string
+     */
+    protected string $_context = '';
+
+    /**
      * Constructor.
      *
      * @param \Cake\I18n\PackageLocator $packages The package locator.
@@ -122,6 +129,17 @@ class TranslatorRegistry
 
             return $package;
         });
+    }
+
+    /**
+     * Sets the context for translations isolation.
+     *
+     * @param string $context The context name or identifier.
+     * @return void
+     */
+    public function setContext(string $context): void
+    {
+        $this->_context = $context;
     }
 
     /**
@@ -191,17 +209,19 @@ class TranslatorRegistry
     {
         $locale ??= $this->getLocale();
 
-        if (isset($this->registry[$name][$locale])) {
-            return $this->registry[$name][$locale];
+        $contextKey = $this->_context ?: '_default_';
+        if (isset($this->registry[$contextKey][$name][$locale])) {
+            return $this->registry[$contextKey][$name][$locale];
         }
 
         if ($this->_cacher === null) {
-            return $this->registry[$name][$locale] = $this->_getTranslator($name, $locale);
+            return $this->registry[$contextKey][$name][$locale] = $this->_getTranslator($name, $locale);
         }
 
         // Cache keys cannot contain / if they go to file engine.
         $keyName = str_replace('/', '.', $name);
-        $key = "translations.{$keyName}.{$locale}";
+        $contextPart = $this->_context ? $this->_context . '.' : '';
+        $key = "translations.{$contextPart}{$keyName}.{$locale}";
         /** @var \Cake\I18n\Translator|null $translator */
         $translator = $this->_cacher->get($key);
 
@@ -210,7 +230,7 @@ class TranslatorRegistry
             $this->_cacher->set($key, $translator);
         }
 
-        return $this->registry[$name][$locale] = $translator;
+        return $this->registry[$contextKey][$name][$locale] = $translator;
     }
 
     /**

--- a/tests/TestCase/I18n/I18nContextTest.php
+++ b/tests/TestCase/I18n/I18nContextTest.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\I18n;
+
+use Cake\Cache\Cache;
+use Cake\Cache\CacheEngineInterface;
+use Cake\I18n\I18n;
+use Cake\TestSuite\TestCase;
+use Psr\SimpleCache\CacheInterface;
+use ReflectionProperty;
+
+/**
+ * I18nContextTest class
+ */
+class I18nContextTest extends TestCase
+{
+    /**
+     * Set Up
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        I18n::clear();
+
+        Cache::clear('_cake_translations_');
+    }
+
+    /**
+     * Test that setting context works on I18n proxy and propagates to the registry.
+     *
+     * @return void
+     */
+    public function testSetContext(): void
+    {
+        I18n::setContext('tenant_123');
+        $registry = I18n::translators();
+
+        $property = new ReflectionProperty($registry, '_context');
+        $this->assertSame('tenant_123', $property->getValue($registry));
+    }
+
+    /**
+     * Test cache key generation when context is set.
+     *
+     * @return void
+     */
+    public function testCacheKeyWithContext(): void
+    {
+        /** @var \Psr\SimpleCache\CacheInterface&\Cake\Cache\CacheEngineInterface&\PHPUnit\Framework\MockObject\MockObject $engine */
+        $engine = $this->createMockForIntersectionOfInterfaces([
+            CacheEngineInterface::class,
+            CacheInterface::class,
+        ]);
+
+        I18n::translators()->setCacher($engine);
+        I18n::setContext('my_app_context');
+
+        // The expected key pattern is: translations.{context}.{domain}.{locale}
+        $expectedKey = 'translations.my_app_context.default.en_US';
+
+        $engine->expects($this->once())
+            ->method('get')
+            ->with($expectedKey)
+            ->willReturn(null);
+
+        I18n::getTranslator('default', 'en_US');
+    }
+
+    /**
+     * Test that empty context results in legacy cache key format (backward compatibility).
+     *
+     * @return void
+     */
+    public function testCacheKeyWithoutContext(): void
+    {
+        /** @var \Psr\SimpleCache\CacheInterface&\Cake\Cache\CacheEngineInterface&\PHPUnit\Framework\MockObject\MockObject $engine */
+        $engine = $this->createMockForIntersectionOfInterfaces([
+            CacheEngineInterface::class,
+            CacheInterface::class,
+        ]);
+
+        I18n::translators()->setCacher($engine);
+        I18n::setContext(''); // No context
+
+        $expectedKey = 'translations.default.en_US';
+
+        $engine->expects($this->once())
+            ->method('get')
+            ->with($expectedKey)
+            ->willReturn(null);
+
+        I18n::getTranslator('default', 'en_US');
+    }
+}


### PR DESCRIPTION
Allow customizing translation cache key (context) to support advanced multi-tenant isolation.

- Introduce I18n::**setContext**() and TranslatorRegistry::**setContext**().
- Update TranslatorRegistry::**get**() to include context in the cache key.
- This allows isolating translation caches in multi-tenant environments (e.g., per-user or per-shop translations).

Example Usage In a multi-tenant application controller or middleware:

```
I18n::setLocale($settings->lang_code); // ja_JP,...
$locale = I18n::getLocale(); // Equals to the setting above.

// Set the context based on the current tenant ID
I18n::setContext((string)$customer->id); // ID is: customer_A, customer_B, ....
// set Translator for Admin plugin, get language overrides by customer for $locale. Fallback to translation for $locale;
I18n::setTranslator('admin', new DatabasePackageLoader($customer->id, $locale), $locale);
```

This will change the cache files:

```
translations.my_app_context.default.en_US
translations.customer_A.default.en_US
translations.customer_B.default.en_US
```

Backward Compatibility: **YES**
