### PR TITLE
Reject cross-table entities in Table persistence and marshalling

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -821,9 +821,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             return;
         }
 
-        // If the entity's source matches this table's registry alias, treat it
-        // as unambiguously belonging here and skip the class check. Source
-        // mismatch falls through; the class check is authoritative.
         if ($entity->getSource() === $this->getRegistryAlias()) {
             return;
         }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -753,6 +753,40 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
+     * Asserts that the given entity belongs to this table instance.
+     *
+     * The entity must either be an instance of the table's configured entity
+     * class, or an instance of the generic ``\Cake\ORM\Entity`` class. The
+     * generic class is allowed as an escape hatch for ad-hoc usage such as
+     * ``$table->delete(new Entity(['id' => 1]))``.
+     *
+     * Catches mistakes like ``$this->Invoices->delete($orderEntity)`` where
+     * an entity from a different table is passed.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity The entity to validate.
+     * @return void
+     * @throws \InvalidArgumentException When the entity does not match the
+     *   configured entity class.
+     */
+    protected function assertEntityClass(EntityInterface $entity): void
+    {
+        $entityClass = $this->getEntityClass();
+        if ($entity instanceof $entityClass) {
+            return;
+        }
+        if ($entity::class === Entity::class) {
+            return;
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Entity of class `%s` does not match the entity class `%s` configured for table `%s`.',
+            $entity::class,
+            $entityClass,
+            $this->getRegistryAlias(),
+        ));
+    }
+
+    /**
      * Add a behavior.
      *
      * Adds a behavior to this table's behavior collection. Behaviors
@@ -2057,6 +2091,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     protected function _processSave(EntityInterface $entity, ArrayObject $options): EntityInterface|false
     {
+        $this->assertEntityClass($entity);
+
         $primaryColumns = (array)$this->getPrimaryKey();
 
         if ($options['checkExisting'] && $primaryColumns && $entity->isNew() && $entity->has($primaryColumns)) {
@@ -2632,6 +2668,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     protected function _processDelete(EntityInterface $entity, ArrayObject $options): bool
     {
+        $this->assertEntityClass($entity);
+
         if ($entity->isNew()) {
             return false;
         }
@@ -3132,6 +3170,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function patchEntity(EntityInterface $entity, array $data, array $options = []): EntityInterface
     {
+        $this->assertEntityClass($entity);
+
         $options['associated'] ??= $this->_associations->keys();
 
         return $this->marshaller()->merge($entity, $data, $options);
@@ -3171,6 +3211,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function patchEntities(iterable $entities, array $data, array $options = []): array
     {
+        foreach ($entities as $entity) {
+            $this->assertEntityClass($entity);
+        }
+
         $options['associated'] ??= $this->_associations->keys();
 
         return $this->marshaller()->mergeMany($entities, $data, $options);
@@ -3336,6 +3380,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function loadInto(EntityInterface|array $entities, array $contain): EntityInterface|array
     {
+        if ($entities instanceof EntityInterface) {
+            $this->assertEntityClass($entities);
+        } else {
+            foreach ($entities as $entity) {
+                $this->assertEntityClass($entity);
+            }
+        }
+
         return (new LazyEagerLoader())->loadInto($entities, $contain, $this);
     }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -275,6 +275,16 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     protected ?string $_entityClass = null;
 
     /**
+     * Whether to assert that entities passed to save/delete/patch/loadInto
+     * belong to this table (matching configured entity class and source).
+     * Disable per table via {@see Table::disableEntityClassAssertion()} when
+     * foreign entities are passed intentionally.
+     *
+     * @var bool
+     */
+    protected bool $_assertEntityClass = true;
+
+    /**
      * Registry key used to create this table object
      *
      * @var string|null
@@ -753,6 +763,44 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
+     * Enables the assertion that entities passed to save/delete/patch/loadInto
+     * belong to this table. The check covers both the entity class and, for
+     * loaded entities, the source.
+     *
+     * @param bool $enable Whether to enable. Defaults to true.
+     * @return $this
+     */
+    public function enableEntityClassAssertion(bool $enable = true)
+    {
+        $this->_assertEntityClass = $enable;
+
+        return $this;
+    }
+
+    /**
+     * Disables the entity-class assertion for this table. Use when foreign
+     * entities are passed intentionally (e.g. polymorphic patterns).
+     *
+     * @return $this
+     */
+    public function disableEntityClassAssertion()
+    {
+        $this->_assertEntityClass = false;
+
+        return $this;
+    }
+
+    /**
+     * Returns whether the entity-class assertion is enabled for this table.
+     *
+     * @return bool
+     */
+    public function isEntityClassAssertionEnabled(): bool
+    {
+        return $this->_assertEntityClass;
+    }
+
+    /**
      * Asserts that the given entity belongs to this table instance.
      *
      * The entity must either be an instance of the table's configured entity
@@ -770,6 +818,19 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     protected function assertEntityClass(EntityInterface $entity): void
     {
+        if (!$this->_assertEntityClass) {
+            return;
+        }
+
+        $source = $entity->getSource();
+        if ($source !== '' && $source !== $this->getRegistryAlias()) {
+            throw new InvalidArgumentException(sprintf(
+                'Entity loaded from `%s` does not match table `%s`.',
+                $source,
+                $this->getRegistryAlias(),
+            ));
+        }
+
         $entityClass = $this->getEntityClass();
         if ($entity instanceof $entityClass) {
             return;

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -282,7 +282,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @var bool
      */
