### PR TITLE
Added support for extracting translations for labels

### DIFF
--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -30,6 +30,7 @@ use Cake\Utility\Fs\Finder;
 use Cake\Utility\Inflector;
 use ReflectionClass;
 use ReflectionException;
+use Throwable;
 
 /**
  * Language string extractor
@@ -845,7 +846,7 @@ class I18nExtractCommand extends Command
         try {
             // @phpstan-ignore argument.type
             $reflection = new ReflectionClass($fqn);
-        } catch (ReflectionException $e) {
+        } catch (Throwable $e) {
             $this->io->warning(
                 sprintf('Could not reflect class/enum %s in file %s: %s', $fqn, $file, $e->getMessage()),
             );

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -876,7 +876,8 @@ class I18nExtractCommand extends Command
                 'line' => 0,
                 'msgctxt' => $label->context,
             ];
-            $this->_addTranslation('default', $label->label, $details);
+
+            $this->_addTranslation($label->domain, $label->label, $details);
         }
     }
 

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -24,9 +24,12 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use Cake\Core\Plugin;
+use Cake\Database\Type\Attribute\Label;
 use Cake\Utility\Filesystem;
 use Cake\Utility\Fs\Finder;
 use Cake\Utility\Inflector;
+use ReflectionClass;
+use ReflectionException;
 
 /**
  * Language string extractor
@@ -461,6 +464,8 @@ class I18nExtractCommand extends Command
                 }
             }
 
+            $this->_extractFileReflection($file, $code);
+
             if (!$isVerbose) {
                 $progress->increment(1);
                 $progress->draw();
@@ -821,6 +826,112 @@ class I18nExtractCommand extends Command
             $count++;
         }
         $io->err("\n");
+    }
+
+    /**
+     * Extract Label attribute strings from a PHP file using reflection.
+     *
+     * @param string $file Absolute path to the file being processed.
+     * @param string $code File contents.
+     * @return void
+     */
+    protected function _extractFileReflection(string $file, string $code): void
+    {
+        $fqn = $this->_parseClassName($code);
+        if ($fqn === null) {
+            return;
+        }
+
+        try {
+            $reflection = new ReflectionClass($fqn);
+        } catch (ReflectionException $e) {
+            $this->io->warning(sprintf('Could not reflect class/enum %s in file %s', $fqn, $file));
+
+            return;
+        }
+
+        if (!$reflection->isEnum()) {
+            return;
+        }
+
+        $relativeFile = '.' . str_replace(ROOT, '', $file);
+
+        foreach ($reflection->getReflectionConstants() as $constant) {
+            if (!$constant->isEnumCase()) {
+                continue;
+            }
+
+            $labelAttributes = $constant->getAttributes(Label::class);
+            if (!$labelAttributes) {
+                continue;
+            }
+
+            /** @var \Cake\Database\Type\Attribute\Label $label */
+            $label = $labelAttributes[0]->newInstance();
+            $details = [
+                'file' => $relativeFile,
+                'line' => 0,
+                'msgctxt' => $label->context,
+            ];
+            $this->_addTranslation('default', $label->label, $details);
+        }
+    }
+
+    /**
+     * Parse the fully qualified class/enum name from PHP source code.
+     *
+     * Uses token_get_all() to read the namespace declaration and the first
+     * class or enum name without executing the file.
+     *
+     * @param string $code PHP source code.
+     * @return string|null Fully qualified name, or null if none found.
+     */
+    protected function _parseClassName(string $code): ?string
+    {
+        $tokens = token_get_all($code);
+        $namespace = '';
+        $waitingForNamespace = false;
+        $waitingForName = false;
+
+        foreach ($tokens as $token) {
+            if (!is_array($token)) {
+                continue;
+            }
+
+            [$type, $value] = $token;
+
+            if ($type === T_WHITESPACE) {
+                continue;
+            }
+
+            if ($type === T_NAMESPACE) {
+                $waitingForNamespace = true;
+                continue;
+            }
+
+            if ($waitingForNamespace) {
+                if ($type === T_STRING || $type === T_NAME_QUALIFIED) {
+                    $namespace = $value;
+                }
+                $waitingForNamespace = false;
+                continue;
+            }
+
+            if ($type === T_ENUM || $type === T_CLASS) {
+                $waitingForName = true;
+                continue;
+            }
+
+            if ($waitingForName && $type === T_STRING) {
+                return $namespace !== '' ? $namespace . '\\' . $value : $value;
+            }
+
+            if ($waitingForName) {
+                $waitingForName = false;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -846,7 +846,7 @@ class I18nExtractCommand extends Command
             $reflection = new ReflectionClass($fqn);
         } catch (ReflectionException $e) {
             $this->io->warning(
-                sprintf('Could not reflect class/enum %s in file %s: %s', $fqn, $file, $e->getMessage())
+                sprintf('Could not reflect class/enum %s in file %s: %s', $fqn, $file, $e->getMessage()),
             );
 
             return;

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -843,6 +843,7 @@ class I18nExtractCommand extends Command
         }
 
         try {
+            // @phpstan-ignore argument.type
             $reflection = new ReflectionClass($fqn);
         } catch (ReflectionException $e) {
             $this->io->warning(

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -464,7 +464,7 @@ class I18nExtractCommand extends Command
                 }
             }
 
-            $this->_extractFileReflection($file, $code);
+            $this->extractFileReflection($file, $code);
 
             if (!$isVerbose) {
                 $progress->increment(1);
@@ -835,9 +835,9 @@ class I18nExtractCommand extends Command
      * @param string $code File contents.
      * @return void
      */
-    protected function _extractFileReflection(string $file, string $code): void
+    protected function extractFileReflection(string $file, string $code): void
     {
-        $fqn = $this->_parseClassName($code);
+        $fqn = $this->parseClassName($code);
         if ($fqn === null) {
             return;
         }
@@ -889,7 +889,7 @@ class I18nExtractCommand extends Command
      * @param string $code PHP source code.
      * @return string|null Fully qualified name, or null if none found.
      */
-    protected function _parseClassName(string $code): ?string
+    protected function parseClassName(string $code): ?string
     {
         $tokens = token_get_all($code);
         $namespace = '';

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -845,7 +845,9 @@ class I18nExtractCommand extends Command
         try {
             $reflection = new ReflectionClass($fqn);
         } catch (ReflectionException $e) {
-            $this->io->warning(sprintf('Could not reflect class/enum %s in file %s', $fqn, $file));
+            $this->io->warning(
+                sprintf('Could not reflect class/enum %s in file %s: %s', $fqn, $file, $e->getMessage())
+            );
 
             return;
         }

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -29,7 +29,6 @@ use Cake\Utility\Filesystem;
 use Cake\Utility\Fs\Finder;
 use Cake\Utility\Inflector;
 use ReflectionClass;
-use ReflectionException;
 use Throwable;
 
 /**

--- a/src/Database/Type/Attribute/Label.php
+++ b/src/Database/Type/Attribute/Label.php
@@ -37,8 +37,8 @@ readonly class Label
      */
     public function __construct(
         public string $label,
-        public string $context = '',
         public string $domain = 'default',
+        public string $context = '',
     ) {
     }
 }

--- a/src/Database/Type/Attribute/Label.php
+++ b/src/Database/Type/Attribute/Label.php
@@ -36,7 +36,7 @@ readonly class Label
      */
     public function __construct(
         public string $label,
-        public string $context = ''
+        public string $context = '',
     ) {
     }
 }

--- a/src/Database/Type/Attribute/Label.php
+++ b/src/Database/Type/Attribute/Label.php
@@ -33,10 +33,12 @@ readonly class Label
      *
      * @param string $label The label to use for the enum case.
      * @param string $context The translation context for the label.
+     * @param string $domain The translation domain for the label.
      */
     public function __construct(
         public string $label,
         public string $context = '',
+        public string $domain = 'default',
     ) {
     }
 }

--- a/src/Database/Type/Attribute/Label.php
+++ b/src/Database/Type/Attribute/Label.php
@@ -32,9 +32,11 @@ readonly class Label
      * Constructor.
      *
      * @param string $label The label to use for the enum case.
+     * @param string $context The translation context for the label.
      */
     public function __construct(
         public string $label,
+        public string $context = ''
     ) {
     }
 }

--- a/src/Database/Type/EnumLabelTrait.php
+++ b/src/Database/Type/EnumLabelTrait.php
@@ -62,15 +62,12 @@ trait EnumLabelTrait
     }
 
     /**
-     * @param string|array{label:string,context:string} $label
+     * Returns the translated label for the enum case.
      *
+     * @param string|array{label:string,context:string} $label
      */
     private function translatedLabel(string|array $label): string
     {
-        if (is_string($label)) {
-            return $label;
-        }
-
         /** @var bool $i18n */
         static $i18n;
 
@@ -78,6 +75,10 @@ trait EnumLabelTrait
 
         if (!$i18n) {
             return $label['label'];
+        }
+
+        if (is_string($label)) {
+            return __($label);
         }
 
         $context = $label['context'] ?? '';

--- a/src/Database/Type/EnumLabelTrait.php
+++ b/src/Database/Type/EnumLabelTrait.php
@@ -38,20 +38,11 @@ trait EnumLabelTrait
      */
     public function label(): string
     {
-        /** @var array<string, string> $labels */
+        /** @var array<string,string|array{label:string,context:string}> $labels */
         static $labels = [];
 
-        /** @var bool $i18n */
-        static $i18n;
-
-        $i18n ??= function_exists('\Cake\I18n\__');
-
         if (isset($labels[$this->name])) {
-            if ($i18n) {
-                return __($labels[$this->name]);
-            }
-
-            return $labels[$this->name];
+            return $this->translatedLabel($labels[$this->name]);
         }
 
         $reflection = new ReflectionClassConstant(static::class, $this->name);
@@ -60,13 +51,41 @@ trait EnumLabelTrait
         if ($enumAttributes === []) {
             $labels[$this->name] = Inflector::humanize(Inflector::underscore($this->name));
         } else {
-            $labels[$this->name] = $enumAttributes[0]->newInstance()->label;
+            $instance = $enumAttributes[0]->newInstance();
+            $labels[$this->name] = [
+                'label' => $instance->label,
+                'context' => $instance->context,
+            ];
         }
 
-        if ($i18n) {
-            return __($labels[$this->name]);
+        return $this->translatedLabel($labels[$this->name]);
+    }
+
+    /**
+     * @param string|array{label:string,context:string} $label
+     *
+     */
+    private function translatedLabel(string|array $label): string
+    {
+        if (is_string($label)) {
+            return $label;
         }
 
-        return $labels[$this->name];
+        /** @var bool $i18n */
+        static $i18n;
+
+        $i18n ??= function_exists('\Cake\I18n\__');
+
+        if (!$i18n) {
+            return $label['label'];
+        }
+
+        $context = $label['context'] ?? '';
+
+        if ($context !== '') {
+            return __x($context, $label['label']);
+        }
+
+        return __($label['label']);
     }
 }

--- a/src/Database/Type/EnumLabelTrait.php
+++ b/src/Database/Type/EnumLabelTrait.php
@@ -17,10 +17,9 @@ declare(strict_types=1);
 namespace Cake\Database\Type;
 
 use Cake\Database\Type\Attribute\Label;
+use Cake\I18n\I18n;
 use Cake\Utility\Inflector;
 use ReflectionClassConstant;
-use function Cake\I18n\__;
-use function Cake\I18n\__x;
 
 /**
  * Trait EnumLabelTrait
@@ -53,12 +52,14 @@ trait EnumLabelTrait
             $labels[$this->name] = [
                 'label' => Inflector::humanize(Inflector::underscore($this->name)),
                 'context' => '',
+                'domain' => 'default',
             ];
         } else {
             $instance = $enumAttributes[0]->newInstance();
             $labels[$this->name] = [
                 'label' => $instance->label,
                 'context' => $instance->context,
+                'domain' => $instance->domain,
             ];
         }
 
@@ -68,25 +69,27 @@ trait EnumLabelTrait
     /**
      * Returns the translated label for the enum case.
      *
-     * @param array{label:string,context:string} $label
+     * @param array{label:string,context:string,domain:string} $label
      */
     private function translatedLabel(array $label): string
     {
         /** @var bool $i18n */
         static $i18n;
 
-        $i18n ??= function_exists('\Cake\I18n\__');
+        $i18n ??= class_exists('Cake\I18n\I18n');
 
         if (!$i18n) {
             return $label['label'];
         }
 
         $context = $label['context'] ?? '';
+        $domain = $label['domain'] ?? 'default';
+        $args = [];
 
         if ($context !== '') {
-            return __x($context, $label['label']);
+            $args['_context'] = $context;
         }
 
-        return __($label['label']);
+        return I18n::getTranslator($domain)->translate($label['label'], $args);
     }
 }

