### PR TITLE
CLI: reject unknown tokens after a parent command with subcommands

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -174,6 +174,24 @@ class CommandRunner implements EventDispatcherInterface
             $name = 'help';
         }
 
+        // If the matched command also has sibling subcommands (e.g. `i18n` exists alongside
+        // `i18n init` / `i18n extract`), an unknown next token is almost always a typo for a
+        // subcommand. Reject it instead of letting it fall through as a positional argument.
+        if (
+            $name !== null
+            && $commands->has($name)
+            && isset($argv[0])
+            && !str_starts_with($argv[0], '-')
+            && $this->hasCommandsWithPrefix($commands, $name)
+        ) {
+            $candidate = $name . ' ' . $argv[0];
+            if (!$commands->has($candidate)) {
+                $io->error($this->unknownSubcommandMessage($commands, $name, $argv[0]));
+
+                return CommandInterface::CODE_ERROR;
+            }
+        }
+
         try {
             $name = $this->resolveName($commands, $io, $name);
         } catch (MissingOptionException $e) {
@@ -351,6 +369,38 @@ class CommandRunner implements EventDispatcherInterface
         }
 
         return false;
+    }
+
+    /**
+     * Build the error message shown when a token following a command name doesn't
+     * match any known subcommand of that command.
+     *
+     * @param \Cake\Console\CommandCollection $commands The command collection.
+     * @param string $name The matched command name (e.g. "i18n").
+     * @param string $token The unknown next token (e.g. "nonsense").
+     * @return string
+     */
+    protected function unknownSubcommandMessage(
+        CommandCollection $commands,
+        string $name,
+        string $token,
+    ): string {
+        $prefix = $name . ' ';
+        $available = [];
+        foreach ($commands->keys() as $key) {
+            if (str_starts_with($key, $prefix)) {
+                $available[] = $key;
+            }
+        }
+        sort($available);
+
+        $message = "Unknown command `{$this->root} {$name} {$token}`.";
+        if ($available !== []) {
+            $message .= "\nAvailable subcommands: `" . implode('`, `', $available) . '`.';
+        }
+        $message .= "\nRun `{$this->root} {$name} --help` to see usage.";
+
+        return $message;
     }
 
     /**

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -173,6 +173,44 @@ class CommandRunnerTest extends TestCase
     }
 
     /**
+     * Test that an unknown token following a command which also has sibling
+     * subcommands is rejected, instead of being silently passed to the base
+     * command as a positional argument.
+     *
+     * For example, given `i18n`, `i18n init` and `i18n extract` are all registered:
+     *   `bin/cake i18n nonsense`
+     * should error rather than silently invoking I18nCommand.
+     */
+    public function testRunUnknownSubcommandErrorsWhenSiblingsExist(): void
+    {
+        $output = new StubConsoleOutput();
+        $runner = $this->getRunner();
+        $result = $runner->run(['cake', 'i18n', 'nonsense'], $this->getMockIo($output));
+
+        $this->assertSame(CommandInterface::CODE_ERROR, $result);
+        $messages = implode("\n", $output->messages());
+        $this->assertStringContainsString('Unknown command `cake i18n nonsense`.', $messages);
+        $this->assertStringContainsString('Available subcommands:', $messages);
+        $this->assertStringContainsString('i18n extract', $messages);
+        $this->assertStringContainsString('i18n init', $messages);
+    }
+
+    /**
+     * Test that an option-like token after a parent command does not trigger
+     * the unknown-subcommand check.
+     */
+    public function testRunOptionAfterParentCommandIsNotASubcommand(): void
+    {
+        $output = new StubConsoleOutput();
+        $runner = $this->getRunner();
+        $result = $runner->run(['cake', 'i18n', '--help'], $this->getMockIo($output));
+
+        $this->assertSame(0, $result);
+        $messages = implode("\n", $output->messages());
+        $this->assertStringNotContainsString('Unknown command', $messages);
+    }
+
+    /**
      * Test using `cake --help` invokes the help command
      */
     public function testRunHelpLongOption(): void


### PR DESCRIPTION
Previously, running e.g. `bin/cake i18n nonsense` silently invoked `I18nCommand` and ignored the `nonsense` token, because:

- `i18n` is a registered command (the interactive `I18nCommand`).
- `i18n` defines no positional arguments, so `ConsoleOptionParser::_parseArg()` silently appends extras instead of rejecting them.

That hid genuine typos and made it look like CakePHP accepted any garbage after a known command name.

## What this changes

In `CommandRunner::run()`, after the existing command-name resolution, when **all** of the following are true:

- the matched command exists in the collection,
- there is at least one more positional token,
- that token is not option-like (does not start with `-`),
- the matched command has *sibling subcommands* (i.e. there are other commands registered with `<name> ` as a prefix),

then the next token is almost certainly meant to be a subcommand. If it doesn't match a registered subcommand, error out with a clear message listing the available subcommands.

```
$ bin/cake i18n nonsense
<error>Error: Unknown command `cake i18n nonsense`.
Available subcommands: `i18n extract`, `i18n init`.
Run `cake i18n --help` to see usage.</error>
```

## What this does NOT change

- Commands without sibling subcommands (the common case) — unchanged.
- Commands that declare positional args via `addArgument()` — unchanged; the parser already validates them.
- Commands like `RoutesGenerateCommand` that intentionally accept arbitrary positional args (`bin/cake routes generate controller:Articles action:view 2`) — unchanged, because `routes generate` has no sibling subcommands.
- Option-like tokens (`--help`, `-v`, etc.) following the command name — unchanged.

## Related

- #19423 (merged on 5.x): off-by-one in the existing "too many arguments" message.
- #19424 (open on 5.x): cleans up the *prefix-only* case (`bin/cake schema_cache nonsense`) by routing to filtered help with only the prefix as argv. Complementary to this PR.

## Alternative considered

Removing the silent-accept branch in `ConsoleOptionParser::_parseArg()` to make every parser strict by default. This was implemented and tested, but it breaks commands (including core's `RoutesGenerateCommand`) that intentionally accept arbitrary positional args without declaring them, and surfaces several test bugs around boolean options being passed values. That route would need a new opt-in API (e.g. a `$parser->allowExtraArguments()` flag) and a wider migration. Out of scope for this PR; happy to follow up if there's appetite.
