### PR TITLE
Fix malformed file path in CommandScanner::scanPlugin()

### DIFF
--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -78,7 +78,7 @@ class CommandScanner
         $namespace = str_replace('/', '\\', $plugin);
         $prefix = Inflector::underscore($plugin) . '.';
 
-        return $this->scanDir($path . 'Command', $namespace . '\Command\\', $prefix, []);
+        return $this->scanDir($path . 'Command' . DIRECTORY_SEPARATOR, $namespace . '\Command\\', $prefix, []);
     }
 
     /**

--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -85,7 +85,7 @@ class CommandScanner
      * Scan a directory for .php files and return the class names that
      * should be within them.
      *
-     * @param string $path The directory to read.
+     * @param string $path The directory to read. Must end with a trailing directory separator.
      * @param string $namespace The namespace the shells live in.
      * @param string $prefix The prefix to apply to commands for their full name.
      * @param array<string> $hide A list of command names to hide as they are internal commands.

--- a/tests/TestCase/Console/CommandScannerTest.php
+++ b/tests/TestCase/Console/CommandScannerTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Console;
+
+use Cake\Console\CommandScanner;
+use Cake\Core\Plugin;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Test case for the CommandScanner
+ */
+class CommandScannerTest extends TestCase
+{
+    /**
+     * @inheritDoc
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->clearPlugins();
+    }
+
+    /**
+     * The `file` value of a scanned plugin command must point at the real
+     * file, i.e. include the `Command` directory separator. Regression test
+     * for a missing separator that produced paths like
+     * `.../src/CommandFooCommand.php`.
+     */
+    public function testScanPluginFilePath(): void
+    {
+        $this->loadPlugins(['Company/TestPluginThree']);
+
+        $expectedFile = Plugin::classPath('Company/TestPluginThree')
+            . 'Command' . DIRECTORY_SEPARATOR . 'CompanyCommand.php';
+
+        $commandScanner = new CommandScanner();
+        $result = $commandScanner->scanPlugin('Company/TestPluginThree');
+
+        $this->assertSame($expectedFile, $result[0]['file']);
+    }
+
+    /**
+     * A non-existent plugin yields no commands.
+     */
+    public function testScanPluginNonExistentPlugin(): void
+    {
+        $commandScanner = new CommandScanner();
+        $this->assertSame([], $commandScanner->scanPlugin('NonExistentPlugin'));
+    }
+}


### PR DESCRIPTION
## What

`CommandScanner::scanPlugin()` builds the scan directory as `$path . 'Command'` without a trailing separator. Since `scanDir()` later does `$path . $file`, every scanned plugin command ended up with a malformed `file` value:

```
.../Plugin/Company/TestPluginThree/src/CommandCompanyCommand.php
```

instead of the real path:

```
.../Plugin/Company/TestPluginThree/src/Command/CompanyCommand.php
```

This is a one-line fix adding the missing directory separator, plus a focused regression test.

## Scope / risk

Deliberately minimal — only the path concatenation and a regression test. `CommandScanner` stays `@internal` and `scanDir()` stays `protected`; no API surface change here.

The malformed value is the `file` key of the scan result, which the framework itself does not consume (command resolution only uses `name`/`fullName`/`class`). So this is an internal correctness fix with no behavior change for command execution — safe for the maintenance branch.

## Branch target

Targeting **5.x**: it is a correctness bug present on 5.x, low risk, and merges upward to 5.next normally. The broader "make `CommandScanner`/discovery public" discussion (see #19400) is intentionally kept out of this PR so the fix can land independently of that direction decision.