--- a/src/Database/Type/EnumLabelTrait.php
+++ b/src/Database/Type/EnumLabelTrait.php
@@ -20,6 +20,7 @@ use Cake\Database\Type\Attribute\Label;
 use Cake\Utility\Inflector;
 use ReflectionClassConstant;
 use function Cake\I18n\__;
+use function Cake\I18n\__x;
 
 /**
  * Trait EnumLabelTrait

--- a/src/Database/Type/EnumLabelTrait.php
+++ b/src/Database/Type/EnumLabelTrait.php
@@ -38,7 +38,7 @@ trait EnumLabelTrait
      */
     public function label(): string
     {
-        /** @var array<string,string|array{label:string,context:string}> $labels */
+        /** @var array<string,array{label:string,context:string}> $labels */
         static $labels = [];
 
         if (isset($labels[$this->name])) {
@@ -49,7 +49,10 @@ trait EnumLabelTrait
         $enumAttributes = $reflection->getAttributes(Label::class);
 
         if ($enumAttributes === []) {
-            $labels[$this->name] = Inflector::humanize(Inflector::underscore($this->name));
+            $labels[$this->name] = [
+                'label' => Inflector::humanize(Inflector::underscore($this->name)),
+                'context' => '',
+            ];
         } else {
             $instance = $enumAttributes[0]->newInstance();
             $labels[$this->name] = [
@@ -64,9 +67,9 @@ trait EnumLabelTrait
     /**
      * Returns the translated label for the enum case.
      *
-     * @param string|array{label:string,context:string} $label
+     * @param array{label:string,context:string} $label
      */
-    private function translatedLabel(string|array $label): string
+    private function translatedLabel(array $label): string
     {
         /** @var bool $i18n */
         static $i18n;
@@ -74,11 +77,7 @@ trait EnumLabelTrait
         $i18n ??= function_exists('\Cake\I18n\__');
 
         if (!$i18n) {
-            return is_string($label) ? $label : $label['label'];
-        }
-
-        if (is_string($label)) {
-            return __($label);
+            return $label['label'];
         }
 
         $context = $label['context'] ?? '';

--- a/src/Database/Type/EnumLabelTrait.php
+++ b/src/Database/Type/EnumLabelTrait.php
@@ -17,9 +17,9 @@ declare(strict_types=1);
 namespace Cake\Database\Type;
 
 use Cake\Database\Type\Attribute\Label;
-use Cake\I18n\I18n;
 use Cake\Utility\Inflector;
 use ReflectionClassConstant;
+use function Cake\I18n\__dx;
 
 /**
  * Trait EnumLabelTrait
@@ -76,7 +76,7 @@ trait EnumLabelTrait
         /** @var bool $i18n */
         static $i18n;
 
-        $i18n ??= class_exists('Cake\I18n\I18n');
+        $i18n ??= function_exists('\Cake\I18n\__dx');
 
         if (!$i18n) {
             return $label['label'];
@@ -84,12 +84,7 @@ trait EnumLabelTrait
 
         $context = $label['context'] ?? '';
         $domain = $label['domain'] ?? 'default';
-        $args = [];
 
-        if ($context !== '') {
-            $args['_context'] = $context;
-        }
-
-        return I18n::getTranslator($domain)->translate($label['label'], $args);
+        return __dx($domain, $context, $label['label']);
     }
 }

--- a/src/Database/Type/EnumLabelTrait.php
+++ b/src/Database/Type/EnumLabelTrait.php
@@ -74,7 +74,7 @@ trait EnumLabelTrait
         $i18n ??= function_exists('\Cake\I18n\__');
 
         if (!$i18n) {
-            return $label['label'];
+            return is_string($label) ? $label : $label['label'];
         }
 
         if (is_string($label)) {

--- a/tests/TestCase/Command/I18nExtractCommandTest.php
+++ b/tests/TestCase/Command/I18nExtractCommandTest.php
@@ -357,6 +357,29 @@ class I18nExtractCommandTest extends TestCase
     }
 
     /**
+     * Test extraction of Label attribute strings from enum cases.
+     */
+    public function testExtractLabelAttributes(): void
+    {
+        $this->exec(
+            'i18n extract ' .
+            '--merge=no ' .
+            '--extract-core=no ' .
+            '--paths=' . TEST_APP . 'TestApp/Model/Enum ' .
+            '--output=' . $this->path . DS,
+        );
+        $this->assertExitSuccess();
+        $this->assertFileExists($this->path . DS . 'default.pot');
+        $result = file_get_contents($this->path . DS . 'default.pot');
+
+        $this->assertStringContainsString('msgid "Published"', $result);
+        $this->assertStringContainsString('msgid "Unpublished"', $result);
+
+        $pattern = '/msgctxt "article_status"\nmsgid "Archived"/';
+        $this->assertMatchesRegularExpression($pattern, $result);
+    }
+
+    /**
      * test relative-paths option
      */
     public function testExtractWithRelativePaths(): void

--- a/tests/TestCase/Database/Type/EnumLabelTraitTest.php
+++ b/tests/TestCase/Database/Type/EnumLabelTraitTest.php
@@ -139,4 +139,29 @@ class EnumLabelTraitTest extends TestCase
         // Explicit Label attribute values are also translated.
         $this->assertSame("L'article est publié", ArticleStatusTraitLabeled::Published->label());
     }
+
+    /**
+     * Test that label() uses __x() with the context from the Label attribute when present.
+     */
+    public function testLabelWithAttributeContextUsesTranslationContext(): void
+    {
+        Cache::clear('_cake_translations_');
+        I18n::clear();
+
+        I18n::setTranslator('default', function () {
+            $package = new Package();
+            $package->setMessages([
+                'Article is a draft' => [
+                    '_context' => [
+                        'ArticleStatus' => 'Article est un brouillon',
+                    ],
+                ],
+            ]);
+
+            return $package;
+        }, 'fr_FR');
+        I18n::setLocale('fr_FR');
+
+        $this->assertSame('Article est un brouillon', ArticleStatusTraitLabeled::Draft->label());
+    }
 }

--- a/tests/TestCase/Database/Type/EnumLabelTraitTest.php
+++ b/tests/TestCase/Database/Type/EnumLabelTraitTest.php
@@ -20,6 +20,7 @@ use Cake\Cache\Cache;
 use Cake\I18n\I18n;
 use Cake\I18n\Package;
 use Cake\TestSuite\TestCase;
+use TestApp\Model\Enum\ArticleDomainStatus;
 use TestApp\Model\Enum\ArticleStatusTrait;
 use TestApp\Model\Enum\ArticleStatusTraitLabeled;
 
@@ -141,7 +142,7 @@ class EnumLabelTraitTest extends TestCase
     }
 
     /**
-     * Test that label() uses __x() with the context from the Label attribute when present.
+     * Test that label() uses the context from the Label attribute when present.
      */
     public function testLabelWithAttributeContextUsesTranslationContext(): void
     {
@@ -163,5 +164,32 @@ class EnumLabelTraitTest extends TestCase
         I18n::setLocale('fr_FR');
 
         $this->assertSame('Article est un brouillon', ArticleStatusTraitLabeled::Draft->label());
+    }
+
+    /**
+     * Test that label() uses the domain from the Label attribute when present.
+     */
+    public function testLabelWithAttributeUsesDomain(): void
+    {
+        Cache::clear('_cake_translations_');
+        I18n::clear();
+
+        I18n::setTranslator('news', function () {
+            $package = new Package();
+            $package->setMessages([
+                'Article is published in the news domain' => [
+                    '_context' => [
+                        'Article' => 'Un article est publié dans la presse.',
+                    ],
+                ],
+                'Article is unpublished in the news domain' => 'Un article est non publié dans la presse.',
+            ]);
+
+            return $package;
+        }, 'fr_FR');
+        I18n::setLocale('fr_FR');
+
+        $this->assertSame('Un article est publié dans la presse.', ArticleDomainStatus::Published->label());
+        $this->assertSame('Un article est non publié dans la presse.', ArticleDomainStatus::Unpublished->label());
     }
 }