-    protected bool $_assertEntityClass = true;
+    protected bool $assertEntityClass = true;
 
     /**
      * Registry key used to create this table object
@@ -771,7 +771,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function enableEntityClassAssertion(bool $enable = true)
     {
-        $this->_assertEntityClass = $enable;
+        $this->assertEntityClass = $enable;
 
         return $this;
     }
@@ -784,7 +784,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function disableEntityClassAssertion()
     {
-        $this->_assertEntityClass = false;
+        $this->assertEntityClass = false;
 
         return $this;
     }
@@ -796,7 +796,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function isEntityClassAssertionEnabled(): bool
     {
-        return $this->_assertEntityClass;
+        return $this->assertEntityClass;
     }
 
     /**
@@ -817,7 +817,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     protected function assertEntityClass(EntityInterface $entity): void
     {
-        if (!$this->_assertEntityClass) {
+        if (!$this->assertEntityClass) {
             return;
         }
 
@@ -826,10 +826,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
 
         $entityClass = $this->getEntityClass();
-        if ($entity instanceof $entityClass) {
-            return;
-        }
-        if ($entity::class === Entity::class) {
+        if ($entity instanceof $entityClass || $entity::class === Entity::class) {
             return;
         }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -276,9 +276,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
     /**
      * Whether to assert that entities passed to save/delete/patch/loadInto
-     * belong to this table (matching configured entity class and source).
-     * Disable per table via {@see Table::disableEntityClassAssertion()} when
-     * foreign entities are passed intentionally.
+     * match the table's configured entity class. Disable per table via
+     * {@see Table::disableEntityClassAssertion()} when foreign entities are
+     * passed intentionally.
      *
      * @var bool
      */
