### PR TITLE
Improve help command usage.

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -177,7 +177,7 @@ class CommandRunner implements EventDispatcherInterface
         // Check if this is a command prefix (e.g., "cache" has subcommands like "cache clear")
         // Show help for that prefix instead of running the base command
         if ($name !== null && !$commands->has($name) && $this->hasCommandsWithPrefix($commands, $name)) {
-            $argv = array_merge([$name], $argv);
+            $argv = [$name];
             $name = 'help';
         }
 

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -16,8 +16,11 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Console;
 
+use Cake\Command\SchemacacheBuildCommand;
+use Cake\Command\SchemacacheClearCommand;
 use Cake\Command\VersionCommand;
 use Cake\Console\Arguments;
+use Cake\Console\Command\HelpCommand;
 use Cake\Console\CommandCollection;
 use Cake\Console\CommandFactoryInterface;
 use Cake\Console\CommandInterface;
@@ -141,6 +144,28 @@ class CommandRunnerTest extends TestCase
         $this->assertStringContainsString('<info>cache:</info>', $messages);
         $this->assertStringContainsString('cache clear', $messages);
         $this->assertStringContainsString('cache list', $messages);
+    }
+
+    /**
+     * Test that running an invalid subcommand shows help listing commands
+     * that start with the given prefix.
+     */
+    public function testRunInvalidSubcommandShowsPrefixHelp(): void
+    {
+        $output = new StubConsoleOutput();
+        $app = $this->makeAppWithCommands([
+            'help' => HelpCommand::class,
+            'schema_cache build' => SchemacacheBuildCommand::class,
+            'schema_cache clear' => SchemacacheClearCommand::class,
+        ]);
+        $runner = new CommandRunner($app);
+        $result = $runner->run(['cake', 'schema_cache', 'invalid'], $this->getMockIo($output));
+
+        $this->assertSame(0, $result);
+        $messages = implode("\n", $output->messages());
+        $this->assertStringContainsString('<info>schema_cache:</info>', $messages);
+        $this->assertStringContainsString('schema_cache build', $messages);
+        $this->assertStringContainsString('schema_cache clear', $messages);
     }
 
     /**


### PR DESCRIPTION
When the command runner auto switches to using the HelpCommand for an invalid command name, it's called with only 1 argument so that it can show some help text instead of generating a "too many arguments" exception. For e.g. when using `bin/cake schema_cache invalid`

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