--- a/tests/test_app/TestApp/Model/Enum/ArticleDomainStatus.php
+++ b/tests/test_app/TestApp/Model/Enum/ArticleDomainStatus.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Model\Enum;
+
+use Cake\Database\Type\Attribute\Label;
+use Cake\Database\Type\EnumLabelTrait;
+
+enum ArticleDomainStatus
+{
+    use EnumLabelTrait;
+
+    #[Label('Article is published in the news domain', context: 'Article', domain: 'news')]
+    case Published;
+
+    #[Label('Article is unpublished in the news domain', domain: 'news')]
+    case Unpublished;
+}

--- a/tests/test_app/TestApp/Model/Enum/ArticleDomainStatus.php
+++ b/tests/test_app/TestApp/Model/Enum/ArticleDomainStatus.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * Redistributions of files must retain the above copyright notice
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @since         5.0.0
+ * @since         5.4.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestApp\Model\Enum;
@@ -21,7 +21,7 @@ enum ArticleDomainStatus
 {
     use EnumLabelTrait;
 
-    #[Label('Article is published in the news domain', context: 'Article', domain: 'news')]
+    #[Label('Article is published in the news domain', domain: 'news', context: 'Article')]
     case Published;
 
     #[Label('Article is unpublished in the news domain', domain: 'news')]

--- a/tests/test_app/TestApp/Model/Enum/ArticleStatusExtract.php
+++ b/tests/test_app/TestApp/Model/Enum/ArticleStatusExtract.php
@@ -24,6 +24,6 @@ enum ArticleStatusExtract: string
     #[Label('Unpublished')]
     case Unpublished = 'N';
 
-    #[Label('Archived', 'article_status')]
+    #[Label('Archived', context: 'article_status')]
     case Archived = 'A';
 }

