### PR TITLE
Fix stale docblock on testDeleteOrFailGetEntity

### DIFF
--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -6552,7 +6552,7 @@ class TableTest extends TestCase
     }
 
     /**
-     * Tests that deleteOrFail returns the right entity
+     * Tests that the PersistenceFailedException raised by deleteOrFail carries the failing entity.
      */
     public function testDeleteOrFailGetEntity(): void
     {


### PR DESCRIPTION
## Summary

`Table::deleteOrFail()` now returns `void` in 6.x, so the previous *"Tests that deleteOrFail returns the right entity"* wording on `testDeleteOrFailGetEntity` is misleading.

What the test actually verifies is that the `PersistenceFailedException` raised by `deleteOrFail()` carries the failing entity via `getEntity()`. Updated the docblock to reflect that.

No behavior change, comment-only.