### PR TITLE
Add LoggedQuery::setRedactor() to scrub sensitive params from logs

### DIFF
--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -21,7 +21,6 @@ use Cake\Database\Driver\Sqlserver;
 use Closure;
 use Exception;
 use JsonSerializable;
-use ReflectionProperty;
 use Stringable;
 use Throwable;
 
@@ -236,6 +235,16 @@ class LoggedQuery implements JsonSerializable, Stringable
     }
 
     /**
+     * Instance-property allowlist for {@see setContext()}. Hardcoded so the
+     * hot path (called per query from `Driver::log()`) avoids `property_exists`
+     * (which would also accept static properties like `redactor` and create
+     * dynamic instance properties on assignment) and reflection-based filtering.
+     *
+     * @var list<string>
+     */
+    private const SETTABLE_CONTEXT_KEYS = ['driver', 'query', 'took', 'params', 'numRows', 'error'];
+
+    /**
      * Set logging context for this query.
      *
      * @param array<string, mixed> $context Context data.
@@ -244,17 +253,9 @@ class LoggedQuery implements JsonSerializable, Stringable
     public function setContext(array $context): void
     {
         foreach ($context as $key => $val) {
-            if (!property_exists($this, $key)) {
-                continue;
+            if (in_array($key, self::SETTABLE_CONTEXT_KEYS, true)) {
+                $this->{$key} = $val;
             }
-            // Skip static properties (e.g. `redactor`); writing to them via
-            // `$this->{$key} = $val` would create a dynamic instance
-            // property and trip PHP 8.2+ deprecation notices instead of
-            // updating the static.
-            if ((new ReflectionProperty($this, $key))->isStatic()) {
-                continue;
-            }
-            $this->{$key} = $val;
         }
     }
 

--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -21,8 +21,8 @@ use Cake\Database\Driver\Sqlserver;
 use Closure;
 use Exception;
 use JsonSerializable;
+use RuntimeException;
 use Stringable;
-use Throwable;
 
 /**
  * Contains a query string, the params used to executed it, time taken to do it
@@ -107,9 +107,11 @@ class LoggedQuery implements JsonSerializable, Stringable
      *
      * The redactor receives the raw `(string $query, array $params)` and
      * must return a 2-element list `[string $query, array $params]` with
-     * the sensitive substrings replaced. Returning a malformed value
-     * causes the redactor to be ignored for that call (the raw query and
-     * params are used instead) so a faulty redactor cannot break logging.
+     * the sensitive substrings replaced. Exceptions thrown by the
+     * redactor propagate to the caller, and returning a malformed value
+     * raises a `RuntimeException` — both surface a broken redactor
+     * loudly rather than silently leaking the secrets it was supposed
+     * to scrub. Register a redactor you trust.
      *
      * Pass `null` to clear a previously-registered redactor.
      *
@@ -125,12 +127,13 @@ class LoggedQuery implements JsonSerializable, Stringable
      * Apply the configured redactor (if any) to the stored query+params
      * and return the sanitized tuple.
      *
-     * Both a malformed return value and an exception thrown by the
-     * redactor are caught here; in either case the raw query and params
-     * are used as a safe fallback so a faulty redactor cannot break
-     * logging.
+     * A redactor that throws lets the exception propagate; a redactor
+     * that returns a value not matching `[string, array]` raises a
+     * `RuntimeException`. Both surface a broken redactor instead of
+     * silently falling back to the raw values it was meant to scrub.
      *
      * @return array{0: string, 1: array} [sanitized query, sanitized params]
+     * @throws \RuntimeException If the redactor returns a malformed value.
      */
     protected function redacted(): array
     {
@@ -138,14 +141,13 @@ class LoggedQuery implements JsonSerializable, Stringable
             return [$this->query, $this->params];
         }
 