--- a/tests/test_app/TestApp/Model/Enum/ArticleStatusExtract.php
+++ b/tests/test_app/TestApp/Model/Enum/ArticleStatusExtract.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         5.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Model\Enum;
+
+use Cake\Database\Type\Attribute\Label;
+
+enum ArticleStatusExtract: string
+{
+    #[Label('Published')]
+    case Published = 'Y';
+
+    #[Label('Unpublished')]
+    case Unpublished = 'N';
+
+    #[Label('Archived', 'article_status')]
+    case Archived = 'A';
+}

--- a/tests/test_app/TestApp/Model/Enum/ArticleStatusTraitLabeled.php
+++ b/tests/test_app/TestApp/Model/Enum/ArticleStatusTraitLabeled.php
@@ -29,4 +29,7 @@ enum ArticleStatusTraitLabeled: string implements EnumLabelInterface
     case Unpublished = 'N';
 
     case PendingReview = 'P';
+
+    #[Label('Article is a draft', context: 'ArticleStatus')]
+    case Draft = 'D';
 }


### PR DESCRIPTION
Follow up for: https://github.com/cakephp/cakephp/pull/19405
Adds support for extracting the newly added Label attributes for enum constants.

The code specifically checks for enums but it can easily be extended if we decide to use labels in other places.

I added a context attribute to labels to allow users to disambiguate their labels.

