### PR TITLE
Fix association throws exception when connection is not set or database not present

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -20,6 +20,7 @@ use Cake\Collection\CollectionInterface;
 use Cake\Core\App;
 use Cake\Core\ConventionsTrait;
 use Cake\Database\Exception\DatabaseException;
+use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\ExpressionInterface;
@@ -566,7 +567,7 @@ abstract class Association
                     E_USER_WARNING,
                 );
             }
-        } catch (DatabaseException) {
+        } catch (DatabaseException | MissingConnectionException) {
             // Schema is not yet loaded, can't check for clashes
         }
 

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -568,7 +568,7 @@ abstract class Association
                 );
             }
         } catch (DatabaseException | MissingConnectionException) {
-            // Schema is not yet loaded, can't check for clashes
+            // Schema can't be read, so skip checking for property/column clashes.
         }
 
         return $this;

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1397,6 +1397,28 @@ class BelongsToManyTest extends TestCase
     }
 
     /**
+     * Tests that property is being set doesn't throw exception when connection is not configured.
+     */
+    public function testPropertyOption_MissingConnectionError(): void
+    {
+        $connection = ConnectionManager::get('test');
+        $this->skipIf($connection->getDriver() instanceof Sqlite, 'Skip for sqlite');
+
+        // Create a dummy database connection to test
+        $originalConfig = ConnectionManager::getConfig('test');
+        ConnectionManager::drop('test');
+        ConnectionManager::setConfig('test', $originalConfig + ['database' => 'nonexistent']);
+
+        $config = ['propertyName' => 'thing_placeholder', 'sourceTable' => $this->article];
+        $association = new BelongsToMany('Thing', $config);
+        $this->assertSame('thing_placeholder', $association->getProperty());
+
+        // Clean up
+        ConnectionManager::drop('test');
+        ConnectionManager::setConfig('test', $originalConfig);
+    }
+
+    /**
      * Test that plugin names are omitted from property()
      */
     public function testPropertyNoPlugin(): void

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1397,9 +1397,9 @@ class BelongsToManyTest extends TestCase
     }
 
     /**
-     * Tests that property is being set doesn't throw exception when connection is not configured.
+     * Tests that property is being set doesn't throw an exception when connection is not configured.
      */
-    public function testPropertyOption_MissingConnectionError(): void
+    public function testPropertyOptionMissingConnectionError(): void
     {
         $connection = ConnectionManager::get('test');
         $this->skipIf($connection->getDriver() instanceof Sqlite, 'Skip for sqlite');
@@ -1407,15 +1407,23 @@ class BelongsToManyTest extends TestCase
         // Create a dummy database connection to test
         $originalConfig = ConnectionManager::getConfig('test');
         ConnectionManager::drop('test');
-        ConnectionManager::setConfig('test', $originalConfig + ['database' => 'nonexistent']);
+        ConnectionManager::setConfig('test', ['database' => 'nonexistent'] + $originalConfig);
 
-        $config = ['propertyName' => 'thing_placeholder', 'sourceTable' => $this->article];
-        $association = new BelongsToMany('Thing', $config);
-        $this->assertSame('thing_placeholder', $association->getProperty());
-
-        // Clean up
-        ConnectionManager::drop('test');
-        ConnectionManager::setConfig('test', $originalConfig);
+        // Used try...finally to restore original configuration in case there's an exception mid-test
+        try {
+            $table = new Table([
+                'alias' => 'Articles',
+                'table' => 'articles',
+                'connection' => ConnectionManager::get('test'),
+            ]);
+            $config = ['propertyName' => 'thing_placeholder', 'sourceTable' => $table];
+            $association = new BelongsToMany('Thing', $config);
+            $this->assertSame('thing_placeholder', $association->getProperty());
+        } finally {
+            // Clean up
+            ConnectionManager::drop('test');
+            ConnectionManager::setConfig('test', $originalConfig);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes issue introduced by PR #18859.

After the upgrade to v5.3.*, our testsuite started failing because in CI we set database which doesn't exist to the `default` connection. When calling any cake command from CI which don't interact with the database it still tries to connect to the database due to `$this->_sourceTable->getSchema()->columns()` in the `Association::setProperty()` method.