### PR TITLE
Update ORM Query docblock references to SelectQuery

### DIFF
--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -154,9 +154,9 @@ class SelectQuery extends Query implements IteratorAggregate
      * })
      * ```
      *
-     * By default no fields are selected, if you have an instance of `Cake\ORM\Query` and try to append
-     * fields you should also call `Cake\ORM\Query::enableAutoFields()` to select the default fields
-     * from the table.
+     * By default no fields are selected, if you have an instance of `Cake\ORM\Query\SelectQuery` and try to
+     * append fields you should also call `Cake\ORM\Query\SelectQuery::enableAutoFields()` to select the
+     * default fields from the table.
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string|float|int $fields fields to be added to the list.
      * @param bool $overwrite whether to reset fields with passed list or not

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -39,7 +39,7 @@ class LazyEagerLoader
      *
      * @param \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface> $entities a single entity or list of entities
      * @param array $contain A `contain()` compatible array.
-     * @see \Cake\ORM\Query::contain()
+     * @see \Cake\ORM\Query\SelectQuery::contain()
      * @param \Cake\ORM\Table $source The table to use for fetching the top level entities
      * @return \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface>
      */

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -800,9 +800,9 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * })
      * ```
      *
-     * By default, no fields are selected, if you have an instance of `Cake\ORM\Query` and try to append
-     * fields you should also call `Cake\ORM\Query::enableAutoFields()` to select the default fields
-     * from the table.
+     * By default, no fields are selected, if you have an instance of `Cake\ORM\Query\SelectQuery` and try to
+     * append fields you should also call `Cake\ORM\Query\SelectQuery::enableAutoFields()` to select the
+     * default fields from the table.
      *
      * If you pass an instance of a `Cake\ORM\Table` or `Cake\ORM\Association` class,
      * all the fields in the schema of the table or the association will be added to

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -3282,7 +3282,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @param \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface> $entities a single entity or list of entities
      * @param array $contain A `contain()` compatible array.
-     * @see \Cake\ORM\Query::contain()
+     * @see \Cake\ORM\Query\SelectQuery::contain()
      * @return \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface>
      */
     public function loadInto(EntityInterface|array $entities, array $contain): EntityInterface|array


### PR DESCRIPTION
## Summary

The `Cake\ORM\Query` class is a `class_alias` for `Cake\ORM\Query\SelectQuery` on 5.x (see `src/ORM/Query.php`), so the existing references still resolve. This is a docblock-only cleanup that retargets see-annotations and prose at the concrete `SelectQuery` class for clarity, matching the cleanup already done on 6.x in #19435 — where the alias was removed entirely and those references genuinely became stale.

The 6.x PR also removed the BC autoload trigger

```php
class_exists(\Cake\ORM\Query::class);
```

at the bottom of `src/ORM/Query/SelectQuery.php`. That part is intentionally NOT ported here — the trigger is still needed on 5.x to load the alias.

Changes:

- `src/Database/Query/SelectQuery.php` — prose retargeted to `SelectQuery`
- `src/ORM/Query/SelectQuery.php` — prose retargeted to `SelectQuery`
- `src/ORM/LazyEagerLoader.php` — see-annotation retargeted to `SelectQuery`
- `src/ORM/Table.php` — see-annotation retargeted to `SelectQuery`

Docblock-only; no behavior change.
