### PR TITLE
Add security.txt

### DIFF
--- a/security.txt
+++ b/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:security@cakephp.org
+Expires: 2027-06-01T04:59:00.000Z
+Preferred-Languages: en, de
+Canonical: https://cakephp.org/.well-known/security.txt
+Policy: https://book.cakephp.org/5.x/contributing/tickets.html#reporting-security-issues
+


### PR DESCRIPTION
Generated via https://securitytxt.org/

I do not purport to be an authority on the content of this document, I only noticed that we do not have one (*we do have a security issues policy in the docs) and wished to create the first draft and get the discussion started.