### PR TITLE
Fix split-package generics.variance failure from #19440 covariance

### DIFF
--- a/src/ORM/phpstan.neon.dist
+++ b/src/ORM/phpstan.neon.dist
@@ -14,6 +14,17 @@ parameters:
 			identifier: missingType.iterableValue
 		- '#Unsafe usage of new static\(\).#'
 		- "#^Method Cake\\\\ORM\\\\Query\\\\SelectQuery\\:\\:find\\(\\) should return static\\(Cake\\\\ORM\\\\Query\\\\SelectQuery\\<TSubject of array\\|Cake\\\\Datasource\\\\EntityInterface\\>\\) but returns Cake\\\\ORM\\\\Query\\\\SelectQuery\\<TSubject of array\\|Cake\\\\Datasource\\\\EntityInterface\\>\\.$#"
+		# Release-coordination lag: the released cakephp/database still declares
+		# Database\Query\SelectQuery's template as invariant, while the ORM
+		# subclass' TSubject is now covariant. Both are consistent inside the
+		# monorepo (root phpstan is green); the standalone split analysis pulls
+		# the released database package. Remove once cakephp/database ships the
+		# covariant template marker.
+		-
+			message: '#^Template type TSubject is declared as covariant, but occurs in invariant position in extended type Cake\\Database\\Query\\SelectQuery<TSubject of array\|Cake\\Datasource\\EntityInterface> of class Cake\\ORM\\Query\\SelectQuery\.$#'
+			identifier: generics.variance
+			path: Query/SelectQuery.php
+			count: 1
 		- '#^PHPDoc tag @var with type callable\(\): mixed is not subtype of native type Closure\(string\): string\.$#'
 
 		-


### PR DESCRIPTION
## Problem

`5.next` is currently red on the **Static Analysis for Split Packages** CI job (since the 5.x→5.next merge that brought #19440 onto the branch).

The standalone ORM split-package analysis reports:

```
Template type TSubject is declared as covariant, but occurs in invariant
position in extended type Cake\Database\Query\SelectQuery<...> of class
Cake\ORM\Query\SelectQuery.   [identifier=generics.variance]
src/ORM/Query/SelectQuery.php:50
```

## Root cause

#19440 made `Cake\ORM\Query\SelectQuery`'s `TSubject` template covariant, and made `Cake\Database\Query\SelectQuery`'s `T` covariant in the same change — so the two are consistent **inside the monorepo**, and the root phpstan run ("Coding Standard & Static Analysis") stays green.

The split-package job analyzes `src/ORM` standalone with `cakephp/database` resolved from the **released** package (`5.4.0-RC1`), whose `Cake\Database\Query\SelectQuery` still declares the template as invariant (`template T`). A covariant subclass template passed to an invariant parent template is a legitimate `generics.variance` error — but only because the released parent predates #19440's covariance.

Reproduced locally with the exact CI setup (released `cakephp/database` 5.4.0-RC1, pinned phpstan 2.1.45, the package's own `phpstan.neon.dist`): 1 error before, `[OK] No errors` after this change.

## Fix

A scoped `ignoreErrors` entry in `src/ORM/phpstan.neon.dist` (the split-package config; the root monorepo config is independent and unaffected). It matches the existing precedent in the very same file — there is already a hand-curated ignore for a `SelectQuery::find()` split-package generics lag of the same nature.

The entry is narrow: exact message + `identifier: generics.variance` + `path: Query/SelectQuery.php` + `count: 1`, with a comment stating it should be removed once `cakephp/database` ships the covariant template marker.

## Scope

- Touches only `src/ORM/phpstan.neon.dist`.
- Not a code/behavior change; the covariance itself (#19440) is intentional and correct within the monorepo.
- Independent of #19441 (which is rebased on top of this state and inherits the same red check until this lands).

Related: #19440
