### PR TITLE
Add Connection.afterCommit event for outermost-commit hooks

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -33,6 +33,8 @@ use Cake\Database\Schema\CachedCollection;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\CollectionInterface as SchemaCollectionInterface;
 use Cake\Datasource\ConnectionInterface;
+use Cake\Event\EventDispatcherInterface;
+use Cake\Event\EventDispatcherTrait;
 use Cake\Log\Log;
 use Closure;
 use Psr\SimpleCache\CacheInterface;
@@ -41,9 +43,24 @@ use function Cake\Core\env;
 
 /**
  * Represents a connection with a database server.
+ *
+ * ### Events
+ *
+ * - `Connection.afterCommit` Fired after the outermost transaction commits.
+ *   Listeners receive the connection as the event subject. Not fired on
+ *   rollback or for nested commits. Useful for hooks that must run only once
+ *   per top-level transaction commit, regardless of how many ORM operations
+ *   participated in it.
+ *
+ * @implements \Cake\Event\EventDispatcherInterface<\Cake\Database\Connection>
  */
-class Connection implements ConnectionInterface
+class Connection implements ConnectionInterface, EventDispatcherInterface
 {
+    /**
+     * @use \Cake\Event\EventDispatcherTrait<\Cake\Database\Connection>
+     */
+    use EventDispatcherTrait;
+
     /**
      * Contains the configuration params for this connection.
      *
@@ -528,6 +545,8 @@ class Connection implements ConnectionInterface
             foreach ($callbacks as $cb) {
                 $cb();
             }
+
+            $this->dispatchEvent('Connection.afterCommit');
 
             return $result;
         }

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -48,9 +48,7 @@ use function Cake\Core\env;
  *
  * - `Connection.afterCommit` Fired after the outermost transaction commits.
  *   Listeners receive the connection as the event subject. Not fired on
- *   rollback or for nested commits. Useful for hooks that must run only once
- *   per top-level transaction commit, regardless of how many ORM operations
- *   participated in it.
+ *   rollback or for nested commits.
  *
  * @implements \Cake\Event\EventDispatcherInterface<\Cake\Database\Connection>
  */

--- a/src/Database/composer.json
+++ b/src/Database/composer.json
@@ -28,6 +28,7 @@
         "cakephp/core": "5.4.*@dev",
         "cakephp/chronos": "^3.3",
         "cakephp/datasource": "5.4.*@dev",
+        "cakephp/event": "5.4.*@dev",
         "psr/log": "^3.0"
     },
     "require-dev": {

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -30,6 +30,7 @@ use Cake\Database\Schema\CachedCollection;
 use Cake\Database\Schema\Collection;
 use Cake\Database\StatementInterface;
 use Cake\Datasource\ConnectionManager;
+use Cake\Event\EventInterface;
 use Cake\Log\Log;
 use Cake\Test\TestCase\Database\Driver\BaseDriverTrait;
 use Cake\TestSuite\TestCase;
@@ -1408,5 +1409,89 @@ class ConnectionTest extends TestCase
             // Expected
         }
         $this->assertFalse($secondFired, 'Remaining callbacks should not execute when one throws');
+    }
+
+    public function testAfterCommitEventFiresOnOuterCommit(): void
+    {
+        $fired = false;
+        $this->connection->getEventManager()->on(
+            'Connection.afterCommit',
+            function () use (&$fired): void {
+                $fired = true;
+            },
+        );
+
+        $this->connection->begin();
+        $this->assertFalse($fired, 'Event must not fire before commit');
+        $this->connection->commit();
+        $this->assertTrue($fired, 'Event must fire after outermost commit');
+    }
+
+    public function testAfterCommitEventNotFiredOnRollback(): void
+    {
+        $fired = false;
+        $this->connection->getEventManager()->on(
+            'Connection.afterCommit',
+            function () use (&$fired): void {
+                $fired = true;
+            },
+        );
+
+        $this->connection->begin();
+        $this->connection->rollback();
+        $this->assertFalse($fired);
+    }
+
+    public function testAfterCommitEventFiresOnceForNestedTransactions(): void
+    {
+        $fireCount = 0;
+        $this->connection->getEventManager()->on(
+            'Connection.afterCommit',
+            function () use (&$fireCount): void {
+                $fireCount++;
+            },
+        );
+
+        $this->connection->begin();
+        $this->connection->begin(); // nested
+        $this->connection->commit(); // commit nested
+        $this->assertSame(0, $fireCount, 'Nested commit must not fire the event');
+        $this->connection->commit(); // commit outermost
+        $this->assertSame(1, $fireCount, 'Event must fire exactly once on outermost commit');
+    }
+
+    public function testAfterCommitEventSubjectIsConnection(): void
+    {
+        $subject = null;
+        $this->connection->getEventManager()->on(
+            'Connection.afterCommit',
+            function (EventInterface $event) use (&$subject): void {
+                $subject = $event->getSubject();
+            },
+        );
+
+        $this->connection->begin();
+        $this->connection->commit();
+
+        $this->assertSame($this->connection, $subject);
+    }
+
+    public function testAfterCommitEventFiresAfterCallbacks(): void
+    {
+        $order = [];
+        $this->connection->getEventManager()->on(
+            'Connection.afterCommit',
+            function () use (&$order): void {
+                $order[] = 'event';
+            },
+        );
+
+        $this->connection->begin();
+        $this->connection->afterCommit(function () use (&$order): void {
+            $order[] = 'callback';
+        });
+        $this->connection->commit();
+
+        $this->assertSame(['callback', 'event'], $order);
     }
 }


### PR DESCRIPTION
## Summary

Adds a `Connection.afterCommit` event that listeners can subscribe to in order to react after the outermost transaction commits. This is the supported replacement for code that previously relied on `Model.afterSaveCommit` firing from within an outer transaction (the deferred-dispatch path is being reverted in #19417).

## Major Changes

- **`src/Database/Connection.php`** — Implements `Cake\Event\EventDispatcherInterface` and uses `Cake\Event\EventDispatcherTrait`. Dispatches `Connection.afterCommit` in `commit()` after the existing `afterCommit()` callback queue runs, so listeners observe state consistent with all queued callbacks having executed.
- **`src/Database/composer.json`** — Adds `cakephp/event` as a runtime dependency of the database package.

## Behavior

- Fires once per outermost commit.
- Does not fire on rollback or for nested commits.
- Does not fire if any preceding `afterCommit()` callback throws (existing loop short-circuits).
- Event subject is the connection.

## Migration path

Listeners that previously needed a "fires after the outer transaction commits" hook can subscribe at the connection level:

```php
$connection->getEventManager()->on(
    'Connection.afterCommit',
    function (\Cake\Event\EventInterface $event): void {
        // runs once per outermost commit
    },
);
```

This complements `Model.afterSaveCommit` (entity-level, fires when an atomic save commits) by providing a transaction-level hook that's independent of any specific Table or save operation.

## Companion PR

Companion to #19417, which restores `src/ORM/Table.php` to its 5.x state. With both PRs merged, the 5.x semantics of `Model.afterSaveCommit` are preserved, and userland gets an explicit, supported hook for outermost-commit reactions.