@@ -764,8 +764,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
     /**
      * Enables the assertion that entities passed to save/delete/patch/loadInto
-     * belong to this table. The check covers both the entity class and, for
-     * loaded entities, the source.
+     * match the table's configured entity class.
      *
      * @param bool $enable Whether to enable. Defaults to true.
      * @return $this
@@ -820,15 +819,6 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     {
         if (!$this->_assertEntityClass) {
             return;
-        }
-
-        $source = $entity->getSource();
-        if ($source !== '' && $source !== $this->getRegistryAlias()) {
-            throw new InvalidArgumentException(sprintf(
-                'Entity loaded from `%s` does not match table `%s`.',
-                $source,
-                $this->getRegistryAlias(),
-            ));
         }
 
         $entityClass = $this->getEntityClass();

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -821,6 +821,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             return;
         }
 
+        // If the entity's source matches this table's registry alias, treat it
+        // as unambiguously belonging here and skip the class check. Source
+        // mismatch falls through; the class check is authoritative.
+        if ($entity->getSource() === $this->getRegistryAlias()) {
+            return;
+        }
+
         $entityClass = $this->getEntityClass();
         if ($entity instanceof $entityClass) {
             return;

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6994,6 +6994,105 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests that an entity carrying a source from a different registry alias is
+     * rejected even when its class would otherwise pass the class check. Catches
+     * the case where two tables share the same entity class (or use the generic
+     * Entity class) but hold rows from different tables.
+     */
+    public function testDeleteRejectsEntityWithMismatchedSource(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $article = new Article(['id' => 1]);
+        $article->setNew(false);
+        $article->setSource('OtherArticles');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Entity loaded from `OtherArticles` does not match table `Articles`.',
+        );
+
+        $articles->delete($article);
+    }
+
+    /**
+     * Tests that the source check also catches mismatches on save().
+     */
+    public function testSaveRejectsEntityWithMismatchedSource(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $article = new Article(['title' => 'a', 'body' => 'b']);
+        $article->setSource('OtherArticles');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Entity loaded from `OtherArticles` does not match table `Articles`.',
+        );
+
+        $articles->save($article);
+    }
+
+    /**
+     * Tests that an entity with empty source still passes the source check —
+     * freshly-`new`'d entities have no source and should not be treated as
+     * cross-table mismatches.
+     */
+    public function testSaveAcceptsEntityWithEmptySource(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $article = new Article(['title' => 'a', 'body' => 'b']);
+
+        $this->assertSame('', $article->getSource());
+        $this->assertNotFalse($articles->save($article));
+    }
+
+    /**
+     * Tests that disableEntityClassAssertion() skips the class check, restoring
+     * pre-19428 behavior for tables that intentionally accept foreign entities.
+     */
+    public function testDisableEntityClassAssertionSkipsClassCheck(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->disableEntityClassAssertion();
+
+        $tag = new Tag(['id' => 1]);
+        $tag->setNew(false);
+
+        $this->assertTrue($articles->delete($tag));
+    }
+
+    /**
+     * Tests that disableEntityClassAssertion() also skips the source check.
+     */
+    public function testDisableEntityClassAssertionSkipsSourceCheck(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->disableEntityClassAssertion();
+
+        $article = new Article(['id' => 1]);
+        $article->setNew(false);
+        $article->setSource('OtherArticles');
+
+        $this->assertTrue($articles->delete($article));
+    }
+
+    /**
+     * Tests the enable/disable/isEnabled accessor trio for the entity-class
+     * assertion. Setters are chainable and reflect in isEntityClassAssertionEnabled().
+     */
+    public function testEntityClassAssertionAccessors(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+
+        $this->assertTrue($articles->isEntityClassAssertionEnabled(), 'Defaults to enabled');
+        $this->assertSame($articles, $articles->disableEntityClassAssertion());
+        $this->assertFalse($articles->isEntityClassAssertionEnabled());
+        $this->assertSame($articles, $articles->enableEntityClassAssertion());
+        $this->assertTrue($articles->isEntityClassAssertionEnabled());
+        $articles->enableEntityClassAssertion(false);
+        $this->assertFalse($articles->isEntityClassAssertionEnabled(), 'enableEntityClassAssertion(false) disables');
+    }
+
+    /**
      * Helper method to skip tests when connection is SQLServer.
      */
     public function skipIfSqlServer(): void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6882,6 +6882,118 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests that passing an entity from a different table to delete()
