### PR TITLE
6.0: Change Table::deleteManyOrFail() return type to void

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2454,28 +2454,26 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * Deletes multiple entities of a table.
+     * Deletes multiple entities of a table or throws a PersistenceFailedException
+     * if any one of the records fails to delete.
      *
      * The records will be deleted in a transaction which will be rolled back if
      * any one of the records fails to delete due to failed validation or database
      * error.
      *
-     * @template TDeletedEntity of \Cake\Datasource\EntityInterface
-     * @param iterable<TDeletedEntity> $entities Entities to delete.
+     * @param iterable<\Cake\Datasource\EntityInterface> $entities Entities to delete.
      * @param array<string, mixed> $options Options used when calling Table::save() for each entity.
-     * @return iterable<TDeletedEntity> Entities list.
+     * @return void
      * @throws \Cake\ORM\Exception\PersistenceFailedException
      * @see \Cake\ORM\Table::delete() for options and events related to this method.
      */
-    public function deleteManyOrFail(iterable $entities, array $options = []): iterable
+    public function deleteManyOrFail(iterable $entities, array $options = []): void
     {
         $failed = $this->doDeleteMany($entities, $options);
 
         if ($failed !== null) {
             throw new PersistenceFailedException($failed, ['deleteMany']);
         }
-
-        return $entities;
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3541,8 +3541,7 @@ class TableTest extends TestCase
         $entities = $table->find()->limit(2)->all()->toArray();
         $this->assertCount(2, $entities);
 
-        $result = $table->deleteManyOrFail($entities);
-        $this->assertSame($entities, $result);
+        $table->deleteManyOrFail($entities);
 
         $count = $table->find()->where(['id IN' => Hash::extract($entities, '{n}.id')])->count();
         $this->assertSame(0, $count, 'Find should not return > 0.');


### PR DESCRIPTION
## Summary

Companion to the existing `Table::deleteOrFail(): void` change on 6.x. `deleteManyOrFail()` currently returns `iterable`, but the body is literally:

```php
public function deleteManyOrFail(iterable $entities, array $options = []): iterable
{
    $failed = $this->doDeleteMany($entities, $options);

    if ($failed !== null) {
        throw new PersistenceFailedException($failed, ['deleteMany']);
    }

    return $entities;
}
```

The return is the same iterable that was passed in. Callers already have those entities; the return value carries no information. Same pattern that motivated changing `deleteOrFail()` from `bool` to `void` (its `bool` was always `true` when not throwing).

This finishes the cleanup for the delete-OrFail family:

| Method                  | 5.x return        | 6.x return  |
|-------------------------|-------------------|-------------|
| `deleteOrFail`          | `bool`            | `void` (already done on 6.x) |
| `deleteManyOrFail`      | `iterable`        | `void` (this PR) |

