### PR TITLE
5.next: Add seek/keyset pagination support to ORM and paginator

### DIFF
--- a/src/Database/Expression/OrderByExpression.php
+++ b/src/Database/Expression/OrderByExpression.php
@@ -58,6 +58,51 @@ class OrderByExpression extends QueryExpression
     }
 
     /**
+     * Return the ordering as a list of `[field, direction]` pairs.
+     *
+     * `field` is returned as a string for simple column ordering, or as an
+     * `ExpressionInterface` instance for complex expressions where the caller
+     * must resolve the field identity. `direction` is the upper-cased direction,
+     * either `'ASC'` or `'DESC'`.
+     *
+     * Ordering entries that cannot be decomposed into a field/direction pair
+     * (for example a raw SQL fragment expression) are returned with a `null`
+     * direction so the caller can decide how to handle them.
+     *
+     * @return array<int, array{0: \Cake\Database\ExpressionInterface|array|string, 1: 'ASC'|'DESC'|null}>
+     */
+    public function toList(): array
+    {
+        $pairs = [];
+        foreach ($this->_conditions as $key => $value) {
+            if (is_string($key) && (is_string($value) || $value instanceof ExpressionInterface)) {
+                $direction = is_string($value) ? strtoupper($value) : null;
+                if ($direction !== null && !in_array($direction, ['ASC', 'DESC'], true)) {
+                    $direction = null;
+                }
+                $pairs[] = [$key, $direction];
+                continue;
+            }
+
+            if ($value instanceof OrderClauseExpression) {
+                $field = $value->getField();
+                $direction = strtoupper($value->getDirection() ?: '');
+                if (!in_array($direction, ['ASC', 'DESC'], true)) {
+                    $direction = null;
+                }
+                $pairs[] = [$field, $direction];
+                continue;
+            }
+
+            if ($value instanceof ExpressionInterface) {
+                $pairs[] = [$value, null];
+            }
+        }
+
+        return $pairs;
+    }
+
+    /**
      * Auxiliary function used for decomposing a nested array of conditions and
      * building a tree structure inside this object to represent the full SQL expression.
      *

--- a/src/Database/Expression/OrderClauseExpression.php
+++ b/src/Database/Expression/OrderClauseExpression.php
@@ -48,6 +48,16 @@ class OrderClauseExpression implements ExpressionInterface, FieldInterface
     }
 
     /**
+     * Get the sort direction.
+     *
+     * @return string Either `'ASC'` or `'DESC'`.
+     */
+    public function getDirection(): string
+    {
+        return $this->_direction;
+    }
+
+    /**
      * @inheritDoc
      */
     public function sql(ValueBinder $binder): string

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -20,11 +20,14 @@ use ArrayIterator;
 use Cake\Core\Exception\CakeException;
 use Cake\Database\Connection;
 use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\WindowExpression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
 use Cake\Database\StatementInterface;
 use Cake\Database\TypeMap;
+use Cake\Datasource\Paging\CursorEncoder;
+use Cake\Datasource\Paging\Exception\InvalidCursorException;
 use Closure;
 use InvalidArgumentException;
 use IteratorAggregate;
@@ -421,6 +424,196 @@ class SelectQuery extends Query implements IteratorAggregate
         $this->offset((int)$offset);
 
         return $this;
