### PR TITLE
5.next: I18n translator cache key prefix + configurable cache pool

### DIFF
--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -42,7 +42,7 @@ class I18n
      *
      * @var string
      */
-    public const DEFAULT_CACHE_POOL = '_cake_translations_';
+    public const DEFAULT_CACHE_CONFIG = '_cake_translations_';
 
     /**
      * The translators collection
@@ -63,7 +63,7 @@ class I18n
      *
      * @var string
      */
-    protected static string $_cachePool = self::DEFAULT_CACHE_POOL;
+    protected static string $_cacheConfig = self::DEFAULT_CACHE_CONFIG;
 
     /**
      * Returns the translators collection instance. It can be used
@@ -89,9 +89,9 @@ class I18n
 
         if (class_exists(Cache::class)) {
             try {
-                $pool = Cache::pool(static::$_cachePool);
+                $pool = Cache::pool(static::$_cacheConfig);
             } catch (InvalidArgumentException $e) {
-                if (static::$_cachePool !== self::DEFAULT_CACHE_POOL) {
+                if (static::$_cacheConfig !== self::DEFAULT_CACHE_CONFIG) {
                     throw $e;
                 }
                 $pool = Cache::pool('_cake_core_');
@@ -113,20 +113,20 @@ class I18n
      * cacher after translators have been built, use
      * {@see \Cake\I18n\TranslatorRegistry::setCacher()} directly.
      *
-     * @param string $poolName The Cache config name to use for translator persistence.
+     * @param string $name The Cache config name to use for translator persistence.
      * @return void
      * @throws \RuntimeException When the translators registry has already been built.
      */
-    public static function setCachePool(string $poolName): void
+    public static function setCacheConfig(string $name): void
     {
         if (static::$_collection !== null) {
             throw new RuntimeException(
-                '`I18n::setCachePool()` must be called before the translators registry is built. '
+                '`I18n::setCacheConfig()` must be called before the translators registry is built. '
                 . 'Call `I18n::clear()` first, or use `I18n::translators()->setCacher()` to swap the cacher.',
             );
         }
 
-        static::$_cachePool = $poolName;
+        static::$_cacheConfig = $name;
     }
 
     /**

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -22,6 +22,7 @@ use Cake\I18n\Exception\I18nException;
 use Cake\I18n\Formatter\IcuFormatter;
 use Cake\I18n\Formatter\SprintfFormatter;
 use Locale;
+use RuntimeException;
 use function Cake\Core\deprecationWarning;
 
 /**
@@ -37,6 +38,13 @@ class I18n
     public const DEFAULT_LOCALE = 'en_US';
 
     /**
+     * Default Cache configuration name used for translator persistence.
+     *
+     * @var string
+     */
+    public const DEFAULT_CACHE_POOL = '_cake_translations_';
+
+    /**
      * The translators collection
      *
      * @var \Cake\I18n\TranslatorRegistry|null
@@ -49,6 +57,13 @@ class I18n
      * @var string|null
      */
     protected static ?string $_defaultLocale = null;
+
+    /**
+     * The Cache configuration name used by the default translators registry.
+     *
+     * @var string
+     */
+    protected static string $_cachePool = self::DEFAULT_CACHE_POOL;
 
     /**
      * Returns the translators collection instance. It can be used
@@ -74,8 +89,11 @@ class I18n
 
         if (class_exists(Cache::class)) {
             try {
-                $pool = Cache::pool('_cake_translations_');
-            } catch (InvalidArgumentException) {
+                $pool = Cache::pool(static::$_cachePool);
+            } catch (InvalidArgumentException $e) {
+                if (static::$_cachePool !== self::DEFAULT_CACHE_POOL) {
+                    throw $e;
+                }
                 $pool = Cache::pool('_cake_core_');
                 deprecationWarning(
                     '5.1.0',
@@ -86,6 +104,29 @@ class I18n
         }
 
         return static::$_collection;
+    }
+
+    /**
+     * Sets the Cache configuration name used by the default translators registry.
+     *
+     * Must be called before the first translator is resolved. To swap the
+     * cacher after translators have been built, use
+     * {@see \Cake\I18n\TranslatorRegistry::setCacher()} directly.
+     *
+     * @param string $poolName The Cache config name to use for translator persistence.
+     * @return void
+     * @throws \RuntimeException When the translators registry has already been built.
+     */
+    public static function setCachePool(string $poolName): void
+    {
+        if (static::$_collection !== null) {
+            throw new RuntimeException(
+                'I18n::setCachePool() must be called before the translators registry is built. '
+                . 'Call I18n::clear() first, or use I18n::translators()->setCacher() to swap the cacher.',
+            );
+        }
+
+        static::$_cachePool = $poolName;
     }
 
     /**

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -63,7 +63,7 @@ class I18n
      *
      * @var string
      */
