### PR TITLE
DateTimeType: accept date-only Y-m-d strings, marshal to midnight

### DIFF
--- a/src/Database/Type/DateTimeTimezoneType.php
+++ b/src/Database/Type/DateTimeTimezoneType.php
@@ -43,5 +43,6 @@ class DateTimeTimezoneType extends DateTimeType
         'Y-m-d\TH:i:sP',
         'Y-m-d\TH:i:s.u',
         'Y-m-d\TH:i:s.uP',
+        '!Y-m-d',
     ];
 }

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -56,6 +56,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
         'Y-m-d\TH:i:sP',
         'Y-m-d\TH:i:s.u',
         'Y-m-d\TH:i:s.uP',
+        '!Y-m-d',
     ];
 
     /**

--- a/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
@@ -240,6 +240,7 @@ class DateTimeFractionalTypeTest extends TestCase
             ['2017-04-05T17:18:00.1234567+00:00', null],
 
             // valid string types
+            ['2014-02-14', new DateTime('2014-02-14 00:00:00')],
             ['2014-02-14 12:02', new DateTime('2014-02-14 12:02')],
             ['2014-02-14 12:02:12', new DateTime('2014-02-14 12:02:12')],
             ['2014-02-14 00:00:00.123456', new DateTime('2014-02-14 00:00:00.123456')],

--- a/tests/TestCase/Database/Type/DateTimeTimezoneTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTimezoneTypeTest.php
@@ -262,6 +262,7 @@ class DateTimeTimezoneTypeTest extends TestCase
             ['2017-04-05T17:18:00.1234567+00:00', null],
 
             // valid string types
+            ['2014-02-14', new DateTime('2014-02-14 00:00:00')],
             ['2014-02-14 12:02', new DateTime('2014-02-14 12:02')],
             ['2014-02-14 12:02:12', new DateTime('2014-02-14 12:02:12')],
             ['2014-02-14 00:00:00.123456', new DateTime('2014-02-14 00:00:00.123456')],
@@ -351,6 +352,7 @@ class DateTimeTimezoneTypeTest extends TestCase
             // valid string types
             ['1392387900', new DateTime('@1392387900')],
             [1392387900, new DateTime('@1392387900')],
+            ['2014-02-14', new DateTime('2014-02-14 00:00:00')],
             ['2014-02-14 00:00:00', new DateTime('2014-02-14 00:00:00')],
             ['2014-02-14 13:14:15', new DateTime('2014-02-14 13:14:15')],
             ['2014-02-14T13:14:15', new DateTime('2014-02-14T13:14:15')],

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -228,6 +228,7 @@ class DateTimeTypeTest extends TestCase
             // valid string types
             ['1392387900', new DateTime('@1392387900')],
             [1392387900, new DateTime('@1392387900')],
+            ['2014-02-14', new DateTime('2014-02-14 00:00:00')],
             ['2014-02-14 12:02', new DateTime('2014-02-14 12:02')],
             ['2014-02-14 00:00:00', new DateTime('2014-02-14 00:00:00')],
             ['2014-02-14 13:14:15', new DateTime('2014-02-14 13:14:15')],


### PR DESCRIPTION
## Summary

`DateTimeType::marshal()` currently rejects date-only strings (`Y-m-d`) by silently returning `null` — no error, no warning, the user's input is just dropped on the floor.

```php
$type = new DateTimeType();
$type->marshal('2026-04-30');        // null  ← surprising
$type->marshal('2026-04-30 07:32');  // DateTime — fine
```

This is inconsistent with the rest of the framework / ecosystem:

- `Y-m-d H:i` (no seconds) is already accepted via `_marshalFormats` (added in #14544).
- PHP's `DateTimeImmutable`, MySQL, and Postgres all accept a date-only string when assigning to a `DATETIME`/`TIMESTAMP` column, defaulting the time to midnight.
- HTML5 `<input type="date">` values are `Y-m-d` — feeding one into a `datetime` field via a hidden form input or `Form->control()` is a very common path that today silently nulls out.

## Change

Add `'!Y-m-d'` to `_marshalFormats` in:

- `src/Database/Type/DateTimeType.php`
- `src/Database/Type/DateTimeTimezoneType.php` (overrides the parent array)

The leading `!` resets unset time fields to `00:00:00` rather than the current time-of-day, which matches what users expect when handing a plain date to a datetime column.

Listed **last** in the format array so the more specific time-bearing formats are still tried first — e.g. `'2014-02-14 12:02'` continues to match `Y-m-d H:i` and is not accidentally truncated to midnight.

`DateTimeFractionalType` inherits the parent's `_marshalFormats`, so it picks up the new behavior automatically; a regression test is added for it as well.

## Behavior

| Input                       | Before  | After                        |
|-----------------------------|---------|------------------------------|
| `'2026-04-30'`              | `null`  | `2026-04-30 00:00:00`        |
| `'2026-04-30 07:32'`        | parsed  | parsed (unchanged)           |
| `'2026-04-30 07:32:00'`     | parsed  | parsed (unchanged)           |
| `'derpy'` / `'2013-nope!'`  | `null`  | `null` (unchanged)           |

## Discussion

Two reasonable alternative directions, both rejected:

1. **Throw a marshalling exception instead of returning null.** Strictly correct ("use `DateType` if you mean a date"), but more disruptive and arguably out of scope for a single bugfix — silent-null is the existing failure mode for every unparseable input, not specific to date-only.
2. **Leave it alone, document `DateType`.** Doesn't fix the silent data loss for the very common HTML5 date-input → datetime field path.

The minimal, consistent fix is to honor what the user clearly meant.

