### PR TITLE
BaseCommand: tolerate single-token $name in getOptionParser()

### DIFF
--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -151,7 +151,20 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
      */
     public function getOptionParser(): ConsoleOptionParser
     {
-        [$root, $name] = explode(' ', $this->name, 2);
+        // `$this->name` is normally rewritten to `"<root> <name>"` by
+        // `CommandRunner::resolve()` before `run()` is called. Direct
+        // callers (queue tasks, custom dispatchers, plain instantiation
+        // in tests) skip that step, leaving subclass overrides like
+        // `protected string $name = 'my_command';` as a single token —
+        // which previously caused `explode()` to return a one-element
+        // array and `new ConsoleOptionParser(null)` to throw a TypeError.
+        // Tolerate the missing root by falling back to 'cake' here.
+        if (str_contains($this->name, ' ')) {
+            [$root, $name] = explode(' ', $this->name, 2);
+        } else {
+            $root = 'cake';
+            $name = $this->name;
+        }
         $parser = new ConsoleOptionParser($name);
         $parser->setRootName($root);
         $parser->setDescription(static::getDescription());

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -151,14 +151,6 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
      */
     public function getOptionParser(): ConsoleOptionParser
     {
-        // `$this->name` is normally rewritten to `"<root> <name>"` by
-        // `CommandRunner::resolve()` before `run()` is called. Direct
-        // callers (queue tasks, custom dispatchers, plain instantiation
-        // in tests) skip that step, leaving subclass overrides like
-        // `protected string $name = 'my_command';` as a single token —
-        // which previously caused `explode()` to return a one-element
-        // array and `new ConsoleOptionParser(null)` to throw a TypeError.
-        // Tolerate the missing root by falling back to 'cake' here.
         if (str_contains($this->name, ' ')) {
             [$root, $name] = explode(' ', $this->name, 2);
         } else {

--- a/tests/TestCase/Console/BaseCommandTest.php
+++ b/tests/TestCase/Console/BaseCommandTest.php
@@ -209,4 +209,52 @@ class BaseCommandTest extends TestCase
 
         $this->assertSame('Alice', $command->capturedName);
     }
+
+    /**
+     * Subclasses commonly override `protected string $name` to a single
+     * bare token (e.g. `'my_command'`), expecting `CommandRunner` to
+     * rewrite it to `"cake my_command"` via setName() before running.
+     * Direct callers (queue tasks, custom dispatchers, plain
+     * instantiation in tests) skip that step. getOptionParser() must
+     * tolerate the missing root rather than throw a TypeError from
+     * `new ConsoleOptionParser(null)`.
+     */
+    public function testGetOptionParserToleratesSingleTokenName(): void
+    {
+        $command = new class extends Command {
+            protected string $name = 'single_token_name';
+
+            public function execute(Arguments $args, ConsoleIo $io): int
+            {
+                return static::CODE_SUCCESS;
+            }
+        };
+
+        $parser = $command->getOptionParser();
+
+        $this->assertSame('single_token_name', $parser->getCommand());
+        $this->assertStringContainsString('cake single_token_name', $parser->help());
+    }
+
+    /**
+     * Counterpart: when the name is already space-formatted
+     * (BaseCommand's default `cake unknown`, custom roots like
+     * `app foo`), getOptionParser() must keep both halves intact.
+     */
+    public function testGetOptionParserPreservesSpaceFormattedName(): void
+    {
+        $command = new class extends Command {
+            protected string $name = 'app foo';
+
+            public function execute(Arguments $args, ConsoleIo $io): int
+            {
+                return static::CODE_SUCCESS;
+            }
+        };
+
+        $parser = $command->getOptionParser();
+
+        $this->assertSame('foo', $parser->getCommand());
+        $this->assertStringContainsString('app foo', $parser->help());
+    }
 }

--- a/tests/TestCase/Console/BaseCommandTest.php
+++ b/tests/TestCase/Console/BaseCommandTest.php
@@ -210,15 +210,6 @@ class BaseCommandTest extends TestCase
         $this->assertSame('Alice', $command->capturedName);
     }
 
