### PR TITLE
Drop references to the deleted Cake\ORM\Query class

### DIFF
--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -154,9 +154,9 @@ class SelectQuery extends Query implements IteratorAggregate
      * })
      * ```
      *
-     * By default no fields are selected, if you have an instance of `Cake\ORM\Query` and try to append
-     * fields you should also call `Cake\ORM\Query::enableAutoFields()` to select the default fields
-     * from the table.
+     * By default no fields are selected, if you have an instance of `Cake\ORM\Query\SelectQuery` and try to
+     * append fields you should also call `Cake\ORM\Query\SelectQuery::enableAutoFields()` to select the
+     * default fields from the table.
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string|float|int $fields fields to be added to the list.
      * @param bool $overwrite whether to reset fields with passed list or not

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -39,7 +39,7 @@ class LazyEagerLoader
      *
      * @param \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface> $entities a single entity or list of entities
      * @param array $contain A `contain()` compatible array.
-     * @see \Cake\ORM\Query::contain()
+     * @see \Cake\ORM\Query\SelectQuery::contain()
      * @param \Cake\ORM\Table $source The table to use for fetching the top level entities
      * @return \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface>
      */

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -800,9 +800,9 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * })
      * ```
      *
-     * By default, no fields are selected, if you have an instance of `Cake\ORM\Query` and try to append
-     * fields you should also call `Cake\ORM\Query::enableAutoFields()` to select the default fields
-     * from the table.
+     * By default, no fields are selected, if you have an instance of `Cake\ORM\Query\SelectQuery` and try to
+     * append fields you should also call `Cake\ORM\Query\SelectQuery::enableAutoFields()` to select the
+     * default fields from the table.
      *
      * If you pass an instance of a `Cake\ORM\Table` or `Cake\ORM\Association` class,
      * all the fields in the schema of the table or the association will be added to
@@ -1832,7 +1832,3 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
         return $this->autoFields;
     }
 }
-
-// phpcs:disable
-class_exists(\Cake\ORM\Query::class);
-// phpcs:enable

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -3192,7 +3192,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @param \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface> $entities a single entity or list of entities
      * @param array $contain A `contain()` compatible array.
-     * @see \Cake\ORM\Query::contain()
+     * @see \Cake\ORM\Query\SelectQuery::contain()
      * @return \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface>
      */
     public function loadInto(EntityInterface|array $entities, array $contain): EntityInterface|array


### PR DESCRIPTION
## Summary

The `Cake\ORM\Query` BC alias was removed from 6.x (the file `src/ORM/Query.php` is gone), but a handful of references to it stayed behind. Each of these now points at a class that does not exist:

| Location | What's stale |
|---|---|
| `src/ORM/Query/SelectQuery.php:1836-1838` | `class_exists(\Cake\ORM\Query::class);` block (plus the `phpcs:disable`/`phpcs:enable` pair around it) — used to trigger autoload of the alias file on 5.x. On 6.x it silently looks up a class that does not exist. |
| `src/ORM/LazyEagerLoader.php:42` | `@see \Cake\ORM\Query::contain()` |
| `src/ORM/Table.php:3195` | `@see \Cake\ORM\Query::contain()` |
| `src/Database/Query/SelectQuery.php:157-159` | Long-form docblock prose: *"if you have an instance of `Cake\ORM\Query` ..."* |
| `src/ORM/Query/SelectQuery.php:803-805` | Same prose |

All references are retargeted at `Cake\ORM\Query\SelectQuery` (the class that survives on 6.x). The dead autoload trigger block is removed.

No behavior change.