### PR TITLE
CommandCollection::discoverDirectory() (alternative to #19400)

### DIFF
--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -202,6 +202,52 @@ class CommandCollection implements IteratorAggregate, Countable
     }
 
     /**
+     * Auto-discover commands in a filesystem directory.
+     *
+     * Useful for registering commands that live in a subdirectory and
+     * namespace of the application (e.g. `src/Command/Maintenance/`)
+     * without listing each command individually, typically from
+     * `Application::console()`:
+     *
+     * ```
+     * $commands->addMany($commands->discoverDirectory(
+     *     ROOT . '/src/Command/Maintenance',
+     *     'App\\Command\\Maintenance',
+     *     'maintenance ',
+     * ));
+     * ```
+     *
+     * The directory is scanned non-recursively. A non-empty `$prefix` is
+     * required: it produces a `prefix.command` long name so a discovered
+     * command whose short name collides with an existing one is exposed
+     * only under its prefixed name instead of silently replacing it -
+     * the same short-name de-duplication {@see discoverPlugin()} relies
+     * on (an empty prefix would defeat it). The prefixed long name itself
+     * follows the same last-wins precedence as `discoverPlugin()` /
+     * `autoDiscover()`. The path and namespace are normalized, so a
+     * trailing separator is optional.
+     *
+     * @param string $path The directory to scan.
+     * @param string $namespace The namespace the commands live in.
+     * @param string $prefix Prefix applied to each command's full name.
+     * @return array<string, class-string<\Cake\Console\CommandInterface>> Discovered commands.
+     * @throws \InvalidArgumentException When `$prefix` is empty.
+     */
+    public function discoverDirectory(string $path, string $namespace, string $prefix): array
+    {
+        if ($prefix === '') {
+            throw new InvalidArgumentException(
+                'A non-empty `$prefix` is required so discovered commands ' .
+                'de-duplicate against existing ones instead of overwriting them.',
+            );
+        }
+        $namespace = rtrim($namespace, '\\') . '\\';
+        $scanner = new CommandScanner();
+
+        return $this->resolveNames($scanner->scanDir($path, $namespace, $prefix));
+    }
+
+    /**
      * Resolve names based on existing commands
      *
      * @param array<array<string, string>> $input The results of a CommandScanner operation.

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -218,14 +218,12 @@ class CommandCollection implements IteratorAggregate, Countable
      * ```
      *
      * The directory is scanned non-recursively. A non-empty `$prefix` is
-     * required: it produces a `prefix.command` long name so a discovered
-     * command whose short name collides with an existing one is exposed
-     * only under its prefixed name instead of silently replacing it -
-     * the same short-name de-duplication {@see discoverPlugin()} relies
-     * on (an empty prefix would defeat it). The prefixed long name itself
-     * follows the same last-wins precedence as `discoverPlugin()` /
-     * `autoDiscover()`. The path and namespace are normalized, so a
-     * trailing separator is optional.
+     * required. The prefix produces a `prefix.command` long name so discovered
+     * commands whose short name collides with an existing command is exposed
+     * only under its prefixed name, and does not replace an existing command.
+     * The prefixed long name itself follows the same last-wins
+     * precedence as `discoverPlugin()` / `autoDiscover()`. The path and
+     * namespace are normalized, so a trailing separator is optional.
      *
      * @param string $path The directory to scan.
      * @param string $namespace The namespace the commands live in.

--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -24,8 +24,11 @@ use Cake\Utility\Inflector;
 use ReflectionClass;
 
 /**
- * Used by CommandCollection and CommandTask to scan the filesystem
- * for command classes.
+ * Scans the filesystem for command classes.
+ *
+ * Implementation detail behind CommandCollection's discovery methods.
+ * Not part of the supported public API - use CommandCollection
+ * (e.g. `discoverDirectory()`) instead.
  *
  * @internal
  */
@@ -58,8 +61,6 @@ class CommandScanner
         return $this->scanDir(
             App::classPath('Command')[0],
             $appNamespace . '\Command\\',
-            '',
-            [],
         );
     }
 