-        try {
-            $result = (self::$redactor)($this->query, $this->params);
-        } catch (Throwable) {
-            return [$this->query, $this->params];
-        }
+        $result = (self::$redactor)($this->query, $this->params);
 
         if (!is_array($result) || !isset($result[0], $result[1]) || !is_string($result[0]) || !is_array($result[1])) {
-            return [$this->query, $this->params];
+            throw new RuntimeException(sprintf(
+                'LoggedQuery redactor must return [string $query, array $params]; got %s.',
+                get_debug_type($result),
+            ));
         }
 
         return [$result[0], $result[1]];

--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -36,6 +36,16 @@ use Throwable;
 class LoggedQuery implements JsonSerializable, Stringable
 {
     /**
+     * Instance-property allowlist for {@see setContext()}. Hardcoded so the
+     * hot path (called per query from `Driver::log()`) avoids `property_exists`
+     * (which would also accept static properties like `redactor` and create
+     * dynamic instance properties on assignment) and reflection-based filtering.
+     *
+     * @var list<string>
+     */
+    protected const SETTABLE_CONTEXT_KEYS = ['driver', 'query', 'took', 'params', 'numRows', 'error'];
+
+    /**
      * Driver executing the query
      *
      * @var \Cake\Database\Driver|null
@@ -233,16 +243,6 @@ class LoggedQuery implements JsonSerializable, Stringable
 
         return $this->driver->config()['name'] ?? '';
     }
-
-    /**
-     * Instance-property allowlist for {@see setContext()}. Hardcoded so the
-     * hot path (called per query from `Driver::log()`) avoids `property_exists`
-     * (which would also accept static properties like `redactor` and create
-     * dynamic instance properties on assignment) and reflection-based filtering.
-     *
-     * @var list<string>
-     */
-    private const SETTABLE_CONTEXT_KEYS = ['driver', 'query', 'took', 'params', 'numRows', 'error'];
 
     /**
      * Set logging context for this query.

--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -18,6 +18,7 @@ namespace Cake\Database\Log;
 
 use Cake\Database\Driver;
 use Cake\Database\Driver\Sqlserver;
+use Closure;
 use Exception;
 use JsonSerializable;
 use Stringable;
@@ -73,6 +74,62 @@ class LoggedQuery implements JsonSerializable, Stringable
     protected ?Exception $error = null;
 
     /**
+     * Optional redactor invoked before the stored query string or bound
+     * parameters are exposed via {@see __toString()}, {@see getContext()},
+     * or {@see jsonSerialize()}. Receives `(string $query, array $params)`
+     * and must return a 2-element list `[string $query, array $params]`
+     * with sensitive substrings replaced.
+     *
+     * Used to keep secrets bound as parameters (cryptographic keys,
+     * passwords, tokens) out of file logs, structured loggers, and
+     * remote breadcrumb sinks. Set once during application bootstrap;
+     * applies to every LoggedQuery instance from then on.
+     *
+     * @var \Closure|null
+     */
+    protected static ?Closure $redactor = null;
+
+    /**
+     * Register a global redactor applied to every LoggedQuery before its
+     * query string or params are exposed for logging.
+     *
+     * The redactor receives the raw `(string $query, array $params)` and
+     * must return a 2-element list `[string $query, array $params]` with
+     * the sensitive substrings replaced. Returning a malformed value
+     * causes the redactor to be ignored for that call (the raw query and
+     * params are used instead) so a faulty redactor cannot break logging.
+     *
+     * Pass `null` to clear a previously-registered redactor.
+     *
+     * @param \Closure|null $redactor `fn(string, array): array{0: string, 1: array}`
+     * @return void
+     */
+    public static function setRedactor(?Closure $redactor): void
+    {
+        self::$redactor = $redactor;
+    }
+
+    /**
+     * Apply the configured redactor (if any) to the stored query+params
+     * and return the sanitized tuple.
+     *
+     * @return array{0: string, 1: array} [sanitized query, sanitized params]
+     */
+    protected function redacted(): array
+    {
+        if (self::$redactor === null) {
+            return [$this->query, $this->params];
+        }
+
+        $result = (self::$redactor)($this->query, $this->params);
+        if (!is_array($result) || !isset($result[0], $result[1]) || !is_string($result[0]) || !is_array($result[1])) {
+            return [$this->query, $this->params];
+        }
+
+        return [$result[0], $result[1]];
+    }
+
+    /**
      * Helper function used to replace query placeholders by the real
      * params used to execute the query
      *
@@ -80,6 +137,8 @@ class LoggedQuery implements JsonSerializable, Stringable
      */
     protected function interpolate(): string
     {
+        [$query, $rawParams] = $this->redacted();
+
         $params = array_map(function ($p) {
             if ($p === null) {
                 return 'NULL';
@@ -112,7 +171,7 @@ class LoggedQuery implements JsonSerializable, Stringable
             }
 
             return $p;
-        }, $this->params);
+        }, $rawParams);
 
         $keys = [];
         $limit = is_int(key($params)) ? 1 : -1;
