### PR TITLE
Propagate TEntity to find()/findOrCreate()/loadInto() and friends

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1271,11 +1271,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @param string $type the type of query to perform
      * @param mixed ...$args Arguments that match up to finder-specific parameters
-     * @return \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array> The query builder
+     * @return \Cake\ORM\Query\SelectQuery<TEntity|array> The query builder
      */
     public function find(string $type = 'all', mixed ...$args): SelectQuery
     {
-        /** @var \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array> $query */
+        /** @var \Cake\ORM\Query\SelectQuery<TEntity|array> $query */
         $query = $this->callFinder($type, $this->selectQuery(), ...$args);
 
         return $query;
@@ -1359,8 +1359,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * ]
      * ```
      *
-     * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array> $query The query to find with
-     * @return \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array> The query builder
+     * @param \Cake\ORM\Query\SelectQuery<TEntity|array> $query The query to find with
+     * @return \Cake\ORM\Query\SelectQuery<TEntity|array> The query builder
      */
     public function findList(
         SelectQuery $query,
@@ -1417,11 +1417,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * $table->find('threaded', keyField: 'id', parentField: 'ancestor_id', nestingKey: 'children');
      * ```
      *
-     * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array> $query The query to find with
+     * @param \Cake\ORM\Query\SelectQuery<TEntity|array> $query The query to find with
      * @param \Closure|array|string|null $keyField The path to the key field.
      * @param \Closure|array|string $parentField The path to the parent field.
      * @param string $nestingKey The key to nest children under.
