### PR TITLE
ConsoleOutput::_write: restore isset() guard for unset _output (partial fix)

### DIFF
--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -292,7 +292,8 @@ class ConsoleOutput
      */
     protected function _write(string $message): int
     {
-        if (!is_resource($this->_output)) {
+        // @phpstan-ignore isset.property (property may not be set: ConsoleOutput::__destruct() unsets _output)
+        if (!isset($this->_output) || !is_resource($this->_output)) {
             return 0;
         }
 

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -296,4 +296,47 @@ class ConsoleOutputTest extends TestCase
             @unlink($tmpfile);
         }
     }
+
+    /**
+     * `ConsoleOutput::__destruct()` unsets the `_output` property, so any
+     * write that reaches the same instance during the rest of the shutdown
+     * sequence sees an undefined property — observed when another
+     * destructor (e.g. `Connection::__destruct()`) routes a `Log::warning()`
+     * through a globally registered `ConsoleLog` engine.
+     *
+     * `_write()` must guard with `isset()` in addition to `is_resource()`;
+     * reading an undefined property emits an "Undefined property" warning
+     * before evaluating to false.
+     */
+    public function testWriteAfterDestructIsNoOpWithoutWarning(): void
+    {
+        $tmpfile = tempnam(sys_get_temp_dir(), 'cakephp_console_output_test_');
+        $this->assertIsString($tmpfile);
+        $stream = fopen($tmpfile, 'w');
+        $this->assertIsResource($stream);
+
+        $captured = [];
+        set_error_handler(function (int $errno, string $errstr) use (&$captured): bool {
+            $captured[] = $errstr;
+
+            return true;
+        });
+
+        try {
+            $output = new ConsoleOutput($stream);
+            // Explicitly invoke the destructor to simulate the shutdown cascade
+            // where this instance is destructed before another logging caller
+            // reaches it.
+            $output->__destruct();
+
+            $this->assertSame(0, $output->write('after-destruct', 0));
+            $this->assertSame([], $captured, 'write() must not emit warnings after __destruct()');
+        } finally {
+            restore_error_handler();
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+            @unlink($tmpfile);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

PR #19420 (5.3.5) replaced the existing `isset()` guard in `ConsoleOutput::_write()` with `is_resource()` alone. That handles the closed-stream case the PR targeted, but it doesn't handle the case where the `_output` property itself is undefined — which is the state `ConsoleOutput::__destruct()` puts the instance in on line 388:

```php
public function __destruct()
{
    if (isset($this->_output) && is_resource($this->_output)) {
        fclose($this->_output);
    }
    unset($this->_output);   // <-- property is now undefined on this instance
}
```

Any `_write()` on the same instance after that — typical during PHP's shutdown destructor cascade when another destructor (e.g. `Connection::__destruct()`) routes a `Log::warning()` through a globally registered `ConsoleLog` engine — reads an undefined property:

```
PHP Warning: Undefined property: Cake\Console\ConsoleOutput::$_output
  in src/Console/ConsoleOutput.php on line 295
Stack:
  Cake\Database\Connection::__destruct()
  → Cake\Log\Log::warning()
  → Cake\Log\Engine\ConsoleLog::log()
  → Cake\Console\ConsoleOutput::write()
  → Cake\Console\ConsoleOutput::_write()
```

`is_resource()` on an undefined property emits this warning before evaluating to false; PHP then returns 0 from `_write()`, so it's "just" a noisy diagnostic rather than a fatal, but it surfaces in test suites, CI logs and any environment that escalates warnings to exceptions.

This restores the conjunction PR #17617 originally introduced for the same defensive reason — #19420's cleanup commit ("Drop orphaned phpstan-ignore now that the isset() guard is gone") removed `isset()` without re-evaluating whether `_write()` also needed it. It did, and `__destruct()` itself keeps the same `isset() && is_resource()` shape on line 385.

## What this PR does

- Adds `isset($this->_output)` to the early-return in `_write()`, alongside the existing `is_resource()`.
- Adds `testWriteAfterDestructIsNoOpWithoutWarning` covering exactly the cascade above (explicit `__destruct()`, then `write()`, asserts no captured warnings and a 0-byte return).
- The new test fails on `5.x` before this commit with: `'Undefined property: Cake\Console\ConsoleOutput::$_output'`. It passes with the guard restored.

## More changes are likely needed to fully resolve this class of issue

This PR is the minimal, targeted fix for the reported symptom. There are at least three related questions worth a follow-up before this is closed:

1. **`ConsoleInput::read()` has no guard at all.** Same `unset($this->_input)` shape in its destructor (line 70), but `read()` directly calls `fgets($this->_input)` without any `isset()` or `is_resource()` precheck. Less practically reachable than `_write()` (read isn't typically invoked from another destructor) but the symmetry is worth fixing.
2. **`unset()` in the destructors themselves.** Both `ConsoleOutput::__destruct()` and `ConsoleInput::__destruct()` end with `unset($this->_*)`. After `fclose()` the resource is invalid; the `unset()` adds nothing useful and is what creates the "undefined property" state that callers now have to defensively guard against. Worth discussing whether `unset()` should be dropped entirely — that would let `_write()` keep the simpler `is_resource()`-only guard #19420 wanted, and would mirror what `fclose()` alone does for the resource lifecycle.
3. **Globally registered `ConsoleLog` engines outliving their `ConsoleOutput`.** This is the root cause in the long-running CLI scenario described in #19420 — the destructor cascade exposes it but doesn't create it. Worth thinking about whether `ConsoleIo::setLoggers()` should weak-reference (or de-register on instance destruction) its underlying output, so subsequent log writes from unrelated code paths don't reach a torn-down ConsoleOutput at all. That's a bigger change and out of scope here.

Happy to follow up on (1) and (2) in a separate PR once there's directional agreement; (3) is more of an architectural conversation.

## Refs

- Reintroduces (and updates the rationale of) the `isset()` guard from #17617.
- Caused by #19420 (5.3.5). Symptom reproduces on `5.3.5` with `error_reporting=E_ALL`.
