### PR TITLE
5.next: Extract AbstractStreamResponse from JsonStreamResponse

### DIFF
--- a/src/Http/Response/AbstractStreamResponse.php
+++ b/src/Http/Response/AbstractStreamResponse.php
@@ -1,0 +1,279 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http\Response;
+
+use Cake\Core\Configure;
+use Cake\Core\InstanceConfigTrait;
+use Cake\Http\CallbackStream;
+use Cake\Http\Response;
+use Cake\Log\Log;
+use Closure;
+use InvalidArgumentException;
+
+/**
+ * Base class for response types that stream an `iterable` payload to the
+ * client memory-efficiently.
+ *
+ * Concrete subclasses such as {@see \Cake\Http\Response\JsonStreamResponse}
+ * produce the wire format (JSON, CSV, XML, …); this class owns the streaming
+ * lifecycle that is common to all of them:
+ *
+ * - Wires a {@see \Cake\Http\CallbackStream} into the response body.
+ * - Emits the streaming-friendly headers (Content-Type with charset and
+ *   `X-Accel-Buffering: no` so proxies / nginx do not buffer the response).
+ * - Provides the {@see self::output()}, {@see self::outputAndFlush()} and
+ *   {@see self::flushOutputBuffers()} primitives subclasses use to write
+ *   the wire format, including the threshold-based flush counter driven by
+ *   the `flushEvery` option.
+ * - Provides {@see self::logStreamError()} (gated on `cakephp/log` being
+ *   installed) for surfacing encoding failures server-side.
+ * - Implements the PSR-7 immutability helpers
+ *   ({@see self::withStreamOptions()} / {@see self::getStreamOptions()}).
+ *
+ * Subclasses must implement {@see self::contentType()} (the MIME type without
+ * the charset suffix) and {@see self::streamData()} (the actual write loop).
+ * They may override {@see self::normalizeStreamOptions()} to validate
+ * format-specific options on top of the base validation.
+ */
+abstract class AbstractStreamResponse extends Response
+{
+    use InstanceConfigTrait;
+
+    /**
+     * The iterable data to stream.
+     *
+     * @var iterable
+     */
+    protected iterable $data;
+
+    /**
+     * Number of streamed rows since the last flush.
+     *
+     * @var int
+     */
+    protected int $rowsSinceLastFlush = 0;
+
+    /**
+     * Default streaming options shared by all concrete subclasses.
+     *
+     * Subclasses extend this array with their format-specific options.
+     *
+     * @var array<string, mixed>
+     */
+    protected array $_defaultConfig = [
+        'flushEvery' => 1,
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param iterable $data The iterable data to stream (array, generator, ResultSet, etc.).
+     * @param array<string, mixed> $options Streaming options. The base accepts
+     *   `flushEvery` (int >= 1) controlling how many items are buffered before
+     *   flushing. Subclasses add their own keys.
+     */
+    public function __construct(iterable $data, array $options = [])
+    {
+        $this->data = $data;
+        $this->setConfig(
+            $this->normalizeStreamOptions($options + $this->_defaultConfig, $options),
+            null,
+            false,
+        );
+
+        $stream = new CallbackStream($this->createStreamCallback());
+        parent::__construct(['stream' => $stream]);
+
+        $this->applyStreamingHeaders();
+    }
+
+    /**
+     * Create the streaming callback installed on the response body.
+     *
+     * @return \Closure
+     */
+    protected function createStreamCallback(): Closure
+    {
+        return function (): void {
+            $this->streamData();
+        };
+    }
+
+    /**
+     * Write the streamed payload using {@see self::output()} /
+     * {@see self::outputAndFlush()}.
+     *
+     * Called from the response body callback. Subclasses own the wire format,
+     * including any wrapper bytes, item separators and end-of-stream handling.
+     *
+     * @return void
+     */
+    abstract protected function streamData(): void;
+
+    /**
+     * Return the response MIME type without the charset suffix.
+     *
+     * Called when applying streaming headers so subclasses can return a
+     * different value depending on the active stream options (e.g. JSON vs
+     * NDJSON share one response class but emit different content types).
+     *
+     * @return string
+     */
+    abstract protected function contentType(): string;
+
+    /**
+     * Validate and normalize the streaming options.
+     *
+     * Subclasses overriding this method should call `parent::normalizeStreamOptions()`
+     * so the shared options (currently `flushEvery`) keep their validation.
+     *
+     * @param array<string, mixed> $options Merged options.
+     * @param array<string, mixed> $originalOptions Original options passed by the caller.
+     * @return array<string, mixed>
+     */
+    protected function normalizeStreamOptions(array $options, array $originalOptions = []): array
+    {
+        if (!is_int($options['flushEvery']) || $options['flushEvery'] < 1) {
+            throw new InvalidArgumentException('`flushEvery` must be an integer greater than or equal to 1');
+        }
+
+        return $options;
+    }
+
+    /**
+     * Apply headers derived from the active stream options.
+     *
+     * Sets the Content-Type (with charset) returned by {@see self::contentType()}
+     * and `X-Accel-Buffering: no` so reverse proxies do not buffer the body.
+     *
+     * @return void
+     */
+    protected function applyStreamingHeaders(): void
+    {
+        $charset = Configure::read('App.encoding') ?? 'UTF-8';
+        $contentType = $this->contentType() . '; charset=' . $charset;
+
+        $this->_setHeader('Content-Type', $contentType);
+        $this->_setHeader('X-Accel-Buffering', 'no');
+    }
+
+    /**
+     * Output data without flushing.
+     *
+     * Used for structural bytes like wrapper brackets / separators that do not
+     * need an immediate flush.
+     *
+     * @param string $data The data to output.
+     * @return void
+     */
+    protected function output(string $data): void
+    {
+        echo $data;
+    }
+
+    /**
+     * Output data and flush to the client subject to the `flushEvery` threshold.
+     *
+     * @param string $data The data to output and flush.
+     * @param bool $force Whether to force an immediate flush regardless of threshold.
+     * @return void
+     */
+    protected function outputAndFlush(string $data, bool $force = false): void
+    {
+        echo $data;
+        $this->rowsSinceLastFlush++;
+
+        if ($force || $this->rowsSinceLastFlush >= $this->getConfigOrFail('flushEvery')) {
+            $this->flushOutputBuffers();
+        }
+    }
+
+    /**
+     * Flush output buffers when it is safe to do so.
+     *
+     * Only flushes at the implicit output buffer level (1) or when no buffering
+     * is active. Higher levels indicate explicit buffering (e.g. tests wrapping
+     * the call in `ob_start()`) which should not be disturbed.
+     *
+     * @return void
+     */
+    protected function flushOutputBuffers(): void
+    {
+        $level = ob_get_level();
+        if ($level <= 1) {
+            if ($level === 1) {
+                ob_flush();
+            }
+            flush();
+            $this->rowsSinceLastFlush = 0;
+        }
+    }
+
+    /**
+     * Log a streaming error.
+     *
+     * No-op when `cakephp/log` is not installed (keeps the dependency
+     * optional for the `cakephp/http` package).
+     *
+     * @param string $message Error message.
+     * @param int $index Item index where the error occurred.
+     * @return void
+     */
+    protected function logStreamError(string $message, int $index): void
+    {
+        if (class_exists(Log::class)) {
+            Log::error(sprintf(
+                '%s encoding failed at index %d: %s',
+                static::class,
+                $index,
+                $message,
+            ));
+        }
+    }
+
+    /**
+     * Get the streaming options.
+     *
+     * @return array<string, mixed>
+     */
+    public function getStreamOptions(): array
+    {
+        return $this->getConfig();
+    }
+
+    /**
+     * Return an instance with updated streaming options.
+     *
+     * The body callback is rebuilt so the new instance streams using the
+     * updated options.
+     *
+     * @param array<string, mixed> $options Options to merge with existing options.
+     * @return static
+     */
+    public function withStreamOptions(array $options): static
+    {
+        $new = clone $this;
+        $new->setConfig(
+            $this->normalizeStreamOptions($options + $this->getConfig(), $options),
+            null,
+            false,
+        );
+        $new->applyStreamingHeaders();
+
+        return $new->withBody(new CallbackStream($new->createStreamCallback()));
+    }
+}

--- a/src/Http/Response/JsonStreamResponse.php
+++ b/src/Http/Response/JsonStreamResponse.php
@@ -17,11 +17,6 @@ declare(strict_types=1);
 namespace Cake\Http\Response;
 
 use Cake\Core\Configure;
-use Cake\Core\InstanceConfigTrait;
-use Cake\Http\CallbackStream;
-use Cake\Http\Response;
-use Cake\Log\Log;
-use Closure;
 use InvalidArgumentException;
 use JsonException;
 
@@ -65,10 +60,8 @@ use JsonException;
  * - 100,000 rows @ 1KB each: ~1KB memory (not ~100MB)
  * - Time to first byte: after first row (not after all rows)
  */
-class JsonStreamResponse extends Response
+class JsonStreamResponse extends AbstractStreamResponse
 {
-    use InstanceConfigTrait;
-
     /**
      * Default JSON encoding flags (consistent with JsonView).
      *
@@ -101,20 +94,6 @@ class JsonStreamResponse extends Response
     ];
 
     /**
-     * The iterable data to stream.
-     *
-     * @var iterable
-     */
-    protected iterable $data;
-
-    /**
-     * Number of streamed rows since the last flush.
-     *
-     * @var int
-     */
-    protected int $rowsSinceLastFlush = 0;
-
-    /**
      * Default streaming options.
      *
      * @var array<string, mixed>
@@ -144,38 +123,33 @@ class JsonStreamResponse extends Response
      */
     public function __construct(iterable $data, array $options = [])
     {
-        $this->data = $data;
-        $this->setConfig($this->normalizeStreamOptions($options + $this->_defaultConfig, $options), null, false);
-
-        $stream = new CallbackStream($this->createStreamCallback());
-        parent::__construct(['stream' => $stream]);
-
-        $this->applyStreamingHeaders();
+        parent::__construct($data, $options);
     }
 
     /**
-     * Create the streaming callback.
-     *
-     * The callback uses echo + flush for true streaming, sending data
-     * to the client as each item is encoded rather than buffering everything.
-     *
-     * @return \Closure
+     * @inheritDoc
      */
-    protected function createStreamCallback(): Closure
+    protected function streamData(): void
     {
-        return function (): void {
-            if ($this->getConfigOrFail('format') === self::FORMAT_NDJSON) {
-                $this->streamNdjson();
-            } else {
-                $this->streamJson();
-            }
-        };
+        if ($this->getConfigOrFail('format') === self::FORMAT_NDJSON) {
+            $this->streamNdjson();
+        } else {
+            $this->streamJson();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function contentType(): string
+    {
+        return $this->getConfigOrFail('format') === self::FORMAT_NDJSON
+            ? 'application/x-ndjson'
+            : 'application/json';
     }
 
     /**
      * Stream data as standard JSON.
-     *
-     * Uses echo + flush to send data immediately to the client.
      *
      * @return void
      */
@@ -229,8 +203,6 @@ class JsonStreamResponse extends Response
 
     /**
      * Stream data as NDJSON (newline-delimited JSON).
-     *
-     * Uses echo + flush to send each line immediately to the client.
      *
      * @return void
      */
@@ -358,11 +330,7 @@ class JsonStreamResponse extends Response
     }
 
     /**
-     * Normalize and validate stream options.
-     *
-     * @param array<string, mixed> $options Merged options.
-     * @param array<string, mixed> $originalOptions Original options passed by the caller.
-     * @return array<string, mixed>
+     * @inheritDoc
      */
     protected function normalizeStreamOptions(array $options, array $originalOptions = []): array
     {
@@ -378,127 +346,7 @@ class JsonStreamResponse extends Response
         if (Configure::read('debug') && !isset($originalOptions['flags'])) {
             $options['flags'] |= JSON_PRETTY_PRINT;
         }
-        if (!is_int($options['flushEvery']) || $options['flushEvery'] < 1) {
-            throw new InvalidArgumentException('`flushEvery` must be an integer greater than or equal to 1');
-        }
 
-        return $options;
-    }
-
-    /**
-     * Apply headers derived from the active stream options.
-     *
-     * @return void
-     */
-    protected function applyStreamingHeaders(): void
-    {
-        $charset = Configure::read('App.encoding') ?? 'UTF-8';
-        $mimeType = $this->getConfigOrFail('format') === self::FORMAT_NDJSON
-            ? 'application/x-ndjson'
-            : 'application/json';
-        $contentType = $mimeType . '; charset=' . $charset;
-
-        $this->_setHeader('Content-Type', $contentType);
-        // Prevent proxy/nginx buffering for true streaming
-        $this->_setHeader('X-Accel-Buffering', 'no');
-    }
-
-    /**
-     * Output data without flushing.
-     *
-     * Used for structural elements like brackets that don't need immediate flushing.
-     *
-     * @param string $data The data to output.
-     * @return void
-     */
-    protected function output(string $data): void
-    {
-        echo $data;
-    }
-
-    /**
-     * Output data and flush to client immediately.
-     *
-     * This ensures data is sent to the client right away rather than
-     * being buffered, enabling true streaming behavior.
-     *
-     * @param string $data The data to output and flush.
-     * @param bool $force Whether to force an immediate flush regardless of threshold.
-     * @return void
-     */
-    protected function outputAndFlush(string $data, bool $force = false): void
-    {
-        echo $data;
-        $this->rowsSinceLastFlush++;
-
-        if ($force || $this->rowsSinceLastFlush >= $this->getConfigOrFail('flushEvery')) {
-            $this->flushOutputBuffers();
-        }
-    }
-
-    /**
-     * Flush output buffers when it is safe to do so.
-     *
-     * @return void
-     */
-    protected function flushOutputBuffers(): void
-    {
-        // Only flush if we're at the implicit output buffer level (1) or no buffering.
-        // Higher levels indicate explicit buffering (e.g., tests) that we shouldn't disturb.
-        $level = ob_get_level();
-        if ($level <= 1) {
-            if ($level === 1) {
-                ob_flush();
-            }
-            flush();
-            $this->rowsSinceLastFlush = 0;
-        }
-    }
-
-    /**
-     * Log a streaming error.
-     *
-     * @param string $message Error message.
-     * @param int $index Item index where error occurred.
-     * @return void
-     */
-    protected function logStreamError(string $message, int $index): void
-    {
-        if (class_exists(Log::class)) {
-            Log::error(sprintf(
-                'JsonStreamResponse encoding failed at index %d: %s',
-                $index,
-                $message,
-            ));
-        }
-    }
-
-    /**
-     * Get the streaming options.
-     *
-     * @return array<string, mixed>
-     */
-    public function getStreamOptions(): array
-    {
-        return $this->getConfig();
-    }
-
-    /**
-     * Return an instance with updated streaming options.
-     *
-     * @param array<string, mixed> $options Options to merge with existing options.
-     * @return static
-     */
-    public function withStreamOptions(array $options): static
-    {
-        $new = clone $this;
-        $new->setConfig(
-            $this->normalizeStreamOptions($options + $this->getConfig(), $options),
-            null,
-            false,
-        );
-        $new->applyStreamingHeaders();
-
-        return $new->withBody(new CallbackStream($new->createStreamCallback()));
+        return parent::normalizeStreamOptions($options, $originalOptions);
     }
 }

--- a/src/Http/Response/JsonStreamResponse.php
+++ b/src/Http/Response/JsonStreamResponse.php
@@ -40,6 +40,16 @@ use JsonException;
  * return new JsonStreamResponse($query, ['format' => 'ndjson']);
  * ```
  *
+ * ### Options
+ *
+ * - `root` (string|null, default: null): Wrap data in `{"root": [...]}`
+ * - `envelope` (array, default: []): Static metadata merged with streaming data
+ * - `dataKey` (string, default: 'data'): Key for streaming data when envelope is used
+ * - `format` (string, default: 'json'): Output format — 'json' or 'ndjson'
+ * - `transform` (callable|null, default: null): Transform each item before encoding
+ * - `flags` (int, default: DEFAULT_JSON_FLAGS): JSON encode flags
+ * - `flushEvery` (int, default: 1): Flush output buffers every N items
+ *
  * ### ORM Integration
  *
  * For true streaming benefits, use unbuffered queries and avoid result formatters:
@@ -107,24 +117,6 @@ class JsonStreamResponse extends AbstractStreamResponse
         'flags' => self::DEFAULT_JSON_FLAGS,
         'flushEvery' => 1,
     ];
-
-    /**
-     * Constructor.
-     *
-     * @param iterable $data The iterable data to stream (array, generator, ResultSet, etc.)
-     * @param array<string, mixed> $options Streaming options:
-     *   - `root`: Wrap data in `{"root": [...]}` (string|null, default: null)
-     *   - `envelope`: Static metadata merged with streaming data (array, default: [])
-     *   - `dataKey`: Key for streaming data when envelope is used (string, default: 'data')
-     *   - `format`: Output format - 'json' or 'ndjson' (string, default: 'json')
-     *   - `transform`: Transform each item before encoding (callable|null, default: null)
-     *   - `flags`: JSON encode flags (int, default: DEFAULT_JSON_FLAGS)
-     *   - `flushEvery`: Flush output buffers every N items (int, default: 1)
-     */
-    public function __construct(iterable $data, array $options = [])
-    {
-        parent::__construct($data, $options);
-    }
 
     /**
      * @inheritDoc

--- a/tests/TestCase/Http/Response/AbstractStreamResponseTest.php
+++ b/tests/TestCase/Http/Response/AbstractStreamResponseTest.php
@@ -1,0 +1,216 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http\Response;
+
+use Cake\Core\Configure;
+use Cake\Http\Response\AbstractStreamResponse;
+use Cake\Log\Engine\ArrayLog;
+use Cake\Log\Log;
+use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use Throwable;
+
+/**
+ * Tests for {@see \Cake\Http\Response\AbstractStreamResponse} that exercise
+ * the shared streaming lifecycle independently of any concrete wire format.
+ */
+class AbstractStreamResponseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Log::setConfig('streamtest', ['className' => ArrayLog::class]);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Log::drop('streamtest');
+    }
+
+    /**
+     * Capture body output emitted by the streaming callback.
+     */
+    protected function getStreamedBody(AbstractStreamResponse $response): string
+    {
+        ob_start();
+        try {
+            (string)$response->getBody();
+        } catch (Throwable $exception) {
+            ob_end_clean();
+
+            throw $exception;
+        }
+
+        return ob_get_clean() ?: '';
+    }
+
+    public function testEmitsContentTypeWithCharsetAndAccelBufferingHeader(): void
+    {
+        $response = $this->newFixture([['id' => 1]]);
+
+        $this->assertSame('text/plain; charset=UTF-8', $response->getHeaderLine('Content-Type'));
+        $this->assertSame('no', $response->getHeaderLine('X-Accel-Buffering'));
+    }
+
+    public function testContentTypeUsesAppEncodingWhenSet(): void
+    {
+        $original = Configure::read('App.encoding');
+        Configure::write('App.encoding', 'ISO-8859-1');
+        try {
+            $response = $this->newFixture([['id' => 1]]);
+            $this->assertSame('text/plain; charset=ISO-8859-1', $response->getHeaderLine('Content-Type'));
+        } finally {
+            Configure::write('App.encoding', $original);
+        }
+    }
+
+    public function testStreamDataIsInvokedViaResponseBody(): void
+    {
+        $response = $this->newFixture([['id' => 1], ['id' => 2]]);
+
+        $this->assertSame('1|2|', $this->getStreamedBody($response));
+    }
+
+    public function testInvalidFlushEveryThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('`flushEvery` must be an integer greater than or equal to 1');
+
+        $this->newFixture([], ['flushEvery' => 0]);
+    }
+
+    public function testNonIntegerFlushEveryThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('`flushEvery` must be an integer greater than or equal to 1');
+
+        $this->newFixture([], ['flushEvery' => 'every']);
+    }
+
+    public function testOutputAndFlushBatchesAccordingToFlushEvery(): void
+    {
+        $response = $this->newFixture(
+            [['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4]],
+            ['flushEvery' => 2],
+            simulateSuccessfulFlush: true,
+        );
+
+        $this->getStreamedBody($response);
+
+        $this->assertSame(2, $response->flushCalls);
+    }
+
+    public function testLogStreamErrorIncludesSubclassNameAndIndex(): void
+    {
+        $response = $this->newFixture([]);
+        $response->triggerLogStreamError('boom', 7);
+
+        $messages = Log::engine('streamtest')->read();
+        $this->assertCount(1, $messages);
+        $this->assertStringContainsString(
+            sprintf('%s encoding failed at index 7: boom', $response::class),
+            $messages[0],
+        );
+    }
+
+    public function testGetStreamOptionsReturnsCurrentConfig(): void
+    {
+        $response = $this->newFixture([], ['flushEvery' => 5]);
+
+        $this->assertSame(['flushEvery' => 5], $response->getStreamOptions());
+    }
+
+    public function testWithStreamOptionsReturnsNewInstanceAndPreservesOriginal(): void
+    {
+        $response = $this->newFixture([['id' => 1]]);
+        $new = $response->withStreamOptions(['flushEvery' => 3]);
+
+        $this->assertNotSame($response, $new);
+        $this->assertSame(1, $response->getStreamOptions()['flushEvery']);
+        $this->assertSame(3, $new->getStreamOptions()['flushEvery']);
+    }
+
+    public function testWithStreamOptionsRebuildsStreamCallback(): void
+    {
+        $response = $this->newFixture([['id' => 1], ['id' => 2]]);
+        $new = $response->withStreamOptions(['flushEvery' => 1]);
+
+        $this->assertSame('1|2|', $this->getStreamedBody($new));
+    }
+
+    /**
+     * Build a minimal concrete subclass used to exercise the abstract behavior.
+     *
+     * The fixture writes `{id}|` per row using {@see AbstractStreamResponse::outputAndFlush()},
+     * exposes a counter for `flushOutputBuffers()` invocations, and exposes a
+     * public wrapper around the protected `logStreamError()` so tests can drive
+     * each piece directly.
+     *
+     * @param iterable $data Data to stream.
+     * @param array<string, mixed> $options Stream options.
+     * @param bool $simulateSuccessfulFlush When true, the fixture resets the
+     *   flush counter on every `flushOutputBuffers()` call so threshold-based
+     *   batching tests work even when PHPUnit wraps output in ob_start() and
+     *   the parent flush would otherwise no-op (and intentionally not reset
+     *   the counter).
+     * @return object Anonymous instance of AbstractStreamResponse with test hooks.
+     */
+    protected function newFixture(
+        iterable $data,
+        array $options = [],
+        bool $simulateSuccessfulFlush = false,
+    ): object {
+        return new class ($data, $options, $simulateSuccessfulFlush) extends AbstractStreamResponse {
+            public int $flushCalls = 0;
+
+            protected bool $simulateSuccessfulFlush;
+
+            public function __construct(iterable $data, array $options, bool $simulateSuccessfulFlush)
+            {
+                $this->simulateSuccessfulFlush = $simulateSuccessfulFlush;
+                parent::__construct($data, $options);
+            }
+
+            protected function contentType(): string
+            {
+                return 'text/plain';
+            }
+
+            protected function streamData(): void
+            {
+                foreach ($this->data as $row) {
+                    $this->outputAndFlush($row['id'] . '|');
+                }
+            }
+
+            protected function flushOutputBuffers(): void
+            {
+                $this->flushCalls++;
+                parent::flushOutputBuffers();
+                if ($this->simulateSuccessfulFlush) {
+                    $this->rowsSinceLastFlush = 0;
+                }
+            }
+
+            public function triggerLogStreamError(string $message, int $index): void
+            {
+                $this->logStreamError($message, $index);
+            }
+        };
+    }
+}

--- a/tests/TestCase/Http/Response/AbstractStreamResponseTest.php
+++ b/tests/TestCase/Http/Response/AbstractStreamResponseTest.php
@@ -211,6 +211,42 @@ class AbstractStreamResponseTest extends TestCase
             {
                 $this->logStreamError($message, $index);
             }
+
+            public function triggerFlush(): void
+            {
+                $this->flushOutputBuffers();
+            }
         };
+    }
+
+    public function testFlushOutputBuffersAtImplicitLevelInvokesObFlush(): void
+    {
+        $response = $this->newFixture([]);
+
+        // Collapse the entire OB stack and start exactly one buffer so
+        // flushOutputBuffers() takes the `$level === 1` branch and calls
+        // ob_flush(). PHPUnit normally adds its own buffers around tests.
+        $depth = 0;
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+            $depth++;
+        }
+        ob_start();
+
+        try {
+            // Empty buffer: ob_flush() inside flushOutputBuffers() still runs
+            // (the coverage target), but emits nothing to stdout.
+            $this->assertSame(1, ob_get_level(), 'precondition: ob_get_level == 1');
+            $response->triggerFlush();
+            $remaining = ob_get_clean();
+        } finally {
+            // Restore the buffer depth PHPUnit had so it can capture our output
+            for ($i = 0; $i < $depth; $i++) {
+                ob_start();
+            }
+        }
+
+        // ob_flush() executed cleanly on the single-level buffer.
+        $this->assertSame('', $remaining);
     }
 }

--- a/tests/TestCase/Http/Response/AbstractStreamResponseTest.php
+++ b/tests/TestCase/Http/Response/AbstractStreamResponseTest.php
@@ -211,42 +211,6 @@ class AbstractStreamResponseTest extends TestCase
             {
                 $this->logStreamError($message, $index);
             }
-
-            public function triggerFlush(): void
-            {
-                $this->flushOutputBuffers();
-            }
         };
-    }
-
-    public function testFlushOutputBuffersAtImplicitLevelInvokesObFlush(): void
-    {
-        $response = $this->newFixture([]);
-
-        // Collapse the entire OB stack and start exactly one buffer so
-        // flushOutputBuffers() takes the `$level === 1` branch and calls
-        // ob_flush(). PHPUnit normally adds its own buffers around tests.
-        $depth = 0;
-        while (ob_get_level() > 0) {
-            ob_end_clean();
-            $depth++;
-        }
-        ob_start();
-
-        try {
-            // Empty buffer: ob_flush() inside flushOutputBuffers() still runs
-            // (the coverage target), but emits nothing to stdout.
-            $this->assertSame(1, ob_get_level(), 'precondition: ob_get_level == 1');
-            $response->triggerFlush();
-            $remaining = ob_get_clean();
-        } finally {
-            // Restore the buffer depth PHPUnit had so it can capture our output
-            for ($i = 0; $i < $depth; $i++) {
-                ob_start();
-            }
-        }
-
-        // ob_flush() executed cleanly on the single-level buffer.
-        $this->assertSame('', $remaining);
     }
 }


### PR DESCRIPTION
## Summary

Pulls the streaming lifecycle shared by `JsonStreamResponse` into a new `AbstractStreamResponse` base class so a forthcoming `CsvStreamResponse` (and any future `XmlStreamResponse`) can extend it instead of duplicating the machinery.

Background: during review of [cakephp/cakephp#19367](https://github.com/cakephp/cakephp/pull/19367) ADmad suggested an `AbstractStreamResponse` could help once other streaming formats arrived, but we deferred extracting it from a single consumer. A CSV streaming response for `friendsofcake/cakephp-csvview` is now the second concrete case (see [FriendsOfCake/cakephp-csvview#89](https://github.com/FriendsOfCake/cakephp-csvview/issues/89)), so the extraction now has two real consumers driving its shape.

## What moves into AbstractStreamResponse

- `iterable $data` storage + `CallbackStream` wiring to the response body
- `applyStreamingHeaders()` — Content-Type (via abstract `contentType()`) and `X-Accel-Buffering: no`
- `output()`, `outputAndFlush()`, `flushOutputBuffers()` primitives
- The `flushEvery` option and its threshold counter
- `logStreamError()` — gated on `cakephp/log` being installed (no hard dependency added)
- `normalizeStreamOptions()` — base validates `flushEvery`; subclasses override and call parent
- `withStreamOptions()` / `getStreamOptions()` — PSR-7 immutability helpers

Two abstract hooks subclasses must implement:

- `contentType(): string` — MIME type without charset suffix (lets a subclass return different types based on options, like JSON / NDJSON)
- `streamData(): void` — the actual write loop using the inherited output primitives

## What stays in JsonStreamResponse

- JSON / NDJSON format constants and the `format` option
- `root`, `envelope`, `dataKey`, `transform`, `flags` config
- `streamJson()` / `streamNdjson()` write loops
- `encodeStreamItem()`, `buildStreamErrorMarker()`, JSON wrapper helpers
- Pretty-print-in-debug-mode behavior
- Format validation in `normalizeStreamOptions()` (defers to parent for `flushEvery`)

## Behavior

No public-API changes. `JsonStreamResponse` keeps the same constructor signature, methods, and constants. All 25 existing cases in `JsonStreamResponseTest` pass without modification.

One minor internal shift: `logStreamError()` previously hard-coded `"JsonStreamResponse encoding failed at index N: ..."`; it now uses `static::class` so each subclass logs under its own FQCN automatically.

## Tests

Adds `AbstractStreamResponseTest` (10 cases) exercising the shared lifecycle via a minimal anonymous fixture subclass:

- Content-Type with default and `App.encoding`-derived charset
- `X-Accel-Buffering: no` header set
- `streamData()` dispatch through the body callback
- `flushEvery` validation (zero, non-int both rejected)
- Threshold-based flush batching
- `logStreamError()` format captured via `ArrayLog`
- `getStreamOptions()` returns the active config
- `withStreamOptions()` returns a new instance, preserves the original, and rebuilds the stream callback

PHPStan and phpcs both clean on the four changed files.

## Follow-up

A `CsvStreamResponse` PR will extend this abstract from the `friendsofcake/cakephp-csvview` plugin once this lands. Whether a hypothetical `XmlStreamResponse` belongs in core or in a separate plugin can be revisited if/when the need arises.

Opening as **draft** so the design can be reviewed before any downstream work depends on the shape.
