### PR TITLE
Fix 6.x CI regressions from 5.next merge

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,9 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="7.0.0-beta17@a7f96f911fc869c40c48ec977e21f01a8ca534bd">
+<files psalm-version="7.0.0-beta19@7e751c06a756fa64dc4c759c09fe4a173afcb433">
+  <file src="src/Cache/Engine/PhpEngine.php">
+    <TaintedInclude>
+      <code><![CDATA[$path]]></code>
+    </TaintedInclude>
+  </file>
   <file src="src/Command/PluginLoadCommand.php">
     <TaintedSSRF>
       <code><![CDATA[$file]]></code>
     </TaintedSSRF>
+  </file>
+  <file src="src/Controller/Component/FlashComponent.php">
+    <MethodSignatureMismatch>
+      <code><![CDATA[public function configShallow(array|string $key, mixed $value = null): static]]></code>
+      <code><![CDATA[public function setConfig(array|string $key, mixed $value = null, bool $merge = true): static]]></code>
+    </MethodSignatureMismatch>
   </file>
   <file src="src/Controller/ComponentRegistry.php">
     <OverriddenMethodAccess>
@@ -31,8 +42,8 @@
   </file>
   <file src="src/Core/InstanceConfigTrait.php">
     <UnsupportedPropertyReferenceUsage>
-      <code><![CDATA[$update = &$this->_config]]></code>
-      <code><![CDATA[$update = &$this->_config]]></code>
+      <code><![CDATA[$update = &$this->config]]></code>
+      <code><![CDATA[$update = &$this->config]]></code>
     </UnsupportedPropertyReferenceUsage>
   </file>
   <file src="src/Core/PluginConfig.php">
@@ -42,10 +53,23 @@
   </file>
   <file src="src/Datasource/EntityTrait.php">
     <UnsupportedPropertyReferenceUsage>
-      <code><![CDATA[$value = &$this->_fields[$field]]]></code>
+      <code><![CDATA[$value = &$this->fields[$field]]]></code>
     </UnsupportedPropertyReferenceUsage>
   </file>
+  <file src="src/ORM/Query/SelectQuery.php">
+    <MethodSignatureMismatch>
+      <code><![CDATA[SelectQuery]]></code>
+      <code><![CDATA[SelectQuery]]></code>
+      <code><![CDATA[SelectQuery]]></code>
+      <code><![CDATA[SelectQuery]]></code>
+      <code><![CDATA[SelectQuery]]></code>
+      <code><![CDATA[SelectQuery]]></code>
+    </MethodSignatureMismatch>
+  </file>
   <file src="src/TestSuite/TestCase.php">
+    <NoValue>
+      <code><![CDATA[return $this->capturedError;]]></code>
+    </NoValue>
     <UndefinedVariable>
       <code><![CDATA[$previousHandler]]></code>
     </UndefinedVariable>

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -863,7 +863,7 @@ class I18nExtractCommand extends Command
                 'msgctxt' => $label->context,
             ];
 
-            $this->_addTranslation($label->domain, $label->label, $details);
+            $this->addTranslation($label->domain, $label->label, $details);
         }
     }
 

--- a/src/Http/Response/JsonStreamResponse.php
+++ b/src/Http/Response/JsonStreamResponse.php
@@ -101,13 +101,6 @@ class JsonStreamResponse extends Response
     ];
 
     /**
-     * The iterable data to stream.
-     *
-     * @var iterable
-     */
-    protected iterable $data;
-
-    /**
      * Number of streamed rows since the last flush.
      *
      * @var int
@@ -119,7 +112,7 @@ class JsonStreamResponse extends Response
      *
      * @var array<string, mixed>
      */