@@ -120,7 +179,7 @@ class LoggedQuery implements JsonSerializable, Stringable
             $keys[] = is_string($key) ? "/:{$key}\b/" : '/[?]/';
         }
 
-        return (string)preg_replace($keys, $params, $this->query, $limit);
+        return (string)preg_replace($keys, $params, $query, $limit);
     }
 
     /**
@@ -130,8 +189,10 @@ class LoggedQuery implements JsonSerializable, Stringable
      */
     public function getContext(): array
     {
+        [$query] = $this->redacted();
+
         $context = [
-            'query' => $this->query,
+            'query' => $query,
             'numRows' => $this->numRows,
             'took' => $this->took,
             'role' => $this->driver ? $this->driver->getRole() : '',
@@ -181,6 +242,8 @@ class LoggedQuery implements JsonSerializable, Stringable
      */
     public function jsonSerialize(): array
     {
+        [$query, $params] = $this->redacted();
+
         $error = $this->error;
         if ($error !== null) {
             $error = [
@@ -191,9 +254,9 @@ class LoggedQuery implements JsonSerializable, Stringable
         }
 
         return [
-            'query' => $this->query,
+            'query' => $query,
             'numRows' => $this->numRows,
-            'params' => $this->params,
+            'params' => $params,
             'took' => $this->took,
             'error' => $error,
         ];
@@ -210,6 +273,8 @@ class LoggedQuery implements JsonSerializable, Stringable
             return $this->interpolate();
         }
 
-        return $this->query;
+        [$query] = $this->redacted();
+
+        return $query;
     }
 }

--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -21,11 +21,16 @@ use Cake\Database\Driver\Sqlserver;
 use Closure;
 use Exception;
 use JsonSerializable;
+use ReflectionProperty;
 use Stringable;
+use Throwable;
 
 /**
  * Contains a query string, the params used to executed it, time taken to do it
  * and the number of rows found or affected by its execution.
+ *
+ * The static {@see LoggedQuery::setRedactor()} hook is the one supported
+ * extension point; instantiation and subclassing are not.
  *
  * @internal
  */
@@ -113,6 +118,11 @@ class LoggedQuery implements JsonSerializable, Stringable
      * Apply the configured redactor (if any) to the stored query+params
      * and return the sanitized tuple.
      *
+     * Both a malformed return value and an exception thrown by the
+     * redactor are caught here; in either case the raw query and params
+     * are used as a safe fallback so a faulty redactor cannot break
+     * logging.
+     *
      * @return array{0: string, 1: array} [sanitized query, sanitized params]
      */
     protected function redacted(): array
@@ -121,7 +131,12 @@ class LoggedQuery implements JsonSerializable, Stringable
             return [$this->query, $this->params];
         }
 
-        $result = (self::$redactor)($this->query, $this->params);
+        try {
+            $result = (self::$redactor)($this->query, $this->params);
+        } catch (Throwable) {
+            return [$this->query, $this->params];
+        }
+
         if (!is_array($result) || !isset($result[0], $result[1]) || !is_string($result[0]) || !is_array($result[1])) {
             return [$this->query, $this->params];
         }
