### PR TITLE
Resolve default order through SortableFieldsBuilder

### DIFF
--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -592,6 +592,55 @@ class NumericPaginator implements PaginatorInterface
 
         $sortAllowed = $builder !== null;
 
+        // Resolve a default `order` that uses builder/alias/combined sort keys.
+        // Keys the builder does not know (plain columns) pass through unchanged,
+        // because the default order is developer-controlled, not user input.
+        $defaultSortKey = null;
+        $defaultSortDirection = null;
+        if ($builder !== null && isset($options['order']) && is_array($options['order'])) {
+            $resolvedOrder = [];
+            $leadingResolved = null;
+            foreach ($options['order'] as $field => $dir) {
+                // Builder direction matching is lowercase-only, so normalize
+                // here just like parseSortParams() does for user input.
+                $direction = is_string($dir) ? strtolower($dir) : $dir;
+                $resolved = is_string($field) && is_string($direction)
+                    ? $builder->resolve($field, $direction, true)
+                    : null;
+                if ($resolved === null) {
+                    // Pass through with the original direction; the DB treats
+                    // the ORDER BY keyword case-insensitively.
+                    $resolvedOrder[$field] = $dir;
+
+                    continue;
+                }
+
+                // Only surface the alias as the active default sort when it is
+                // the leading `order` entry; otherwise a plain field ahead of it
+                // is the effective primary sort.
+                if ($resolvedOrder === []) {
+                    $defaultSortKey = $field;
+                    $defaultSortDirection = $direction;
+                    $leadingResolved = $resolved;
+                }
+                foreach ($resolved as $resolvedField => $resolvedDir) {
+                    $resolvedOrder[$resolvedField] = $resolvedDir;
+                }
+            }
+            $options['order'] = $resolvedOrder;
+
+            // If a later `order` entry overrode any field produced by the
+            // leading alias, the default order is no longer equivalent to
+            // selecting that alias, so do not advertise it as the active sort.
+            if (
+                $leadingResolved !== null
+                && array_slice($resolvedOrder, 0, count($leadingResolved), true) !== $leadingResolved
+            ) {
+                $defaultSortKey = null;
+                $defaultSortDirection = null;
+            }
+        }
+
         if (isset($options['sort'])) {
             // Parse sort and direction parameters
             $sortParams = $this->parseSortParams($options);
@@ -622,13 +671,20 @@ class NumericPaginator implements PaginatorInterface
                 // Only keep fields from existing order that aren't already in our resolved order
                 // Account for prefixed vs unprefixed field names (e.g., 'modified' vs 'Alerts.modified')
                 foreach ($existingOrder as $field => $dir) {
-                    // Check if this field (or its unprefixed version) is already in $order
+                    // Check if this field is already in $order, accounting for
+                    // prefixed vs unprefixed names in either direction (e.g.
+                    // `modified` vs `Alerts.modified`). Both must be deduped,
+                    // otherwise _prefix() later collapses them and the existing
+                    // (default) entry would override the requested sort.
                     $alreadyInOrder = isset($order[$field]);
                     if (!$alreadyInOrder && str_contains($field, '.')) {
                         [$alias, $fieldName] = explode('.', $field, 2);
                         if ($alias === $modelAlias && isset($order[$fieldName])) {
                             $alreadyInOrder = true;
                         }
+                    }
+                    if (!$alreadyInOrder && !str_contains($field, '.') && isset($order[$modelAlias . '.' . $field])) {
+                        $alreadyInOrder = true;
                     }
                     if (!$alreadyInOrder) {
                         $order[$field] = $dir;
@@ -658,12 +714,16 @@ class NumericPaginator implements PaginatorInterface
             return $options;
         }
 
-        if (
-            $options['sort'] === null
-            && count($options['order']) >= 1
-            && !is_numeric(key($options['order']))
-        ) {
-            $options['sort'] = key($options['order']);
+        if ($options['sort'] === null) {
+            if ($defaultSortKey !== null) {
+                // Highlight the alias/combined key in PaginatorHelper without
+                // forcing a query string for the default sort. Report the alias
+                // direction so it matches the equivalent click-driven sort.
+                $options['sort'] = $defaultSortKey;
+                $options['sortDirection'] = $defaultSortDirection;
+            } elseif (count($options['order']) >= 1 && !is_numeric(key($options['order']))) {
+                $options['sort'] = key($options['order']);
+            }
         }
 
         $options['order'] = $this->_prefix($object, $options['order'], $sortAllowed);

--- a/tests/TestCase/Datasource/Paging/NumericPaginatorSortFieldTest.php
+++ b/tests/TestCase/Datasource/Paging/NumericPaginatorSortFieldTest.php
@@ -640,4 +640,326 @@ class NumericPaginatorSortFieldTest extends TestCase
         $this->assertEquals('desc', $pagingParams['direction']);
         $this->assertEquals($expected, $pagingParams['completeSort']);
     }
+
+    /**
+     * Default `order` may use an alias/combined sort key resolved via the builder.
+     *
+     * @return void
+     */
+    public function testDefaultOrderResolvesCombinedKey(): void
+    {
+        $settings = [
+            'order' => ['newest' => 'asc'],
+            'sortableFields' => [
+                'newest' => [
+                    SortField::asc('title'),
+                    SortField::desc('published'),
+                ],
+            ],
+        ];
+
+        $result = $this->paginator->paginate($this->table, [], $settings);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertSame('newest', $pagingParams['sort']);
+        $this->assertSame('asc', $pagingParams['direction']);
+        $this->assertSame([
+            'Articles.title' => 'asc',
+            'Articles.published' => 'desc',
+        ], $pagingParams['completeSort']);
+
+        // Reversing the default direction reverses non-locked fields
+        $settings['order'] = ['newest' => 'desc'];
+        $result = $this->paginator->paginate($this->table, [], $settings);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertSame('newest', $pagingParams['sort']);
+        $this->assertSame('desc', $pagingParams['direction']);
+        $this->assertSame([
+            'Articles.title' => 'desc',
+            'Articles.published' => 'asc',
+        ], $pagingParams['completeSort']);
+    }
+
+    /**
+     * Uppercase directions in the default order resolve the same as lowercase.
+     *
+     * @return void
+     */
+    public function testDefaultOrderResolvesUppercaseDirection(): void
+    {
+        $settings = [
+            'order' => ['newest' => 'DESC'],
+            'sortableFields' => [
+                'newest' => [
+                    SortField::asc('title'),
+                    SortField::desc('published'),
+                ],
+            ],
+        ];
+
+        $result = $this->paginator->paginate($this->table, [], $settings);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertSame('newest', $pagingParams['sort']);
+        $this->assertSame('desc', $pagingParams['direction']);
+        $this->assertSame([
+            'Articles.title' => 'desc',
+            'Articles.published' => 'asc',
+        ], $pagingParams['completeSort']);
+    }
+
+    /**
+     * Locked SortField keeps its locked direction within a default order.
+     *
+     * @return void
+     */
+    public function testDefaultOrderResolvesLockedSortField(): void
+    {
+        $settings = [
+            'order' => ['popular' => 'desc'],
+            'sortableFields' => [
+                'popular' => [
+                    SortField::desc('published', locked: true),
+                    SortField::asc('title'),
+                ],
+            ],
+        ];
+
+        $result = $this->paginator->paginate($this->table, [], $settings);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertSame('popular', $pagingParams['sort']);
+        $this->assertSame([
+            'Articles.published' => 'desc', // locked, not reversed
+            'Articles.title' => 'desc', // toggleable, reversed
+        ], $pagingParams['completeSort']);
+    }
+
+    /**
+     * A plain column not registered in the builder must pass through unchanged
+     * (BC: the default `order` is developer-controlled, not user input).
+     *
+     * @return void
+     */
+    public function testDefaultOrderPlainColumnPassesThrough(): void
+    {
+        $settings = [
+            'order' => ['id' => 'desc'],
+            'sortableFields' => [
+                'newest' => [
+                    SortField::asc('title'),
+                ],
+            ],
+        ];
+
+        $result = $this->paginator->paginate($this->table, [], $settings);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertSame('id', $pagingParams['sort']);
+        $this->assertSame(['Articles.id' => 'desc'], $pagingParams['completeSort']);
+    }
+
+    /**
+     * When a plain field precedes an alias in the default order, the plain
+     * field stays the effective primary sort and is the highlighted key.
+     *
+     * @return void
+     */
+    public function testDefaultOrderPlainFieldBeforeAliasKeepsPrimarySort(): void
+    {
+        $settings = [
+            'order' => ['id' => 'desc', 'newest' => 'asc'],
+            'sortableFields' => [
+                'newest' => [
+                    SortField::asc('title'),
+                    SortField::desc('published'),
+                ],
+            ],
+        ];
+
+        $result = $this->paginator->paginate($this->table, [], $settings);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertSame('id', $pagingParams['sort']);
+        $this->assertSame('desc', $pagingParams['direction']);
+        $this->assertSame([
+            'Articles.id' => 'desc',
+            'Articles.title' => 'asc',
+            'Articles.published' => 'desc',
+        ], $pagingParams['completeSort']);
+    }
+
+    /**
+     * When a later default-order entry overrides a column produced by the
+     * leading alias, the alias is no longer advertised as the active sort
+     * (the default order is not equivalent to selecting that alias).
+     *
+     * @return void
+     */
+    public function testDefaultOrderAliasNotAdvertisedWhenOverridden(): void
+    {
+        $settings = [
+            'order' => ['newest' => 'asc', 'published' => 'asc'],
+            'sortableFields' => [
+                'newest' => [
+                    SortField::asc('title'),
+                    SortField::desc('published'),
+                ],
+            ],
+        ];
+
+        $result = $this->paginator->paginate($this->table, [], $settings);
+        $pagingParams = $result->pagingParams();
+
+        // 'published' => 'asc' overrides newest's published => desc, so the
+        // result is not equivalent to clicking the `newest` header.
+        $this->assertSame('title', $pagingParams['sort']);
+        $this->assertSame([
+            'Articles.title' => 'asc',
+            'Articles.published' => 'asc',
+        ], $pagingParams['completeSort']);
+    }
+
+    /**
+     * A user sort on another column is prepended; the resolved default order
+     * is appended after it.
+     *
+     * @return void
+     */
+    public function testDefaultOrderAppendedAfterUserSort(): void
+    {
+        $settings = [
+            'order' => ['newest' => 'asc'],
+            'sortableFields' => [
+                'author_id',
+                'newest' => [
+                    SortField::asc('title'),
+                    SortField::desc('published'),
+                ],
+            ],
+        ];
+
+        $result = $this->paginator->paginate(
+            $this->table,
+            ['sort' => 'author_id', 'direction' => 'desc'],
+            $settings,
+        );
+        $pagingParams = $result->pagingParams();
+
+        $this->assertSame('author_id', $pagingParams['sort']);
+        $this->assertSame('desc', $pagingParams['direction']);
+        $this->assertSame([
+            'Articles.author_id' => 'desc',
+            'Articles.title' => 'asc',
+            'Articles.published' => 'desc',
+        ], $pagingParams['completeSort']);
+    }
+
+    /**
+     * A user sort wins over a resolved default even when the builder mixes
+     * prefixed and unprefixed names for the same column.
+     *
+     * @return void
+     */
+    public function testDefaultOrderUserSortWinsWithInconsistentPrefixing(): void
+    {
+        $settings = [
+            'order' => ['newest' => 'asc'],
+            'sortableFields' => [
+                'newest' => [
+                    SortField::asc('title'), // unprefixed
+                ],
+                'title' => [
+                    SortField::asc('Articles.title'), // prefixed, same column
+                ],
+            ],
+        ];
+
+        $result = $this->paginator->paginate(
+            $this->table,
+            ['sort' => 'title', 'direction' => 'desc'],
+            $settings,
+        );
+        $pagingParams = $result->pagingParams();
+
+        $this->assertSame('title', $pagingParams['sort']);
+        $this->assertSame('desc', $pagingParams['direction']);
+        // The requested desc must win; the default must not re-add an
+        // unprefixed `title` that _prefix() would collapse back to asc.
+        $this->assertSame(['Articles.title' => 'desc'], $pagingParams['completeSort']);
+    }
+
+    /**
+     * Mixed SortField objects and plain string fields within a default order.
+     *
+     * @return void
+     */
+    public function testDefaultOrderResolvesMixedSortFieldAndString(): void
+    {
+        $settings = [
+            'order' => ['mixed' => 'desc'],
+            'sortableFields' => [
+                'mixed' => [
+                    SortField::desc('published'),
+                    'author_id',
+                    SortField::asc('title', locked: true),
+                ],
+            ],
+        ];
+
+        $result = $this->paginator->paginate($this->table, [], $settings);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertSame('mixed', $pagingParams['sort']);
+        $this->assertSame('desc', $pagingParams['direction']);
+        $this->assertSame([
+            'Articles.published' => 'asc', // reversed (desc default toggled)
+            'Articles.author_id' => 'desc', // plain string uses requested direction
+            'Articles.title' => 'asc', // locked, ignores requested direction
+        ], $pagingParams['completeSort']);
+    }
+
+    /**
+     * Toggling the default alias link off (back to default direction) keeps the
+     * resolved order and does not require a sort param.
+     *
+     * @return void
+     */
+    public function testDefaultOrderAliasIsHighlightedWithoutQueryString(): void
+    {
+        $settings = [
+            'order' => ['newest' => 'asc'],
+            'sortableFields' => [
+                'newest' => [
+                    SortField::asc('title'),
+                    SortField::desc('published'),
+                ],
+            ],
+        ];
+
+        // No query string at all -> alias is still the active sort
+        $result = $this->paginator->paginate($this->table, [], $settings);
+        $pagingParams = $result->pagingParams();
+
+        $this->assertSame('newest', $pagingParams['sort']);
+        $this->assertSame([
+            'Articles.title' => 'asc',
+            'Articles.published' => 'desc',
+        ], $pagingParams['completeSort']);
+
+        // Explicitly requesting the alias yields the same resolved order
+        $result = $this->paginator->paginate(
+            $this->table,
+            ['sort' => 'newest', 'direction' => 'asc'],
+            $settings,
+        );
+        $pagingParams = $result->pagingParams();
+
+        $this->assertSame('newest', $pagingParams['sort']);
+        $this->assertSame([
+            'Articles.title' => 'asc',
+            'Articles.published' => 'desc',
+        ], $pagingParams['completeSort']);
+    }
 }


### PR DESCRIPTION
Fixes #19444

### Problem

`sortableFields` (builder / alias / combined keys) only applied to
user-driven sort params. The default `order` array was passed to the query
verbatim, so a default using an alias or combined key failed:

```php
protected array $paginate = [
    'order' => ['best-deal' => 'asc'],
    'sortableFields' => function (SortableFieldsBuilder $builder) {
        return $builder->add('best-deal', [
            SortField::desc('in_stock'),
            SortField::asc('price'),
        ]);
    },
];
```

`best-deal` is not a real column, so this threw. The known workarounds
(duplicating the resolved columns into `order`, or force-injecting a sort
query param) are fragile and desync from the builder definition.

### Solution

`NumericPaginator::validateSort()` now resolves a default `order` through
the same `SortableFieldsBuilder` used for click-driven sorting, before the
existing sort handling. Because it reuses `resolve()`, locked `SortField`s
and direction inversion behave identically for the default and the clicked
sort. `['best-deal' => 'asc']` produces `ORDER BY in_stock DESC, price ASC`;
`['best-deal' => 'desc']` reverses the non-locked fields.

The alias is reported as the active sort so `PaginatorHelper` highlights
the correct link without forcing a query string for the default ordering.

### Design decisions

- **Unregistered keys pass through unchanged.** A plain column not known to
  the builder (e.g. `'order' => ['created' => 'desc']` alongside a builder)
  is kept as-is. The default order is developer-controlled, not user input,
  so there is no reason to restrict it to the builder allowlist and silently
  dropping it would be a behavior break.
- **The alias is only advertised when it truly is the active sort.** It is
  not surfaced when a plain field precedes it in `order`, nor when a later
  `order` entry overrides a column it resolved to — in those cases the
  result is not equivalent to selecting the alias.
- **Uppercase directions** (`'DESC'`) are normalized before resolution, as
  `parseSortParams()` already does for user input.
- The existing prefixed/unprefixed de-duplication in the sort branch was
  asymmetric; it is now symmetric so a requested sort is not overridden by
  the resolved default when the builder mixes `title` and `Alias.title`.

Docs for the `sortableFields` feature do not exist in cakephp/docs yet
(the feature is new); a docs change covering default order will follow
there separately.
