### PR TITLE
improve event listener registration

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -23,7 +23,6 @@ use Cake\Console\Exception\StopException;
 use Cake\Core\ConsoleApplicationInterface;
 use Cake\Core\ConsoleHelpHeaderProviderInterface;
 use Cake\Core\ContainerApplicationInterface;
-use Cake\Core\EventAwareApplicationInterface;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
@@ -138,13 +137,6 @@ class CommandRunner implements EventDispatcherInterface
         assert($argv !== [], 'Cannot run any commands. No arguments received.');
 
         $this->bootstrap();
-
-        if ($this->app instanceof EventAwareApplicationInterface) {
-            $eventManager = $this->getEventManager();
-            $eventManager = $this->app->events($eventManager);
-            $eventManager = $this->app->pluginEvents($eventManager);
-            $this->setEventManager($eventManager);
-        }
 
         $commands = new CommandCollection([
             'help' => HelpCommand::class,

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -190,6 +190,9 @@ abstract class BaseApplication implements
         if (is_array($plugins)) {
             $this->plugins->addFromConfig($plugins);
         }
+
+        $eventManager = $this->events($this->getEventManager());
+        $this->setEventManager($this->pluginEvents($eventManager));
     }
 
     /**
@@ -350,9 +353,6 @@ abstract class BaseApplication implements
         $container = $this->getContainer();
         $container->add(ServerRequest::class, $request);
         $container->add(ContainerInterface::class, $container);
-
-        $eventManager = $this->events($this->getEventManager());
-        $this->setEventManager($this->pluginEvents($eventManager));
 
         $this->controllerFactory ??= new ControllerFactory($container);
 

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Console;
 
+use Cake\Command\Command;
 use Cake\Command\VersionCommand;
 use Cake\Console\Arguments;
 use Cake\Console\CommandCollection;
@@ -24,8 +25,10 @@ use Cake\Console\CommandInterface;
 use Cake\Console\CommandRunner;
 use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\StubConsoleOutput;
+use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
 use Cake\Core\ConsoleHelpHeaderProviderInterface;
+use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerInterface;
 use Cake\Http\BaseApplication;
@@ -566,6 +569,50 @@ class CommandRunnerTest extends TestCase
 
         $this->assertTrue($app->customEventFired, 'Custom event should have been fired');
         $this->assertTrue($app->pluginEventFired, 'Plugin event should have been fired');
+    }
+
+    public function testRunRegistersPluginEventsForCommands(): void
+    {
+        $output = new StubConsoleOutput();
+        $plugin = new class extends BasePlugin {
+            public bool $commandEventFired = false;
+
+            public function events(EventManagerInterface $eventManager): EventManagerInterface
+            {
+                $eventManager->on('Test.commandEvent', function (): void {
+                    $this->commandEventFired = true;
+                });
+
+                return $eventManager;
+            }
+        };
+        $command = new class extends Command {
+            public function execute(Arguments $args, ConsoleIo $io): int
+            {
+                $this->getEventManager()->dispatch(new Event('Test.commandEvent'));
+
+                return CommandInterface::CODE_SUCCESS;
+            }
+        };
+        $app = new class ($this->config, $command) extends Application {
+            public function __construct(
+                string $configDir,
+                protected Command $command,
+            ) {
+                parent::__construct($configDir);
+            }
+
+            public function console(CommandCollection $commands): CommandCollection
+            {
+                return $commands->add('test_command', $this->command);
+            }
+        };
+        $app->addPlugin($plugin);
+
+        $runner = new CommandRunner($app);
+        $runner->run(['cake', 'test_command'], $this->getMockIo($output));
+
+        $this->assertTrue($plugin->commandEventFired, 'Plugin event should have been fired by the command');
     }
 
     protected function makeAppWithCommands(array $commands): BaseApplication

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -24,9 +24,13 @@ use Cake\Core\Configure;
 use Cake\Core\Container;
 use Cake\Core\Plugin;
 use Cake\Core\PluginApplicationInterface;
+use Cake\Event\EventInterface;
 use Cake\Event\EventManagerInterface;
 use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
+use Cake\Http\Response;
+use Cake\Http\Server;
+use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
@@ -34,6 +38,8 @@ use Cake\TestSuite\TestCase;
 use Company\TestPluginThree\TestPluginThreePlugin;
 use Mockery;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use TestPlugin\TestPluginPlugin as TestPlugin;
 
 /**
@@ -202,6 +208,39 @@ class BasePluginTest extends TestCase
         $this->assertSame($expected . 'templates' . DS, $plugin->getTemplatePath());
     }
 
+    public function testServerBuildMiddlewareEventIsCalledOnBootstrap(): void
+    {
+        $basePlugin = new class extends BasePlugin
+        {
+            public bool $isCalled = false;
+
+            public function events(EventManagerInterface $eventManager): EventManagerInterface
+            {
+                return $eventManager->on('Server.buildMiddleware', function (EventInterface $event): void {
+                    $this->isCalled = true;
+                });
+            }
+        };
+
+        $app = new class (dirname(__DIR__, 2) . '/test_app/config') extends BaseApplication
+        {
+            public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+            {
+                return $middlewareQueue;
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new Response(['status' => 200]);
+            }
+        };
+        $app->addPlugin($basePlugin);
+
+        $server = new Server($app);
+        $server->run(new ServerRequest());
+        $this->assertTrue($basePlugin->isCalled);
+    }
+
     public function testEventsAreRegistered(): void
     {
         static::setAppNamespace();
@@ -233,6 +272,7 @@ class BasePluginTest extends TestCase
             }
         };
         $app = $app->addPlugin($basePlugin);
+        $app->bootstrap();
         $app->handle($request);
         $this->assertNotEmpty($app->getEventManager()->listeners('testTrue'));
     }

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -24,6 +24,7 @@ use Cake\Core\Configure;
 use Cake\Core\Container;
 use Cake\Core\Plugin;
 use Cake\Core\PluginApplicationInterface;
+use Cake\Event\Event;
 use Cake\Event\EventInterface;
 use Cake\Event\EventManagerInterface;
 use Cake\Http\BaseApplication;
@@ -40,6 +41,7 @@ use Mockery;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use TestPlugin\TestPluginPlugin as TestPlugin;
 
 /**
@@ -238,6 +240,47 @@ class BasePluginTest extends TestCase
 
         $server = new Server($app);
         $server->run(new ServerRequest());
+        $this->assertTrue($basePlugin->isCalled);
+    }
+
+    public function testMiddlewareEventIsCaughtByPluginEventsListener(): void
+    {
+        $basePlugin = new class extends BasePlugin
+        {
+            public bool $isCalled = false;
+
+            public function events(EventManagerInterface $eventManager): EventManagerInterface
+            {
+                return $eventManager->on('Test.middlewareEvent', function (EventInterface $event): void {
+                    $this->isCalled = true;
+                });
+            }
+        };
+
+        $app = new class (dirname(__DIR__, 2) . '/test_app/config') extends BaseApplication
+        {
+            public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+            {
+                return $middlewareQueue->add(function (
+                    ServerRequestInterface $request,
+                    RequestHandlerInterface $handler,
+                ): ResponseInterface {
+                    $this->getEventManager()->dispatch(new Event('Test.middlewareEvent'));
+
+                    return $handler->handle($request);
+                });
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new Response(['status' => 200]);
+            }
+        };
+        $app->addPlugin($basePlugin);
+
+        $server = new Server($app);
+        $server->run(new ServerRequest());
+
         $this->assertTrue($basePlugin->isCalled);
     }
 

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -27,6 +27,8 @@ use Cake\Event\EventInterface;
 use Cake\Event\EventManagerInterface;
 use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
+use Cake\Http\Response;
+use Cake\Http\Server;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\Routing\RouteBuilder;
@@ -34,6 +36,7 @@ use Cake\Routing\RouteCollection;
 use Cake\TestSuite\TestCase;
 use Mockery;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use TestPlugin\TestPluginPlugin as TestPlugin;
 
 /**
@@ -294,6 +297,35 @@ class BaseApplicationTest extends TestCase
         $this->assertTrue($container->has('testing'));
     }
 
+    public function testServerBuildMiddlewareEventIsCalledOnBootstrap(): void
+    {
+        $app = new class (dirname(__DIR__, 2) . '/test_app/config') extends BaseApplication {
+            public bool $isCalled = false;
+
+            public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+            {
+                return $middlewareQueue;
+            }
+
+            public function events(EventManagerInterface $eventManager): EventManagerInterface
+            {
+                return $eventManager->on('Server.buildMiddleware', function (EventInterface $event): void {
+                    $this->isCalled = true;
+                });
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new Response(['status' => 200]);
+            }
+        };
+        $server = new Server($app);
+        $server->run(new ServerRequest());
+
+        $app->bootstrap();
+        $this->assertTrue($app->isCalled);
+    }
+
     public function testEventsAreRegistered(): void
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/cakes']);
@@ -305,6 +337,7 @@ class BaseApplicationTest extends TestCase
         ]);
 
         $app = $this->app;
+        $app->bootstrap();
         $app->handle($request);
         $this->assertNotEmpty($app->getEventManager()->listeners('testTrue'));
     }

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -23,6 +23,7 @@ use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
 use Cake\Core\Container;
 use Cake\Core\ContainerInterface;
+use Cake\Event\Event;
 use Cake\Event\EventInterface;
 use Cake\Event\EventManagerInterface;
 use Cake\Http\BaseApplication;
@@ -37,6 +38,7 @@ use Cake\TestSuite\TestCase;
 use Mockery;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use TestPlugin\TestPluginPlugin as TestPlugin;
 
 /**
@@ -323,6 +325,41 @@ class BaseApplicationTest extends TestCase
         $server->run(new ServerRequest());
 
         $app->bootstrap();
+        $this->assertTrue($app->isCalled);
+    }
+
+    public function testMiddlewareEventIsCaughtByApplicationEventsListener(): void
+    {
+        $app = new class (dirname(__DIR__, 2) . '/test_app/config') extends BaseApplication {
+            public bool $isCalled = false;
+
+            public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+            {
+                return $middlewareQueue->add(function (
+                    ServerRequestInterface $request,
+                    RequestHandlerInterface $handler,
+                ): ResponseInterface {
+                    $this->getEventManager()->dispatch(new Event('Test.middlewareEvent'));
+
+                    return $handler->handle($request);
+                });
+            }
+
+            public function events(EventManagerInterface $eventManager): EventManagerInterface
+            {
+                return $eventManager->on('Test.middlewareEvent', function (EventInterface $event): void {
+                    $this->isCalled = true;
+                });
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new Response(['status' => 200]);
+            }
+        };
+        $server = new Server($app);
+        $server->run(new ServerRequest());
+
         $this->assertTrue($app->isCalled);
     }
 


### PR DESCRIPTION
Resolves #19421 

This moves the event listener registration from the `handle()` method to the end of the `bootstrap()` method and therefore works in both the CLI and web context. 

With this its as early as possible but still gets called inside our Testsuite as IntegrationTestTrait calls [`->bootstrap()`](https://github.com/cakephp/cakephp/blob/5.x/src/TestSuite/IntegrationTestTrait.php#L561)