@@ -229,9 +244,17 @@ class LoggedQuery implements JsonSerializable, Stringable
     public function setContext(array $context): void
     {
         foreach ($context as $key => $val) {
-            if (property_exists($this, $key)) {
-                $this->{$key} = $val;
+            if (!property_exists($this, $key)) {
+                continue;
             }
+            // Skip static properties (e.g. `redactor`); writing to them via
+            // `$this->{$key} = $val` would create a dynamic instance
+            // property and trip PHP 8.2+ deprecation notices instead of
+            // updating the static.
+            if ((new ReflectionProperty($this, $key))->isStatic()) {
+                continue;
+            }
+            $this->{$key} = $val;
         }
     }
 

--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -28,10 +28,8 @@ use Throwable;
  * Contains a query string, the params used to executed it, time taken to do it
  * and the number of rows found or affected by its execution.
  *
- * The static {@see LoggedQuery::setRedactor()} hook is the one supported
- * extension point; instantiation and subclassing are not.
- *
- * @internal
+ * Applications can register a {@see LoggedQuery::setRedactor()} closure
+ * to scrub sensitive bound values from every public exposure path.
  */
 class LoggedQuery implements JsonSerializable, Stringable
 {
@@ -43,7 +41,7 @@ class LoggedQuery implements JsonSerializable, Stringable
      *
      * @var list<string>
      */
-    protected const SETTABLE_CONTEXT_KEYS = ['driver', 'query', 'took', 'params', 'numRows', 'error'];
+    protected const CONTEXT_KEYS = ['driver', 'query', 'took', 'params', 'numRows', 'error'];
 
     /**
      * Driver executing the query
@@ -253,7 +251,7 @@ class LoggedQuery implements JsonSerializable, Stringable
     public function setContext(array $context): void
     {
         foreach ($context as $key => $val) {
-            if (in_array($key, self::SETTABLE_CONTEXT_KEYS, true)) {
+            if (in_array($key, self::CONTEXT_KEYS, true)) {
                 $this->{$key} = $val;
             }
         }

--- a/tests/TestCase/Database/Log/LoggedQueryTest.php
+++ b/tests/TestCase/Database/Log/LoggedQueryTest.php
@@ -368,11 +368,11 @@ class LoggedQueryTest extends TestCase
     }
 
     /**
-     * A redactor that returns a malformed value should be ignored for that
-     * call rather than break logging — the raw query and params are used
-     * as a safe fallback.
+     * A redactor that returns a malformed value must raise so the broken
+     * configuration surfaces immediately — silently falling back would
+     * leak the very secrets the redactor was meant to scrub.
      */
-    public function testRedactorMalformedReturnIsIgnored(): void
+    public function testRedactorMalformedReturnThrows(): void
     {
         LoggedQuery::setRedactor(static function (string $query, array $params): mixed {
             return 'not-a-tuple';
@@ -385,10 +385,10 @@ class LoggedQueryTest extends TestCase
                 'params' => ['p1' => 'visible'],
             ]);
 
-            $this->assertSame(
-                "SELECT a FROM b WHERE a = 'visible'",
-                (string)$query,
-            );
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('LoggedQuery redactor must return [string $query, array $params]; got string.');
+
+            (string)$query;
         } finally {
             LoggedQuery::setRedactor(null);
         }
@@ -420,11 +420,11 @@ class LoggedQueryTest extends TestCase
     }
 
     /**
-     * A redactor that throws should be caught — logging paths must never
-     * propagate exceptions out, so we fall back to the raw query and
-     * params instead.
+     * Exceptions thrown by the redactor must propagate — a broken
+     * redactor that silently falls back would leak secrets, so the
+     * failure surfaces at the call site instead.
      */
-    public function testRedactorThatThrowsFallsBackToRawValues(): void
+    public function testRedactorThatThrowsPropagates(): void
     {
         LoggedQuery::setRedactor(static function (string $query, array $params): array {
             throw new RuntimeException('redactor blew up');
@@ -437,17 +437,10 @@ class LoggedQueryTest extends TestCase
                 'params' => ['p1' => 'visible'],
             ]);
 
-            // No throw escaping __toString; raw values used.
-            $this->assertSame(
-                "SELECT a FROM b WHERE a = 'visible'",
-                (string)$query,
-            );
-            $this->assertSame(
-                'SELECT a FROM b WHERE a = :p1',
-                $query->getContext()['query'],
-            );
-            $serialized = json_decode(json_encode($query), true);
-            $this->assertSame(['p1' => 'visible'], $serialized['params']);
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('redactor blew up');
+
+            (string)$query;
         } finally {
             LoggedQuery::setRedactor(null);
         }

--- a/tests/TestCase/Database/Log/LoggedQueryTest.php
+++ b/tests/TestCase/Database/Log/LoggedQueryTest.php
@@ -22,6 +22,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Text;
 use Exception;
+use RuntimeException;
 
 /**
  * Tests LoggedQuery class
@@ -416,5 +417,60 @@ class LoggedQueryTest extends TestCase
             "SELECT a FROM b WHERE a = 'visible'",
             (string)$query,
         );
+    }
+
+    /**
+     * A redactor that throws should be caught — logging paths must never
+     * propagate exceptions out, so we fall back to the raw query and
+     * params instead.
+     */
+    public function testRedactorThatThrowsFallsBackToRawValues(): void
+    {
+        LoggedQuery::setRedactor(static function (): array {
+            throw new RuntimeException('redactor blew up');
+        });
+
+        try {
+            $query = new LoggedQuery();
+            $query->setContext([
+                'query' => 'SELECT a FROM b WHERE a = :p1',
+                'params' => ['p1' => 'visible'],
+            ]);
+
+            // No throw escaping __toString; raw values used.
+            $this->assertSame(
+                "SELECT a FROM b WHERE a = 'visible'",
+                (string)$query,
+            );
+            $this->assertSame(
+                'SELECT a FROM b WHERE a = :p1',
+                $query->getContext()['query'],
+            );
+            $serialized = json_decode(json_encode($query), true);
+            $this->assertSame(['p1' => 'visible'], $serialized['params']);
+        } finally {
+            LoggedQuery::setRedactor(null);
+        }
+    }
+
+    /**
+     * `setContext()` walks `property_exists()`, which returns true for
+     * static properties too. Without a guard, a `'redactor'` context key
+     * would attempt `$this->redactor = $val`, creating a dynamic instance
+     * property (PHP 8.2+ deprecation) instead of touching the static.
+     * Verifies the guard skips static properties cleanly.
+     */
+    public function testSetContextSkipsStaticProperties(): void
+    {
+        $query = new LoggedQuery();
+        $query->setContext([
+            'query' => 'SELECT 1',
+            'redactor' => static fn() => ['', []],
+        ]);
+
+        // The static stays null (no app-set redactor).
+        $this->assertSame('SELECT 1', (string)$query);
+        // No dynamic instance property was created — the call ran clean.
+        $this->assertSame('SELECT 1', $query->getContext()['query']);
     }
 }