+    }
+
+    /**
+     * Apply a seek/keyset cursor that returns records *after* the given position
+     * in the current ORDER BY sequence.
+     *
+     * The keys of `$cursor` must match the order clauses already configured on
+     * the query (identical field identifiers and count), and must be applied after
+     * all `orderBy()` calls. The resulting WHERE predicate is an OR-expanded
+     * lexicographic comparison compatible with any supported driver:
+     *
+     * ```
+     * WHERE (col1 < a1)
+     *    OR (col1 = a1 AND col2 < a2)
+     *    OR ...
+     * ```
+     *
+     * The comparison operator per column is derived from the order direction
+     * (`DESC` → `<`, `ASC` → `>`). Seek pagination requires deterministic
+     * ordering — typically ending in a unique tie-breaker column.
+     *
+     * Cursor columns must be `NOT NULL`. SQL's three-valued logic would make
+     * `NULL < x` evaluate to `NULL` (skipping rows from the seek predicate) and
+     * drivers disagree on `NULL` placement in `ORDER BY`, so any `null` in
+     * `$cursor` raises {@see \Cake\Datasource\Paging\Exception\InvalidCursorException}.
+     * Add a `NOT NULL` tie-breaker (typically the primary key) if your leading
+     * order columns are nullable.
+     *
+     * @param array<string, mixed> $cursor Cursor key/value pairs. Keys must match
+     *   order clauses on the query, in the same order.
+     * @return $this
+     * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException When the
+     *   cursor is empty, the query has no order clauses, the cursor keys do
+     *   not match the ordering, or any cursor value is `null`.
+     */
+    public function seekAfter(array $cursor)
+    {
+        return $this->applySeek($cursor, after: true);
+    }
+
+    /**
+     * Apply a seek/keyset cursor that returns records *before* the given position
+     * in the current ORDER BY sequence.
+     *
+     * Semantically mirrors {@see self::seekAfter()} with the comparison direction
+     * flipped. Note that `seekBefore()` only applies the predicate; result ordering
+     * is untouched. Paginators that need newest-first display for backward pages
+     * must reverse the fetched rows themselves (this is what `SeekPaginator` does).
+     *
+     * @param array<string, mixed> $cursor Cursor key/value pairs. Keys must match
+     *   order clauses on the query, in the same order.
+     * @return $this
+     * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException
+     */
+    public function seekBefore(array $cursor)
+    {
+        return $this->applySeek($cursor, after: false);
+    }
+
+    /**
+     * Apply a seek cursor decoded from a signed opaque token.
+     *
+     * @param string $token Signed token previously produced by
+     *   {@see \Cake\Datasource\Paging\CursorEncoder::encode()}.
+     * @return $this
+     * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException
+     */
+    public function seekAfterToken(string $token)
+    {
+        return $this->seekAfter(CursorEncoder::decode($token));
+    }
+
+    /**
+     * Apply a backward seek cursor decoded from a signed opaque token.
+     *
+     * @param string $token Signed token previously produced by
+     *   {@see \Cake\Datasource\Paging\CursorEncoder::encode()}.
+     * @return $this
+     * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException
+     */
+    public function seekBeforeToken(string $token)
+    {
+        return $this->seekBefore(CursorEncoder::decode($token));
+    }
+
+    /**
+     * Shared seek application for {@see self::seekAfter()} / {@see self::seekBefore()}.
+     *
+     * @param array<string, mixed> $cursor Cursor key/value pairs.
+     * @param bool $after Whether the cursor targets records after (true) or before (false)
+     *   the cursor position.
+     * @return $this
+     * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException
+     */
+    protected function applySeek(array $cursor, bool $after)
+    {
+        if ($cursor === []) {
+            throw new InvalidCursorException('Seek cursor must not be empty.');
+        }
+
+        foreach ($cursor as $key => $value) {
+            if ($value === null) {
+                throw new InvalidCursorException(sprintf(
+                    'Seek cursor value for column `%s` is `null`. Seek pagination requires non-nullable cursor '
+                    . 'columns — SQL\'s three-valued logic would silently skip rows, and drivers disagree on '
+                    . '`NULL` placement in `ORDER BY`. Add a `NOT NULL` tie-breaker (typically the primary key) '
+                    . 'or exclude nullable columns from the seek order.',
+                    $key,
+                ));
+            }
+        }
+
+        $order = $this->clause('order');
+        if (!$order instanceof OrderByExpression) {
+            throw new InvalidCursorException(
+                'Seek pagination requires at least one `orderBy()` clause before calling seekAfter/seekBefore.',
+            );
+        }
+
+        $pairs = $order->toList();
+        if ($pairs === []) {
+            throw new InvalidCursorException(
+                'Seek pagination requires at least one `orderBy()` clause before calling seekAfter/seekBefore.',
+            );
+        }
+
+        $cursorKeys = array_keys($cursor);
+        $orderedKeys = [];
+        foreach ($pairs as [$field, $direction]) {
+            if (!is_string($field) || $direction === null) {
+                throw new InvalidCursorException(
+                    'Seek pagination requires simple column ordering with an ASC or DESC direction. '
+                    . 'Complex order expressions are not supported as cursor columns.',
+                );
+            }
+            $orderedKeys[] = $field;
+        }
+
+        if ($cursorKeys !== $orderedKeys) {
+            throw new InvalidCursorException(sprintf(
+                'Seek cursor keys do not match the current ordering. Expected `%s`, received `%s`.',
+                implode('`, `', $orderedKeys),
+                implode('`, `', array_map(fn($k) => (string)$k, $cursorKeys)),
+            ));
+        }
+
+        $cursorValues = array_values($cursor);
+        $disjunction = $this->expr()->setConjunction('OR');
+
+        foreach ($pairs as $i => [$field, $direction]) {
+            assert(is_string($field) && is_string($direction));
+
+            $conjunction = $this->expr();
+            for ($j = 0; $j < $i; $j++) {
+                [$prevField, ] = $pairs[$j];
+                assert(is_string($prevField));
+                $conjunction->eq($prevField, $cursorValues[$j]);
+            }
+
+            $operator = $this->comparisonOperator($direction, $after);
+            match ($operator) {
+                '<' => $conjunction->lt($field, $cursorValues[$i]),
+                '>' => $conjunction->gt($field, $cursorValues[$i]),
+            };
+
+            $disjunction->add($conjunction);
+        }
+
+        $this->where($disjunction);
+
+        return $this;
+    }
+
+    /**
+     * Map an order direction + seek direction to a strict comparison operator.
+     *
+     * - `DESC` + after  → `<` (next page: smaller values)
+     * - `ASC`  + after  → `>`
+     * - `DESC` + before → `>`
+     * - `ASC`  + before → `<`
+     *
+     * @param string $orderDirection `'ASC'` or `'DESC'`.
+     * @param bool $after Whether the seek targets records after the cursor.
+     * @return '<'|'>' Strict comparison operator.
+     */
+    protected function comparisonOperator(string $orderDirection, bool $after): string
+    {
+        $descending = strtoupper($orderDirection) === 'DESC';
+
+        return $descending === $after ? '<' : '>';
     }
 
     /**

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -19,6 +19,7 @@ namespace Cake\Database\Query;
 use ArrayIterator;
 use Cake\Core\Exception\CakeException;
 use Cake\Database\Connection;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\WindowExpression;
@@ -26,8 +27,6 @@ use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
 use Cake\Database\StatementInterface;
 use Cake\Database\TypeMap;
-use Cake\Datasource\Paging\CursorEncoder;
-use Cake\Datasource\Paging\Exception\InvalidCursorException;
 use Closure;
 use InvalidArgumentException;
 use IteratorAggregate;
@@ -448,16 +447,20 @@ class SelectQuery extends Query implements IteratorAggregate
      * Cursor columns must be `NOT NULL`. SQL's three-valued logic would make
      * `NULL < x` evaluate to `NULL` (skipping rows from the seek predicate) and
      * drivers disagree on `NULL` placement in `ORDER BY`, so any `null` in
-     * `$cursor` raises {@see \Cake\Datasource\Paging\Exception\InvalidCursorException}.
+     * `$cursor` raises {@see \Cake\Database\Exception\DatabaseException}.
      * Add a `NOT NULL` tie-breaker (typically the primary key) if your leading
      * order columns are nullable.
+     *
+     * For opaque/signed cursor tokens, decode them to an array first via the
+     * paging-layer cursor encoder and pass the result here — token decoding is
+     * intentionally kept out of the database layer.
      *
      * @param array<string, mixed> $cursor Cursor key/value pairs. Keys must match
      *   order clauses on the query, in the same order.
      * @return $this
-     * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException When the
-     *   cursor is empty, the query has no order clauses, the cursor keys do
-     *   not match the ordering, or any cursor value is `null`.
+     * @throws \Cake\Database\Exception\DatabaseException When the cursor is empty,
+     *   the query has no order clauses, the cursor keys do not match the
+     *   ordering, or any cursor value is `null`.
      */
     public function seekAfter(array $cursor)
     {
@@ -476,37 +479,11 @@ class SelectQuery extends Query implements IteratorAggregate
      * @param array<string, mixed> $cursor Cursor key/value pairs. Keys must match
      *   order clauses on the query, in the same order.
      * @return $this
-     * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException
+     * @throws \Cake\Database\Exception\DatabaseException
      */
     public function seekBefore(array $cursor)
     {
         return $this->applySeek($cursor, after: false);
-    }
-
-    /**
-     * Apply a seek cursor decoded from a signed opaque token.
-     *
-     * @param string $token Signed token previously produced by
-     *   {@see \Cake\Datasource\Paging\CursorEncoder::encode()}.
-     * @return $this
-     * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException
-     */
-    public function seekAfterToken(string $token)
-    {
-        return $this->seekAfter(CursorEncoder::decode($token));
-    }
-
-    /**
-     * Apply a backward seek cursor decoded from a signed opaque token.
-     *
-     * @param string $token Signed token previously produced by
-     *   {@see \Cake\Datasource\Paging\CursorEncoder::encode()}.
-     * @return $this
-     * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException
-     */
-    public function seekBeforeToken(string $token)
-    {
-        return $this->seekBefore(CursorEncoder::decode($token));
     }
 
     /**
@@ -516,17 +493,17 @@ class SelectQuery extends Query implements IteratorAggregate
      * @param bool $after Whether the cursor targets records after (true) or before (false)
      *   the cursor position.
      * @return $this
-     * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException
+     * @throws \Cake\Database\Exception\DatabaseException
      */
     protected function applySeek(array $cursor, bool $after)
     {
         if ($cursor === []) {
-            throw new InvalidCursorException('Seek cursor must not be empty.');
+            throw new DatabaseException('Seek cursor must not be empty.');
         }
 
         foreach ($cursor as $key => $value) {
             if ($value === null) {
-                throw new InvalidCursorException(sprintf(
+                throw new DatabaseException(sprintf(
                     'Seek cursor value for column `%s` is `null`. Seek pagination requires non-nullable cursor '
                     . 'columns — SQL\'s three-valued logic would silently skip rows, and drivers disagree on '
                     . '`NULL` placement in `ORDER BY`. Add a `NOT NULL` tie-breaker (typically the primary key) '
@@ -538,14 +515,14 @@ class SelectQuery extends Query implements IteratorAggregate
 
         $order = $this->clause('order');
         if (!$order instanceof OrderByExpression) {
-            throw new InvalidCursorException(
+            throw new DatabaseException(
                 'Seek pagination requires at least one `orderBy()` clause before calling seekAfter/seekBefore.',
             );
         }
 
         $pairs = $order->toList();
         if ($pairs === []) {
-            throw new InvalidCursorException(
+            throw new DatabaseException(
                 'Seek pagination requires at least one `orderBy()` clause before calling seekAfter/seekBefore.',
             );
         }
@@ -554,7 +531,7 @@ class SelectQuery extends Query implements IteratorAggregate
         $orderedKeys = [];
         foreach ($pairs as [$field, $direction]) {
             if (!is_string($field) || $direction === null) {
-                throw new InvalidCursorException(
+                throw new DatabaseException(
                     'Seek pagination requires simple column ordering with an ASC or DESC direction. '
                     . 'Complex order expressions are not supported as cursor columns.',
                 );
@@ -563,7 +540,7 @@ class SelectQuery extends Query implements IteratorAggregate
         }
 
         if ($cursorKeys !== $orderedKeys) {
-            throw new InvalidCursorException(sprintf(
+            throw new DatabaseException(sprintf(
                 'Seek cursor keys do not match the current ordering. Expected `%s`, received `%s`.',
                 implode('`, `', $orderedKeys),
                 implode('`, `', array_map(fn($k) => (string)$k, $cursorKeys)),

--- a/src/Datasource/Paging/CursorEncoder.php
+++ b/src/Datasource/Paging/CursorEncoder.php
@@ -1,0 +1,140 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Datasource\Paging;
+
+use Cake\Datasource\Paging\Exception\InvalidCursorException;
+use Cake\Utility\Security;
+use JsonException;
+
+/**
+ * Encodes and decodes opaque, signed cursor tokens for seek pagination.
+ *
+ * Tokens have the shape `<base64url(json)>.<base64url(hmac)>` where the HMAC
+ * is computed over the JSON payload using `Security::getSalt()` (or an
+ * explicit secret) as the key. Decoding verifies the signature in
+ * constant time before returning the payload.
+ */
+class CursorEncoder
+{
+    /**
+     * Hash algorithm used for cursor signatures.
+     *
+     * @var string
+     */
+    protected const HASH_ALGO = 'sha256';
+
+    /**
+     * Encode a structured cursor into a signed opaque token.
+     *
+     * @param array<string, mixed> $cursor Cursor key/value pairs.
+     * @param string|null $secret Override secret. Defaults to `Security::getSalt()`.
+     * @return string Signed token safe for URL transport.
+     * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException
+     */
+    public static function encode(array $cursor, ?string $secret = null): string
+    {
+        try {
+            $json = json_encode($cursor, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+        } catch (JsonException $e) {
+            throw new InvalidCursorException('Cursor payload is not JSON encodable.', null, $e);
+        }
+
+        $payload = self::base64UrlEncode($json);
+        $signature = self::base64UrlEncode(
+            hash_hmac(self::HASH_ALGO, $payload, $secret ?? Security::getSalt(), true),
+        );
+
+        return $payload . '.' . $signature;
+    }
+
+    /**
+     * Decode and verify a signed cursor token.
+     *
+     * @param string $token Signed token produced by {@see self::encode()}.
+     * @param string|null $secret Override secret. Defaults to `Security::getSalt()`.
+     * @return array<string, mixed> Decoded cursor payload.
+     * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException
+     *   If the token is malformed or the signature does not verify.
+     */
+    public static function decode(string $token, ?string $secret = null): array
+    {
+        $parts = explode('.', $token, 2);
+        if (count($parts) !== 2 || $parts[0] === '' || $parts[1] === '') {
+            throw new InvalidCursorException('Cursor token is malformed.');
+        }
+
+        [$payload, $signature] = $parts;
+        $expected = self::base64UrlEncode(
+            hash_hmac(self::HASH_ALGO, $payload, $secret ?? Security::getSalt(), true),
+        );
+
+        if (!hash_equals($expected, $signature)) {
+            throw new InvalidCursorException('Cursor token signature is invalid.');
+        }
+
+        $json = self::base64UrlDecode($payload);
+        if ($json === null) {
+            throw new InvalidCursorException('Cursor token payload is malformed.');
+        }
+
+        try {
+            $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new InvalidCursorException('Cursor token payload is not valid JSON.', null, $e);
+        }
+
+        if (!is_array($decoded)) {
+            throw new InvalidCursorException('Cursor token payload must decode to an array.');
+        }
+
+        /** @var array<string, mixed> */
+        return $decoded;
+    }
+
+    /**
+     * URL-safe base64 encode.
+     *
+     * @param string $value Raw value.
+     * @return string
+     */
+    protected static function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+
+    /**
+     * URL-safe base64 decode.
+     *
+     * @param string $value Encoded value.
+     * @return string|null Decoded bytes or `null` if malformed.
+     */
+    protected static function base64UrlDecode(string $value): ?string
+    {
+        $padded = strtr($value, '-_', '+/');
+        $remainder = strlen($padded) % 4;
+        if ($remainder > 0) {
+            $padded .= str_repeat('=', 4 - $remainder);
+        }
+
+        $decoded = base64_decode($padded, true);
+        if ($decoded === false) {
+            return null;
+        }
+
+        return $decoded;
+    }
+}

--- a/src/Datasource/Paging/CursorPaginatedInterface.php
+++ b/src/Datasource/Paging/CursorPaginatedInterface.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Datasource\Paging;
+
+/**
+ * Describes cursor/seek paginated result sets.
+ *
+ * Cursor paginated results do not have a meaningful page number or total count.
+ * Instead, callers advance through the result set via opaque cursor tokens
+ * pointing at a stable position in a deterministic ordering.
+ *
+ * @template TKey
+ * @template-covariant TValue
+ * @template-extends \Cake\Datasource\Paging\PaginatedInterface<TKey, TValue>
+ */
+interface CursorPaginatedInterface extends PaginatedInterface
+{
+    /**
+     * Pagination type identifier.
+     *
+     * Returns `'seek'` for cursor paginated results.
+     *
+     * @return string
+     */
+    public function paginationType(): string;
+
+    /**
+     * Structured cursor pointing at the record after the last item on this page.
+     *
+     * Returns `null` if there is no next page or cursor metadata is unavailable.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function nextCursor(): ?array;
+
+    /**
+     * Structured cursor pointing at the record before the first item on this page.
+     *
+     * Returns `null` if there is no previous page or cursor metadata is unavailable.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function previousCursor(): ?array;
+
+    /**
+     * Opaque signed token for the next cursor, safe to expose over HTTP.
+     *
+     * @return string|null
+     */
+    public function nextCursorToken(): ?string;
+
+    /**
+     * Opaque signed token for the previous cursor, safe to expose over HTTP.
+     *
+     * @return string|null
+     */
+    public function previousCursorToken(): ?string;
+}

--- a/src/Datasource/Paging/CursorPaginatedResultSet.php
+++ b/src/Datasource/Paging/CursorPaginatedResultSet.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Datasource\Paging;
+
+/**
+ * Cursor/seek paginated result set.
+ *
+ * Extends {@see \Cake\Datasource\Paging\PaginatedResultSet} with cursor metadata
+ * for seek pagination. Page-oriented accessors inherited from the parent class
+ * return neutral values — `currentPage()` is always `1`, `pageCount()`/`totalCount()`
+ * are `null`.
+ *
+ * @template TKey
+ * @template TValue
+ * @extends \Cake\Datasource\Paging\PaginatedResultSet<TKey, TValue>
+ * @implements \Cake\Datasource\Paging\CursorPaginatedInterface<TKey, TValue>
+ */
+class CursorPaginatedResultSet extends PaginatedResultSet implements CursorPaginatedInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function paginationType(): string
+    {
+        return 'seek';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function nextCursor(): ?array
+    {
+        return $this->params['nextCursor'] ?? null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function previousCursor(): ?array
+    {
+        return $this->params['previousCursor'] ?? null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function nextCursorToken(): ?string
+    {
+        return $this->params['nextCursorToken'] ?? null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function previousCursorToken(): ?string
+    {
+        return $this->params['previousCursorToken'] ?? null;
+    }
+}

--- a/src/Datasource/Paging/Exception/InvalidCursorException.php
+++ b/src/Datasource/Paging/Exception/InvalidCursorException.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Datasource\Paging\Exception;
+
+use Cake\Core\Exception\CakeException;
+
+/**
+ * Thrown when a seek/cursor pagination cursor is malformed, incomplete,
+ * fails signature verification, or does not match the expected ordering.
+ */
+class InvalidCursorException extends CakeException
+{
+}

--- a/src/Datasource/Paging/SeekPaginator.php
+++ b/src/Datasource/Paging/SeekPaginator.php
@@ -1,0 +1,448 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Datasource\Paging;
+
+use ArrayIterator;
+use Cake\Core\Exception\CakeException;
+use Cake\Database\Expression\OrderByExpression;
+use Cake\Database\Query\SelectQuery as DatabaseSelectQuery;
+use Cake\Datasource\Paging\Exception\InvalidCursorException;
+use Cake\Datasource\QueryInterface;
+use Cake\Datasource\RepositoryInterface;
+
+/**
+ * Seek / keyset pagination strategy.
+ *
+ * In contrast to {@see \Cake\Datasource\Paging\NumericPaginator}, this paginator
+ * advances through results via opaque cursor tokens anchored to a stable
+ * deterministic ordering, avoiding the `OFFSET` scaling and consistency issues
+ * of page-number based pagination.
+ *
+ * ## Required configuration
+ *
+ * - Query must have an explicit `orderBy()` that is deterministic (typically
+ *   ending in a unique tie-breaker column).
+ * - Only simple column ordering is supported as a cursor source.
+ *
+ * ## Request parameters
+ *
+ * Recognized keys from request params / settings:
+ *
+ * - `cursor` — signed cursor token (or structured array) produced by a prior page.
+ * - `direction` — `'after'` (default, next page) or `'before'` (previous page).
+ * - `limit` — page size.
+ *
+ * ## Example
+ *
+ * ```
+ * $articles = $this->paginate($query, [
+ *     'className' => \Cake\Datasource\Paging\SeekPaginator::class,
+ * ]);
+ * ```
+ */
+class SeekPaginator extends NumericPaginator
+{
+    /**
+     * {@inheritDoc}
+     *
+     * Seek pagination does not expose `sort`/`direction` (which control offset
+     * ordering): a seek paginator's ordering must be deterministic and stable
+     * across requests, so changing it via request params would invalidate
+     * outstanding cursor tokens. The `cursor` token is the sole advancement
+     * mechanism. Direction (`after`/`before`) is taken from raw request params
+     * directly to bypass NumericPaginator's sort-direction stripping.
+     */
+    protected array $_defaultConfig = [
+        'page' => 1,
+        'limit' => 20,
+        'maxLimit' => 100,
+        'allowedParameters' => ['limit', 'cursor'],
+        'sortableFields' => null,
+        'finder' => 'all',
+        'scope' => null,
+    ];
+
+    /**
+     * Resolved cursor for the requested page, or `null` if this is the first page.
+     *
+     * @var array<string, mixed>|null
+     */
+    protected ?array $requestedCursor = null;
+
+    /**
+     * Requested seek direction: `'after'` (forward) or `'before'` (backward).
+     *
+     * @var string
+     */
+    protected string $requestedDirection = 'after';
+
+    /**
+     * Ordered list of cursor column names derived from the query ordering.
+     *
+     * @var array<int, string>
+     */
+    protected array $cursorColumns = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function paginate(
+        mixed $target,
+        array $params = [],
+        array $settings = [],
+    ): PaginatedInterface {
+        $query = null;
+        if ($target instanceof QueryInterface) {
+            $query = $target;
+            $target = $query->getRepository();
+            if ($target === null) {
+                throw new CakeException('No repository set for query.');
+            }
+        }
+
+        assert(
+            $target instanceof RepositoryInterface,
+            'Pagination target must be an instance of `' . QueryInterface::class
+                . '` or `' . RepositoryInterface::class . '`.',
+        );
+
+        $this->captureSeekParams($params, $settings);
+
+        $data = $this->extractData($target, $params, $settings);
+
+        $query = $this->getQuery($target, $query, $data);
+        if (!$query instanceof DatabaseSelectQuery) {
+            throw new InvalidCursorException(
+                'Seek pagination is only supported for `Cake\\Database\\Query\\SelectQuery` instances.',
+            );
+        }
+        $orderPairs = $this->extractOrderPairs($query);
+        $this->cursorColumns = array_map(fn(array $p) => $p[0], $orderPairs);
+        $this->applyCursor($query);
+
+        // For a backward page we need the N records immediately preceding the
+        // cursor in the query's logical ordering. We flip the ORDER BY so LIMIT
+        // picks the right end of the predicate, then reverse the rows in PHP so
+        // the caller sees them in the original ordering.
+        if ($this->requestedDirection === 'before') {
+            $this->flipOrdering($query, $orderPairs);
+        }
+
+        $limit = (int)$data['options']['limit'];
+        $items = $query->limit($limit + 1)->all();
+
+        $hasMore = count($items) > $limit;
+        if ($hasMore) {
+            $items = $items->take($limit);
+        }
+
+        $rows = iterator_to_array($items, false);
+        if ($this->requestedDirection === 'before') {
+            $rows = array_reverse($rows);
+        }
+
+        $this->pagingParams['count'] = count($rows);
+        $this->pagingParams['totalCount'] = null;
+
+        $pagingParams = $this->buildParams($data);
+        $pagingParams = $this->addCursorParams($pagingParams, $rows, $hasMore);
+
+        return $this->buildCursorPaginated($rows, $pagingParams);
+    }
+
+    /**
+     * Read the seek `cursor` and `direction` out of raw request params (before
+     * the inherited extractData/validateSort flow mangles or strips them).
+     *
+     * @param array<string, mixed> $params Raw request params.
+     * @param array<string, mixed> $settings Paginator settings.
+     * @return void
+     */
+    protected function captureSeekParams(array $params, array $settings): void
+    {
+        $scope = $settings['scope'] ?? null;
+        if ($scope !== null && isset($params[$scope]) && is_array($params[$scope])) {
+            $params = $params[$scope];
+        }
+
+        $direction = $params['direction'] ?? $settings['direction'] ?? 'after';
+        if (!in_array($direction, ['after', 'before'], true)) {
+            $direction = 'after';
+        }
+        $this->requestedDirection = $direction;
+
+        $cursor = $params['cursor'] ?? $settings['cursor'] ?? null;
+        if ($cursor === null || $cursor === '') {
+            $this->requestedCursor = null;
+
+            return;
+        }
+
+        if (is_array($cursor)) {
+            $this->requestedCursor = $cursor;
+
+            return;
+        }
+
+        if (!is_string($cursor)) {
+            throw new InvalidCursorException('Cursor must be a signed token string or a structured array.');
+        }
+
+        $this->requestedCursor = CursorEncoder::decode($cursor);
+    }
+
+    /**
+     * Extract `[field, direction]` pairs from the query's ORDER BY clause and
+     * validate that every entry is usable as a cursor column.
+     *
+     * @param \Cake\Database\Query\SelectQuery<mixed> $query Query instance.
+     * @return array<int, array{0: string, 1: 'ASC'|'DESC'}>
+     * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException
+     */
+    protected function extractOrderPairs(DatabaseSelectQuery $query): array
+    {
+        $order = $query->clause('order');
+        if (!$order instanceof OrderByExpression) {
+            throw new InvalidCursorException(
+                'Seek pagination requires an explicit `orderBy()` on the query. '
+                . 'The ordering must be deterministic — typically ending in a unique tie-breaker column.',
+            );
+        }
+
+        $pairs = [];
+        foreach ($order->toList() as [$field, $direction]) {
+            if (!is_string($field) || $direction === null) {
+                throw new InvalidCursorException(
+                    'Seek pagination does not support complex order expressions as cursor columns. '
+                    . 'Use explicit column references.',
+                );
+            }
+            $pairs[] = [$field, $direction];
+        }
+
+        if ($pairs === []) {
+            throw new InvalidCursorException('Seek pagination requires an explicit `orderBy()` on the query.');
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * Replace the query's ORDER BY with the same columns in the opposite direction.
+     *
+     * @param \Cake\Database\Query\SelectQuery<mixed> $query Query instance.
+     * @param array<int, array{0: string, 1: 'ASC'|'DESC'}> $pairs Current order pairs.
+     * @return void
+     */
+    protected function flipOrdering(DatabaseSelectQuery $query, array $pairs): void
+    {
+        $flipped = [];
+        foreach ($pairs as [$field, $direction]) {
+            $flipped[$field] = $direction === 'ASC' ? 'DESC' : 'ASC';
+        }
+        $query->orderBy($flipped, true);
+    }
+
+    /**
+     * Apply the resolved cursor to the query, if one was provided.
+     *
+     * @param \Cake\Database\Query\SelectQuery<mixed> $query Query instance.
+     * @return void
+     */
+    protected function applyCursor(DatabaseSelectQuery $query): void
+    {
+        if ($this->requestedCursor === null) {
+            return;
+        }
+
+        if ($this->requestedDirection === 'before') {
+            $query->seekBefore($this->requestedCursor);
+        } else {
+            $query->seekAfter($this->requestedCursor);
+        }
+    }
+
+    /**
+     * Build cursor values for next/previous pages from the fetched rows.
+     *
+     * @param array<string, mixed> $pagingParams Base paging params.
+     * @param array<int, mixed> $rows Fetched rows (in result order).
+     * @param bool $hasMore Whether the query returned more rows than the page size
+     *   (i.e. there is at least one additional record beyond this page in the
+     *   forward direction of the query).
+     * @return array<string, mixed>
+     */
+    protected function addCursorParams(array $pagingParams, array $rows, bool $hasMore): array
+    {
+        $pagingParams['nextCursor'] = null;
+        $pagingParams['previousCursor'] = null;
+        $pagingParams['nextCursorToken'] = null;
+        $pagingParams['previousCursorToken'] = null;
+
+        if ($rows === []) {
+            $pagingParams['hasNextPage'] = false;
+            $pagingParams['hasPrevPage'] = $this->requestedCursor !== null;
+
+            return $pagingParams;
+        }
+
+        $first = $rows[0];
+        $last = $rows[count($rows) - 1];
+
+        if ($this->requestedDirection === 'after') {
+            $hasNextPage = $hasMore;
+            $hasPrevPage = $this->requestedCursor !== null;
+        } else {
+            // For backward pages, a "next" is the row we came from (always true when
+            // the user navigated back), and a "prev" exists if more records preceded
+            // this page.
+            $hasNextPage = true;
+            $hasPrevPage = $hasMore;
+        }
+
+        if ($hasNextPage) {
+            $cursor = $this->buildCursor($last);
+            $pagingParams['nextCursor'] = $cursor;
+            $pagingParams['nextCursorToken'] = CursorEncoder::encode($cursor);
+        }
+        if ($hasPrevPage) {
+            $cursor = $this->buildCursor($first);
+            $pagingParams['previousCursor'] = $cursor;
+            $pagingParams['previousCursorToken'] = CursorEncoder::encode($cursor);
+        }
+
+        $pagingParams['hasNextPage'] = $hasNextPage;
+        $pagingParams['hasPrevPage'] = $hasPrevPage;
+
+        return $pagingParams;
+    }
+
+    /**
+     * Extract cursor values from a result row.
+     *
+     * Fails loudly if a boundary row has `null` in a cursor column: emitting
+     * such a cursor would produce tokens that silently skip rows on the
+     * follow-up request due to SQL's NULL comparison semantics. Cursor columns
+     * must be `NOT NULL` — use a non-nullable tie-breaker (typically the primary
+     * key) when leading order columns are nullable.
+     *
+     * @param mixed $row Result row — entity or array.
+     * @return array<string, mixed>
+     * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException When any
+     *   cursor column on the boundary row is `null`.
+     */
+    protected function buildCursor(mixed $row): array
+    {
+        $cursor = [];
+        foreach ($this->cursorColumns as $column) {
+            $value = $this->readRowValue($row, $column);
+            if ($value === null) {
+                throw new InvalidCursorException(sprintf(
+                    'Boundary row has `null` in cursor column `%s`. Seek pagination requires non-nullable '
+                    . 'cursor columns — use a `NOT NULL` tie-breaker (typically the primary key) or exclude '
+                    . 'nullable columns from the seek order.',
+                    $column,
+                ));
+            }
+            $cursor[$column] = $value;
+        }
+
+        return $cursor;
+    }
+
+    /**
+     * Read a column value from a row, handling both entities and arrays and
+     * stripping any table alias prefix.
+     *
+     * @param mixed $row Row.
+     * @param string $column Column identifier, optionally prefixed with alias.
+     * @return mixed
+     */
+    protected function readRowValue(mixed $row, string $column): mixed
+    {
+        $short = $column;
+        if (str_contains($column, '.')) {
+            [, $short] = explode('.', $column, 2);
+        }
+
+        if (is_array($row)) {
+            return $row[$column] ?? $row[$short] ?? null;
+        }
+        if (is_object($row)) {
+            if (method_exists($row, 'get')) {
+                $value = $row->get($short);
+                if ($value !== null) {
+                    return $value;
+                }
+            }
+            if (isset($row->{$short})) {
+                return $row->{$short};
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Build the final cursor paginated result set.
+     *
+     * @param array<int, mixed> $rows Rows in display order.
+     * @param array<string, mixed> $pagingParams Paging params including cursors.
+     * @return \Cake\Datasource\Paging\CursorPaginatedInterface<int, mixed>
+     */
+    protected function buildCursorPaginated(array $rows, array $pagingParams): CursorPaginatedInterface
+    {
+        return new CursorPaginatedResultSet(new ArrayIterator($rows), $pagingParams);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getCount(QueryInterface $query, array $data): ?int
+    {
+        // Seek pagination intentionally skips the count query.
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function buildParams(array $data): array
+    {
+        $this->pagingParams = [
+            'perPage' => $data['options']['limit'],
+            'requestedPage' => 1,
+            'alias' => $data['alias'],
+            'scope' => $data['options']['scope'],
+            'maxLimit' => $data['options']['maxLimit'],
+            'currentPage' => 1,
+            'pageCount' => null,
+            'totalCount' => null,
+            'start' => 0,
+            'end' => 0,
+            'hasPrevPage' => false,
+            'hasNextPage' => false,
+            'sort' => $data['options']['sort'] ?? null,
+            'direction' => $data['options']['direction'] ?? null,
+            'sortDefault' => false,
+            'directionDefault' => false,
+            'completeSort' => [],
+        ] + $this->pagingParams;
+
+        return $this->pagingParams;
+    }
+}

--- a/src/Datasource/Paging/SeekPaginator.php
+++ b/src/Datasource/Paging/SeekPaginator.php
@@ -75,6 +75,8 @@ class SeekPaginator extends NumericPaginator
         'sortableFields' => null,
         'finder' => 'all',
         'scope' => null,
+        'cursor' => null,
+        'direction' => null,
     ];
 
     /**
@@ -121,7 +123,7 @@ class SeekPaginator extends NumericPaginator
                 . '` or `' . RepositoryInterface::class . '`.',
         );
 
-        $this->captureSeekParams($params, $settings);
+        $this->captureSeekParams($target->getAlias(), $params, $settings);
 
         $data = $this->extractData($target, $params, $settings);
 
@@ -169,15 +171,37 @@ class SeekPaginator extends NumericPaginator
      * Read the seek `cursor` and `direction` out of raw request params (before
      * the inherited extractData/validateSort flow mangles or strips them).
      *
+     * Honors the same alias-scoped settings pattern as
+     * {@see \Cake\Datasource\Paging\NumericPaginator::getDefaults()}: when
+     * `$settings[$alias]` is an array, its contents take precedence as the
+     * effective settings for cursor/direction/scope.
+     *
+     * @param string $alias Repository alias for per-model settings unwrapping.
      * @param array<string, mixed> $params Raw request params.
      * @param array<string, mixed> $settings Paginator settings.
      * @return void
      */
-    protected function captureSeekParams(array $params, array $settings): void
+    protected function captureSeekParams(string $alias, array $params, array $settings): void
     {
+        if (isset($settings[$alias]) && is_array($settings[$alias])) {
+            $settings = $settings[$alias] + $settings;
+        }
+
         $scope = $settings['scope'] ?? null;
         if ($scope !== null && isset($params[$scope]) && is_array($params[$scope])) {
             $params = $params[$scope];
+        }
+
+        $cursor = $params['cursor'] ?? $settings['cursor'] ?? null;
+        if ($cursor === null || $cursor === '') {
+            // `direction = before` only makes sense paired with a cursor. Without
+            // one, the caller's intent is "the first page", so normalize to
+            // `after` to avoid flipping ORDER BY without a predicate (which would
+            // return the last page instead).
+            $this->requestedCursor = null;
+            $this->requestedDirection = 'after';
+
+            return;
         }
 
         $direction = $params['direction'] ?? $settings['direction'] ?? 'after';
@@ -185,13 +209,6 @@ class SeekPaginator extends NumericPaginator
             $direction = 'after';
         }
         $this->requestedDirection = $direction;
-
-        $cursor = $params['cursor'] ?? $settings['cursor'] ?? null;
-        if ($cursor === null || $cursor === '') {
-            $this->requestedCursor = null;
-
-            return;
-        }
 
         if (is_array($cursor)) {
             $this->requestedCursor = $cursor;
@@ -375,9 +392,15 @@ class SeekPaginator extends NumericPaginator
      * Read a column value from a row, handling both entities and arrays and
      * stripping any table alias prefix.
      *
+     * Distinguishes "column not selected" from "column present but null" so
+     * misconfigured queries get a precise error instead of being mistaken for
+     * a NULL boundary value.
+     *
      * @param mixed $row Row.
      * @param string $column Column identifier, optionally prefixed with alias.
      * @return mixed
+     * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException When the
+     *   column is not present on the row at all (i.e. not selected by the query).
      */
     protected function readRowValue(mixed $row, string $column): mixed
     {
@@ -387,21 +410,26 @@ class SeekPaginator extends NumericPaginator
         }
 
         if (is_array($row)) {
-            return $row[$column] ?? $row[$short] ?? null;
-        }
-        if (is_object($row)) {
-            if (method_exists($row, 'get')) {
-                $value = $row->get($short);
-                if ($value !== null) {
-                    return $value;
-                }
+            if (array_key_exists($column, $row)) {
+                return $row[$column];
             }
-            if (isset($row->{$short})) {
+            if (array_key_exists($short, $row)) {
+                return $row[$short];
+            }
+        } elseif (is_object($row)) {
+            if (method_exists($row, 'has') && $row->has($short)) {
+                return method_exists($row, 'get') ? $row->get($short) : $row->{$short};
+            }
+            if (property_exists($row, $short)) {
                 return $row->{$short};
             }
         }
 
-        return null;
+        throw new InvalidCursorException(sprintf(
+            'Cursor column `%s` is not present on the result row. '
+            . 'Ensure the column is included in the query\'s `select()` (or available via the entity).',
+            $column,
+        ));
     }
 
     /**

--- a/src/Datasource/Paging/SeekPaginator.php
+++ b/src/Datasource/Paging/SeekPaginator.php
@@ -18,6 +18,7 @@ namespace Cake\Datasource\Paging;
 
 use ArrayIterator;
 use Cake\Core\Exception\CakeException;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Query\SelectQuery as DatabaseSelectQuery;
 use Cake\Datasource\Paging\Exception\InvalidCursorException;
@@ -269,10 +270,16 @@ class SeekPaginator extends NumericPaginator
             return;
         }
 
-        if ($this->requestedDirection === 'before') {
-            $query->seekBefore($this->requestedCursor);
-        } else {
-            $query->seekAfter($this->requestedCursor);
+        try {
+            if ($this->requestedDirection === 'before') {
+                $query->seekBefore($this->requestedCursor);
+            } else {
+                $query->seekAfter($this->requestedCursor);
+            }
+        } catch (DatabaseException $e) {
+            // Re-wrap database-layer validation errors as a paging-layer exception
+            // so callers of paginate() only have to catch one type.
+            throw new InvalidCursorException($e->getMessage(), null, $e);
         }
     }
 

--- a/src/Datasource/Paging/SeekPaginator.php
+++ b/src/Datasource/Paging/SeekPaginator.php
@@ -239,7 +239,7 @@ class SeekPaginator extends NumericPaginator
                 'Seek pagination is only supported for query implementations that expose ordering metadata.',
             );
         }
-        $order = call_user_func([$query, 'clause'], 'order');
+        $order = $query->clause('order');
         if (!is_object($order) || !is_callable([$order, 'toList'])) {
             throw new InvalidCursorException(
                 'Seek pagination requires an explicit `orderBy()` on the query. '

--- a/src/Datasource/Paging/SeekPaginator.php
+++ b/src/Datasource/Paging/SeekPaginator.php
@@ -18,12 +18,10 @@ namespace Cake\Datasource\Paging;
 
 use ArrayIterator;
 use Cake\Core\Exception\CakeException;
-use Cake\Database\Exception\DatabaseException;
-use Cake\Database\Expression\OrderByExpression;
-use Cake\Database\Query\SelectQuery as DatabaseSelectQuery;
 use Cake\Datasource\Paging\Exception\InvalidCursorException;
 use Cake\Datasource\QueryInterface;
 use Cake\Datasource\RepositoryInterface;
+use Throwable;
 
 /**
  * Seek / keyset pagination strategy.
@@ -53,6 +51,10 @@ use Cake\Datasource\RepositoryInterface;
  * $articles = $this->paginate($query, [
  *     'className' => \Cake\Datasource\Paging\SeekPaginator::class,
  * ]);
+ *
+ * // In templates, use prev()/next() or seekPrev()/seekNext() from PaginatorHelper.
+ * echo $this->Paginator->prev('Previous');
+ * echo $this->Paginator->next('Next');
  * ```
  */
 class SeekPaginator extends NumericPaginator
@@ -128,11 +130,6 @@ class SeekPaginator extends NumericPaginator
         $data = $this->extractData($target, $params, $settings);
 
         $query = $this->getQuery($target, $query, $data);
-        if (!$query instanceof DatabaseSelectQuery) {
-            throw new InvalidCursorException(
-                'Seek pagination is only supported for `Cake\\Database\\Query\\SelectQuery` instances.',
-            );
-        }
         $orderPairs = $this->extractOrderPairs($query);
         $this->cursorColumns = array_map(fn(array $p) => $p[0], $orderPairs);
         $this->applyCursor($query);
@@ -227,14 +224,23 @@ class SeekPaginator extends NumericPaginator
      * Extract `[field, direction]` pairs from the query's ORDER BY clause and
      * validate that every entry is usable as a cursor column.
      *
-     * @param \Cake\Database\Query\SelectQuery<mixed> $query Query instance.
+     * Requires a query implementation that exposes `clause('order')` returning
+     * an object with a `toList()` method, as provided by CakePHP's database
+     * select queries.
+     *
+     * @param \Cake\Datasource\QueryInterface $query Query instance.
      * @return array<int, array{0: string, 1: 'ASC'|'DESC'}>
      * @throws \Cake\Datasource\Paging\Exception\InvalidCursorException
      */
-    protected function extractOrderPairs(DatabaseSelectQuery $query): array
+    protected function extractOrderPairs(QueryInterface $query): array
     {
-        $order = $query->clause('order');
-        if (!$order instanceof OrderByExpression) {
+        if (!is_callable([$query, 'clause'])) {
+            throw new InvalidCursorException(
+                'Seek pagination is only supported for query implementations that expose ordering metadata.',
+            );
+        }
+        $order = call_user_func([$query, 'clause'], 'order');
+        if (!is_object($order) || !is_callable([$order, 'toList'])) {
             throw new InvalidCursorException(
                 'Seek pagination requires an explicit `orderBy()` on the query. '
                 . 'The ordering must be deterministic — typically ending in a unique tie-breaker column.',
@@ -242,7 +248,7 @@ class SeekPaginator extends NumericPaginator
         }
 
         $pairs = [];
-        foreach ($order->toList() as [$field, $direction]) {
+        foreach (call_user_func([$order, 'toList']) as [$field, $direction]) {
             if (!is_string($field) || $direction === null) {
                 throw new InvalidCursorException(
                     'Seek pagination does not support complex order expressions as cursor columns. '
@@ -262,11 +268,11 @@ class SeekPaginator extends NumericPaginator
     /**
      * Replace the query's ORDER BY with the same columns in the opposite direction.
      *
-     * @param \Cake\Database\Query\SelectQuery<mixed> $query Query instance.
+     * @param \Cake\Datasource\QueryInterface $query Query instance.
      * @param array<int, array{0: string, 1: 'ASC'|'DESC'}> $pairs Current order pairs.
      * @return void
      */
-    protected function flipOrdering(DatabaseSelectQuery $query, array $pairs): void
+    protected function flipOrdering(QueryInterface $query, array $pairs): void
     {
         $flipped = [];
         foreach ($pairs as [$field, $direction]) {
@@ -278,24 +284,31 @@ class SeekPaginator extends NumericPaginator
     /**
      * Apply the resolved cursor to the query, if one was provided.
      *
-     * @param \Cake\Database\Query\SelectQuery<mixed> $query Query instance.
+     * @param \Cake\Datasource\QueryInterface $query Query instance.
      * @return void
      */
-    protected function applyCursor(DatabaseSelectQuery $query): void
+    protected function applyCursor(QueryInterface $query): void
     {
         if ($this->requestedCursor === null) {
             return;
         }
 
+        $method = $this->requestedDirection === 'before' ? 'seekBefore' : 'seekAfter';
+        if (!is_callable([$query, $method])) {
+            throw new InvalidCursorException(
+                'Seek pagination is only supported for query implementations that can apply seek cursors.',
+            );
+        }
+        /** @var callable(array<string, mixed>): mixed $callback */
+        $callback = [$query, $method];
+
         try {
-            if ($this->requestedDirection === 'before') {
-                $query->seekBefore($this->requestedCursor);
-            } else {
-                $query->seekAfter($this->requestedCursor);
+            $callback($this->requestedCursor);
+        } catch (Throwable $e) {
+            if ($e instanceof InvalidCursorException) {
+                throw $e;
             }
-        } catch (DatabaseException $e) {
-            // Re-wrap database-layer validation errors as a paging-layer exception
-            // so callers of paginate() only have to catch one type.
+
             throw new InvalidCursorException($e->getMessage(), null, $e);
         }
     }
@@ -427,7 +440,7 @@ class SeekPaginator extends NumericPaginator
 
         throw new InvalidCursorException(sprintf(
             'Cursor column `%s` is not present on the result row. '
-            . 'Ensure the column is included in the query\'s `select()` (or available via the entity).',
+            . "Ensure the column is included in the query's `select()` (or available via the entity).",
             $column,
         ));
     }

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\View\Helper;
 
 use Cake\Core\Exception\CakeException;
+use Cake\Datasource\Paging\CursorPaginatedInterface;
 use Cake\Datasource\Paging\PaginatedInterface;
 use Cake\Datasource\Paging\SortField;
 use Cake\Utility\Hash;
@@ -33,6 +34,10 @@ use function Cake\I18n\__;
  * Pagination Helper class for easy generation of pagination links.
  *
  * PaginationHelper encloses all methods needed when working with pagination.
+ *
+ * For seek/cursor paginated result sets, `prev()` and `next()` generate
+ * `cursor`/`direction` URLs instead of page-number links. Page-number oriented
+ * UI such as `numbers()` is still only meaningful for numeric pagination.
  *
  * @property \Cake\View\Helper\UrlHelper $Url
  * @property \Cake\View\Helper\NumberHelper $Number
@@ -63,6 +68,7 @@ class PaginatorHelper extends Helper
      * - `url['?']['sort']` the key that the recordset is sorted.
      * - `url['?']['direction']` Direction of the sorting (default: 'asc').
      * - `url['?']['page']` Page number to use in links.
+     * - `url['?']['cursor']` Seek pagination cursor token to use in links.
      * - `escape` Defines if the title field for the link should be escaped (default: true).
      * - `sortFormat` Format for sort URLs: 'separate' (default, ?sort=x&direction=y) or 'combined' (?sort=x-y).
      * - `routePlaceholders` An array specifying which paging params should be
@@ -116,7 +122,7 @@ class PaginatorHelper extends Helper
         parent::__construct($view, $config);
 
         $query = $this->_View->getRequest()->getQueryParams();
-        unset($query['page'], $query['limit'], $query['sort'], $query['direction']);
+        unset($query['page'], $query['limit'], $query['sort'], $query['direction'], $query['cursor']);
         $this->setConfig(
             'options.url',
             array_merge($this->_View->getRequest()->getParam('pass', []), ['?' => $query]),
@@ -280,10 +286,7 @@ class PaginatorHelper extends Helper
             return $out;
         }
 
-        $url = $this->generateUrl(
-            ['page' => $this->paginated()->currentPage() + $options['step']],
-            $options['url'],
-        );
+        $url = $this->generateUrl($this->buildToggleLinkOptions($options['step']), $options['url']);
 
         $out = $templater->format($template, [
             'url' => $url,
@@ -298,7 +301,32 @@ class PaginatorHelper extends Helper
     }
 
     /**
-     * Generates a "previous" link for a set of paged records
+     * Build pagination params for prev()/next() style links.
+     *
+     * Numeric pagination advances with `page`, while seek pagination advances
+     * via signed cursor tokens and a direction.
+     *
+     * @param int $step Navigation step. Negative values mean previous, positive mean next.
+     * @return array<string, int|string|null>
+     */
+    protected function buildToggleLinkOptions(int $step): array
+    {
+        $paginated = $this->paginated();
+        if ($paginated instanceof CursorPaginatedInterface) {
+            return [
+                'cursor' => $step < 0 ? $paginated->previousCursorToken() : $paginated->nextCursorToken(),
+                'direction' => $step < 0 ? 'before' : 'after',
+                'page' => null,
+            ];
+        }
+
+        return ['page' => $paginated->currentPage() + $step];
+    }
+
+    /**
+     * Generates a "previous" link for a set of paged records.
+     *
+     * For seek/cursor paginated result sets this emits a cursor-based link.
      *
      * ### Options:
      *
@@ -335,7 +363,24 @@ class PaginatorHelper extends Helper
     }
 
     /**
-     * Generates a "next" link for a set of paged records
+     * Generates a "previous" link for cursor/seek paginated records.
+     *
+     * This is an alias for {@see self::prev()} that makes intent explicit when
+     * working with seek pagination in templates.
+     *
+     * @param string $title Title for the link. Defaults to '<< Previous'.
+     * @param array<string, mixed> $options Options for pagination link.
+     * @return string A "previous" link or a disabled link.
+     */
+    public function seekPrev(string $title = '<< Previous', array $options = []): string
+    {
+        return $this->prev($title, $options);
+    }
+
+    /**
+     * Generates a "next" link for a set of paged records.
+     *
+     * For seek/cursor paginated result sets this emits a cursor-based link.
      *
      * ### Options:
      *
@@ -369,6 +414,21 @@ class PaginatorHelper extends Helper
         ];
 
         return $this->_toggledLink($title, $this->hasNext(), $options, $templates);
+    }
+
+    /**
+     * Generates a "next" link for cursor/seek paginated records.
+     *
+     * This is an alias for {@see self::next()} that makes intent explicit when
+     * working with seek pagination in templates.
+     *
+     * @param string $title Title for the link. Defaults to 'Next >>'.
+     * @param array<string, mixed> $options Options for pagination link.
+     * @return string A "next" link or a disabled link.
+     */
+    public function seekNext(string $title = 'Next >>', array $options = []): string
+    {
+        return $this->next($title, $options);
     }
 
     /**
@@ -513,7 +573,7 @@ class PaginatorHelper extends Helper
     public function generateUrlParams(array $options = [], array $url = []): array
     {
         $paging = $this->params();
-        $paging += ['currentPage' => null, 'sort' => null, 'direction' => null, 'limit' => null];
+        $paging += ['currentPage' => null, 'sort' => null, 'direction' => null, 'limit' => null, 'cursor' => null];
         $paging['page'] = $paging['currentPage'];
         unset($paging['currentPage']);
 
@@ -534,7 +594,7 @@ class PaginatorHelper extends Helper
 
         $options += array_intersect_key(
             $paging,
-            ['page' => null, 'limit' => null, 'sort' => null, 'direction' => null],
+            ['page' => null, 'limit' => null, 'sort' => null, 'direction' => null, 'cursor' => null],
         );
 
         if (!empty($options['page']) && $options['page'] === 1) {
@@ -1195,7 +1255,7 @@ class PaginatorHelper extends Helper
         $hiddenFields = $query;
         if ($scope) {
             // Remove limit and page from scoped params
-            unset($hiddenFields[$scope]['limit'], $hiddenFields[$scope]['page']);
+            unset($hiddenFields[$scope]['limit'], $hiddenFields[$scope]['page'], $hiddenFields[$scope]['cursor']);
             if (isset($hiddenFields[$scope]) && empty($hiddenFields[$scope])) {
                 unset($hiddenFields[$scope]);
             }
@@ -1205,7 +1265,7 @@ class PaginatorHelper extends Helper
             }
         } else {
             // Remove pagination params that will be handled separately
-            unset($hiddenFields['limit'], $hiddenFields['page'], $hiddenFields['sort'], $hiddenFields['direction']);
+            unset($hiddenFields['limit'], $hiddenFields['page'], $hiddenFields['sort'], $hiddenFields['direction'], $hiddenFields['cursor']);
             // Set page to 1 if not on first page
             if ($currentPage > 1) {
                 $hiddenFields['page'] = 1;

--- a/tests/TestCase/Database/Query/SelectQuerySeekTest.php
+++ b/tests/TestCase/Database/Query/SelectQuerySeekTest.php
@@ -1,0 +1,168 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\Query;
+
+use Cake\Database\Connection;
+use Cake\Database\Query\SelectQuery;
+use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\Paging\CursorEncoder;
+use Cake\Datasource\Paging\Exception\InvalidCursorException;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Tests for seek/keyset pagination on SelectQuery.
+ */
+class SelectQuerySeekTest extends TestCase
+{
+    protected array $fixtures = ['core.Articles'];
+
+    protected Connection $connection;
+
+    protected string $secret = 'test-cursor-secret-please-use-a-real-salt-in-prod-0123456789';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = ConnectionManager::get('test');
+    }
+
+    protected function newQuery(): SelectQuery
+    {
+        return (new SelectQuery($this->connection))
+            ->select(['id', 'title'])
+            ->from('articles');
+    }
+
+    public function testSeekAfterSingleColumnAscFetchesFollowingRows(): void
+    {
+        $query = $this->newQuery()
+            ->orderBy(['id' => 'ASC'])
+            ->seekAfter(['id' => 1]);
+
+        $ids = array_column($query->execute()->fetchAll('assoc'), 'id');
+        $this->assertSame([2, 3], array_map('intval', $ids));
+    }
+
+    public function testSeekAfterSingleColumnDescFetchesFollowingRows(): void
+    {
+        $query = $this->newQuery()
+            ->orderBy(['id' => 'DESC'])
+            ->seekAfter(['id' => 3]);
+
+        $ids = array_column($query->execute()->fetchAll('assoc'), 'id');
+        $this->assertSame([2, 1], array_map('intval', $ids));
+    }
+
+    public function testSeekBeforeSingleColumnAscFetchesPrecedingRows(): void
+    {
+        // ASC ordering, seek before id=3 → rows with id < 3
+        $query = $this->newQuery()
+            ->orderBy(['id' => 'ASC'])
+            ->seekBefore(['id' => 3]);
+
+        $ids = array_column($query->execute()->fetchAll('assoc'), 'id');
+        $this->assertSame([1, 2], array_map('intval', $ids));
+    }
+
+    public function testSeekAfterCompositeOrderExpandsLexicographically(): void
+    {
+        // Articles fixture rows: (id=1, author_id=1), (id=2, author_id=3), (id=3, author_id=1).
+        // Order by author_id DESC, id DESC produces: (3,2), (1,3), (1,1).
+        // seekAfter at (author_id=3, id=2) expands to:
+        //   author_id < 3 OR (author_id = 3 AND id < 2)
+        // matching (1,3) and (1,1), returned in the original DESC ordering.
+        $query = (new SelectQuery($this->connection))
+            ->select(['id', 'author_id'])
+            ->from('articles')
+            ->orderBy(['author_id' => 'DESC', 'id' => 'DESC'])
+            ->seekAfter(['author_id' => 3, 'id' => 2]);
+
+        $ids = array_column($query->execute()->fetchAll('assoc'), 'id');
+        $this->assertSame([3, 1], array_map('intval', $ids));
+    }
+
+    public function testSeekAfterTokenUsesSignedCursor(): void
+    {
+        $token = CursorEncoder::encode(['id' => 1], $this->secret);
+        $query = $this->newQuery()
+            ->orderBy(['id' => 'ASC']);
+
+        // Swap in our test secret by decoding then seeking — avoids touching Security::getSalt()
+        $query->seekAfter(CursorEncoder::decode($token, $this->secret));
+
+        $ids = array_column($query->execute()->fetchAll('assoc'), 'id');
+        $this->assertSame([2, 3], array_map('intval', $ids));
+    }
+
+    public function testSeekAfterWithoutOrderByThrows(): void
+    {
+        $this->expectException(InvalidCursorException::class);
+        $this->expectExceptionMessage('requires at least one `orderBy()` clause');
+
+        $this->newQuery()->seekAfter(['id' => 1]);
+    }
+
+    public function testSeekAfterWithEmptyCursorThrows(): void
+    {
+        $this->expectException(InvalidCursorException::class);
+        $this->expectExceptionMessage('must not be empty');
+
+        $this->newQuery()
+            ->orderBy(['id' => 'ASC'])
+            ->seekAfter([]);
+    }
+
+    public function testSeekAfterWithMismatchedKeysThrows(): void
+    {
+        $this->expectException(InvalidCursorException::class);
+        $this->expectExceptionMessage('do not match the current ordering');
+
+        $this->newQuery()
+            ->orderBy(['id' => 'ASC'])
+            ->seekAfter(['title' => 'x']);
+    }
+
+    public function testSeekAfterWithWrongKeyOrderThrows(): void
+    {
+        $this->expectException(InvalidCursorException::class);
+        $this->expectExceptionMessage('do not match the current ordering');
+
+        $this->newQuery()
+            ->orderBy(['author_id' => 'DESC', 'id' => 'DESC'])
+            ->seekAfter(['id' => 1, 'author_id' => 3]);
+    }
+
+    public function testSeekAfterRejectsNullCursorValue(): void
+    {
+        $this->expectException(InvalidCursorException::class);
+        $this->expectExceptionMessage('Seek cursor value for column `published` is `null`');
+
+        $this->newQuery()
+            ->orderBy(['published' => 'ASC', 'id' => 'ASC'])
+            ->seekAfter(['published' => null, 'id' => 1]);
+    }
+
+    public function testSeekBeforeRejectsNullCursorValue(): void
+    {
+        $this->expectException(InvalidCursorException::class);
+        $this->expectExceptionMessage('Seek cursor value for column `id` is `null`');
+
+        $this->newQuery()
+            ->orderBy(['id' => 'ASC'])
+            ->seekBefore(['id' => null]);
+    }
+}

--- a/tests/TestCase/Database/Query/SelectQuerySeekTest.php
+++ b/tests/TestCase/Database/Query/SelectQuerySeekTest.php
@@ -17,10 +17,9 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database\Query;
 
 use Cake\Database\Connection;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Query\SelectQuery;
 use Cake\Datasource\ConnectionManager;
-use Cake\Datasource\Paging\CursorEncoder;
-use Cake\Datasource\Paging\Exception\InvalidCursorException;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -31,8 +30,6 @@ class SelectQuerySeekTest extends TestCase
     protected array $fixtures = ['core.Articles'];
 
     protected Connection $connection;
-
-    protected string $secret = 'test-cursor-secret-please-use-a-real-salt-in-prod-0123456789';
 
     protected function setUp(): void
     {
@@ -95,22 +92,9 @@ class SelectQuerySeekTest extends TestCase
         $this->assertSame([3, 1], array_map('intval', $ids));
     }
 
-    public function testSeekAfterTokenUsesSignedCursor(): void
-    {
-        $token = CursorEncoder::encode(['id' => 1], $this->secret);
-        $query = $this->newQuery()
-            ->orderBy(['id' => 'ASC']);
-
-        // Swap in our test secret by decoding then seeking — avoids touching Security::getSalt()
-        $query->seekAfter(CursorEncoder::decode($token, $this->secret));
-
-        $ids = array_column($query->execute()->fetchAll('assoc'), 'id');
-        $this->assertSame([2, 3], array_map('intval', $ids));
-    }
-
     public function testSeekAfterWithoutOrderByThrows(): void
     {
-        $this->expectException(InvalidCursorException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('requires at least one `orderBy()` clause');
 
         $this->newQuery()->seekAfter(['id' => 1]);
@@ -118,7 +102,7 @@ class SelectQuerySeekTest extends TestCase
 
     public function testSeekAfterWithEmptyCursorThrows(): void
     {
-        $this->expectException(InvalidCursorException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('must not be empty');
 
         $this->newQuery()
@@ -128,7 +112,7 @@ class SelectQuerySeekTest extends TestCase
 
     public function testSeekAfterWithMismatchedKeysThrows(): void
     {
-        $this->expectException(InvalidCursorException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('do not match the current ordering');
 
         $this->newQuery()
@@ -138,7 +122,7 @@ class SelectQuerySeekTest extends TestCase
 
     public function testSeekAfterWithWrongKeyOrderThrows(): void
     {
-        $this->expectException(InvalidCursorException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('do not match the current ordering');
 
         $this->newQuery()
@@ -148,7 +132,7 @@ class SelectQuerySeekTest extends TestCase
 
     public function testSeekAfterRejectsNullCursorValue(): void
     {
-        $this->expectException(InvalidCursorException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Seek cursor value for column `published` is `null`');
 
         $this->newQuery()
@@ -158,7 +142,7 @@ class SelectQuerySeekTest extends TestCase
 
     public function testSeekBeforeRejectsNullCursorValue(): void
     {
-        $this->expectException(InvalidCursorException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Seek cursor value for column `id` is `null`');
 
         $this->newQuery()

--- a/tests/TestCase/Datasource/Paging/CursorEncoderTest.php
+++ b/tests/TestCase/Datasource/Paging/CursorEncoderTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Datasource\Paging;
+
+use Cake\Datasource\Paging\CursorEncoder;
+use Cake\Datasource\Paging\Exception\InvalidCursorException;
+use Cake\TestSuite\TestCase;
+
+class CursorEncoderTest extends TestCase
+{
+    protected string $secret = 'test-cursor-secret-please-use-a-real-salt-in-prod-0123456789';
+
+    public function testRoundTripPreservesScalarTypes(): void
+    {
+        $cursor = [
+            'Articles.created' => '2025-01-02 03:04:05',
+            'Articles.id' => 42,
+            'Articles.score' => 3.14,
+            'Articles.featured' => true,
+            'Articles.subtitle' => null,
+        ];
+
+        $token = CursorEncoder::encode($cursor, $this->secret);
+        $decoded = CursorEncoder::decode($token, $this->secret);
+
+        $this->assertSame($cursor, $decoded);
+    }
+
+    public function testTokenIsUrlSafe(): void
+    {
+        $cursor = ['Articles.id' => 1];
+        $token = CursorEncoder::encode($cursor, $this->secret);
+
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+$/', $token);
+        $this->assertStringNotContainsString('=', $token);
+    }
+
+    public function testTamperedPayloadIsRejected(): void
+    {
+        $token = CursorEncoder::encode(['id' => 1], $this->secret);
+        $sig = explode('.', $token, 2)[1];
+
+        $tampered = rtrim(strtr(base64_encode('{"id":999}'), '+/', '-_'), '=') . '.' . $sig;
+
+        $this->expectException(InvalidCursorException::class);
+        $this->expectExceptionMessage('signature is invalid');
+        CursorEncoder::decode($tampered, $this->secret);
+    }
+
+    public function testMismatchedSecretIsRejected(): void
+    {
+        $token = CursorEncoder::encode(['id' => 1], $this->secret);
+
+        $this->expectException(InvalidCursorException::class);
+        CursorEncoder::decode($token, 'different-secret');
+    }
+
+    public function testMalformedTokenIsRejected(): void
+    {
+        $this->expectException(InvalidCursorException::class);
+        $this->expectExceptionMessage('malformed');
+        CursorEncoder::decode('not-a-valid-token', $this->secret);
+    }
+
+    public function testEmptyTokenIsRejected(): void
+    {
+        $this->expectException(InvalidCursorException::class);
+        CursorEncoder::decode('', $this->secret);
+    }
+}

--- a/tests/TestCase/Datasource/Paging/SeekPaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/SeekPaginatorTest.php
@@ -129,6 +129,44 @@ class SeekPaginatorTest extends TestCase
         $this->assertSame(1, $back->items()->current()->id);
     }
 
+    public function testDirectionBeforeWithoutCursorReturnsFirstPage(): void
+    {
+        // `direction=before` without a cursor is normalized to `after` — otherwise
+        // we would flip ORDER BY without applying any predicate and silently return
+        // the *last* page instead of the first.
+        $result = $this->paginator->paginate(
+            $this->baseQuery(),
+            ['direction' => 'before'],
+            ['limit' => 1],
+        );
+
+        $this->assertCount(1, $result);
+        $this->assertSame(1, $result->items()->current()->id);
+        $this->assertFalse($result->hasPrevPage());
+        $this->assertTrue($result->hasNextPage());
+    }
+
+    public function testAliasScopedSettingsAreHonored(): void
+    {
+        // Settings keyed by repository alias should be unwrapped (matches the
+        // pattern used by NumericPaginator::getDefaults).
+        $first = $this->paginator->paginate($this->baseQuery(), [], ['limit' => 1]);
+
+        $second = $this->paginator->paginate(
+            $this->baseQuery(),
+            [],
+            [
+                'Posts' => [
+                    'cursor' => $first->nextCursorToken(),
+                    'limit' => 1,
+                ],
+            ],
+        );
+
+        $this->assertCount(1, $second);
+        $this->assertSame(2, $second->items()->current()->id);
+    }
+
     public function testInvalidTokenThrows(): void
     {
         $this->expectException(InvalidCursorException::class);
@@ -148,6 +186,27 @@ class SeekPaginatorTest extends TestCase
         $this->expectExceptionMessage('requires an explicit `orderBy()`');
 
         $this->paginator->paginate($query, [], ['limit' => 1]);
+    }
+
+    public function testMissingCursorColumnOnBoundaryRowThrowsClearError(): void
+    {
+        $paginator = new class extends SeekPaginator {
+            /**
+             * @param array<int, string> $columns
+             */
+            public function callBuildCursor(array $columns, mixed $row): array
+            {
+                $this->cursorColumns = $columns;
+
+                return $this->buildCursor($row);
+            }
+        };
+
+        $this->expectException(InvalidCursorException::class);
+        $this->expectExceptionMessage('Cursor column `Posts.body` is not present on the result row');
+
+        // Row is missing `body` entirely — distinct from `body => null`.
+        $paginator->callBuildCursor(['Posts.body', 'Posts.id'], ['id' => 7]);
     }
 
     public function testBoundaryRowWithNullCursorColumnThrows(): void

--- a/tests/TestCase/Datasource/Paging/SeekPaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/SeekPaginatorTest.php
@@ -1,0 +1,174 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Datasource\Paging;
+
+use Cake\Datasource\Paging\CursorPaginatedInterface;
+use Cake\Datasource\Paging\Exception\InvalidCursorException;
+use Cake\Datasource\Paging\SeekPaginator;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Security;
+
+/**
+ * Seek paginator integration tests backed by the `posts` fixture (3 rows).
+ *
+ * With `limit=1` we get three pages, enough to exercise forward/backward
+ * traversal, token round-tripping, and hasNext/hasPrev transitions.
+ */
+class SeekPaginatorTest extends TestCase
+{
+    protected array $fixtures = ['core.Posts'];
+
+    protected SeekPaginator $paginator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Security::setSalt(str_repeat('a', 32));
+        $this->paginator = new SeekPaginator();
+    }
+
+    protected function postsTable()
+    {
+        return $this->getTableLocator()->get('Posts');
+    }
+
+    protected function baseQuery()
+    {
+        return $this->postsTable()->find()
+            ->select(['id', 'title'])
+            ->orderBy(['Posts.id' => 'ASC']);
+    }
+
+    public function testFirstPageHasForwardCursorOnly(): void
+    {
+        $result = $this->paginator->paginate($this->baseQuery(), [], ['limit' => 1]);
+
+        $this->assertInstanceOf(CursorPaginatedInterface::class, $result);
+        $this->assertSame('seek', $result->paginationType());
+        $this->assertCount(1, $result);
+        $this->assertSame(1, $result->items()->current()->id);
+
+        $this->assertTrue($result->hasNextPage());
+        $this->assertFalse($result->hasPrevPage());
+        $this->assertSame(['Posts.id' => 1], $result->nextCursor());
+        $this->assertNull($result->previousCursor());
+        $this->assertNotNull($result->nextCursorToken());
+        $this->assertNull($result->previousCursorToken());
+    }
+
+    public function testSecondPageViaTokenHasBothCursors(): void
+    {
+        $first = $this->paginator->paginate($this->baseQuery(), [], ['limit' => 1]);
+
+        $params = ['cursor' => $first->nextCursorToken()];
+        $second = $this->paginator->paginate($this->baseQuery(), $params, ['limit' => 1]);
+
+        $this->assertCount(1, $second);
+        $this->assertSame(2, $second->items()->current()->id);
+        $this->assertTrue($second->hasNextPage());
+        $this->assertTrue($second->hasPrevPage());
+        $this->assertSame(['Posts.id' => 2], $second->nextCursor());
+        $this->assertSame(['Posts.id' => 2], $second->previousCursor());
+    }
+
+    public function testLastPageHasNoForwardCursor(): void
+    {
+        $page1 = $this->paginator->paginate($this->baseQuery(), [], ['limit' => 1]);
+        $page2 = $this->paginator->paginate(
+            $this->baseQuery(),
+            ['cursor' => $page1->nextCursorToken()],
+            ['limit' => 1],
+        );
+        $page3 = $this->paginator->paginate(
+            $this->baseQuery(),
+            ['cursor' => $page2->nextCursorToken()],
+            ['limit' => 1],
+        );
+
+        $this->assertCount(1, $page3);
+        $this->assertSame(3, $page3->items()->current()->id);
+        $this->assertFalse($page3->hasNextPage());
+        $this->assertTrue($page3->hasPrevPage());
+        $this->assertNull($page3->nextCursor());
+    }
+
+    public function testBackwardPagingFetchesPrecedingRecords(): void
+    {
+        $page1 = $this->paginator->paginate($this->baseQuery(), [], ['limit' => 1]);
+        $page2 = $this->paginator->paginate(
+            $this->baseQuery(),
+            ['cursor' => $page1->nextCursorToken()],
+            ['limit' => 1],
+        );
+
+        $back = $this->paginator->paginate(
+            $this->baseQuery(),
+            [
+                'cursor' => $page2->previousCursorToken(),
+                'direction' => 'before',
+            ],
+            ['limit' => 1],
+        );
+
+        $this->assertCount(1, $back);
+        $this->assertSame(1, $back->items()->current()->id);
+    }
+
+    public function testInvalidTokenThrows(): void
+    {
+        $this->expectException(InvalidCursorException::class);
+
+        $this->paginator->paginate(
+            $this->baseQuery(),
+            ['cursor' => 'garbage.token'],
+            ['limit' => 1],
+        );
+    }
+
+    public function testMissingOrderByThrows(): void
+    {
+        $query = $this->postsTable()->find()->select(['id', 'title']);
+
+        $this->expectException(InvalidCursorException::class);
+        $this->expectExceptionMessage('requires an explicit `orderBy()`');
+
+        $this->paginator->paginate($query, [], ['limit' => 1]);
+    }
+
+    public function testBoundaryRowWithNullCursorColumnThrows(): void
+    {
+        // Insert a row with NULL in `body` (nullable column), then page ordering
+        // by that column. The first boundary row will have body=null, which must
+        // trigger the null guard rather than silently emit a corrupt token.
+        $this->postsTable()->save($this->postsTable()->newEntity([
+            'author_id' => 1,
+            'title' => 'Null-body post',
+            'body' => null,
+            'published' => 'Y',
+        ]));
+
+        $query = $this->postsTable()->find()
+            ->select(['id', 'title', 'body'])
+            ->orderBy(['Posts.body' => 'ASC', 'Posts.id' => 'ASC']);
+
+        $this->expectException(InvalidCursorException::class);
+        $this->expectExceptionMessage('Boundary row has `null` in cursor column `Posts.body`');
+
+        $this->paginator->paginate($query, [], ['limit' => 1]);
+    }
+}

--- a/tests/TestCase/Datasource/Paging/SeekPaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/SeekPaginatorTest.php
@@ -152,23 +152,29 @@ class SeekPaginatorTest extends TestCase
 
     public function testBoundaryRowWithNullCursorColumnThrows(): void
     {
-        // Insert a row with NULL in `body` (nullable column), then page ordering
-        // by that column. The first boundary row will have body=null, which must
-        // trigger the null guard rather than silently emit a corrupt token.
-        $this->postsTable()->save($this->postsTable()->newEntity([
-            'author_id' => 1,
-            'title' => 'Null-body post',
-            'body' => null,
-            'published' => 'Y',
-        ]));
+        // Test the buildCursor() guard directly — driving it via paginate() would
+        // depend on driver NULL-ordering (Postgres: NULLs last in ASC; MySQL: NULLs
+        // first), which determines whether the boundary row even carries the NULL.
+        // The contract being verified is: if a cursor column on the boundary row
+        // is `null`, the paginator refuses to emit a corrupt token.
+        $paginator = new class extends SeekPaginator {
+            /**
+             * @param array<int, string> $columns
+             */
+            public function callBuildCursor(array $columns, mixed $row): array
+            {
+                $this->cursorColumns = $columns;
 
-        $query = $this->postsTable()->find()
-            ->select(['id', 'title', 'body'])
-            ->orderBy(['Posts.body' => 'ASC', 'Posts.id' => 'ASC']);
+                return $this->buildCursor($row);
+            }
+        };
 
         $this->expectException(InvalidCursorException::class);
         $this->expectExceptionMessage('Boundary row has `null` in cursor column `Posts.body`');
 
-        $this->paginator->paginate($query, [], ['limit' => 1]);
+        $paginator->callBuildCursor(
+            ['Posts.body', 'Posts.id'],
+            ['body' => null, 'id' => 7],
+        );
     }
 }

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\View\Helper;
 
 use Cake\Core\Configure;
+use Cake\Datasource\Paging\CursorPaginatedResultSet;
 use Cake\Datasource\Paging\PaginatedResultSet;
 use Cake\Datasource\Paging\SortField;
 use Cake\Http\ServerRequest;
@@ -112,6 +113,29 @@ class PaginatorHelperTest extends TestCase
         $this->paginatedResult = new PaginatedResultSet(new ResultSet([]), $params);
 
         $this->Paginator->setPaginated($this->paginatedResult);
+    }
+
+    protected function setCursorPaginatedResult(array $params, bool $merge = true): void
+    {
+        if ($merge) {
+            $params += [
+                'alias' => 'Articles',
+                'currentPage' => 1,
+                'count' => 1,
+                'totalCount' => null,
+                'hasPrevPage' => false,
+                'hasNextPage' => true,
+                'pageCount' => null,
+                'start' => 0,
+                'end' => 0,
+                'nextCursor' => ['Articles.id' => 2],
+                'previousCursor' => null,
+                'nextCursorToken' => 'next-token',
+                'previousCursorToken' => null,
+            ];
+        }
+
+        $this->Paginator->setPaginated(new CursorPaginatedResultSet(new ResultSet([]), $params));
     }
 
     /**
@@ -1518,6 +1542,66 @@ class PaginatorHelperTest extends TestCase
 
         $result = $this->Paginator->next('Next >>', ['disabledTitle' => false]);
         $this->assertSame('', $result, 'disabled + no text = no link');
+    }
+
+    public function testPrevWithCursorPagination(): void
+    {
+        $this->setCursorPaginatedResult([
+            'hasPrevPage' => true,
+            'hasNextPage' => true,
+            'previousCursor' => ['Articles.id' => 1],
+            'previousCursorToken' => 'prev-token',
+        ]);
+
+        $result = $this->Paginator->prev('<< Previous');
+        $expected = [
+            'li' => ['class' => 'prev'],
+            'a' => ['href' => '/?cursor=prev-token&amp;direction=before', 'rel' => 'prev'],
+            '&lt;&lt; Previous',
+            '/a',
+            '/li',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Paginator->seekPrev('Prev');
+        $expected = [
+            'li' => ['class' => 'prev'],
+            'a' => ['href' => '/?cursor=prev-token&amp;direction=before', 'rel' => 'prev'],
+            'Prev',
+            '/a',
+            '/li',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testNextWithCursorPagination(): void
+    {
+        $this->setCursorPaginatedResult([
+            'hasPrevPage' => false,
+            'hasNextPage' => true,
+            'nextCursor' => ['Articles.id' => 2],
+            'nextCursorToken' => 'next-token',
+        ]);
+
+        $result = $this->Paginator->next('Next >>');
+        $expected = [
+            'li' => ['class' => 'next'],
+            'a' => ['href' => '/?cursor=next-token&amp;direction=after', 'rel' => 'next'],
+            'Next &gt;&gt;',
+            '/a',
+            '/li',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Paginator->seekNext('Next');
+        $expected = [
+            'li' => ['class' => 'next'],
+            'a' => ['href' => '/?cursor=next-token&amp;direction=after', 'rel' => 'next'],
+            'Next',
+            '/a',
+            '/li',
+        ];
+        $this->assertHtml($expected, $result);
     }
 
     /**


### PR DESCRIPTION
## Summary

Implements the RFC from #19389: first-class seek/keyset pagination for the ORM and paginator, without BC breaks.

Offset pagination degrades on deep pages, destabilizes under concurrent writes, and forces every API to reinvent cursor serialization. This PR lands a cursor-based alternative on the existing query/paginator surfaces so applications can adopt it without a parallel query builder.

## What's in it

- **`SelectQuery::seekAfter()` / `seekBefore()`** (plus `seekAfterToken()` / `seekBeforeToken()`) translate cursor values against the query's existing `orderBy()` into an OR-expanded lexicographic predicate that works on every supported driver:
  ```
  WHERE (c1 < a1) OR (c1 = a1 AND c2 < a2) OR …
  ```
  Operator per column is derived from ASC/DESC and forward/backward direction.

- **`CursorPaginatedInterface`** extends `PaginatedInterface` as a **sub-interface** — no BC break to anyone implementing the existing contract. Adds `paginationType()`, `nextCursor()`, `previousCursor()`, `nextCursorToken()`, `previousCursorToken()`.

- **`CursorPaginatedResultSet`** subclasses `PaginatedResultSet` and fills in the cursor accessors.

- **`SeekPaginator`** opts in via the standard `className` setting:
  ```php
  $results = \$this->paginate(\$query, [
      'className' => \Cake\Datasource\Paging\SeekPaginator::class,
  ]);
  ```
  Fetches `limit + 1` rows to deduce `hasNextPage`, flips `ORDER BY` + reverses rows for backward paging. Restricts `allowedParameters` to `['limit', 'cursor']` — exposing `sort`/`direction` would invalidate outstanding cursor tokens.

- **`CursorEncoder`** produces URL-safe signed cursor tokens of the form `base64url(json).base64url(hmac-sha256)`, keyed by `Security::getSalt()` (override-able), with constant-time verification and tamper detection.

- **Null-value guard** — both `SelectQuery::applySeek()` and `SeekPaginator::buildCursor()` raise `InvalidCursorException` on `null` values. SQL three-valued logic would silently skip rows (`NULL < x` evaluates to `NULL`), and driver NULL-ordering behavior diverges (MySQL/SQLite/MSSQL place NULLs first in ASC; Postgres/Oracle place them last). Cursor columns must be `NOT NULL`; users should add a non-nullable tie-breaker (typically the primary key).

- **`OrderByExpression::toList()`** and **`OrderClauseExpression::getDirection()`** — small additions needed to read the order clauses programmatically for cursor column derivation.

## BC status

Zero BC breaks. All additions; `PaginatedInterface` itself is untouched (cursor methods live on the new sub-interface). Full test suite and PHPStan green.

## Usage

```php
// Query level
\$articles = \$this->Articles->find()
    ->orderByDesc('Articles.created')
    ->orderByDesc('Articles.id')
    ->seekAfter([
        'Articles.created' => \$cursorCreated,
        'Articles.id' => \$cursorId,
    ])
    ->limit(20);

// Paginator
\$results = \$this->paginate(\$query, [
    'className' => \Cake\Datasource\Paging\SeekPaginator::class,
]);

\$results->nextCursorToken();   // signed opaque token for next page
\$results->previousCursor();    // structured array for internal PHP use
\$results->paginationType();    // 'seek'
```

## Deferred for follow-ups

- No explicit `NULLS FIRST` / `NULLS LAST` handling — the null-value guard fails loudly rather than emit wrong SQL. A future PR can add a `NullOrdering` enum + driver-specific emission once someone hits the limitation.
- No tuple-comparison fast path (`(a,b) > (1,2)`) for drivers that support it — OR-expansion is portable and optimizer-friendly in practice.
- No `Controller::paginate(['strategy' => 'seek'])` alias; `className` is sufficient for now.

Marked **draft** for review of the API shape before documentation and cookbook entries.

Refs #19389