### PR TITLE
Improve error message for duplicate rule names

### DIFF
--- a/src/Datasource/RulesChecker.php
+++ b/src/Datasource/RulesChecker.php
@@ -421,7 +421,7 @@ class RulesChecker
     protected function checkName(string $name, array $rules): void
     {
         if (array_key_exists($name, $rules)) {
-            throw new CakeException('A rule with the same name already exists');
+            throw new CakeException("A rule with the name `{$name}` already exists");
         }
     }
 }


### PR DESCRIPTION
Improve the error message. This makes it similar to the `ValidationSet.php` error which already reports the problematic rule: https://github.com/cakephp/cakephp/blob/75b02a8f8032098303d40ce80d4db169f29b06fb/src/Validation/ValidationSet.php#L161