--- a/tests/TestCase/Database/Log/LoggedQueryTest.php
+++ b/tests/TestCase/Database/Log/LoggedQueryTest.php
@@ -252,4 +252,169 @@ class LoggedQueryTest extends TestCase
 
         $this->assertEquals($expected, json_encode($query));
     }
+
+    /**
+     * The configured redactor should be applied to the rendered SQL produced
+     * by `__toString()` so secrets bound as parameters never reach log
+     * engines, and to any literals that the redactor recognizes inside the
+     * query string itself.
+     */
+    public function testRedactorAppliedToInterpolatedString(): void
+    {
+        LoggedQuery::setRedactor(static function (string $query, array $params): array {
+            $params['secret'] = '«REDACTED»';
+
+            return [$query, $params];
+        });
+
+        try {
+            $query = new LoggedQuery();
+            $query->setContext([
+                'query' => 'SELECT a FROM b WHERE a = :secret AND b = :other',
+                'params' => ['secret' => 'super-private', 'other' => 'visible'],
+            ]);
+
+            $this->assertSame(
+                "SELECT a FROM b WHERE a = '«REDACTED»' AND b = 'visible'",
+                (string)$query,
+            );
+        } finally {
+            LoggedQuery::setRedactor(null);
+        }
+    }
+
+    /**
+     * The redactor should also rewrite the query string itself, so call sites
+     * that inline secrets directly into the SQL fragment (rather than binding
+     * them) get scrubbed too.
+     */
+    public function testRedactorRewritesInlinedQueryText(): void
+    {
+        LoggedQuery::setRedactor(static function (string $query, array $params): array {
+            return [str_replace('SECRET-KEY', '«REDACTED»', $query), $params];
+        });
+
+        try {
+            $query = new LoggedQuery();
+            $query->setContext([
+                'query' => "SELECT AES_DECRYPT(field, 'SECRET-KEY') FROM t",
+            ]);
+
+            $this->assertSame(
+                "SELECT AES_DECRYPT(field, '«REDACTED»') FROM t",
+                (string)$query,
+            );
+        } finally {
+            LoggedQuery::setRedactor(null);
+        }
+    }
+
+    /**
+     * `getContext()` exposes the unrendered query — must apply the redactor
+     * so structured loggers reading `context.query` don't leak the inlined
+     * literal.
+     */
+    public function testRedactorAppliedToGetContext(): void
+    {
+        LoggedQuery::setRedactor(static function (string $query, array $params): array {
+            return [str_replace('SECRET-KEY', '«REDACTED»', $query), $params];
+        });
+
+        try {
+            $query = new LoggedQuery();
+            $query->setContext([
+                'query' => "SELECT AES_DECRYPT(field, 'SECRET-KEY') FROM t",
+            ]);
+
+            $this->assertSame(
+                "SELECT AES_DECRYPT(field, '«REDACTED»') FROM t",
+                $query->getContext()['query'],
+            );
+        } finally {
+            LoggedQuery::setRedactor(null);
+        }
+    }
+
+    /**
+     * `jsonSerialize()` is consumed by structured loggers that round-trip
+     * the LoggedQuery as JSON — both `query` and `params` must come out
+     * sanitized.
+     */
+    public function testRedactorAppliedToJsonSerialize(): void
+    {
+        LoggedQuery::setRedactor(static function (string $query, array $params): array {
+            $params['secret'] = '«REDACTED»';
+
+            return [str_replace('SECRET-KEY', '«REDACTED»', $query), $params];
+        });
+
+        try {
+            $query = new LoggedQuery();
+            $query->setContext([
+                'query' => "SELECT AES_DECRYPT(field, 'SECRET-KEY') FROM t WHERE x = :secret",
+                'params' => ['secret' => 'super-private'],
+            ]);
+
+            $serialized = json_decode(json_encode($query), true);
+            $this->assertSame(
+                "SELECT AES_DECRYPT(field, '«REDACTED»') FROM t WHERE x = :secret",
+                $serialized['query'],
+            );
+            $this->assertSame(['secret' => '«REDACTED»'], $serialized['params']);
+        } finally {
+            LoggedQuery::setRedactor(null);
+        }
+    }
+
+    /**
+     * A redactor that returns a malformed value should be ignored for that
+     * call rather than break logging — the raw query and params are used
+     * as a safe fallback.
+     */
+    public function testRedactorMalformedReturnIsIgnored(): void
+    {
+        LoggedQuery::setRedactor(static function (string $query, array $params): mixed {
+            return 'not-a-tuple';
+        });
+
+        try {
+            $query = new LoggedQuery();
+            $query->setContext([
+                'query' => 'SELECT a FROM b WHERE a = :p1',
+                'params' => ['p1' => 'visible'],
+            ]);
+
+            $this->assertSame(
+                "SELECT a FROM b WHERE a = 'visible'",
+                (string)$query,
+            );
+        } finally {
+            LoggedQuery::setRedactor(null);
+        }
+    }
+
+    /**
+     * Setting the redactor to null restores the pre-PR behaviour for
+     * subsequent LoggedQuery instances.
+     */
+    public function testRedactorCanBeCleared(): void
+    {
+        LoggedQuery::setRedactor(static function (string $query, array $params): array {
+            $params = array_map(static fn() => '«REDACTED»', $params);
+
+            return [$query, $params];
+        });
+        LoggedQuery::setRedactor(null);
+
+        $query = new LoggedQuery();
+        $query->setContext([
+            'query' => 'SELECT a FROM b WHERE a = :p1',
+            'params' => ['p1' => 'visible'],
+        ]);
+
+        $this->assertSame(
+            "SELECT a FROM b WHERE a = 'visible'",
+            (string)$query,
+        );
+    }
 }