-    protected static string $_cacheConfig = self::DEFAULT_CACHE_CONFIG;
+    protected static string $cacheConfig = self::DEFAULT_CACHE_CONFIG;
 
     /**
      * Returns the translators collection instance. It can be used
@@ -89,9 +89,9 @@ class I18n
 
         if (class_exists(Cache::class)) {
             try {
-                $pool = Cache::pool(static::$_cacheConfig);
+                $pool = Cache::pool(static::$cacheConfig);
             } catch (InvalidArgumentException $e) {
-                if (static::$_cacheConfig !== self::DEFAULT_CACHE_CONFIG) {
+                if (static::$cacheConfig !== self::DEFAULT_CACHE_CONFIG) {
                     throw $e;
                 }
                 $pool = Cache::pool('_cake_core_');
@@ -126,7 +126,7 @@ class I18n
             );
         }
 
-        static::$_cacheConfig = $name;
+        static::$cacheConfig = $name;
     }
 
     /**

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -121,8 +121,8 @@ class I18n
     {
         if (static::$_collection !== null) {
             throw new RuntimeException(
-                'I18n::setCachePool() must be called before the translators registry is built. '
-                . 'Call I18n::clear() first, or use I18n::translators()->setCacher() to swap the cacher.',
+                '`I18n::setCachePool()` must be called before the translators registry is built. '
+                . 'Call `I18n::clear()` first, or use `I18n::translators()->setCacher()` to swap the cacher.',
             );
         }
 

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -221,6 +221,13 @@ class TranslatorRegistry
      * into this class. An empty result disables prefixing and keeps the
      * legacy cache key format `translations.{domain}.{locale}`.
      *
+     * The Closure receives the requested package name and resolved locale
+     * (`function (string $name, string $locale): string`), so callers may
+     * vary the prefix per package (e.g. skip prefixing for shared packages)
+     * or per locale. Each distinct resolved prefix produces its own
+     * in-memory bucket, so closures that vary by `$name`/`$locale` will
+     * fragment the registry accordingly.
+     *
      * Prefix values must match `[A-Za-z0-9._-]+` to stay safe across every
      * built-in cache engine.
      *
@@ -256,13 +263,15 @@ class TranslatorRegistry
     /**
      * Resolves the current cache key prefix value.
      *
+     * @param string $name The translator package name being resolved.
+     * @param string $locale The locale being resolved.
      * @return string The resolved prefix or an empty string when none is set.
      * @throws \InvalidArgumentException If a Closure prefix returns an invalid value.
      */