+     * throws when both tables declare a specific entity class.
+     */
+    public function testDeleteRejectsEntityFromOtherTable(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $tag = new Tag(['id' => 1]);
+        $tag->setNew(false);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Entity of class `TestApp\Model\Entity\Tag` does not match the entity class '
+            . '`TestApp\Model\Entity\Article` configured for table `Articles`.',
+        );
+
+        $articles->delete($tag);
+    }
+
+    /**
+     * Tests that passing an entity from a different table to save()
+     * throws when both tables declare a specific entity class.
+     */
+    public function testSaveRejectsEntityFromOtherTable(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $tag = new Tag(['name' => 'new']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $articles->save($tag);
+    }
+
+    /**
+     * Tests that the generic Entity class is accepted as an escape hatch,
+     * allowing ad-hoc operations such as ``$table->delete(new Entity(['id' => 1]))``.
+     */
+    public function testDeleteAcceptsGenericEntity(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $entity = new Entity(['id' => 1]);
+        $entity->setNew(false);
+
+        $this->assertTrue($articles->delete($entity));
+    }
+
+    /**
+     * Tests that a table without a custom entity class accepts any entity
+     * subclass, as there is nothing specific to validate against.
+     */
+    public function testDeleteOnGenericTableAcceptsAnyEntity(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->setEntityClass(Entity::class);
+
+        $tag = new Tag(['id' => 1]);
+        $tag->setNew(false);
+
+        $this->assertTrue($articles->delete($tag));
+    }
+
+    /**
+     * Tests that the cross-table check also fires for deleteMany().
+     */
+    public function testDeleteManyRejectsEntityFromOtherTable(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $article = $articles->get(1);
+        $tag = new Tag(['id' => 1]);
+        $tag->setNew(false);
+
+        $this->expectException(InvalidArgumentException::class);
+        $articles->deleteMany([$article, $tag]);
+    }
+
+    /**
+     * Tests that the cross-table check also fires for saveMany().
+     */
+    public function testSaveManyRejectsEntityFromOtherTable(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $article = new Article(['title' => 'a', 'body' => 'b']);
+        $tag = new Tag(['name' => 'new']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $articles->saveMany([$article, $tag]);
+    }
+
+    /**
+     * Tests that patchEntity() rejects an entity from another table.
+     */
+    public function testPatchEntityRejectsEntityFromOtherTable(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $tag = new Tag(['id' => 1, 'name' => 'foo']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $articles->patchEntity($tag, ['title' => 'updated']);
+    }
+
+    /**
+     * Tests that loadInto() rejects an entity from another table.
+     */
+    public function testLoadIntoRejectsEntityFromOtherTable(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $tag = new Tag(['id' => 1]);
+        $tag->setNew(false);
+
+        $this->expectException(InvalidArgumentException::class);
+        $articles->loadInto($tag, ['Tags']);
+    }
+
+    /**
      * Helper method to skip tests when connection is SQLServer.
      */
     public function skipIfSqlServer(): void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6994,58 +6994,6 @@ class TableTest extends TestCase
     }
 
     /**
-     * Tests that an entity carrying a source from a different registry alias is
-     * rejected even when its class would otherwise pass the class check. Catches
-     * the case where two tables share the same entity class (or use the generic
-     * Entity class) but hold rows from different tables.
-     */
-    public function testDeleteRejectsEntityWithMismatchedSource(): void
-    {
-        $articles = $this->getTableLocator()->get('Articles');
-        $article = new Article(['id' => 1]);
-        $article->setNew(false);
-        $article->setSource('OtherArticles');
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'Entity loaded from `OtherArticles` does not match table `Articles`.',
-        );
-
-        $articles->delete($article);
-    }
-
-    /**
-     * Tests that the source check also catches mismatches on save().
-     */
-    public function testSaveRejectsEntityWithMismatchedSource(): void
-    {
-        $articles = $this->getTableLocator()->get('Articles');
-        $article = new Article(['title' => 'a', 'body' => 'b']);
-        $article->setSource('OtherArticles');
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'Entity loaded from `OtherArticles` does not match table `Articles`.',
-        );
-
-        $articles->save($article);
-    }
-
-    /**
-     * Tests that an entity with empty source still passes the source check —
-     * freshly-`new`'d entities have no source and should not be treated as
-     * cross-table mismatches.
-     */
-    public function testSaveAcceptsEntityWithEmptySource(): void
-    {
-        $articles = $this->getTableLocator()->get('Articles');
-        $article = new Article(['title' => 'a', 'body' => 'b']);
-
-        $this->assertSame('', $article->getSource());
-        $this->assertNotFalse($articles->save($article));
-    }
-
-    /**
      * Tests that disableEntityClassAssertion() skips the class check, restoring
      * pre-19428 behavior for tables that intentionally accept foreign entities.
      */