-    protected array $_defaultConfig = [
+    protected array $defaultConfig = [
         'root' => null,
         'envelope' => [],
         'dataKey' => 'data',
@@ -142,10 +135,9 @@ class JsonStreamResponse extends Response
      *   - `flags`: JSON encode flags (int, default: DEFAULT_JSON_FLAGS)
      *   - `flushEvery`: Flush output buffers every N items (int, default: 1)
      */
-    public function __construct(iterable $data, array $options = [])
+    public function __construct(protected iterable $data, array $options = [])
     {
-        $this->data = $data;
-        $this->setConfig($this->normalizeStreamOptions($options + $this->_defaultConfig, $options), null, false);
+        $this->setConfig($this->normalizeStreamOptions($options + $this->defaultConfig, $options), null, false);
 
         $stream = new CallbackStream($this->createStreamCallback());
         parent::__construct(['stream' => $stream]);
@@ -398,9 +390,9 @@ class JsonStreamResponse extends Response
             : 'application/json';
         $contentType = $mimeType . '; charset=' . $charset;
 
-        $this->_setHeader('Content-Type', $contentType);
+        $this->setHeader('Content-Type', $contentType);
         // Prevent proxy/nginx buffering for true streaming
-        $this->_setHeader('X-Accel-Buffering', 'no');
+        $this->setHeader('X-Accel-Buffering', 'no');
     }
 
     /**

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -613,7 +613,7 @@ class CommandRunnerTest extends TestCase
             }
         };
         $command = new class extends Command {
-            public function execute(Arguments $args, ConsoleIo $io): int
+            public function execute(): int
             {
                 $this->getEventManager()->dispatch(new Event('Test.commandEvent'));
 


### PR DESCRIPTION
## Summary

The May 9 `Merge branch '5.next' into 6.x` (53e1a9b) brought in code that still used the legacy underscore-prefixed property and method names which were dropped on 6.x. That broke CI in four ways simultaneously:

- **`tests/TestCase/Console/CommandRunnerTest.php:616`** — anonymous Command's `execute(Arguments $args, ConsoleIo $io): int` is LSP-incompatible with the parameterless 6.x `Command::execute()` base, causing a PHP fatal that cascaded the entire testsuite matrix (Linux + Windows, MySQL/MariaDB/Postgres/SQLite/SQLServer, PHP 8.4 + 8.5). The test body did not reference either argument, so the parameters are dropped.
- **`src/Http/Response/JsonStreamResponse.php`** — still declared `$_defaultConfig` and called `$this->_setHeader()`. The new `InstanceConfigTrait` reads `$this->defaultConfig` (no underscore), so the `TypeError: Cannot assign null to property $config of type array` cascaded into all 22 `JsonStreamResponseTest` cases. Also picks up the rector suggestion to promote `iterable $data` via constructor property promotion (the second rector finding self-resolved with the test fix above).
- **`src/Command/I18nExtractCommand.php:866`** — calls `$this->_addTranslation()` but the method was renamed to `addTranslation()` on 6.x. Cascaded into 5 `I18nExtractCommandTest` errors.
- **`psalm-baseline.xml`** — the baseline merged in from 5.next still contained CDATA referencing `$this->_config` and `$this->_fields`, which no longer match 6.x sources (those references use `$this->config` / `$this->fields` now). This produced 15 psalm errors: `UnsupportedPropertyReferenceUsage` on the new lines, `UnusedBaselineEntry` for the stale entries, plus genuine new entries that were not yet captured (FlashComponent + SelectQuery `MethodSignatureMismatch`, PhpEngine `TaintedInclude`, TestCase `NoValue`). Regenerated with `tools/psalm --set-baseline=psalm-baseline.xml`.

## Verification

Run locally on the fix branch (PHP 8.4.20, sqlite):

- `vendor/bin/phpunit` → 9977 tests, 0 errors / 0 failures (apart from `ConsoleInputTest::testDataAvailable`, which is explicitly skipped on GitHub Actions and only flaps on local TTYs)
- `tools/phpstan analyse` → OK, no errors
- `tools/phpstan analyse -c tests/phpstan.neon` → OK, no errors
- `tools/psalm` → 0 errors
- `vendor/bin/phpcs --parallel=8` → 0 errors
- `vendor/bin/rector process --dry-run` → no changes suggested
- `php contrib/validate-split-packages-phpstan.php` → exit 0
