### PR TITLE
Narrow Table::find() to SelectQuery<TEntity> + make TSubject covariant

### DIFF
--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -34,7 +34,7 @@ use function Cake\Core\deprecationWarning;
 /**
  * This class is used to generate SELECT queries for the relational database.
  *
- * @template T of mixed
+ * @template-covariant T of mixed
  * @implements \IteratorAggregate<T>
  */
 class SelectQuery extends Query implements IteratorAggregate

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -44,7 +44,7 @@ use Psr\SimpleCache\CacheInterface;
  * into a specific iterator that will be responsible for hydrating results if
  * required.
  *
- * @template TSubject of \Cake\Datasource\EntityInterface|array
+ * @template-covariant TSubject of \Cake\Datasource\EntityInterface|array
  * @extends \Cake\Database\Query\SelectQuery<TSubject>
  */
 class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterface

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1272,11 +1272,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @param string $type the type of query to perform
      * @param mixed ...$args Arguments that match up to finder-specific parameters
-     * @return \Cake\ORM\Query\SelectQuery<TEntity|array> The query builder
+     * @return \Cake\ORM\Query\SelectQuery<TEntity> The query builder
      */
     public function find(string $type = 'all', mixed ...$args): SelectQuery
     {
-        /** @var \Cake\ORM\Query\SelectQuery<TEntity|array> $query */
+        /** @var \Cake\ORM\Query\SelectQuery<TEntity> $query */
         $query = $this->callFinder($type, $this->selectQuery(), ...$args);
 
         return $query;


### PR DESCRIPTION
> [!NOTE]
> Depends on #19439 (typing SelectQuery::first/firstOrFail via TSubject). Opening for discussion of the trade-off described below.

## Summary

Narrows `Table::find()`'s annotated return from `SelectQuery<TEntity|array>` to `SelectQuery<TEntity>`, and aligns the `TSubject` template (and its parent `T`) as `@template-covariant` so the narrower type satisfies all internal sites that receive it.

```diff
-     * @return \Cake\ORM\Query\SelectQuery<TEntity|array> The query builder
+     * @return \Cake\ORM\Query\SelectQuery<TEntity> The query builder
      public function find(string $type = 'all', mixed ...$args): SelectQuery
      {
-         /** @var \Cake\ORM\Query\SelectQuery<TEntity|array> $query */
+         /** @var \Cake\ORM\Query\SelectQuery<TEntity> $query */
          $query = $this->callFinder($type, $this->selectQuery(), ...$args);

- * @template TSubject of \Cake\Datasource\EntityInterface|array
+ * @template-covariant TSubject of \Cake\Datasource\EntityInterface|array
  // (Cake\ORM\Query\SelectQuery)

- * @template T of mixed
+ * @template-covariant T of mixed
  // (Cake\Database\Query\SelectQuery)
```

Pure docblock. Runtime behavior unchanged.

## Motivation

The `|array` half of `SelectQuery<TEntity|array>` exists to model `disableHydration()` mode statically. The cost: every caller of `find()->first()` / `find()->firstOrFail()` (combined with #19439) now sees `TEntity|array|null` / `TEntity|array`. The vast majority of those callers immediately do something entity-shaped (`->id`, `->name`, `set()`, pass to `saveOrFail()`, ...), at which point PHPStan flags the array half — even though the caller never opted into `disableHydration()`.

In a moderately-sized real project (level 8), pairing #19439 with this change moves the residual error count from ~175 (entity/array unions visible everywhere) to ~11 (genuine pre-existing user-code bugs that were being masked by `mixed`).

The trade-off goes the other direction for `disableHydration()` callers: they now get a type that says "I'm an entity" but the runtime is an array. That's a real loss — but `disableHydration()` is already an explicit opt-in, and its callers are presumably ready to add a `@var array<...>` cast at the consumption site. The asymmetry strongly favors the entity case in real codebases.

Concretely, before:

```php
$user = $usersTable->find()->where([...])->first();  // User|array|null
$user->set('role', 'admin');                          // Cannot call set() on array|User
```

After:

```php
$user = $usersTable->find()->where([...])->first();  // User|null
$user?->set('role', 'admin');                         // ✔
```

And `disableHydration()` callers handle the widening themselves:

```php
/** @var array<int, array<string, mixed>> $rows */
$rows = $usersTable->find()->disableHydration()->all()->toArray();
```

## Covariance

The annotation changes by themselves cause TSubject covariance errors at every Cake-internal site that receives a `SelectQuery<TEntity>` where it declared `SelectQuery<TEntity|array>` (Association, BelongsToMany, CounterCacheBehavior, LazyEagerLoader, Table::_processFindOrCreate, Table::subquery, ...). Switching `TSubject` to `@template-covariant` resolves all of them in one line. The change is sound: `TSubject` is used only in `@return` positions across `SelectQuery` (first, firstOrFail, all, toArray, IteratorAggregate) and is never accepted as `@param`. `Cake\Datasource\ResultSetInterface` already declares its `TValue` covariant for the same reason; this brings `SelectQuery` into alignment.

The parent `Cake\Database\Query\SelectQuery::$T` covariance follows: same shape, only used in `@implements IteratorAggregate<T>`.

## Verification

- `composer stan` — clean on changed files. One pre-existing `Cake\I18n\DateTime::toQuarter()` covariance error remains; unrelated, present on `5.x` before this PR.
- `composer cs-check` — no new violations on touched files.
- End-to-end against a real consumer (level 8): with #19439 + this PR, `find()->first()` → `User|null` and downstream `save/saveOrFail/patchEntity` all resolve their method-level templates without caller-side annotations.

## Open questions for review

1. Is the trade-off (favor entity case at the cost of explicit narrowing for disableHydration callers) the right default? My read: yes, because the wide type forces work on the common path to support the rare path.
2. Should related sites also narrow (`findAll`, `findList`, `findThreaded`, `subquery`, `_processFindOrCreate`, `_getFindOrCreateQuery`, `loadInto`, `_dynamicFinder`)? They have the same `|array` widening today. Doing all of them is more cohesive; doing just `find()` is the minimum viable change. Drafted with just `find()` for clarity — happy to expand if maintainers prefer.

## Related

- #19439 — typing `SelectQuery::first()` / `firstOrFail()` via TSubject (prerequisite for this PR to be useful end-to-end)
- #19388 — Add TEntity class template
- #19438 — Propagate TEntity to find()/findOrCreate()/loadInto() and friends