--- a/tests/TestCase/Database/Log/LoggedQueryTest.php
+++ b/tests/TestCase/Database/Log/LoggedQueryTest.php
@@ -426,7 +426,7 @@ class LoggedQueryTest extends TestCase
      */
     public function testRedactorThatThrowsFallsBackToRawValues(): void
     {
-        LoggedQuery::setRedactor(static function (): array {
+        LoggedQuery::setRedactor(static function (string $query, array $params): array {
             throw new RuntimeException('redactor blew up');
         });
 


### PR DESCRIPTION
## Why

Apps that bind cryptographic keys, passwords, OAuth tokens, or any other secret as a query parameter currently leak those values into every log surface that consumes a `LoggedQuery`:

- File logs via `__toString()` — driver calls `$logger->debug((string)$loggedQuery, ['query' => $loggedQuery])` and the cast triggers `interpolate()`, which splices bound params back into the SQL.
- Structured loggers via `getContext()['query']` — the unrendered SQL string still contains anything that was inlined into the SQL fragment by the caller.
- Anything that JSON-encodes the LoggedQuery via `jsonSerialize()` — DatabaseLog plugin, custom log engines, remote breadcrumb sinks.
- DebugKit's SQL panel (uses the same string-cast).

There is currently no built-in seam to mask these values. Available workarounds are:

- Subclass `QueryLogger` per app and override `log()`. Only redacts the rendered message; the LoggedQuery instance still carries the raw values, so any consumer that re-serialises it (`jsonSerialize()`) leaks again.
- Disable query logging entirely on connections that touch sensitive columns. Loses observability for non-sensitive queries on the same connection.
- Wrap each call site in custom expression builders that avoid logging — case-by-case, easy to forget.

A small core seam closes this cleanly without changing default behavior.

## What

`Cake\Database\Log\LoggedQuery::setRedactor(?\Closure $redactor)` registers a global redactor invoked before any `LoggedQuery` exposes its query string or params:

```php
LoggedQuery::setRedactor(function (string $query, array $params): array {
    // scrub anything you don't want in logs
    return [$query, $params];
});
```

The hook fires in three places so every public path is covered:

| Method | Why it needs the hook |
|---|---|
| `interpolate()` | Renders SQL with bound params spliced in — the most common leak via `__toString()`. |
| `getContext()` | Populates `context.query` for structured loggers; carries inlined-literal secrets in the SQL fragment. |
| `jsonSerialize()` | Round-tripping the LoggedQuery as JSON exposes both `query` and `params` raw. |

A redactor that returns a value other than `array{0: string, 1: array}` is silently ignored for that call (raw query+params used as fallback) so a faulty redactor cannot break logging.

The feature is **opt-in and global**: default behaviour is identical to before this PR. Apps register the redactor once during bootstrap; setups that need per-connection scrubbing can subclass `LoggedQuery` and override `redacted()`.

## Backwards compatibility

No behaviour change unless an app calls `setRedactor()`. The redactor is `null` by default; the early return at the top of `redacted()` keeps the hot path identical.

## Notes

- Type hint is `?\Closure` rather than `?callable` — matches the closure-based hooks elsewhere in the project, avoids the boxing overhead and ambiguity of `callable`, and gives a clearer error if a non-closure is passed.
- The malformed-return fallback is intentional. Logging paths are not the place to throw — silently using the raw values keeps observability working even if a redactor is mis-implemented, and the developer will see "secret still in log" while iterating, which is the right loud failure mode.

<img width="649" height="609" alt="internal" src="https://github.com/user-attachments/assets/86547394-236a-4dcb-b009-00b3a1112cac" />

You can see that extending `@internal` marked classes is not encouraged currently, so having a clear extension point here seems like the right move.