### PR TITLE
Type SelectQuery::first()/firstOrFail() via the TSubject template

### DIFF
--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -788,7 +788,7 @@ class TreeBehavior extends Behavior
             ->where([$this->_table->aliasField($primaryKey) => $id])
             ->first();
 
-        if (!$node) {
+        if (!$node instanceof EntityInterface) {
             throw new RecordNotFoundException(sprintf('Node `%s` was not found in the tree.', $id));
         }
 

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -582,7 +582,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * $singleUser = $query->select(['id', 'username'])->first();
      * ```
      *
-     * @return mixed The first result from the ResultSet.
+     * @return TSubject|null The first result from the ResultSet.
      */
     public function first(): mixed
     {
@@ -597,7 +597,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * Get the first result from the executing query or raise an exception.
      *
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When there is no first record.
-     * @return mixed The first result from the ResultSet.
+     * @return TSubject The first result from the ResultSet.
      */
     public function firstOrFail(): mixed
     {


### PR DESCRIPTION
## Summary

Tightens the `@return` annotations on `Cake\ORM\Query\SelectQuery::first()` and `firstOrFail()` so the `TSubject` template the class already declares actually reaches the caller.

```diff
-     * @return mixed The first result from the ResultSet.
+     * @return TSubject|null The first result from the ResultSet.
      public function first(): mixed

-     * @return mixed The first result from the ResultSet.
+     * @return TSubject The first result from the ResultSet.
      public function firstOrFail(): mixed
```

Docblock-only. Runtime behavior unchanged.

## Motivation

After #19388 and #19438, the class-level `TEntity` template propagates through `Table::find()` / `findOrCreate()` / `loadInto()` and friends, so a Table typed as

```php
/**
 * @extends \Cake\ORM\Table<array{}, \App\Model\Entity\User>
 */
class UsersTable extends Table {}
```

resolves `find()` to `SelectQuery<User|array>`. But the moment a caller does the most common thing — pull a single row out of the query — the propagated type evaporates because `first()` / `firstOrFail()` still declare `@return mixed`:

```php
$user = $usersTable->find()->where([...])->first();  // mixed
$usersTable->saveOrFail($user);                      // Unable to resolve TSavedEntity
```

PHPStan sees `$user` as `mixed`, and the downstream `saveOrFail()` then can't resolve `@template TSavedEntity of EntityInterface` because `mixed` doesn't satisfy `EntityInterface`. The error cascades into every save/saveOrFail/patchEntity call site that originates from a `find()->first()` (combined with ide-helper now correctly suppressing the redundant `@method` overrides per dereuromark/cakephp-ide-helper#445/#446, which used to mask this gap).

This PR is the missing puzzle piece. With it:

- `find()->first()` → `User|null` (was `mixed`)
- `find()->firstOrFail()` → `User` (was `mixed`)
- downstream `save()` / `saveOrFail()` / `patchEntity()` calls resolve `TSavedEntity` / `TPatchedEntity` to the concrete entity class without any caller-side annotations

In a moderately-sized real project, this eliminates ~20 `argument.templateType` errors at level 8 with no other changes.

## Why the change is safe

- Pure docblock change, no signature or native-return change.
- The runtime is already correct: `first()` delegates to `$this->all()->first()`, which is typed `TSubject|null` via `CollectionInterface::first()` (`CollectionInterface` returns `TValue|null` and `ResultSetInterface<TKey, TValue>` extends it with `TValue = TSubject`). The method's own annotation was just out of sync with what the body returns.
- `firstOrFail()` already throws on null, so dropping null from its return type is correct.
- BC: `mixed` is a superset of `TSubject|null` — every existing caller that was satisfied with `mixed` is still satisfied. Conversely, callers that previously assumed a concrete entity type (e.g. via method overrides emitted by ide-helper) now get that concrete type from the parent directly.

## Collateral fix

`TreeBehavior::_getNode()` newly fails phpstan against the tightened return because its narrowing was relying on `mixed` swallowing the `EntityInterface|array` distinction:

```diff
-        if (!$node) {
+        if (!$node instanceof EntityInterface) {
             throw new RecordNotFoundException(...);
         }
```

Runtime behavior unchanged — `TreeBehavior` never calls `disableHydration()`, so the array branch of `TSubject` is unreachable here. The new check just makes the implicit assumption explicit and satisfies the type system.

## Verification

- `composer stan` — clean for the changed files (one pre-existing `Cake\I18n\DateTime::toQuarter` covariance error remains; unrelated, present on `5.x` before this PR).
- `composer cs-check` — no new violations on the touched files.

## Related

- #19388 — Add TEntity class template
- #19438 — Propagate TEntity to find()/findOrCreate()/loadInto() and friends
- dereuromark/cakephp-ide-helper#445, #446 — Suppress redundant method overrides when the parent template covers them (this PR is the last piece needed to make that suppression silent on user projects)
- CakeDC/cakephp-phpstan#47 — discussion thread where this gap surfaced