-    protected function resolveCacheKeyPrefix(): string
+    protected function resolveCacheKeyPrefix(string $name, string $locale): string
     {
         if ($this->cacheKeyPrefix instanceof Closure) {
-            $value = ($this->cacheKeyPrefix)();
+            $value = ($this->cacheKeyPrefix)($name, $locale);
             if ($value === '') {
                 return '';
             }
@@ -305,7 +314,7 @@ class TranslatorRegistry
     {
         $locale ??= $this->getLocale();
 
-        $prefix = $this->resolveCacheKeyPrefix();
+        $prefix = $this->resolveCacheKeyPrefix($name, $locale);
         $bucket = $prefix !== '' ? $prefix : static::DEFAULT_BUCKET;
 
         if (isset($this->registry[$bucket][$name][$locale])) {

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -255,7 +255,7 @@ class TranslatorRegistry
      *
      * @return void
      */
-    public function clearInMemoryRegistry(): void
+    public function clear(): void
     {
         $this->registry = [];
     }

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 namespace Cake\I18n;
 
 use Cake\Cache\CacheEngineInterface;
+use Closure;
+use InvalidArgumentException;
 use Psr\SimpleCache\CacheInterface;
 use function Cake\Core\deprecationWarning;
 
@@ -34,11 +36,39 @@ class TranslatorRegistry
     public const FALLBACK_LOADER = '_fallback';
 
     /**
-     * A registry to retain translator objects.
+     * Bucket key used for in-memory lookups when no cache key prefix is set.
      *
-     * @var array<string, array<string, \Cake\I18n\Translator>>
+     * @var string
+     */
+    protected const DEFAULT_BUCKET = '_default_';
+
+    /**
+     * Pattern of characters allowed in a cache key prefix.
+     *
+     * Restricted to the subset that every built-in CakePHP cache engine
+     * accepts and that never collides with PSR-16 reserved characters.
+     *
+     * @var string
+     */
+    protected const PREFIX_PATTERN = '/^[A-Za-z0-9._-]+$/';
+
+    /**
+     * A registry to retain translator objects, keyed by prefix bucket, name and locale.
+     *
+     * @var array<string, array<string, array<string, \Cake\I18n\Translator>>>
      */
     protected array $registry = [];
+
+    /**
+     * Cache key prefix segment used to isolate translations, e.g. per tenant.
+     *
+     * A string is applied as-is. A Closure is invoked on every get() call and
+     * must return a string. An empty result disables prefixing and restores
+     * the legacy cache key format.
+     *
+     * @var \Closure|string
+     */
+    protected Closure|string $cacheKeyPrefix = '';
 
     /**
      * The current locale code.
@@ -178,6 +208,90 @@ class TranslatorRegistry
     }
 
     /**
+     * Sets a prefix segment added to translator cache keys and in-memory
+     * lookup buckets.
+     *
+     * Intended for isolating translations in multi-tenant applications where
+     * dynamic loaders may produce different messages for the same domain and
+     * locale per tenant.
+     *
+     * Accepts either a string (static prefix) or a Closure that returns a
+     * string. Closures are resolved on every {@see get()} call so the current
+     * tenant identifier can be pulled from user-land without pushing state
+     * into this class. An empty result disables prefixing and keeps the
+     * legacy cache key format `translations.{domain}.{locale}`.
+     *
+     * Prefix values must match `[A-Za-z0-9._-]+` to stay safe across every
+     * built-in cache engine.
+     *
+     * Unrelated to the gettext message context used by {@see __x()}.
+     *
+     * @param \Closure|string $prefix Static prefix or a Closure returning one.
+     * @return void
+     * @throws \InvalidArgumentException If a non-empty string prefix contains invalid characters.
+     */
+    public function setCacheKeyPrefix(Closure|string $prefix): void
+    {
+        if (is_string($prefix) && $prefix !== '') {
+            $this->assertValidPrefix($prefix);
+        }
+
+        $this->cacheKeyPrefix = $prefix;
+    }
+
+    /**
+     * Drops all in-memory translator instances.
+     *
+     * Does not touch the persistent cache or any configured prefix/cacher.
+     * Intended for long-running workers that switch tenants between jobs
+     * and want to bound memory growth.
+     *
+     * @return void
+     */
+    public function clearInMemoryRegistry(): void
+    {
+        $this->registry = [];
+    }
+
+    /**
+     * Resolves the current cache key prefix value.
+     *
+     * @return string The resolved prefix or an empty string when none is set.
+     * @throws \InvalidArgumentException If a Closure prefix returns an invalid value.
+     */
+    protected function resolveCacheKeyPrefix(): string
+    {
+        if ($this->cacheKeyPrefix instanceof Closure) {
+            $value = ($this->cacheKeyPrefix)();
+            if ($value === '') {
+                return '';
+            }
+            $this->assertValidPrefix($value);
+
+            return $value;
+        }
+
+        return $this->cacheKeyPrefix;
+    }
+
+    /**
+     * Validates a prefix string.
+     *
+     * @param string $prefix The value to check.
+     * @return void
+     * @throws \InvalidArgumentException When the value does not match the allowed pattern.
+     */
+    protected function assertValidPrefix(string $prefix): void
+    {
+        if (!preg_match(static::PREFIX_PATTERN, $prefix)) {
+            throw new InvalidArgumentException(sprintf(
+                'Translator cache key prefix `%s` contains invalid characters. Allowed: A-Z, a-z, 0-9, `.`, `_`, `-`.',
+                $prefix,
+            ));
+        }
+    }
+
+    /**
      * Gets a translator from the registry by package for a locale.
      *
      * @param string $name The translator package to retrieve.
@@ -191,17 +305,22 @@ class TranslatorRegistry
     {
         $locale ??= $this->getLocale();
 
-        if (isset($this->registry[$name][$locale])) {
-            return $this->registry[$name][$locale];
+        $prefix = $this->resolveCacheKeyPrefix();
+        $bucket = $prefix !== '' ? $prefix : static::DEFAULT_BUCKET;
+
+        if (isset($this->registry[$bucket][$name][$locale])) {
+            return $this->registry[$bucket][$name][$locale];
         }
 
         if ($this->_cacher === null) {
-            return $this->registry[$name][$locale] = $this->_getTranslator($name, $locale);
+            return $this->registry[$bucket][$name][$locale] = $this->_getTranslator($name, $locale);
         }
 
         // Cache keys cannot contain / if they go to file engine.
         $keyName = str_replace('/', '.', $name);
-        $key = "translations.{$keyName}.{$locale}";
+        $key = $prefix !== ''
+            ? "translations.{$prefix}.{$keyName}.{$locale}"
+            : "translations.{$keyName}.{$locale}";
         /** @var \Cake\I18n\Translator|null $translator */
         $translator = $this->_cacher->get($key);
 
@@ -210,7 +329,7 @@ class TranslatorRegistry
             $this->_cacher->set($key, $translator);
         }
 
-        return $this->registry[$name][$locale] = $translator;
+        return $this->registry[$bucket][$name][$locale] = $translator;
     }
 
     /**

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -926,12 +926,7 @@ class I18nTest extends TestCase
      */
     public function testSetCachePoolRoutesToConfiguredConfig(): void
     {
-        Cache::setConfig('_i18n_alt_', [
-            'engine' => 'File',
-            'prefix' => 'i18n_alt_',
-            'serialize' => true,
-        ]);
-        Cache::clear('_i18n_alt_');
+        Cache::setConfig('_i18n_alt_', ['engine' => 'Array']);
 
         I18n::setCachePool('_i18n_alt_');
 
@@ -968,12 +963,7 @@ class I18nTest extends TestCase
      */
     public function testSetCachePoolAfterClearRebuilds(): void
     {
-        Cache::setConfig('_i18n_alt_', [
-            'engine' => 'File',
-            'prefix' => 'i18n_alt_',
-            'serialize' => true,
-        ]);
-        Cache::clear('_i18n_alt_');
+        Cache::setConfig('_i18n_alt_', ['engine' => 'Array']);
 
         I18n::getTranslator();
         I18n::clear();

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -22,6 +22,7 @@ use Cake\I18n\Package;
 use Cake\I18n\Translator;
 use Cake\I18n\TranslatorRegistry;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 use function Cake\I18n\__;
 use function Cake\I18n\__d;
 use function Cake\I18n\__dn;
@@ -50,9 +51,13 @@ class I18nTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
-        I18n::clear();
         I18n::setDefaultFormatter('default');
         I18n::setLocale(I18n::getDefaultLocale());
+        I18n::clear();
+        I18n::setCachePool(I18n::DEFAULT_CACHE_POOL);
+        if (Cache::getConfig('_i18n_alt_')) {
+            Cache::drop('_i18n_alt_');
+        }
         $this->clearPlugins();
         Cache::clear('_cake_translations_');
     }
@@ -913,5 +918,68 @@ class I18nTest extends TestCase
         $this->assertSame('Standorte', __dn('wa', 'Location', 'Locations', 0));
         $this->assertSame('Standort', __dn('wa', 'Location', 'Locations', 1));
         $this->assertSame('Standorte', __dn('wa', 'Location', 'Locations', 2));
+    }
+
+    /**
+     * Setting the cache pool before the registry is built routes translator
+     * persistence to the configured Cache config.
+     */
+    public function testSetCachePoolRoutesToConfiguredConfig(): void
+    {
+        Cache::setConfig('_i18n_alt_', [
+            'engine' => 'File',
+            'prefix' => 'i18n_alt_',
+            'serialize' => true,
+        ]);
+        Cache::clear('_i18n_alt_');
+
+        I18n::setCachePool('_i18n_alt_');
+
+        I18n::getTranslator();
+
+        $this->assertInstanceOf(
+            Translator::class,
+            Cache::read('translations.default.en_US', '_i18n_alt_'),
+            'Translator must be persisted to the configured alternate pool.',
+        );
+        $this->assertNull(
+            Cache::read('translations.default.en_US', '_cake_translations_'),
+            'Default translations pool must not receive writes when another pool is configured.',
+        );
+    }
+
+    /**
+     * Calling setCachePool() after translators() has already built the
+     * registry throws to surface the ordering bug loudly.
+     */
+    public function testSetCachePoolAfterBuildThrows(): void
+    {
+        I18n::getTranslator();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('setCachePool');
+        I18n::setCachePool('_i18n_alt_');
+    }
+
+    /**
+     * Calling setCachePool() after clear() rebuilds the registry with the
+     * new pool, making the setting usable between requests in long-lived
+     * processes.
+     */
+    public function testSetCachePoolAfterClearRebuilds(): void
+    {
+        Cache::setConfig('_i18n_alt_', [
+            'engine' => 'File',
+            'prefix' => 'i18n_alt_',
+            'serialize' => true,
+        ]);
+        Cache::clear('_i18n_alt_');
+
+        I18n::getTranslator();
+        I18n::clear();
+        I18n::setCachePool('_i18n_alt_');
+        I18n::getTranslator();
+
+        $this->assertInstanceOf(Translator::class, Cache::read('translations.default.en_US', '_i18n_alt_'));
     }
 }

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -54,7 +54,7 @@ class I18nTest extends TestCase
         I18n::setDefaultFormatter('default');
         I18n::setLocale(I18n::getDefaultLocale());
         I18n::clear();
-        I18n::setCachePool(I18n::DEFAULT_CACHE_POOL);
+        I18n::setCacheConfig(I18n::DEFAULT_CACHE_CONFIG);
         if (Cache::getConfig('_i18n_alt_')) {
             Cache::drop('_i18n_alt_');
         }
@@ -921,14 +921,14 @@ class I18nTest extends TestCase
     }
 
     /**
-     * Setting the cache pool before the registry is built routes translator
+     * Setting the cache config before the registry is built routes translator
      * persistence to the configured Cache config.
      */
