### PR TITLE
Fix a potential file handling weakness in element()

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1406,7 +1406,9 @@ class View implements EventDispatcherInterface
      * Check that a view file path does not go outside of the defined template paths.
      *
      * Only paths that contain `..` will be checked, as they are the ones most likely to
-     * have the ability to resolve to files outside of the template paths.
+     * have the ability to resolve to files outside of the template paths. A candidate
+     * that does not exist on the current root (realpath returning false) is passed
+     * through so the path cascade can try the next root.
      *
      * @param string $file The path to the template file.
      * @param string $path Base path that $file should be inside of.
@@ -1419,7 +1421,11 @@ class View implements EventDispatcherInterface
             return $file;
         }
         $absolute = realpath($file);
-        if ($absolute === false || !str_starts_with($absolute, $path)) {
+        if ($absolute === false) {
+            // Candidate does not exist on this root; let the path cascade continue.
+            return $file;
+        }
+        if (!str_starts_with($absolute, $path)) {
             throw new InvalidArgumentException(sprintf(
                 'Cannot use `%s` as a template, it is not within any view template path.',
                 $file,

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1520,7 +1520,7 @@ class View implements EventDispatcherInterface
         $name .= $this->_ext;
         foreach ($this->getElementPaths($plugin) as $path) {
             if (is_file($path . $name)) {
-                return $path . $name;
+                return $this->_checkFilePath($path . $name, $path);
             }
         }
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1382,8 +1382,9 @@ class View implements EventDispatcherInterface
         $name .= $this->_ext;
         $paths = $this->_paths($plugin);
         foreach ($paths as $path) {
-            if (is_file($path . $name)) {
-                return $this->_checkFilePath($path . $name, $path);
+            $filepath = $this->_checkFilePath($path . $name, $path);
+            if (is_file($filepath)) {
+                return $filepath;
             }
         }
 
@@ -1476,8 +1477,9 @@ class View implements EventDispatcherInterface
         $name .= $this->_ext;
 
         foreach ($this->getLayoutPaths($plugin) as $path) {
-            if (is_file($path . $name)) {
-                return $this->_checkFilePath($path . $name, $path);
+            $filepath = $this->_checkFilePath($path . $name, $path);
+            if (is_file($filepath)) {
+                return $filepath;
             }
         }
 
@@ -1519,8 +1521,9 @@ class View implements EventDispatcherInterface
 
         $name .= $this->_ext;
         foreach ($this->getElementPaths($plugin) as $path) {
-            if (is_file($path . $name)) {
-                return $this->_checkFilePath($path . $name, $path);
+            $filepath = $this->_checkFilePath($path . $name, $path);
+            if (is_file($filepath)) {
+                return $filepath;
             }
         }
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -708,6 +708,16 @@ class ViewTest extends TestCase
     }
 
     /**
+     * Test element name cannot escape the view template path.
+     */
+    public function testElementPathEscape(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('it is not within any view template path.');
+        $this->View->element('../../../check');
+    }
+
+    /**
      * Test loading nonexistent plugin view element
      */
     public function testElementMissingPluginElement(): void


### PR DESCRIPTION
If View::element() is supplied request data, element names can be manipulated to include files outside of a view template path.

This could be leveraged to expose secrets, or application code.

Thank you to Nguyen Danh Quan (@z3moo) and Ta Quoc Hung (@get-wright) for reporting this issue through our security process.