@@ -78,7 +79,7 @@ class CommandScanner
         $namespace = str_replace('/', '\\', $plugin);
         $prefix = Inflector::underscore($plugin) . '.';
 
-        return $this->scanDir($path . 'Command', $namespace . '\Command\\', $prefix, []);
+        return $this->scanDir($path . 'Command' . DIRECTORY_SEPARATOR, $namespace . '\Command\\', $prefix);
     }
 
     /**
@@ -90,12 +91,16 @@ class CommandScanner
      * @param string $prefix The prefix to apply to commands for their full name.
      * @param array<string> $hide A list of command names to hide as they are internal commands.
      * @return array The list of shell info arrays based on scanning the filesystem and inflection.
+     * @internal Reachable via CommandCollection discovery; not a supported entry point on its own.
      */
-    protected function scanDir(string $path, string $namespace, string $prefix, array $hide): array
+    public function scanDir(string $path, string $namespace, string $prefix = '', array $hide = []): array
     {
         if (!is_dir($path)) {
             return [];
         }
+        // Normalize to a single trailing separator so `file` paths are
+        // correct regardless of how callers pass the directory.
+        $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 
         // This ensures `Command` class is not added to the list.
         $hide[] = '';

--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -79,7 +79,7 @@ class CommandScanner
         $namespace = str_replace('/', '\\', $plugin);
         $prefix = Inflector::underscore($plugin) . '.';
 
-        return $this->scanDir($path . 'Command' . DIRECTORY_SEPARATOR, $namespace . '\Command\\', $prefix);
+        return $this->scanDir($path . 'Command', $namespace . '\Command\\', $prefix);
     }
 
     /**

--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -98,8 +98,7 @@ class CommandScanner
         if (!is_dir($path)) {
             return [];
         }
-        // Normalize to a single trailing separator so `file` paths are
-        // correct regardless of how callers pass the directory.
+
         $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 
         // This ensures `Command` class is not added to the list.

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -20,6 +20,7 @@ use Cake\Command\RoutesCommand;
 use Cake\Command\VersionCommand;
 use Cake\Console\CommandCollection;
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -347,6 +348,82 @@ class CommandCollectionTest extends TestCase
         );
         $this->assertSame($result['company'], $result['company/test_plugin_three.company']);
         $this->clearPlugins();
+    }
+
+    /**
+     * Discovering commands in an arbitrary directory + namespace.
+     */
+    public function testDiscoverDirectory(): void
+    {
+        $this->loadPlugins(['Company/TestPluginThree']);
+        $path = Plugin::classPath('Company/TestPluginThree') . 'Command' . DIRECTORY_SEPARATOR;
+        $class = 'Company\TestPluginThree\Command\CompanyCommand';
+
+        $collection = new CommandCollection();
+        $result = $collection->discoverDirectory($path, 'Company\TestPluginThree\Command\\', 'maint.');
+
+        $this->assertSame(
+            ['company' => $class, 'maint.company' => $class],
+            $result,
+        );
+        $this->clearPlugins();
+    }
+
+    /**
+     * A non-empty prefix gives a long name to fall back on, so a
+     * colliding short name does not silently overwrite an existing
+     * command (it is exposed only under the prefixed name).
+     */
+    public function testDiscoverDirectoryDeduplicates(): void
+    {
+        $this->loadPlugins(['Company/TestPluginThree']);
+        $path = Plugin::classPath('Company/TestPluginThree') . 'Command' . DIRECTORY_SEPARATOR;
+        $class = 'Company\TestPluginThree\Command\CompanyCommand';
+
+        $collection = new CommandCollection();
+        $collection->add('company', DemoCommand::class);
+        $result = $collection->discoverDirectory($path, 'Company\TestPluginThree\Command\\', 'maint.');
+
+        $this->assertArrayNotHasKey('company', $result, 'Existing command not overwritten');
+        $this->assertSame(['maint.company' => $class], $result);
+        $this->clearPlugins();
+    }
+
+    /**
+     * A missing trailing separator on either the path or the namespace
+     * must not break discovery (both are normalized), so a new public
+     * caller cannot trip the malformed `file` path / empty-result issues.
+     */
+    public function testDiscoverDirectoryWithoutTrailingSeparators(): void
+    {
+        $this->loadPlugins(['Company/TestPluginThree']);
+        $path = Plugin::classPath('Company/TestPluginThree') . 'Command';
+
+        $collection = new CommandCollection();
+        $result = $collection->discoverDirectory($path, 'Company\TestPluginThree\Command', 'maint.');
+
+        $this->assertArrayHasKey('company', $result);
+        $this->assertArrayHasKey('maint.company', $result);
+        $this->clearPlugins();
+    }
+
+    /**
+     * A non-existent directory yields no commands.
+     */
+    public function testDiscoverDirectoryUnknown(): void
+    {
+        $collection = new CommandCollection();
+        $this->assertSame([], $collection->discoverDirectory('/no/such/dir', 'App\Command\\', 'x.'));
+    }
+
+    /**
+     * An empty prefix is rejected because it would defeat de-duplication.
+     */
+    public function testDiscoverDirectoryEmptyPrefix(): void
+    {
+        $collection = new CommandCollection();
+        $this->expectException(InvalidArgumentException::class);
+        $collection->discoverDirectory('/no/such/dir', 'App\Command\\', '');
     }
 
     /**


### PR DESCRIPTION

This prototypes **option 1** as an alternative to #19400 (which makes `CommandScanner` and `scanDir()` public).

## The problem (same as #19400)

Apps growing many commands want to register everything in a subdirectory + namespace (e.g. `src/Command/Maintenance`) from `Application::console()` without listing each command. Today that requires an anonymous-subclass hack to reach the protected scanner.

## This approach

Instead of promoting the low-level scanner to supported public API, add one focused, intention-revealing method to `CommandCollection` — which is already the public discovery surface (`autoDiscover()`, `discoverPlugin()`):

```php
public function console(CommandCollection $commands): CommandCollection
{
    $commands = parent::console($commands);
    $commands->addMany($commands->discoverDirectory(
        ROOT . '/src/Command/Maintenance',
        'App\\Command\\Maintenance',
        'maintenance ',
    ));

    return $commands;
}
```

`CommandScanner` stays an implementation detail (internal annotation kept), so the discovery engine remains free to refactor. `scanDir()` is made callable only so the collection can delegate.

## Why the public boundary is hardened (vs. exposing the raw scanner)

A second-pass review surfaced exactly the sharp edges a raw `(path, namespace, prefix, hide)` primitive has — which is the core argument for wrapping it:

- **Empty prefix → silent overwrite.** With no prefix `fullName === name`, so `resolveNames()` cannot fall back to a long name and a colliding short name silently replaces an existing command. `discoverPlugin()` never hits this (always `plugin.`-prefixed). Fixed by **requiring a non-empty prefix**, enforced with `InvalidArgumentException`.
- **Namespace trailing separator.** `scanDir()` now normalizes the path; the namespace is normalized too, so callers needn't remember a trailing `\`.
- Path normalization also fixes the latent `scanPlugin()` malformed-`file` bug (proposed standalone for 5.x in #19452).

A deliberate non-change: a fully-qualified (prefixed) name still follows **last-wins precedence**, identical to `discoverPlugin()` / `autoDiscover()`. Making `discoverDirectory()` alone reject full-name collisions would make it inconsistent with the rest of the discovery family and require changing shared `resolveNames()` (a behavior change to stable API). Short-name de-duplication — the footgun unique to directory scanning — is what's addressed.

## Trade-off vs #19400

| | #19400 (scanner public) | This (collection method) |
|---|---|---|
| Supported API surface | whole `CommandScanner` + `scanDir()` | one `CommandCollection` method |
| Refactor freedom | locked (BC-bound) | scanner stays internal |
| Ergonomics | raw `(path, ns, prefix, hide)` | intention-revealing, normalized, guarded |
| Consistency | new pattern | matches `discoverPlugin()` family |

## Not done (prototype scope)

Docs (`Console & Shells` / `Application::console()`) would be added if this direction is chosen.

Targets **5.next** as a non-BC additive feature.