-    public function testSetCachePoolRoutesToConfiguredConfig(): void
+    public function testSetCacheConfigRoutesToConfiguredConfig(): void
     {
         Cache::setConfig('_i18n_alt_', ['engine' => 'Array']);
 
-        I18n::setCachePool('_i18n_alt_');
+        I18n::setCacheConfig('_i18n_alt_');
 
         I18n::getTranslator();
 
@@ -944,30 +944,30 @@ class I18nTest extends TestCase
     }
 
     /**
-     * Calling setCachePool() after translators() has already built the
+     * Calling setCacheConfig() after translators() has already built the
      * registry throws to surface the ordering bug loudly.
      */
-    public function testSetCachePoolAfterBuildThrows(): void
+    public function testSetCacheConfigAfterBuildThrows(): void
     {
         I18n::getTranslator();
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('setCachePool');
-        I18n::setCachePool('_i18n_alt_');
+        $this->expectExceptionMessage('setCacheConfig');
+        I18n::setCacheConfig('_i18n_alt_');
     }
 
     /**
-     * Calling setCachePool() after clear() rebuilds the registry with the
+     * Calling setCacheConfig() after clear() rebuilds the registry with the
      * new pool, making the setting usable between requests in long-lived
      * processes.
      */
-    public function testSetCachePoolAfterClearRebuilds(): void
+    public function testSetCacheConfigAfterClearRebuilds(): void
     {
         Cache::setConfig('_i18n_alt_', ['engine' => 'Array']);
 
         I18n::getTranslator();
         I18n::clear();
-        I18n::setCachePool('_i18n_alt_');
+        I18n::setCacheConfig('_i18n_alt_');
         I18n::getTranslator();
 
         $this->assertInstanceOf(Translator::class, Cache::read('translations.default.en_US', '_i18n_alt_'));

--- a/tests/TestCase/I18n/TranslatorRegistryTest.php
+++ b/tests/TestCase/I18n/TranslatorRegistryTest.php
@@ -208,10 +208,10 @@ class TranslatorRegistryTest extends TestCase
     }
 
     /**
-     * clearInMemoryRegistry() drops cached translator instances without
-     * clearing the cacher or resetting configuration.
+     * clear() drops cached translator instances without clearing the cacher
+     * or resetting configuration.
      */