-    /**
-     * Subclasses commonly override `protected string $name` to a single
-     * bare token (e.g. `'my_command'`), expecting `CommandRunner` to
-     * rewrite it to `"cake my_command"` via setName() before running.
-     * Direct callers (queue tasks, custom dispatchers, plain
-     * instantiation in tests) skip that step. getOptionParser() must
-     * tolerate the missing root rather than throw a TypeError from
-     * `new ConsoleOptionParser(null)`.
-     */
     public function testGetOptionParserToleratesSingleTokenName(): void
     {
         $command = new class extends Command {
@@ -236,11 +227,6 @@ class BaseCommandTest extends TestCase
         $this->assertStringContainsString('cake single_token_name', $parser->help());
     }
 
-    /**
-     * Counterpart: when the name is already space-formatted
-     * (BaseCommand's default `cake unknown`, custom roots like
-     * `app foo`), getOptionParser() must keep both halves intact.
-     */
     public function testGetOptionParserPreservesSpaceFormattedName(): void
     {
         $command = new class extends Command {


### PR DESCRIPTION
## Summary

`BaseCommand::getOptionParser()` does:

```php
[$root, $name] = explode(' ', $this->name, 2);
$parser = new ConsoleOptionParser($name);
```

This assumes `$this->name` always contains a space. `CommandRunner::resolve()` enforces this by calling `setName("{$this->root} {$name}")` before invoking `run()`, but **direct callers** (queue tasks, custom dispatchers, tests that do `(new MyCommand)->run([], $io)`) skip that step.

A subclass override like:

```php
protected string $name = 'my_command';
```

— a documented and widely-used pattern (see `bin/cake my_command` discovery and most app commands in the wild) — is then left as a single token. `explode(...)` returns a one-element array, the destructure makes `$name` null, and `new ConsoleOptionParser(null)` throws:

```
TypeError: Cake\Console\ConsoleOptionParser::__construct():
Argument #1 ($command) must be of type string, null given
```

The error message doesn't point at `BaseCommand` and is confusing because the same command works fine via `bin/cake my_command`.

## Reproduction

```php
$cmd = new class extends \Cake\Command\Command {
    protected string $name = 'my_command';
    public function execute(\Cake\Console\Arguments $args, \Cake\Console\ConsoleIo $io): int { return 0; }
};
$cmd->getOptionParser(); // TypeError
```

I hit this in production while wiring app commands into the [QueueScheduler plugin](https://github.com/dereuromark/cakephp-queue-scheduler), which instantiates `CommandInterface` implementations and calls `run()` directly — see <https://github.com/dereuromark/cakephp-queue-scheduler/pull/27> for the plugin-side workaround. Any plugin/library that wraps Cake commands runs into the same trap.

## Two possible fixes

### Option A — defensive `getOptionParser()` (what this PR ships)

Tolerate the missing root in `getOptionParser()` itself:

```php
if (str_contains($this->name, ' ')) {
    [$root, $name] = explode(' ', $this->name, 2);
} else {
    $root = 'cake';
    $name = $this->name;
}
```

**Pros**
- Smallest, most localised change — only touches the code that does the brittle `explode`.
- `$this->name` is left exactly as the user set it. No surprise mutation.
- `setName()`'s assertion (which already enforces "must contain a space") stays meaningful.

**Cons**
- Other code paths that read `$this->name` directly still see the single-token form. Today nothing else in core does, but a subclass that uses `$this->name` in `execute()` would observe the same value it set, not the rewritten form.

### Option B — auto-prefix in `run()`

Mutate `$this->name` once, at the top of `run()`, so all downstream code (including `getOptionParser`) sees a normalised form:

```php
public function run(array $argv, ConsoleIo $io): ?int
{
    if (!str_contains($this->name, ' ')) {
        $this->setName('cake ' . $this->name);
    }
    $this->initialize();
    // ... unchanged ...
}
```

**Pros**
- Matches what `CommandRunner` already does — same code shape, same end state.
- Any future `getXxx()` that reads `$this->name` automatically sees the normalised value.

**Cons**
- Mutates user-set state — feels heavier than fixing the one method that has the bug.
- `setName()`'s assertion fires on every direct `run()` call, which is fine but slightly noisier in trace output.
- Doesn't help anything that calls `getOptionParser()` *without* going through `run()` (e.g. `bin/cake completion`, third-party introspection). Probably not common but technically a gap.

**My preference**: Option A. It surgically fixes the `explode → null → TypeError` chain at the source and leaves everything else alone. Happy to flip to Option B if reviewers feel the normalisation belongs in `run()`.

## Risk

Very low. The change only affects the no-space branch, which today throws. Nothing should have relied on the old TypeError.

## Related

- Plugin-side workaround for current Cake versions: <https://github.com/dereuromark/cakephp-queue-scheduler/pull/27>
- The plugin-side fix mimics what `CommandRunner` does (`setName('cake ' . $command::defaultName())`). With this core PR merged, the plugin's `setName` call becomes redundant on the new Cake version but stays for backwards compat.

Filed as **draft** so we can settle Option A vs B before locking in.

## Alternative check

We could also only allow `cake ` prefix and as such make a stricter check on `str_starts_with('cake_'` etc
If that makes it more likely to be correct?