### PR TITLE
Add association join key introspection API

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -531,7 +531,7 @@ abstract class Association
 
         return array_values(array_filter(
             (array)$key,
-            static fn(mixed $column): bool => is_string($column) && $column !== '',
+            static fn(string $column): bool => $column !== '',
         ));
     }
 

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -467,6 +467,44 @@ abstract class Association
     }
 
     /**
+     * Gets the source table column(s) participating in the association join.
+     *
+     * For associations with a declared foreign key this returns the normalized
+     * source-side join columns. Associations with custom join conditions and no
+     * declared foreign key may return an empty list if the join columns cannot
+     * be determined.
+     *
+     * @return list<string>
+     */
+    public function getSourceJoinKey(): array
+    {
+        if ($this->isOwningSide($this->getTarget())) {
+            return $this->_normalizeJoinKey($this->getForeignKey());
+        }
+
+        return $this->_normalizeJoinKey($this->getBindingKey());
+    }
+
+    /**
+     * Gets the target table column(s) participating in the association join.
+     *
+     * For associations with a declared foreign key this returns the normalized
+     * target-side join columns. Associations with custom join conditions and no
+     * declared foreign key may return an empty list if the join columns cannot
+     * be determined.
+     *
+     * @return list<string>
+     */
+    public function getTargetJoinKey(): array
+    {
+        if ($this->isOwningSide($this->getTarget())) {
+            return $this->_normalizeJoinKey($this->getBindingKey());
+        }
+
+        return $this->_normalizeJoinKey($this->getForeignKey());
+    }
+
+    /**
      * Sets the name of the field representing the foreign key to the target table.
      *
      * @param array<string>|string $key the key or keys to be used to link both tables together
@@ -477,6 +515,24 @@ abstract class Association
         $this->_foreignKey = $key;
 
         return $this;
+    }
+
+    /**
+     * Normalizes a join key definition into a list of column names.
+     *
+     * @param array<string>|string|false $key Join key configuration.
+     * @return list<string>
+     */
+    protected function _normalizeJoinKey(array|string|false $key): array
+    {
+        if ($key === false) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            (array)$key,
+            static fn(mixed $column): bool => is_string($column) && $column !== '',
+        ));
     }
 
     /**

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -256,11 +256,6 @@ class BelongsTo extends Association
         string $sourceAlias,
         string $targetAlias,
     ): ?array {
-        $left = $this->extractAliasField($key, $sourceAlias);
-        if ($left === null) {
-            return null;
-        }
-
         if ($value instanceof IdentifierExpression) {
             $value = $value->getIdentifier();
         }
@@ -268,12 +263,19 @@ class BelongsTo extends Association
             return null;
         }
 
+        $left = $this->extractAliasField($key, $sourceAlias);
         $right = $this->extractAliasField($value, $targetAlias);
-        if ($right === null) {
-            return null;
+        if ($left !== null && $right !== null) {
+            return [$left, $right];
         }
 
-        return [$left, $right];
+        $left = $this->extractAliasField($key, $targetAlias);
+        $right = $this->extractAliasField($value, $sourceAlias);
+        if ($left !== null && $right !== null) {
+            return [$right, $left];
+        }
+
+        return null;
     }
 
     /**

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -303,6 +303,13 @@ class BelongsTo extends Association
         return null;
     }
 
+    /**
+     * Extracts the field name from an alias-qualified identifier.
+     *
+     * @param string $identifier Identifier to inspect.
+     * @param string $alias Expected table alias.
+     * @return string|null
+     */
     protected function extractAliasField(string $identifier, string $alias): ?string
     {
         $quotedAlias = preg_quote($alias, '/');

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Association;
 
+use Cake\Database\Expression\IdentifierExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association;
 use Cake\ORM\Association\Loader\SelectLoader;
@@ -65,6 +66,30 @@ class BelongsTo extends Association
         $this->_foreignKey = $key;
 
         return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSourceJoinKey(): array
+    {
+        if ($this->getForeignKey() !== false) {
+            return parent::getSourceJoinKey();
+        }
+
+        return array_keys($this->getCustomJoinKeyPairs());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTargetJoinKey(): array
+    {
+        if ($this->getForeignKey() !== false) {
+            return parent::getTargetJoinKey();
+        }
+
+        return array_values($this->getCustomJoinKeyPairs());
     }
 
     /**
@@ -175,5 +200,116 @@ class BelongsTo extends Association
         ]);
 
         return $loader->buildEagerLoader($options);
+    }
+
+    /**
+     * Best-effort extraction of source/target join key pairs from custom
+     * alias-qualified conditions used with `foreignKey => false`.
+     *
+     * @return array<string, string>
+     */
+    protected function getCustomJoinKeyPairs(): array
+    {
+        $conditions = $this->getConditions();
+        if (!is_array($conditions)) {
+            return [];
+        }
+
+        $sourceAlias = $this->getSource()->getAlias();
+        $targetAlias = $this->getAlias();
+        $pairs = [];
+
+        foreach ($conditions as $key => $value) {
+            if (is_string($key)) {
+                $pair = $this->extractJoinKeyPair($key, $value, $sourceAlias, $targetAlias);
+                if ($pair !== null) {
+                    [$sourceKey, $targetKey] = $pair;
+                    $pairs[$sourceKey] = $targetKey;
+                }
+
+                continue;
+            }
+
+            if (!is_string($value)) {
+                continue;
+            }
+
+            $pair = $this->extractJoinKeyPairFromString($value, $sourceAlias, $targetAlias);
+            if ($pair === null) {
+                continue;
+            }
+
+            [$sourceKey, $targetKey] = $pair;
+            $pairs[$sourceKey] = $targetKey;
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * @param mixed $value Condition value.
+     * @return array{string, string}|null
+     */
+    protected function extractJoinKeyPair(
+        string $key,
+        mixed $value,
+        string $sourceAlias,
+        string $targetAlias,
+    ): ?array {
+        $left = $this->extractAliasField($key, $sourceAlias);
+        if ($left === null) {
+            return null;
+        }
+
+        if ($value instanceof IdentifierExpression) {
+            $value = $value->getIdentifier();
+        }
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $right = $this->extractAliasField($value, $targetAlias);
+        if ($right === null) {
+            return null;
+        }
+
+        return [$left, $right];
+    }
+
+    /**
+     * @return array{string, string}|null
+     */
+    protected function extractJoinKeyPairFromString(
+        string $condition,
+        string $sourceAlias,
+        string $targetAlias,
+    ): ?array {
+        if (!preg_match('/^\s*(.+?)\s*=\s*(.+?)\s*$/', $condition, $matches)) {
+            return null;
+        }
+
+        $left = $this->extractAliasField($matches[1], $sourceAlias);
+        $right = $this->extractAliasField($matches[2], $targetAlias);
+        if ($left !== null && $right !== null) {
+            return [$left, $right];
+        }
+
+        $left = $this->extractAliasField($matches[1], $targetAlias);
+        $right = $this->extractAliasField($matches[2], $sourceAlias);
+        if ($left !== null && $right !== null) {
+            return [$right, $left];
+        }
+
+        return null;
+    }
+
+    protected function extractAliasField(string $identifier, string $alias): ?string
+    {
+        $quotedAlias = preg_quote($alias, '/');
+        if (!preg_match('/^' . $quotedAlias . '\.([A-Za-z0-9_]+)$/', trim($identifier), $matches)) {
+            return null;
+        }
+
+        return $matches[1];
     }
 }

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -207,6 +207,32 @@ class BelongsToMany extends Association
     }
 
     /**
+     * Gets the source table column(s) participating in the association join.
+     *
+     * BelongsToMany associations are mediated by a junction table, so there is
+     * no single direct source/target join key pair to expose.
+     *
+     * @return list<string>
+     */
+    public function getSourceJoinKey(): array
+    {
+        return [];
+    }
+
+    /**
+     * Gets the target table column(s) participating in the association join.
+     *
+     * BelongsToMany associations are mediated by a junction table, so there is
+     * no single direct source/target join key pair to expose.
+     *
+     * @return list<string>
+     */
+    public function getTargetJoinKey(): array
+    {
+        return [];
+    }
+
+    /**
      * Sets the sort order in which target records should be returned.
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array<\Cake\Database\ExpressionInterface|string>|string $sort A find() compatible order clause

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -121,6 +121,20 @@ class BelongsToManyTest extends TestCase
     }
 
     /**
+     * Tests that join-key introspection is empty for many-to-many associations.
+     */
+    public function testGetJoinKeys(): void
+    {
+        $assoc = new BelongsToMany('Tags', [
+            'sourceTable' => $this->article,
+            'targetTable' => $this->tag,
+        ]);
+
+        $this->assertSame([], $assoc->getSourceJoinKey());
+        $this->assertSame([], $assoc->getTargetJoinKey());
+    }
+
+    /**
      * Tests that the association reports it can be joined
      */
     public function testCanBeJoined(): void

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -132,13 +132,14 @@ class BelongsToTest extends TestCase
             'bindingKey' => 'id',
             'conditions' => [
                 'Clients.company_uuid' => new IdentifierExpression('Companies.uuid'),
+                'Companies.legacy_uuid' => new IdentifierExpression('Clients.reverse_company_uuid'),
                 'Companies.uuid = Clients.legacy_company_uuid',
                 'Clients.is_active' => true,
             ],
         ]);
 