-    public function testClearInMemoryRegistryDropsEntriesOnly(): void
+    public function testClearDropsEntriesOnly(): void
     {
         [$registry, $cacher] = $this->buildRegistryWithRecordingCacher('en_CA');
         $registry->setCacheKeyPrefix('tenant_a');
@@ -220,7 +220,7 @@ class TranslatorRegistryTest extends TestCase
         $cacher->store = [];
         $cacher->reads = [];
 
-        $registry->clearInMemoryRegistry();
+        $registry->clear();
         $registry->get('default');
 
         $this->assertSame(['translations.tenant_a.default.en_CA'], $cacher->reads);

--- a/tests/TestCase/I18n/TranslatorRegistryTest.php
+++ b/tests/TestCase/I18n/TranslatorRegistryTest.php
@@ -24,6 +24,8 @@ use Cake\I18n\PackageLocator;
 use Cake\I18n\Translator;
 use Cake\I18n\TranslatorRegistry;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use TestApp\Cache\Engine\RecordingCacheEngine;
 use TestApp\Cache\Engine\TestAppCacheEngine;
 
 class TranslatorRegistryTest extends TestCase
@@ -59,5 +61,192 @@ class TranslatorRegistryTest extends TestCase
         $registry->setCacher($cacheEngineNullPackage);
 
         $this->assertSame($package, $registry->get('default')->getPackage());
+    }
+
+    /**
+     * Default cache key format is unchanged when no prefix is set.
+     */
+    public function testDefaultCacheKeyFormatUnchanged(): void
+    {
+        [$registry, $cacher] = $this->buildRegistryWithRecordingCacher('en_CA');
+
+        $registry->get('default');
+
+        $this->assertSame(['translations.default.en_CA'], $cacher->reads);
+        $this->assertSame(['translations.default.en_CA'], array_keys($cacher->store));
+    }
+
+    /**
+     * A static string prefix is injected into cache keys.
+     */
+    public function testStringPrefixInCacheKey(): void
+    {
+        [$registry, $cacher] = $this->buildRegistryWithRecordingCacher('en_CA');
+
+        $registry->setCacheKeyPrefix('tenant_a');
+        $registry->get('default');
+
+        $this->assertSame(['translations.tenant_a.default.en_CA'], $cacher->reads);
+    }
+
+    /**
+     * A Closure prefix is evaluated on every get() call so the current
+     * tenant identifier is always pulled fresh from user-land.
+     */
+    public function testClosurePrefixEvaluatedPerGet(): void
+    {
+        [$registry, $cacher] = $this->buildRegistryWithRecordingCacher('en_CA');
+
+        $state = new class {
+            public string $current = 'tenant_a';
+
+            public int $calls = 0;
+        };
+        $registry->setCacheKeyPrefix(function () use ($state): string {
+            $state->calls++;
+
+            return $state->current;
+        });
+
+        $registry->get('default');
+        $state->current = 'tenant_b';
+        $registry->get('default');
+
+        $this->assertSame(2, $state->calls);
+        $this->assertSame(
+            ['translations.tenant_a.default.en_CA', 'translations.tenant_b.default.en_CA'],
+            $cacher->reads,
+        );
+    }
+
+    /**
+     * Two different prefixes must not cross-contaminate either the
+     * persistent cache or the in-memory registry bucket.
+     */
+    public function testPrefixesIsolateInMemoryAndPersistentLookups(): void
+    {
+        [$registry, $cacher] = $this->buildRegistryWithRecordingCacher('en_CA');
+
+        $state = new class {
+            public string $current = 'tenant_a';
+        };
+        $registry->setCacheKeyPrefix(function () use ($state): string {
+            return $state->current;
+        });
+
+        $translatorA = $registry->get('default');
+        $state->current = 'tenant_b';
+        $translatorB = $registry->get('default');
+
+        $this->assertNotSame($translatorA, $translatorB, 'Different prefixes must resolve distinct translators.');
+
+        $state->current = 'tenant_a';
+        $this->assertSame($translatorA, $registry->get('default'), 'Same prefix must return the cached translator.');
+
+        $this->assertSame(
+            ['translations.tenant_a.default.en_CA', 'translations.tenant_b.default.en_CA'],
+            array_keys($cacher->store),
+            'Cache storage must keep one entry per prefix.',
+        );
+    }
+
+    /**
+     * Empty string prefix disables prefixing and restores the legacy format.
+     */
+    public function testEmptyPrefixRestoresLegacyKey(): void
+    {
+        [$registry, $cacher] = $this->buildRegistryWithRecordingCacher('en_CA');
+
+        $registry->setCacheKeyPrefix('tenant_a');
+        $registry->get('default');
+        $registry->setCacheKeyPrefix('');
+        $registry->get('default');
+
+        $this->assertSame(
+            ['translations.tenant_a.default.en_CA', 'translations.default.en_CA'],
+            $cacher->reads,
+        );
+    }
+
+    /**
+     * A Closure that returns an empty string also disables prefixing.
+     */
+    public function testClosurePrefixReturningEmptyStringDisablesPrefixing(): void
+    {
+        [$registry, $cacher] = $this->buildRegistryWithRecordingCacher('en_CA');
+
+        $registry->setCacheKeyPrefix(fn(): string => '');
+        $registry->get('default');
+
+        $this->assertSame(['translations.default.en_CA'], $cacher->reads);
+    }
+
+    /**
+     * Invalid characters in a static prefix throw immediately.
+     */
+    public function testInvalidStringPrefixThrows(): void
+    {
+        [$registry] = $this->buildRegistryWithRecordingCacher('en_CA');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('tenant/one');
+        $registry->setCacheKeyPrefix('tenant/one');
+    }
+
+    /**
+     * Invalid characters returned by a Closure prefix throw at resolution time.
+     */
+    public function testInvalidClosurePrefixThrowsOnGet(): void
+    {
+        [$registry] = $this->buildRegistryWithRecordingCacher('en_CA');
+
+        $registry->setCacheKeyPrefix(fn(): string => 'bad key');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('bad key');
+        $registry->get('default');
+    }
+
+    /**
+     * clearInMemoryRegistry() drops cached translator instances without
+     * clearing the cacher or resetting configuration.
+     */
+    public function testClearInMemoryRegistryDropsEntriesOnly(): void
+    {
+        [$registry, $cacher] = $this->buildRegistryWithRecordingCacher('en_CA');
+        $registry->setCacheKeyPrefix('tenant_a');
+
+        $registry->get('default');
+        $cacher->store = [];
+        $cacher->reads = [];
+
+        $registry->clearInMemoryRegistry();
+        $registry->get('default');
+
+        $this->assertSame(['translations.tenant_a.default.en_CA'], $cacher->reads);
+    }
+
+    /**
+     * @param string $locale Default locale for the registry.
+     * @return array{\Cake\I18n\TranslatorRegistry, \TestApp\Cache\Engine\RecordingCacheEngine}
+     */
+    protected function buildRegistryWithRecordingCacher(string $locale): array
+    {
+        $package = new Package('default');
+        $packageLocator = new PackageLocator([
+            'default' => [
+                $locale => $package,
+            ],
+        ]);
+        $formatterLocator = new FormatterLocator([
+            'default' => SprintfFormatter::class,
+        ]);
+
+        $cacher = new RecordingCacheEngine();
+
+        $registry = new TranslatorRegistry($packageLocator, $formatterLocator, $locale);
+        $registry->setCacher($cacher);
+
+        return [$registry, $cacher];
     }
 }

