### PR TITLE
Allow setting custom plural rules

### DIFF
--- a/src/I18n/PluralRules.php
+++ b/src/I18n/PluralRules.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\I18n;
 
 use Cake\Core\Exception\CakeException;
+use Closure;
 use InvalidArgumentException;
 use Locale;
 
@@ -133,6 +134,14 @@ class PluralRules
     ];
 
     /**
+     * A map of locale => function that overrides the above map.
+     * Such functions directly resolve the plural form number.
+     *
+     * @var array<string, \Closure(int): int>
+     */
+    protected static array $callableRulesMap = [];
+
+    /**
      * Returns the plural form number for the passed locale corresponding
      * to the countable provided in $n.
      *
@@ -149,8 +158,12 @@ class PluralRules
             throw new InvalidArgumentException('Invalid locale provided');
         }
 
-        if (!isset(static::$_rulesMap[$locale])) {
+        if (!isset(static::$_rulesMap[$locale]) && !isset(static::$callableRulesMap[$locale])) {
             $locale = explode('_', $locale)[0];
+        }
+
+        if (isset(static::$callableRulesMap[$locale])) {
+            return static::$callableRulesMap[$locale]($n);
         }
 
         if (!isset(static::$_rulesMap[$locale])) {
@@ -193,5 +206,33 @@ class PluralRules
             17 => $n === 1 ? 0 : ($n !== 0 && $n % 1000000 === 0 ? 1 : 2),
             default => throw new CakeException('Unable to find plural rule number.'),
         };
+    }
+
+    /**
+     * Set a custom plural rule.
+     *
+     * @param string $locale The locale on which the plural rule is applied.
+     * @param \Closure(int): int $resolver A function that takes a plural number and
+     *   returns the plural form number for $locale.
+     * @throws \InvalidArgumentException If $locale is invalid.
+     * @return void
+     */
+    public static function setRule(string $locale, Closure $resolver): void
+    {
+        $canonicalLocale = Locale::canonicalize($locale);
+
+        if ($canonicalLocale === null) {
+            throw new InvalidArgumentException(sprintf('Invalid locale `%s` provided', $locale));
+        }
+
+        static::$callableRulesMap[$canonicalLocale] = $resolver;
+    }
+
+    /**
+     * Remove any custom rule previously set.
+     */
+    public static function resetRules(): void
+    {
+        static::$callableRulesMap = [];
     }
 }

--- a/tests/TestCase/I18n/PluralRulesTest.php
+++ b/tests/TestCase/I18n/PluralRulesTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\I18n;
 
 use Cake\I18n\PluralRules;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
@@ -25,6 +26,15 @@ use PHPUnit\Framework\Attributes\DataProvider;
  */
 class PluralRulesTest extends TestCase
 {
+    /**
+     * tearDown method
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        PluralRules::resetRules();
+    }
+
     /**
      * Returns the notable combinations for locales and numbers
      * with the respective plural form that should be selected
@@ -132,8 +142,44 @@ class PluralRulesTest extends TestCase
      * Tests that the correct plural form is selected for the locale, number combination
      */
     #[DataProvider('localesProvider')]
-    public function testCalculate(string $locale, int $number, int $expected): void
+    public function testCalculateBuiltInPluralForms(string $locale, int $number, int $expected): void
     {
         $this->assertEquals($expected, PluralRules::calculate($locale, $number));
+    }
+
+    /**
+     * Data provider for custom plural rule that returns double the number
+     *
+     * @return array
+     */
+    public static function customResolverProvider(): array
+    {
+        return [
+            ['en', 'en', 2, 4],
+            ['en', 'en_US', 2, 4],
+            ['en_US', 'en', 2, 1],
+            ['special', 'special', 6, 12],
+        ];
+    }
+
+    /**
+     * Tests that the correct plural form is returned when a custom plural rule is set
+     */
+    #[DataProvider('customResolverProvider')]
+    public function testCalculateCustomResolver(string $ruleLocale, string $calcLocale, int $number, int $expected): void
+    {
+        PluralRules::setRule($ruleLocale, fn(int $n) => $n * 2);
+        $this->assertEquals($expected, PluralRules::calculate($calcLocale, $number));
+    }
+
+    /**
+     * Tests that setting a custom plural rule with an incorrect locale throws an exception
+     */
+    public function testCustomResolverInvalidLocale(): void
+    {
+        $invalidLocale = str_repeat('a', INTL_MAX_LOCALE_LEN + 1);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid locale `{$invalidLocale}` provided");
+        PluralRules::setRule($invalidLocale, fn(int $n) => 42);
     }
 }


### PR DESCRIPTION
### What
This PR allows to set custom plural rules in localization. It helps whenever the plural form used by locale files is absent or differ from CakePHP’s internal PluralRules class.

### Why
Plural rules are defined in PO/MO locale files, but CakePHP uses its own internal set of rules instead. This design is problematic because:
* CakePHP’s internal list regularly gets outdated compared to the [CLDR reference](https://php-gettext.github.io/Languages/) as new CLDR versions are published every 6 months or so. CakePHP’s list lacks some of the plural forms already published by CLDR years ago, such as Breton (br) or Interlingua (ia). Such issues are likely to go largely unnoticed because they primarily affect locales which number of locutor is low, so it is very unlikely that one of them will ever report the issue to CakePHP. Finally, CLDR data itself lacks plural forms for some minority languages (example: Gronings (gos)).
* Whenever an unsupported locale is used, the first plural rule is always used, which is almost always wrong (think of all pluralized strings localized as singular). (Maybe throwing an exception would be more appropriate?)

This has been causing various bugs such as #5348, #13209 and #18740. Ideally, CakePHP should rely on the plural rule defined inside individual PO/MO files, but it adds complexity/overhead and [has once been rejected](https://github.com/cakephp/cakephp/pull/5348). Finally, a simpler approach was [suggested by ADmad](https://github.com/cakephp/cakephp/pull/18741#issuecomment-2965582878), so I implemented that.