-        $this->assertSame(['company_uuid', 'legacy_company_uuid'], $assoc->getSourceJoinKey());
-        $this->assertSame(['uuid', 'uuid'], $assoc->getTargetJoinKey());
+        $this->assertSame(['company_uuid', 'reverse_company_uuid', 'legacy_company_uuid'], $assoc->getSourceJoinKey());
+        $this->assertSame(['uuid', 'legacy_uuid', 'uuid'], $assoc->getTargetJoinKey());
     }
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -107,6 +107,63 @@ class BelongsToTest extends TestCase
     }
 
     /**
+     * Tests that source and target join keys are exposed for declared foreign keys.
+     */
+    public function testGetJoinKeys(): void
+    {
+        $assoc = new BelongsTo('Companies', [
+            'sourceTable' => $this->client,
+            'targetTable' => $this->company,
+        ]);
+
+        $this->assertSame(['company_id'], $assoc->getSourceJoinKey());
+        $this->assertSame(['id'], $assoc->getTargetJoinKey());
+    }
+
+    /**
+     * Tests that custom join conditions can be introspected when foreignKey is false.
+     */
+    public function testGetJoinKeysFromCustomConditions(): void
+    {
+        $assoc = new BelongsTo('Companies', [
+            'sourceTable' => $this->client,
+            'targetTable' => $this->company,
+            'foreignKey' => false,
+            'bindingKey' => 'id',
+            'conditions' => [
+                'Clients.company_uuid' => new IdentifierExpression('Companies.uuid'),
+                'Companies.uuid = Clients.legacy_company_uuid',
+                'Clients.is_active' => true,
+            ],
+        ]);
+
+        $this->assertSame(['company_uuid', 'legacy_company_uuid'], $assoc->getSourceJoinKey());
+        $this->assertSame(['uuid', 'uuid'], $assoc->getTargetJoinKey());
+    }
+
+    /**
+     * Tests that opaque or non-join conditions yield no inferred join keys.
+     */
+    public function testGetJoinKeysFromCustomConditionsWithoutInspectableJoin(): void
+    {
+        $assoc = new BelongsTo('Companies', [
+            'sourceTable' => $this->client,
+            'targetTable' => $this->company,
+            'foreignKey' => false,
+            'conditions' => static fn() => null,
+        ]);
+        $this->assertSame([], $assoc->getSourceJoinKey());
+        $this->assertSame([], $assoc->getTargetJoinKey());
+
+        $assoc->setConditions([
+            'Clients.is_active' => true,
+            'Clients.deleted = 0',
+        ]);
+        $this->assertSame([], $assoc->getSourceJoinKey());
+        $this->assertSame([], $assoc->getTargetJoinKey());
+    }
+
+    /**
      * Tests that the default foreign key condition generation can be disabled.
      */
     public function testDisableForeignKey(): void

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -81,6 +81,20 @@ class HasOneTest extends TestCase
     }
 
     /**
+     * Tests that source and target join keys are exposed for standard hasOne associations.
+     */
+    public function testGetJoinKeys(): void
+    {
+        $assoc = new HasOne('Profiles', [
+            'sourceTable' => $this->user,
+            'targetTable' => $this->profile,
+        ]);
+
+        $this->assertSame(['id'], $assoc->getSourceJoinKey());
+        $this->assertSame(['user_id'], $assoc->getTargetJoinKey());
+    }
+
+    /**
      * Tests that the default foreign key condition generation can be disabled.
      */
     public function testDisableForeignKey(): void