--- a/tests/test_app/TestApp/Cache/Engine/RecordingCacheEngine.php
+++ b/tests/test_app/TestApp/Cache/Engine/RecordingCacheEngine.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Cache\Engine;
+
+/**
+ * In-memory cache engine that records every get() call and stores set()
+ * payloads for inspection. Used by unit tests that assert on cache key
+ * shapes.
+ */
+class RecordingCacheEngine extends TestAppCacheEngine
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public array $store = [];
+
+    /**
+     * @var list<string>
+     */
+    public array $reads = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function get($key, $default = null): mixed
+    {
+        $this->reads[] = $key;
+
+        return $this->store[$key] ?? $default;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set($key, $value, $ttl = null): bool
+    {
+        $this->store[$key] = $value;
+
+        return true;
+    }
+}

--- a/tests/test_app/TestApp/Cache/Engine/RecordingCacheEngine.php
+++ b/tests/test_app/TestApp/Cache/Engine/RecordingCacheEngine.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         5.3.0
+ * @since         5.4.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestApp\Cache\Engine;


### PR DESCRIPTION
## Motivation

Alternative design proposal to #19411 / #19410, which sought to add per-tenant translation cache isolation via a new `I18n::setContext()` global.

The original proposal had two blocking issues raised in review:
- The term "context" already has a specific meaning in i18n (`__x($context, ...)` / gettext `msgctxt` — disambiguation). Overloading it with "tenant cache scope" is bad ergonomics.
- Pushing tenant state onto a static I18n method is fragile — easy to forget per request, no scoped reset, no mid-process switching story.