@@ -7058,21 +7006,6 @@ class TableTest extends TestCase
         $tag->setNew(false);
 
         $this->assertTrue($articles->delete($tag));
-    }
-
-    /**
-     * Tests that disableEntityClassAssertion() also skips the source check.
-     */
-    public function testDisableEntityClassAssertionSkipsSourceCheck(): void
-    {
-        $articles = $this->getTableLocator()->get('Articles');
-        $articles->disableEntityClassAssertion();
-
-        $article = new Article(['id' => 1]);
-        $article->setNew(false);
-        $article->setSource('OtherArticles');
-
-        $this->assertTrue($articles->delete($article));
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6994,6 +6994,22 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests that an entity whose source matches the table's registry alias
+     * short-circuits the assertion: it is treated as unambiguously belonging
+     * to this table even if its concrete class would not pass the class check.
+     */
+    public function testAssertEntityClassAcceptsMatchingSource(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+
+        $tag = new Tag(['id' => 1]);
+        $tag->setNew(false);
+        $tag->setSource('Articles');
+
+        $this->assertTrue($articles->delete($tag));
+    }
+
+    /**
      * Tests that disableEntityClassAssertion() skips the class check, restoring
      * pre-19428 behavior for tables that intentionally accept foreign entities.
      */


### PR DESCRIPTION
Closes #19427.

`Table::delete($entity)` (and friends) currently accept any `EntityInterface`,
so a copy-paste mistake like `$this->Invoices->delete($orderEntity)` silently
deletes from the wrong table.

This change adds an opt-out-by-passing-generic-Entity assertion that fires at
the persistence/marshalling chokepoints and rejects entities whose concrete
class doesn't match the table's configured entity class.

## The check

```php
protected function assertEntityClass(EntityInterface $entity): void
{
    $entityClass = $this->getEntityClass();
    if ($entity instanceof $entityClass) {
        return;
    }
    if ($entity::class === Entity::class) {
        return;
    }

    throw new InvalidArgumentException(...);
}
```

Behavior matrix:

| Case                                                              | Result   |
|-------------------------------------------------------------------|----------|
| Custom `Order` entity to Invoices table (custom `Invoice`)        | throws   |
| Custom `Order` entity to Orders table                             | passes   |
| Generic `Cake\ORM\Entity` to any table                            | passes   |
| Any entity to a table that hasn't configured a custom entity class| passes   |

The escape hatch (literal `Cake\ORM\Entity::class`) preserves ad-hoc usage like
`$table->delete(new Entity(['id' => 1]))`. Subclasses of `Entity` that belong
to a different table do *not* get the escape hatch — that is the bug we want
to catch.

## Wired in at

- `Table::_processSave()` — covers `save`, `saveOrFail`, `saveMany`, `saveManyOrFail`
- `Table::_processDelete()` — covers `delete`, `deleteOrFail`, `deleteMany`, `deleteManyOrFail`
- `Table::patchEntity()` and `Table::patchEntities()`
- `Table::loadInto()` (handles single entity and array forms)

## BC notes

This is a behavior change in a minor: code that previously silently mis-fired
will now throw. Drafting against `5.next` so we can decide whether to land it
as-is, gate it behind a config flag, or soften to a deprecation in 5.x and
throw in 6.0. Happy to adjust based on review.