### PR DESCRIPTION
Refs hacky https://github.com/dereuromark/cakephp-fixture-factories/pull/82

## Problem

For standard ORM associations, downstream code can inspect `getForeignKey()` and
`getBindingKey()` to understand which columns participate in the join.

That breaks down for `belongsTo` associations configured with `foreignKey => false`
and custom `conditions`. In that case core intentionally exposes:

- `getForeignKey() === false`
- `getConditions()` as raw `Closure|array`

This leaves plugin and application code without a stable API for answering a
simple introspection question: which source/target columns are actually used to
join this association?

Consumers that need that information today have to parse raw conditions
manually.

## Solution

This PR adds a small public introspection API:

- `Association::getSourceJoinKey(): list<string>`
- `Association::getTargetJoinKey(): list<string>`

For associations with declared foreign keys, these methods expose the normalized
source-side and target-side join columns directly.

For `BelongsTo` associations using `foreignKey => false`, the new API performs a
best-effort extraction from alias-qualified equality conditions in common forms:

- `['Articles.author_uuid' => 'Authors.uuid']`
- `['Articles.author_uuid' => new IdentifierExpression('Authors.uuid')]`
- `['Articles.author_uuid = Authors.uuid']`
- `['Authors.uuid = Articles.author_uuid']`

Opaque closures and non-join filters still return an empty list, which keeps the
API conservative and avoids claiming more introspection than core can actually
provide.

## Tests

- added coverage for declared join keys on `BelongsTo` and `HasOne`
- added coverage for custom `BelongsTo` join conditions with `foreignKey => false`
- added coverage for non-inspectable / non-join custom conditions

## Notes

This is intentionally narrower than a full condition parser. The goal is to give
consumers a stable public API for the common inspectable cases without exposing
protected internals or forcing them to regex raw condition payloads themselves.