This PR solves the same underlying problem (multi-tenant translation cache isolation with dynamic loaders) with two small, orthogonal knobs and no new global state.

## What

### `TranslatorRegistry::setCacheKeyPrefix(Closure|string $prefix)`

Adds a prefix segment to both the persistent cache key and the in-memory lookup bucket. Accepts either a static string or a Closure.

When a Closure is given, it is evaluated on every `get()` call — so the current tenant identifier is pulled *from* user-land instead of being *pushed into* the registry. Bootstrap is one line:

``` php
I18n::translators()->setCacheKeyPrefix(
    fn (): string => TenantContext::current()?->id ?? ''
);
```

Empty resolved value keeps the legacy `translations.{domain}.{locale}` key format (100% BC for non-multi-tenant users).

Prefix characters are restricted to `[A-Za-z0-9._-]+` so every built-in cache engine accepts them.

Unrelated to the gettext message context used by `__x()`.

### `TranslatorRegistry::clearInMemoryRegistry()`

Drops the in-memory translator map without touching the persistent cacher or configuration. Intended for long-running workers that switch tenants between jobs and want to bound memory growth.

### `I18n::setCachePool(string $poolName)`

Replaces the hardcoded `_cake_translations_` Cache pool with whichever config the app prefers. Must be called before the registry is built; throws a `RuntimeException` otherwise to surface ordering bugs loudly instead of silently ignoring the setting.

