### PR TITLE
View: allow cross-root element traversal with deprecation (follow-up to #19447)

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -36,6 +36,7 @@ use Generator;
 use InvalidArgumentException;
 use LogicException;
 use Throwable;
+use function Cake\Core\deprecationWarning;
 use function Cake\Core\pluginSplit;
 
 /**
@@ -1382,7 +1383,7 @@ class View implements EventDispatcherInterface
         $name .= $this->_ext;
         $paths = $this->_paths($plugin);
         foreach ($paths as $path) {
-            $filepath = $this->_checkFilePath($path . $name, $path);
+            $filepath = $this->_checkFilePath($path . $name, $path, $paths);
             if (is_file($filepath)) {
                 return $filepath;
             }
@@ -1410,12 +1411,20 @@ class View implements EventDispatcherInterface
      * that does not exist on the current root (realpath returning false) is passed
      * through so the path cascade can try the next root.
      *
+     * When `$allowedRoots` is supplied, a candidate that resolves outside `$path` but
+     * inside any of those roots is allowed for now and emits a deprecation warning,
+     * since `..` traversal between configured template roots was permitted before
+     * the path hardening in 5.3.2. This relaxation is removed in 6.x; new code must
+     * use plain element/template names instead of `..` traversal.
+     *
      * @param string $file The path to the template file.
      * @param string $path Base path that $file should be inside of.
+     * @param array<string> $allowedRoots Other configured roots accepted with a
+     *  deprecation warning when `$file` resolves outside `$path`.
      * @return string The file path
      * @throws \InvalidArgumentException
      */
-    protected function _checkFilePath(string $file, string $path): string
+    protected function _checkFilePath(string $file, string $path, array $allowedRoots = []): string
     {
         if (!str_contains($file, '..')) {
             return $file;
@@ -1425,14 +1434,29 @@ class View implements EventDispatcherInterface
             // Candidate does not exist on this root; let the path cascade continue.
             return $file;
         }
-        if (!str_starts_with($absolute, $path)) {
-            throw new InvalidArgumentException(sprintf(
-                'Cannot use `%s` as a template, it is not within any view template path.',
-                $file,
-            ));
+        if (str_starts_with($absolute, $path)) {
+            return $absolute;
+        }
+        foreach ($allowedRoots as $allowedRoot) {
+            if ($allowedRoot !== $path && str_starts_with($absolute, $allowedRoot)) {
+                deprecationWarning(
+                    '5.3.6',
+                    sprintf(
+                        'Resolving `%s` via `..` traversal across configured template roots is deprecated. ' .
+                        'Move the file under the current root or reference it directly. ' .
+                        'This relaxation is removed in 6.x.',
+                        $file,
+                    ),
+                );
+
+                return $absolute;
+            }
         }
 
-        return $absolute;
+        throw new InvalidArgumentException(sprintf(
+            'Cannot use `%s` as a template, it is not within any view template path.',
+            $file,
+        ));
     }
 
     /**
@@ -1482,8 +1506,9 @@ class View implements EventDispatcherInterface
         [$plugin, $name] = $this->pluginSplit($name);
         $name .= $this->_ext;
 
+        $allowedRoots = $this->_paths($plugin);
         foreach ($this->getLayoutPaths($plugin) as $path) {
-            $filepath = $this->_checkFilePath($path . $name, $path);
+            $filepath = $this->_checkFilePath($path . $name, $path, $allowedRoots);
             if (is_file($filepath)) {
                 return $filepath;
             }
@@ -1526,8 +1551,9 @@ class View implements EventDispatcherInterface
         [$plugin, $name] = $this->pluginSplit($name, $pluginCheck);
 
         $name .= $this->_ext;
+        $allowedRoots = $this->_paths($plugin);
         foreach ($this->getElementPaths($plugin) as $path) {
-            $filepath = $this->_checkFilePath($path . $name, $path);
+            $filepath = $this->_checkFilePath($path . $name, $path, $allowedRoots);
             if (is_file($filepath)) {
                 return $filepath;
             }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -718,6 +718,18 @@ class ViewTest extends TestCase
     }
 
     /**
+     * Test that `..` traversal across configured template roots still resolves but
+     * triggers a deprecation warning. The relaxation is removed in 6.x.
+     */
+    public function testElementCrossRootTraversalDeprecated(): void
+    {
+        $this->deprecated(function (): void {
+            $result = $this->View->element('../Posts/header');
+            $this->assertStringContainsString('header template', $result);
+        });
+    }
+
+    /**
      * Test loading nonexistent plugin view element
      */
     public function testElementMissingPluginElement(): void


### PR DESCRIPTION
## Summary

Follow-up to #19447. The path-traversal hardening shipped in 5.3.2 rejects element/template names that resolve outside the iteration's current root — but that includes the legitimate pattern of using `..` inside an element/template name to reach a sibling template root, e.g. `element('../Posts/header')` from within `templates/element/`, which resolves to `templates/Posts/header.php`. Apps that relied on cross-root traversal now hard-fail with `InvalidArgumentException` even though the resolved file lives inside a configured template path.

Example real-world breakage: [dereuromark/cakephp-sandbox#128](https://github.com/dereuromark/cakephp-sandbox/pull/128).

## Change

`View::_checkFilePath()` gains a new optional `$allowedRoots` argument (default `[]` preserves the strict behavior for any third-party subclass that overrides or calls it directly). The three internal callers — template, layout and element loaders — pass `$this->_paths($plugin)` so any resolved file inside one of the configured template roots is accepted.

- File resolves inside the current root → returned (unchanged).
- File resolves inside another configured root → returned **with a `deprecationWarning('5.3.6', ...)`**.
- File resolves outside all configured roots → throws `InvalidArgumentException` (CVE fix preserved).

The relaxation is removed in 6.x — `checkFilePath()` on `6.x` is then already strict and stays that way. Apps should migrate by moving shared partials under the current root, or referencing them directly without `..`.

## Why deprecate rather than silently permit

Cross-root `..` traversal in element names is fragile (semantics depend on `subDir`, hostile to static analysis, surprising when themes change the path set). The pattern should go; this just stops it being a hard regression mid-cycle so apps can migrate without an emergency release.

## Alternative

We could also not deprecate this and keep this lenient "convenience".