### PR TITLE
ConsoleOutput::_write: skip when stream is no longer a resource

### DIFF
--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -293,12 +293,7 @@ class ConsoleOutput
     protected function _write(string $message): int
     {
         // @phpstan-ignore isset.property (property may not be set if constructor throws)
-        if (!isset($this->_output) || !is_resource($this->_output)) {
-            // The stream resource was never opened (constructor threw an error) or has
-            // been closed since — e.g. by a long-running queue worker whose
-            // job-scoped ConsoleIo went out of scope while the globally
-            // registered ConsoleLog engine still references it. Bail silently
-            // so logging paths can't bring the parent process down.
+        if (!is_resource($this->_output)) {
             return 0;
         }
 

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -294,7 +294,7 @@ class ConsoleOutput
     {
         // @phpstan-ignore isset.property (property may not be set if constructor throws)
         if (!isset($this->_output) || !is_resource($this->_output)) {
-            // The stream resource was never opened (constructor threw) or has
+            // The stream resource was never opened (constructor threw an error) or has
             // been closed since — e.g. by a long-running queue worker whose
             // job-scoped ConsoleIo went out of scope while the globally
             // registered ConsoleLog engine still references it. Bail silently

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -293,7 +293,12 @@ class ConsoleOutput
     protected function _write(string $message): int
     {
         // @phpstan-ignore isset.property (property may not be set if constructor throws)
-        if (!isset($this->_output)) {
+        if (!isset($this->_output) || !is_resource($this->_output)) {
+            // The stream resource was never opened (constructor threw) or has
+            // been closed since — e.g. by a long-running queue worker whose
+            // job-scoped ConsoleIo went out of scope while the globally
+            // registered ConsoleLog engine still references it. Bail silently
+            // so logging paths can't bring the parent process down.
             return 0;
         }
 

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -292,7 +292,6 @@ class ConsoleOutput
      */
     protected function _write(string $message): int
     {
-        // @phpstan-ignore isset.property (property may not be set if constructor throws)
         if (!is_resource($this->_output)) {
             return 0;
         }

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -266,4 +266,34 @@ class ConsoleOutputTest extends TestCase
         $expected = "Test line 1.\nTest line 2.";
         $this->assertSame($expected, $result);
     }
+
+    /**
+     * Writing to a closed underlying stream resource must not raise a
+     * TypeError. Long-running queue workers can hold a globally registered
+     * `ConsoleLog` engine whose ConsoleOutput's stream goes out of scope
+     * mid-run; the next write through that engine would otherwise crash
+     * the parent process.
+     */
+    public function testWriteToClosedResourceIsNoOp(): void
+    {
+        $tmpfile = tempnam(sys_get_temp_dir(), 'cakephp_console_output_test_');
+        $this->assertIsString($tmpfile);
+        $stream = fopen($tmpfile, 'w');
+        $this->assertIsResource($stream);
+
+        try {
+            $output = new ConsoleOutput($stream);
+
+            // Sanity: writing to the open stream returns bytes written.
+            $this->assertGreaterThan(0, $output->write('open', 0));
+
+            fclose($stream);
+
+            // After the underlying resource is closed, write() must return 0
+            // rather than throwing a fwrite() TypeError.
+            $this->assertSame(0, $output->write('after-close', 0));
+        } finally {
+            @unlink($tmpfile);
+        }
+    }
 }


### PR DESCRIPTION
## Why

`ConsoleOutput::_write()` already guards against the property being unset (constructor threw before `$this->_output` was assigned), but it does not guard against the case where the property *was* set and the underlying stream resource has since been **closed**. `fwrite()` on a closed resource raises a `TypeError` on PHP 8+, which is fatal in logging paths.

Reproduce:

```php
$tmpfile = tempnam(sys_get_temp_dir(), 'co_');
$stream = fopen($tmpfile, 'w');
$output = new ConsoleOutput($stream);
$output->write('open');         // OK
fclose($stream);
$output->write('after-close');  // TypeError: fwrite(): supplied resource is not a valid stream resource
```

This is reachable in **long-running CLI processes**. A queue worker boots with `ConsoleIo::setLoggers()`, which registers globally-named `ConsoleLog` engines (`stdout`, `stderr`) bound to the worker's `ConsoleOutput`. When per-job `ConsoleIo` instances are created and torn down, the underlying stream resources can go out of scope while the global `Log` registration still references them. The next `Log::write()` call from any code running under the worker — even a diagnostic `info`-level line from a queue task — crashes the parent process.

Sample stack from the wild (a per-account queue task whose only sin was logging a one-line summary):

```text
TypeError: fwrite(): supplied resource is not a valid stream resource
#0 ConsoleOutput.php(300): fwrite()
#1 ConsoleOutput.php(224): _write()
#2 ConsoleLog.php(97): ConsoleOutput->write()
#3 Log.php(381): ConsoleLog->log()
#4 LogTrait.php(41): Log::write()
#5 <queue task>::run()
#6 Queue\Processor::runJob()
#7 Queue\Processor::run()
#8 Queue\Command\RunCommand::execute()
…
```

## What

Add an `is_resource()` check alongside the existing `isset()` guard in `ConsoleOutput::_write()`. If the stream is gone, the write degrades to a no-op (returns `0`) rather than throwing.

```diff
-        if (!isset($this->_output)) {
+        if (!isset($this->_output) || !is_resource($this->_output)) {
             return 0;
         }
         return (int)fwrite($this->_output, $message);
```

Defensive philosophy: logging paths must never propagate exceptions out. The caller already gets `0` for the "stream not yet initialised" case; treating "stream closed" the same way is consistent and silent-failure on log writes is the right behaviour for production.

## Tests

One new test case in `ConsoleOutputTest`:

* `testWriteToClosedResourceIsNoOp` — open a stream, construct ConsoleOutput, write once (sanity, returns bytes), `fclose()` the stream, write again — must return `0` without throwing.

All existing `ConsoleOutputTest` cases still pass (18 / 40).

## Backwards compatibility

Strictly safer. The previous behaviour for closed-stream writes was an unhandled `TypeError`; the new behaviour is `return 0`. Callers that relied on the TypeError as a signal would already have been crashing in production.