This is the cleaner form of ADmad's suggestion on the original PR: make the cache layer configurable rather than adding new state.

## Example (the original multi-tenant use case)

Bootstrap:

``` php
I18n::setCachePool('_my_translations_'); // optional, uses a dedicated pool
I18n::translators()->setCacheKeyPrefix(
    fn (): string => TenantContext::current()?->id ?? ''
);
```

Per request / per job:

``` php
I18n::setLocale($tenant->locale);
I18n::setTranslator('admin', new DatabasePackageLoader($tenant->id, $tenant->locale));

echo __d('admin', 'Topic');
// cached under translations.{tenantId}.admin.{locale}
```

Queue workers switching tenants:

``` php
foreach ($jobsByTenant as $tenantId => $jobs) {
    TenantContext::set($tenantId);
    // ... process jobs ...
    I18n::translators()->clearInMemoryRegistry();
}
```

## BC notes

- Default cache key format is unchanged when no prefix is set (covered by a regression test).
- Internal shape of `TranslatorRegistry::$registry` changes from `[$name][$locale]` to `[$bucket][$name][$locale]`. Property is `protected` and not documented as an extension point. Subclasses reaching into it directly will need to adapt.

## Docs

Not included here — will follow in cakephp/docs once the API lands. Key points to cover in the guide: the bootstrap snippet, the note that `setCacheKeyPrefix` is unrelated to `__x()`, the queue-worker reset pattern, and the `setCachePool` ordering requirement.

## Relation to existing PRs

- Supersedes #19411 (same goal, different API).
- #19410 targets 4.x which is EOL — can be closed.
