### PR TITLE
FormHelper: default to HTML5 `hidden` attribute (strict-CSP compatible)

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -173,7 +173,9 @@ class FormHelper extends Helper
             'requiredClass' => 'required',
             // CSS class added to the input when the field has validation errors
             'errorClass' => 'form-error',
-            // Class to use instead of "display:none" style attribute for hidden elements
+            // CSS class for the hidden block / postLink form. When set,
+            // this class is emitted instead of the HTML5 `hidden` boolean
+            // attribute that is used by default.
             'hiddenClass' => '',
             // CSS class added to the input containers
             'containerClass' => 'input',
@@ -665,6 +667,13 @@ class FormHelper extends Helper
     /**
      * Wrap the given content in a hidden div.
      *
+     * Defaults to the HTML5 `hidden` boolean attribute, which is functionally
+     * equivalent to `style="display:none;"` but does not require
+     * `style-src 'unsafe-inline'` under a strict Content-Security-Policy.
+     * Apps that need a custom mechanism (e.g. a Tailwind utility class) can
+     * set the `hiddenClass` template option, which takes precedence and
+     * emits `class="…"` instead.
+     *
      * @param string $content Content to wrap.
      * @return string
      */
@@ -673,7 +682,7 @@ class FormHelper extends Helper
         $hiddenClass = $this->templater()->get('hiddenClass');
         $hiddenBlockAttrs = $hiddenClass
             ? ['class' => $hiddenClass]
-            : ['style' => 'display:none;'];
+            : ['hidden' => true];
 
         return $this->formatTemplate('hiddenBlock', [
             'content' => $content,
@@ -1923,7 +1932,9 @@ class FormHelper extends Helper
         ];
         $hiddenClass = $this->templater()->get('hiddenClass');
         if ($hiddenClass === '' || $hiddenClass === null) {
-            $formOptions['style'] = 'display:none;';
+            // HTML5 `hidden` boolean attribute — functionally equivalent to
+            // `style="display:none;"` but strict-CSP compatible.
+            $formOptions['hidden'] = true;
         } else {
             $formOptions['class'] = $hiddenClass;
         }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -397,7 +397,7 @@ class FormHelperTest extends TestCase
                 'method' => 'post', 'action' => '/articles/add',
                 'accept-charset' => $encoding, 'enctype' => 'multipart/form-data',
             ],
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/div',
         ];
@@ -694,7 +694,7 @@ class FormHelperTest extends TestCase
         ];
 
         $extra = [
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => $override],
             '/div',
         ];
@@ -750,7 +750,7 @@ class FormHelperTest extends TestCase
                 'action' => '/articles/edit/1',
                 'accept-charset' => $encoding,
             ],
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'PUT'],
             '/div',
         ];
@@ -787,7 +787,7 @@ class FormHelperTest extends TestCase
                 'action' => '/Articles/edit/1',
                 'accept-charset' => $encoding,
             ],
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'PUT'],
             '/div',
         ];
@@ -802,7 +802,7 @@ class FormHelperTest extends TestCase
                 'action' => '/Articles/publish/1',
                 'accept-charset' => $encoding,
             ],
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'PUT'],
             '/div',
         ];
@@ -811,7 +811,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->create($this->article, ['url' => '/Articles/publish']);
         $expected = [
             'form' => ['method' => 'post', 'action' => '/Articles/publish', 'accept-charset' => $encoding],
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'PUT'],
             '/div',
         ];
@@ -825,7 +825,7 @@ class FormHelperTest extends TestCase
                 'method' => 'post', 'action' => '/Pages/signup/1',
                 'accept-charset' => $encoding,
             ],
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'PUT'],
             '/div',
         ];