-     * @return \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array> The query builder
+     * @return \Cake\ORM\Query\SelectQuery<TEntity|array> The query builder
      */
     public function findThreaded(
         SelectQuery $query,
@@ -1631,14 +1631,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *   transaction (default: true)
      * - defaults: Whether to use the search criteria as default values for the new entity (default: true)
      *
-     * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array>|callable|array $search The criteria to find existing
+     * @param \Cake\ORM\Query\SelectQuery<TEntity|array>|callable|array $search The criteria to find existing
      *   records by. Note that when you pass a query object you'll have to use
      *   the 2nd arg of the method to modify the entity data before saving.
      * @param callable|array|null $callback An array of data key/value pairs or a callback that will
      *   be invoked for newly created entities. This callback will be called *before* the entity
      *   is persisted.
      * @param array<string, mixed> $options The options to use when saving.
-     * @return \Cake\Datasource\EntityInterface An entity.
+     * @return TEntity An entity.
      * @throws \Cake\ORM\Exception\PersistenceFailedException When the entity couldn't be saved
      */
     public function findOrCreate(
@@ -1666,13 +1666,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Performs the actual find and/or create of an entity based on the passed options.
      *
-     * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array>|callable|array $search The criteria to find an existing record by, or a callable that will
+     * @param \Cake\ORM\Query\SelectQuery<TEntity|array>|callable|array $search The criteria to find an existing record by, or a callable that will
      *   customize the find query.
      * @param callable|array|null $callback Data or a callback that will be invoked for newly
      *   created entities. This callback will be called *before* the entity
      *   is persisted.
      * @param array<string, mixed> $options The options to use when saving.
-     * @return \Cake\Datasource\EntityInterface|array An entity.
+     * @return TEntity|array An entity.
      * @throws \Cake\ORM\Exception\PersistenceFailedException When the entity couldn't be saved
      * @throws \InvalidArgumentException
      */
@@ -1700,7 +1700,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             $entity = $this->patchEntity($entity, $data, ['accessibleFields' => $accessibleFields]);
         }
         if ($callback !== null) {
-            /** @var \Cake\Datasource\EntityInterface $entity */
+            /** @var TEntity $entity */
             $entity = $callback($entity) ?: $entity;
         }
         unset($options['defaults']);
@@ -1717,8 +1717,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Gets the query object for findOrCreate().
      *
-     * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array>|callable|array $search The criteria to find existing records by.
-     * @return \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array>
+     * @param \Cake\ORM\Query\SelectQuery<TEntity|array>|callable|array $search The criteria to find existing records by.
+     * @return \Cake\ORM\Query\SelectQuery<TEntity|array>
      */
     protected function _getFindOrCreateQuery(SelectQuery|callable|array $search): SelectQuery
     {
@@ -1792,11 +1792,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * This is useful for subqueries.
      *
-     * @return \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array>
+     * @return \Cake\ORM\Query\SelectQuery<TEntity|array>
      */
     public function subquery(): SelectQuery
     {
-        return $this->queryFactory->select($this)->disableAutoAliasing();
+        /** @var \Cake\ORM\Query\SelectQuery<TEntity|array> $query */
+        $query = $this->queryFactory->select($this)->disableAutoAliasing();
+
+        return $query;
     }
 
     /**
@@ -2779,7 +2782,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @param string $method The method name that was fired.
      * @param array $args List of arguments passed to the function.
-     * @return \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array>
+     * @return \Cake\ORM\Query\SelectQuery<TEntity|array>
      * @throws \BadMethodCallException when there are missing arguments, or when
      *  and & or are combined.
      */

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -264,7 +264,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * The name of the class that represent a single row for this table
      *
      * @var string|null
-     * @phpstan-var class-string<\Cake\Datasource\EntityInterface>|null
+     * @phpstan-var class-string<TEntity>|null
      */
     protected ?string $_entityClass = null;
 
@@ -695,11 +695,12 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Returns the class used to hydrate rows for this table.
      *
-     * @return class-string<\Cake\Datasource\EntityInterface>
+     * @return class-string<TEntity>
      */
     public function getEntityClass(): string
     {
         if (!$this->_entityClass) {
+            /** @var class-string<TEntity> $default */
             $default = Entity::class;
             $self = static::class;
             $parts = explode('\\', $self);
@@ -714,7 +715,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 return $this->_entityClass = $default;
             }
 
-            /** @var class-string<\Cake\Datasource\EntityInterface>|null $class */
+            /** @var class-string<TEntity>|null $class */
             $class = App::className($name, 'Model/Entity');
             if (!$class) {
                 throw new MissingEntityException([$name]);
@@ -735,7 +736,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function setEntityClass(string $name)
     {
-        /** @var class-string<\Cake\Datasource\EntityInterface>|null $class */
+        /** @var class-string<TEntity>|null $class */
         $class = App::className($name, 'Model/Entity');
         if ($class === null) {
             throw new MissingEntityException([$name]);
@@ -3283,14 +3284,17 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * The properties for the associations to be loaded will be overwritten on each entity.
      *
-     * @param \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface> $entities a single entity or list of entities
+     * @param TEntity|array<TEntity> $entities a single entity or list of entities
      * @param array $contain A `contain()` compatible array.
      * @see \Cake\ORM\Query\SelectQuery::contain()
-     * @return \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface>
+     * @return TEntity|array<TEntity>
      */
     public function loadInto(EntityInterface|array $entities, array $contain): EntityInterface|array
     {
-        return (new LazyEagerLoader())->loadInto($entities, $contain, $this);
+        /** @var TEntity|array<TEntity> $result */
+        $result = (new LazyEagerLoader())->loadInto($entities, $contain, $this);
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
## Summary

Propagates the class-level `TEntity` template (added in #19388) to the remaining Table methods that flow entities. Builds on the existing template work — does not introduce new templates.

After this change, a Table typed as

```php
/**
 * @extends \Cake\ORM\Table<array{}, \App\Model\Entity\User>
 */
class UsersTable extends Table {
}
```

resolves to concrete entity types in:

- `find()` → `SelectQuery<User|array>` (was `SelectQuery<EntityInterface|array>`)
- `findOrCreate()` → `User` (was `EntityInterface`)
- `findList()`, `findThreaded()`, `subquery()`, `_processFindOrCreate()`, `_getFindOrCreateQuery()`, `_dynamicFinder()` → `SelectQuery<TEntity|array>` throughout
- `loadInto()` → `TEntity|array<TEntity>` for both param and return
- `getEntityClass()` → `class-string<TEntity>` (and the matching `$_entityClass` property doc + `setEntityClass()` internal cast)

`findAll()` already used `TEntity` after #19388 — this PR completes the pattern across the rest of the entity-flowing surface.

## Backward compatibility

Docblock-only. `@template TEntity of EntityInterface = EntityInterface` means callers that haven't typed their Table see exactly the same types as before (the default resolves to `EntityInterface`). Typed Tables now get narrower types where they previously got widened ones.

Three internal expression types updated to keep the implementation aligned with the tightened return annotations:

- `_processFindOrCreate()` — the callback-result cast widened back to `EntityInterface` and now uses `TEntity` (the callback contract is "receive an entity, return one of the same type").
- `subquery()` — narrows the `queryFactory->select()` result via a local `@var` annotation.
- `loadInto()` — pins `LazyEagerLoader::loadInto()`'s widened return back to `TEntity|array<TEntity>`.
- `getEntityClass()` — the `Entity::class` fallback path is asserted as `class-string<TEntity>` via a local `@var` cast. That fallback only fires when no `Model/Entity` class is discovered, at which point the typed contract is degraded regardless.

## Motivation

Plugins like [dereuromark/cakephp-ide-helper](https://github.com/dereuromark/cakephp-ide-helper) emit `@method` overrides on user Tables to add the concrete entity return types the parent didn't propagate. Those overrides silently strip the parent's `@throws` annotations (phpDoc `@method` has no `@throws` slot), so PHPStan flags ordinary `catch (PersistenceFailedException $e)` / `catch (RecordNotFoundException $e)` blocks around `findOrCreate()` / `get()` etc. as `catch.neverThrown`. With `TEntity` flowing through the rest of the parent's surface, those overrides become redundant on the plugin side and the `@throws` survives.

The matching ide-helper change is at [dereuromark/cakephp-ide-helper#445](https://github.com/dereuromark/cakephp-ide-helper/pull/445) (already merged for `get`/`newEmptyEntity`/`save`/`saveOrFail`); a follow-up will drop the `find`/`findOrCreate`/`loadInto` overrides once this lands.

Related: <https://github.com/CakeDC/cakephp-phpstan/issues/47>

## Verification

```
composer stan       # ok (phpstan + psalm)
composer cs-check   # ok
vendor/bin/phpunit tests/TestCase/ORM/   # 1476 tests green
```