@@ -1060,7 +1060,7 @@ class FormHelperTest extends TestCase
         ]);
         $expected = [
             'form' => ['method' => 'post', 'action' => '/articles/publish', 'accept-charset' => $encoding],
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => [
                 'type' => 'hidden',
                 'name' => '_csrfToken',
@@ -1145,7 +1145,7 @@ class FormHelperTest extends TestCase
             [],
         ]));
         $expected = [
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => [
                 'type' => 'hidden',
                 'name' => '_Token[fields]',
@@ -1190,7 +1190,7 @@ class FormHelperTest extends TestCase
         $hash .= ':' . 'Model.valid';
         $hash = urlencode($hash);
         $expected = [
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => [
                 'type' => 'hidden',
                 'name' => '_Token[fields]',
@@ -1387,7 +1387,7 @@ class FormHelperTest extends TestCase
         ]));
 
         $expected = [
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => [
                 'type' => 'hidden',
                 'name' => '_Token[fields]',
@@ -1448,7 +1448,7 @@ class FormHelperTest extends TestCase
         ]));
 
         $expected = [
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => [
                 'type' => 'hidden',
                 'name' => '_Token[fields]',
@@ -1587,7 +1587,7 @@ class FormHelperTest extends TestCase
             [],
         ]));
         $expected = [
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => [
                 'type' => 'hidden',
                 'name' => '_Token[fields]',
@@ -1677,7 +1677,7 @@ class FormHelperTest extends TestCase
             ]));
 
         $expected = [
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => [
                 'type' => 'hidden',
                 'name' => '_Token[fields]',
@@ -1749,7 +1749,7 @@ class FormHelperTest extends TestCase
             ]));
 
         $expected = [
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => [
                 'type' => 'hidden',
                 'name' => '_Token[fields]',
@@ -1822,7 +1822,7 @@ class FormHelperTest extends TestCase
         ]));
 
         $expected = [
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => [
                 'type' => 'hidden',
                 'name' => '_Token[fields]',
@@ -1881,7 +1881,7 @@ class FormHelperTest extends TestCase
 
         $hash = 'f98315a7d5515e5ae32e35f7d680207c085fae69%3AAddresses.id';
         $expected = [
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => [
                 'type' => 'hidden',
                 'name' => '_Token[fields]',
@@ -1935,7 +1935,7 @@ class FormHelperTest extends TestCase
         $hash = 'f98315a7d5515e5ae32e35f7d680207c085fae69%3AAddresses.id';
 
         $expected = [
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => [
                 'type' => 'hidden',
                 'name' => '_Token[fields]',
@@ -1992,7 +1992,7 @@ class FormHelperTest extends TestCase
         $encoding = strtolower(Configure::read('App.encoding'));
         $expected = [
             'form' => ['method' => 'post', 'action' => '/articles/add', 'accept-charset' => $encoding],
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => [
                 'type' => 'hidden',
                 'name' => '_csrfToken',
@@ -2113,7 +2113,7 @@ class FormHelperTest extends TestCase
         ]));
 
         $expected = [
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => [
                 'type' => 'hidden',
                 'name' => '_Token[fields]',
@@ -7089,7 +7089,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->postButton('Hi', '/controller/action', ['method' => 'patch']);
         $expected = [
             'form' => ['method' => 'post', 'action' => '/controller/action', 'accept-charset' => 'utf-8'],
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'PATCH'],
             '/div',
             'button' => ['type' => 'submit'],
@@ -7158,13 +7158,13 @@ class FormHelperTest extends TestCase
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/1', 'accept-charset' => 'utf-8',
             ],
-            ['div' => ['style' => 'display:none;']],
+            ['div' => ['hidden' => 'hidden']],
             ['input' => ['type' => 'hidden', 'name' => '_csrfToken', 'value' => 'testkey']],
             '/div',
             'button' => ['type' => 'submit'],
             'Delete',
             '/button',
-            ['div' => ['style' => 'display:none;']],
+            ['div' => ['hidden' => 'hidden']],
             ['input' => ['type' => 'hidden', 'name' => '_Token[fields]', 'value' => 'preg:/[\w\d%]+/']],
             ['input' => ['type' => 'hidden', 'name' => '_Token[unlocked]', 'value' => '']],
             ['input' => [
@@ -7187,7 +7187,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/1',
-                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/form',
@@ -7221,7 +7221,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'target' => '_blank', 'action' => '/posts/delete/1',
-                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/form',
@@ -7243,7 +7243,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/1',
-                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/form',
@@ -7265,7 +7265,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/1',
-                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/form',
@@ -7288,7 +7288,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/1',
-                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/form',
@@ -7313,7 +7313,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/1',
-                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/form',
@@ -7348,7 +7348,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/1',
-                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/form',
@@ -7378,7 +7378,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/Posts/delete/1?a=b&amp;c=d',
-                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/form',
@@ -7436,11 +7436,11 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/1',
-                'name', 'style' => 'display:none;',
+                'name', 'hidden' => 'hidden',
             ],
             ['input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST']],
             ['input' => ['type' => 'hidden', 'name' => 'id', 'value' => '1']],
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => ['type' => 'hidden', 'name' => '_Token[fields]', 'value' => $hash]],
             ['input' => ['type' => 'hidden', 'name' => '_Token[unlocked]', 'value' => '']],
             ['input' => [
@@ -7504,11 +7504,11 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/1',
-                'name', 'style' => 'display:none;',
+                'name', 'hidden' => 'hidden',
             ],
             ['input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST']],
             ['input' => ['type' => 'hidden', 'name' => 'id', 'value' => '1']],
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => ['type' => 'hidden', 'name' => '_Token[fields]', 'value' => $hash]],
             ['input' => ['type' => 'hidden', 'name' => '_Token[unlocked]', 'value' => '']],
             '/div',
@@ -7563,11 +7563,11 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/1',
-                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
             ],
             ['input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST']],
             ['input' => ['type' => 'hidden', 'name' => '_csrfToken', 'value' => 'testkey']],
-            'div' => ['style' => 'display:none;'],
+            'div' => ['hidden' => 'hidden'],
             ['input' => ['type' => 'hidden', 'name' => '_Token[fields]', 'value' => 'preg:/[\w\d%]+/']],
             ['input' => ['type' => 'hidden', 'name' => '_Token[unlocked]', 'value' => '']],
             ['input' => [
@@ -7602,7 +7602,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/1',
-                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/form',
@@ -7625,14 +7625,14 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/1',
-                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/form',
             [
                 'form' => [
                     'method' => 'post', 'action' => '/posts/delete/2',
-                    'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                    'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
                 ],
             ],
             ['input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'DELETE']],
@@ -7652,7 +7652,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/1',
-                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/form',
@@ -7672,7 +7672,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/4',
-                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'POST'],
             '/form',
@@ -7691,7 +7691,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'action' => '/posts/delete/1',
-                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'DELETE'],
             '/form',
@@ -7709,7 +7709,7 @@ class FormHelperTest extends TestCase
         $expected = [
             'form' => [
                 'method' => 'post', 'target' => '_blank', 'action' => '/posts/delete/1',
-                'name' => 'preg:/post_\w+/', 'style' => 'display:none;',
+                'name' => 'preg:/post_\w+/', 'hidden' => 'hidden',
             ],
             'input' => ['type' => 'hidden', 'name' => '_method', 'value' => 'DELETE'],
             '/form',


### PR DESCRIPTION
Refs #17729.

## Problem

`FormHelper`'s default `hiddenBlock` template — the wrapper around CSRF tokens on every form — emits `style="display:none;"`. Same for the form generated inside `postLink()`. Both require `style-src 'unsafe-inline'` and break out of the box under a strict Content-Security-Policy.

The opt-in `hiddenClass` template option added in #18066 lets adopters supply their own class, but every app has to set it manually. In practice most `cakephp-app` installs that try strict CSP get a wall of `style-src` violations from these two paths until they discover `hiddenClass`.

## Change

Default to the HTML5 `hidden` boolean attribute:

```diff
- $hiddenBlockAttrs = $hiddenClass
-     ? ['class' => $hiddenClass]
-     : ['style' => 'display:none;'];
+ $hiddenBlockAttrs = $hiddenClass
+     ? ['class' => $hiddenClass]
+     : ['hidden' => true];
```

Same swap inside `postLink()`'s `$formOptions`. Output goes from

```html
<div style="display:none;">…</div>
```

to

```html
<div hidden="hidden">…</div>
```

## Why `hidden` and not just removing the wrapper

In #17729 the discussion landed on: keeping the wrapper matters because some CSS libs add spacing to all inputs, which would be visible if hidden inputs aren't constrained. `hidden` keeps the wrapper *and* keeps the input visually suppressed (UA stylesheet sets `[hidden] { display: none }`), so the existing visual contract is preserved.

## Browser compatibility

The `hidden` HTML5 boolean attribute is part of the HTML Living Standard and has been supported by every browser CakePHP 5.x already targets:

| Browser | Supported since |
|---|---|
| Chrome | 1.0 (2008) |
| Firefox | 4.0 (2011) |
| Safari | 5.0 (2010) |
| Edge (Chromium and legacy) | all versions |
| Opera | 11.0 (2010) |
| Internet Explorer | 11 (2013) |
| iOS Safari | 4.0 (2010) |

caniuse reports >99.9% global support. There is no realistic browser environment where `style="display:none;"` works but `[hidden]` does not.

## Why now (vs. the original ticket)

#17729 was closed without a behavior change because at the time markstory said: *"Removing the hidden div could break existing applications so we'd have to wait for a major release to change it."* Two things have changed since:

1. **The change here is narrower than what was rejected then.** The original concern was about *removing* the wrapper entirely, which would expose hidden inputs to surrounding-CSS spacing. This PR keeps the wrapper — only the suppression *mechanism* changes from inline `style` to `[hidden]`. UA stylesheet `display: none` still applies; visual output is identical for any app that doesn't intentionally style `[style="display:none;"]` (an extraordinarily rare selector in real apps).

2. **The opt-in workaround has shipped and been observed.** Since #18066 introduced `hiddenClass`, the tribal knowledge "if you want strict CSP, set `hiddenClass`" has spread, but adopters still hit the violations first and only fix them after seeing them in the console. Flipping the default takes that step out of every strict-CSP onboarding without requiring a major release: the existing `hiddenClass` opt-out continues to work for the vanishingly small set of apps that depended on the literal `style="display:none;"` markup.

In short: the original blocker was BC-risk vs. an unsemantic-but-working visual default. After #18066, this PR only swaps the *default mechanism* among two functionally equivalent options, both already tested as paths.

In my case my apps could drop this extra config in the future:
https://github.com/dereuromark/cakephp-tinyauth-demo/blob/e044e18f9eca325c67af72f63a65976346056d7a/src/View/AppView.php#L48-L50

## Documentation note (not in this PR)

`cookbook` will need a one-line note in the FormHelper templates section that the default became `hidden` and that `hiddenClass` is the way to override.
