### PR TITLE
Add JsonPathExpression to support json path clauses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,12 @@ jobs:
       if: matrix.db-type == 'mysql' && matrix.dependencies == 'lowest'
       run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql:5.7 --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
 
-    - name: Setup PostgreSQL with PostGIS
-      if: matrix.db-type == 'pgsql'
+    - name: Setup PostgreSQL 12 with PostGIS
+      if: matrix.db-type == 'pgsql' && matrix.php-version == '8.2'
+      run: docker run --rm --name=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=cakephp -p 5432:5432 -d postgis/postgis:12-3.5
+
+    - name: Setup PostgreSQL 18 with PostGIS
+      if: matrix.db-type == 'pgsql' && matrix.php-version != '8.2'
       run: docker run --rm --name=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=cakephp -p 5432:5432 -d postgis/postgis:18-3.6
 
     - name: Setup MariaDB 11.8

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -19,6 +19,8 @@ namespace Cake\Database\Driver;
 use Cake\Database\Driver;
 use Cake\Database\DriverFeatureEnum;
 use Cake\Database\Expression\DistinctComparisonExpression;
+use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\StringAggExpression;
 use Cake\Database\Query;
 use Cake\Database\Query\SelectQuery;
@@ -39,6 +41,7 @@ class Mysql extends Driver
     protected function _expressionTranslators(): array
     {
         return [
+            FunctionExpression::class => '_transformFunctionExpression',
             StringAggExpression::class => 'transformStringAggExpression',
             DistinctComparisonExpression::class => 'transformDistinctComparisonExpression',
         ];
@@ -353,6 +356,33 @@ class Mysql extends Driver
         }
 
         return $this->_version;
+    }
+
+    /**
+     * Receives a FunctionExpression and changes it so that it conforms to this SQL dialect.
+     *
+     * @param \Cake\Database\Expression\FunctionExpression $expression The function expression to transform.
+     * @return void
+     */
+    protected function _transformFunctionExpression(FunctionExpression $expression): void
+    {
+        if ($this->isMariadb()) {
+            return;
+        }
+
+        switch ($expression->getName()) {
+            case 'JSON_EXISTS':
+                $expression
+                    ->setName('JSON_CONTAINS_PATH')
+                    ->iterateParts(function ($p, $key) {
+                        if ($key === 1) {
+                            return new QueryExpression(["'all'", $p], ['literal'], ',', parentheses: false);
+                        }
+
+                        return $p;
+                    });
+                break;
+        }
     }
 
     /**

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -345,16 +345,28 @@ class Postgres extends Driver
                     ->add([') + (1' => 'literal']); // Postgres starts on index 0 but Sunday should be 1
                 break;
             case 'JSON_VALUE':
-                $expression->setName('JSONB_PATH_QUERY')
-                    ->iterateParts(function ($p, $key) {
-                        if ($key === 0) {
-                            $p = sprintf('%s::jsonb', $p);
-                        } elseif ($key === 1) {
-                            $p = sprintf("'%s'::jsonpath", $this->quoteIdentifier($p['value']));
-                        }
+                if (version_compare($this->version(), '17.0', '<')) {
+                    $expression->setName('JSONB_PATH_QUERY')
+                        ->iterateParts(function ($p, $key) {
+                            if ($key === 0) {
+                                return $p = sprintf('%s::jsonb', $p);
+                            }
 
-                        return $p;
-                    });
+                            return $p;
+                        });
+                }
+                break;
+            case 'JSON_EXISTS':
+                if (version_compare($this->version(), '17.0', '<')) {
+                    $expression->setName('JSONB_PATH_EXISTS')
+                        ->iterateParts(function ($p, $key) {
+                            if ($key === 0) {
+                                return sprintf('%s::jsonb', $p);
+                            }
+
+                            return $p;
+                        });
+                }
                 break;
         }
     }

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -19,6 +19,7 @@ namespace Cake\Database\Driver;
 use Cake\Database\Driver;
 use Cake\Database\DriverFeatureEnum;
 use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\StringAggExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\Schema\SchemaDialect;
@@ -324,6 +325,22 @@ class Sqlite extends Driver
                 break;
             case 'JSON_VALUE':
                 $expression->setName('JSON_EXTRACT');
+                break;
+            case 'JSON_EXISTS':
+                $expression
+                    ->setName('JSON_TYPE')
+                    ->iterateParts(function ($p, $key) {
+                        if ($key === 1) {
+                            return new QueryExpression(
+                                [$p, ') IS NOT NULL AND (1'],
+                                [null, 'literal'],
+                                '',
+                                parentheses: false,
+                            );
+                        }
+
+                        return $p;
+                    });
                 break;
         }
     }

--- a/src/Database/Expression/JsonPathExpression.php
+++ b/src/Database/Expression/JsonPathExpression.php
@@ -1,0 +1,242 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+use Cake\Database\ExpressionInterface;
+use Cake\Database\TypedResultInterface;
+use Cake\Database\TypedResultTrait;
+use Cake\Database\ValueBinder;
+use Closure;
+
+/**
+ * Represents a JSON path expression with optional clauses for each json function.
+ */
+class JsonPathExpression implements ExpressionInterface, TypedResultInterface
+{
+    use TypedResultTrait;
+
+    public const BEHAVIOR_NULL = 'NULL';
+    public const BEHAVIOR_ERROR = 'ERROR';
+    public const BEHAVIOR_DEFAULT = 'DEFAULT';
+
+    /**
+     * @var string
+     */
+    protected string $path;
+
+    /**
+     * @var array<string, array{value: mixed, type: string|null}>
+     */
+    protected array $passing = [];
+
+    /**
+     * @var string|null
+     */
+    protected ?string $returning = null;
+
+    /**
+     * @var array{behavior: string, value: mixed}|null
+     */
+    protected ?array $onEmpty = null;
+
+    /**
+     * @var array{behavior: string, value: mixed}|null
+     */
+    protected ?array $onError = null;
+
+    /**
+     * Constructor.
+     *
+     * @param string $path The json path
+     */
+    public function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * Sets the RETURNING clause.
+     *
+     * Not all database engines support all clauses. Check for support
+     * before using.
+     *
+     * @param string $type The sql data type to return
+     * @return $this
+     */
+    public function returning(string $type)
+    {
+        $this->returning = $type;
+
+        return $this;
+    }
+
+    /**
+     * Sets the PASSING clause.
+     *
+     * Not all database engines support all clauses. Check for support
+     * before using.
+     *
+     * @param array<string, string|int|float|bool> $passing Mapping of variable name to value.
+     * @param array<string, string|int> $types Optional mapping of variable name to binding type.
+     * @return $this
+     */
+    public function passing(array $passing, array $types = [])
+    {
+        foreach ($passing as $name => $value) {
+            $type = $types[$name] ?? null;
+            if ($type === null) {
+                $type = match (true) {
+                    is_string($value) => 'string',
+                    is_int($value) => 'integer',
+                    is_float($value) => 'float',
+                    is_bool($value) => 'boolean',
+                    default => null,
+                };
+            }
+
+            $this->passing[$name] = ['value' => $value, 'type' => $type];
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets the ON EMPTY clause.
+     *
+     * Not all database engines support all clauses. Check for support
+     * before using.
+     *
+     * @param self::BEHAVIOR_* $behavior The behavior on empty (NULL, ERROR, or DEFAULT).
+     * @param mixed $value The default value if behavior is DEFAULT.
+     * @return $this
+     */
+    public function onEmpty(string $behavior, mixed $value = null)
+    {
+        $this->onEmpty = ['behavior' => $behavior, 'value' => $value];
+
+        return $this;
+    }
+
+    /**
+     * Sets the ON ERROR clause.
+     *
+     * Not all database engines support all clauses. Check for support
+     * before using.
+     *
+     * @param self::BEHAVIOR_* $behavior The behavior on error (NULL, ERROR, or DEFAULT).
+     * @param mixed $value The default value if behavior is DEFAULT.
+     * @return $this
+     */
+    public function onError(string $behavior, mixed $value = null)
+    {
+        $this->onError = ['behavior' => $behavior, 'value' => $value];
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function sql(ValueBinder $binder): string
+    {
+        $sql = "'{$this->path}'";
+
+        if ($this->passing) {
+            $passing = [];
+            foreach ($this->passing as $name => ['value' => $value, 'type' => $type]) {
+                if ($value instanceof ExpressionInterface) {
+                    $exprSql = $value->sql($binder);
+                } else {
+                    $placeholder = $binder->placeholder('param');
+                    $binder->bind($placeholder, $value, $type);
+                    $exprSql = $placeholder;
+                }
+                $passing[] = sprintf('%s AS %s', $exprSql, $name);
+            }
+            $sql .= ' PASSING ' . implode(', ', $passing);
+        }
+
+        if ($this->returning) {
+            $sql .= ' RETURNING ' . $this->returning;
+        }
+
+        if ($this->onEmpty !== null) {
+            $sql .= ' ' . $this->behaviorSql($this->onEmpty, 'EMPTY', $binder);
+        }
+
+        if ($this->onError !== null) {
+            $sql .= ' ' . $this->behaviorSql($this->onError, 'ERROR', $binder);
+        }
+
+        return $sql;
+    }
+
+    /**
+     * Generates the SQL for ON EMPTY or ON ERROR clauses.
+     *
+     * @param array $clause The clause configuration.
+     * @param string $type The type of clause (EMPTY or ERROR).
+     * @param \Cake\Database\ValueBinder $binder The value binder.
+     * @return string
+     */
+    protected function behaviorSql(array $clause, string $type, ValueBinder $binder): string
+    {
+        $behavior = strtoupper($clause['behavior']);
+        if ($behavior === self::BEHAVIOR_DEFAULT) {
+            $value = $clause['value'];
+            if ($value instanceof ExpressionInterface) {
+                $value = $value->sql($binder);
+            } elseif (is_string($value)) {
+                $value = sprintf("'%s'", str_replace("'", "''", $value));
+            } elseif (is_bool($value)) {
+                $value = $value ? 'TRUE' : 'FALSE';
+            } elseif ($value === null) {
+                $value = 'NULL';
+            }
+
+            // DEFAULT clause require a literal value
+            return sprintf('DEFAULT %s ON %s', $value, $type);
+        }
+
+        return sprintf('%s ON %s', $behavior, $type);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function traverse(Closure $callback)
+    {
+        foreach ($this->passing as ['value' => $value]) {
+            if ($value instanceof ExpressionInterface) {
+                $callback($value);
+                $value->traverse($callback);
+            }
+        }
+
+        if ($this->onEmpty !== null && $this->onEmpty['value'] instanceof ExpressionInterface) {
+            $callback($this->onEmpty['value']);
+            $this->onEmpty['value']->traverse($callback);
+        }
+
+        if ($this->onError !== null && $this->onError['value'] instanceof ExpressionInterface) {
+            $callback($this->onError['value']);
+            $this->onError['value']->traverse($callback);
+        }
+
+        return $this;
+    }
+}

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -51,6 +51,11 @@ class QueryExpression implements ExpressionInterface, Countable
     protected array $_conditions = [];
 
     /**
+     * @var bool
+     */
+    protected bool $parentheses = true;
+
+    /**
      * Constructor. A new expression object can be created without any params and
      * be built dynamically. Otherwise, it is possible to pass an array of conditions
      * containing either a tree-like array structure to be parsed and/or other
@@ -63,13 +68,17 @@ class QueryExpression implements ExpressionInterface, Countable
      * passed in $conditions.
      * @param string $conjunction the glue that will join all the string conditions at this
      * level of the expression tree. For example "AND", "OR", "XOR"...
+     * @param bool $parentheses Whether to wrap this expression in parentheses when it is converted to sql string.
+     *  This is useful when you want to create a sub-expression and you don't want it to be wrapped in parentheses.
      * @see \Cake\Database\Expression\QueryExpression::add() for more details on $conditions and $types
      */
     public function __construct(
         ExpressionInterface|array|string $conditions = [],
         TypeMap|array $types = [],
         string $conjunction = 'AND',
+        bool $parentheses = true,
     ) {
+        $this->parentheses = $parentheses;
         $this->setTypeMap($types);
         $this->setConjunction(strtoupper($conjunction));
         if ($conditions) {
@@ -589,7 +598,7 @@ class QueryExpression implements ExpressionInterface, Countable
             return '';
         }
         $conjunction = $this->_conjunction;
-        $template = $len === 1 ? '%s' : '(%s)';
+        $template = !$this->parentheses || $len === 1 ? '%s' : '(%s)';
         $parts = [];
         foreach ($this->_conditions as $part) {
             if ($part instanceof Query) {

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -18,6 +18,7 @@ namespace Cake\Database;
 
 use Cake\Database\Expression\AggregateExpression;
 use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\JsonPathExpression;
 use Cake\Database\Expression\StringAggExpression;
 use InvalidArgumentException;
 
@@ -344,21 +345,55 @@ class FunctionsBuilder
     }
 
     /**
-     * Returns a FunctionExpression representing the Json Value
+     * Returns a FunctionExpression representing JSON_VALUE().
+     *
+     * If the SQL standard version isn't supported some drivers will fall back to a vendor specific implementation.
+     * The vendor specific implemention will only support a string path and won't support the additional clauses.
+     * Check for support before using.
      *
      * @param \Cake\Database\ExpressionInterface|string $expression The Json value or json field
-     * @param string $jsonPath A valid JSON PATH Query
-     * @param array $types list of types to bind to the arguments
+     * @param \Cake\Database\Expression\JsonPathExpression|string $jsonPath A valid JSON path or path expression
+     * @param array $types List of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
     public function jsonValue(
         ExpressionInterface|string $expression,
-        string $jsonPath,
+        JsonPathExpression|string $jsonPath,
         array $types = [],
     ): FunctionExpression {
+        if (is_string($jsonPath)) {
+            $jsonPath = new JsonPathExpression($jsonPath);
+        }
+
         $params = $this->toLiteralParam($expression) + [$jsonPath];
 
-        return new FunctionExpression('JSON_VALUE', $params, $types);
+        return new FunctionExpression('JSON_VALUE', $params, $types, $jsonPath->getReturnType());
+    }
+
+    /**
+     * Returns a FunctionExpression representing JSON_EXISTS().
+     *
+     * If the SQL standard version isn't supported some drivers will fall back to a vendor specific implementation.
+     * The vendor specific implemention will only support a string path and won't support the additional clauses.
+     * Check for support before using.
+     *
+     * @param \Cake\Database\ExpressionInterface|string $expression The Json value or json field
+     * @param \Cake\Database\Expression\JsonPathExpression|string $jsonPath A valid JSON path expression
+     * @param array $types List of types to bind to the arguments
+     * @return \Cake\Database\Expression\FunctionExpression
+     */
+    public function jsonExists(
+        ExpressionInterface|string $expression,
+        JsonPathExpression|string $jsonPath,
+        array $types = [],
+    ): FunctionExpression {
+        if (is_string($jsonPath)) {
+            $jsonPath = new JsonPathExpression($jsonPath);
+        }
+
+        $params = $this->toLiteralParam($expression) + [$jsonPath];
+
+        return new FunctionExpression('JSON_EXISTS', $params, $types, 'boolean');
     }
 
     /**

--- a/tests/TestCase/Database/Expression/JsonPathExpressionTest.php
+++ b/tests/TestCase/Database/Expression/JsonPathExpressionTest.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The Open Group Test Suite License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\Expression;
+
+use Cake\Database\Expression\JsonPathExpression;
+use Cake\Database\ValueBinder;
+use Cake\TestSuite\TestCase;
+
+class JsonPathExpressionTest extends TestCase
+{
+    public function testFullPath(): void
+    {
+        $expr = new JsonPathExpression('$.id');
+
+        $binder = new ValueBinder();
+        $this->assertSame("'$.id'", $expr->sql($binder));
+
+        $expr
+            ->passing(['val' => 123, 'name' => 'literal_name'])
+            ->returning('int')
+            ->onEmpty(JsonPathExpression::BEHAVIOR_DEFAULT, 0)
+            ->onError(JsonPathExpression::BEHAVIOR_ERROR);
+
+        $binder = new ValueBinder();
+        $this->assertSame("'$.id' PASSING :param0 AS val, :param1 AS name RETURNING int DEFAULT 0 ON EMPTY ERROR ON ERROR", $expr->sql($binder));
+        $this->assertSame(123, $binder->bindings()[':param0']['value']);
+        $this->assertSame('literal_name', $binder->bindings()[':param1']['value']);
+    }
+
+    public function testPassing(): void
+    {
+        $expr = (new JsonPathExpression('$.id'))
+            ->passing(['val' => 123, 'name' => 'literal_name'], ['val' => 'integer', 'name' => 'string']);
+
+        $binder = new ValueBinder();
+        $this->assertSame("'$.id' PASSING :param0 AS val, :param1 AS name", $expr->sql($binder));
+        $this->assertSame(123, $binder->bindings()[':param0']['value']);
+        $this->assertSame('literal_name', $binder->bindings()[':param1']['value']);
+    }
+
+    public function testReturning(): void
+    {
+        $expr = (new JsonPathExpression('$.id'))
+            ->returning('int');
+
+        $binder = new ValueBinder();
+        $this->assertSame("'$.id' RETURNING int", $expr->sql($binder));
+    }
+
+    public function testOnEmpty(): void
+    {
+        // Test behavior without value
+        $expr = (new JsonPathExpression('$.id'))
+            ->onEmpty(JsonPathExpression::BEHAVIOR_ERROR);
+
+        $binder = new ValueBinder();
+        $this->assertSame("'$.id' ERROR ON EMPTY", $expr->sql($binder));
+
+        // Test behavior with value
+        $expr->onEmpty(JsonPathExpression::BEHAVIOR_DEFAULT, 0);
+
+        $binder = new ValueBinder();
+        $this->assertSame("'$.id' DEFAULT 0 ON EMPTY", $expr->sql($binder));
+    }
+
+    public function testOnError(): void
+    {
+        // Test behavior without value
+        $expr = (new JsonPathExpression('$.id'))
+            ->onError(JsonPathExpression::BEHAVIOR_ERROR);
+
+        $binder = new ValueBinder();
+        $this->assertSame("'$.id' ERROR ON ERROR", $expr->sql($binder));
+
+        // Test behavioar with value
+        $expr->onError(JsonPathExpression::BEHAVIOR_DEFAULT, 0);
+
+        $binder = new ValueBinder();
+        $this->assertSame("'$.id' DEFAULT 0 ON ERROR", $expr->sql($binder));
+    }
+}

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -316,7 +316,17 @@ class FunctionsBuilderTest extends TestCase
     {
         $function = $this->functions->jsonValue('field', '$');
         $this->assertInstanceOf(FunctionExpression::class, $function);
-        $this->assertSame('JSON_VALUE(field, :param0)', $function->sql(new ValueBinder()));
+        $this->assertSame("JSON_VALUE(field, '$')", $function->sql(new ValueBinder()));
         $this->assertSame('string', $function->getReturnType());
+    }
+
+    /**
+     * Tests generating a JSON_EXISTS() function
+     */
+    public function testJsonExists(): void
+    {
+        $function = $this->functions->jsonExists('field', '$');
+        $this->assertInstanceOf(FunctionExpression::class, $function);
+        $this->assertSame("JSON_EXISTS(field, '$')", $function->sql(new ValueBinder()));
     }
 }

--- a/tests/TestCase/Database/Query/UpdateQueryTest.php
+++ b/tests/TestCase/Database/Query/UpdateQueryTest.php
@@ -17,9 +17,6 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database\Query;
 
 use Cake\Database\Driver\Mysql;
-use Cake\Database\Driver\Postgres;
-use Cake\Database\Driver\Sqlite;
-use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
@@ -493,44 +490,5 @@ class UpdateQueryTest extends TestCase
         $comment = $result->fetchAll('assoc')[0]['comment'];
         $result->closeCursor();
         $this->assertSame(['a' => 'b', 'c' => true], $comment);
-    }
-
-    /**
-     * Test jsonValue() Expression
-     */
-    public function testJsonValue(): void
-    {
-        $skip = false;
-        $driver = $this->connection->getDriver();
-        $version = $this->connection->getDriver()->version();
-        if ($driver instanceof Postgres && version_compare($version, '12.0.0', '<')) {
-            $skip = true;
-        } elseif ($driver instanceof Mysql && version_compare($version, '8.0.21', '<')) {
-            $skip = true;
-        } elseif ($driver instanceof Sqlserver && version_compare($version, '13', '<')) {
-            $skip = true;
-        } elseif ($driver instanceof Sqlite && version_compare($version, '3.19', '<')) {
-            $skip = true;
-        }
-        $this->skipIf($skip, 'The current database backend does not support JSON value operations');
-
-        $query = new UpdateQuery($this->connection);
-        $query
-            ->update('comments')
-            ->set('comment', ['a' => ['a1' => 'b1'], 'c' => true, 'scores' => [25, 36, 48]], 'json')
-            ->where(['id' => 1]);
-        $query->execute()->closeCursor();
-
-        $query = new SelectQuery($this->connection);
-        $query
-            ->select(['score' => $query->func()->jsonValue('comment', '$.scores[1]')])
-            ->from('comments')
-            ->where(['id' => 1])
-            ->getSelectTypeMap()->setTypes(['score' => 'integer']);
-
-        $result = $query->execute();
-        $comment = $result->fetchAll('assoc')[0]['score'];
-        $result->closeCursor();
-        $this->assertSame(36, $comment);
     }
 }

--- a/tests/TestCase/Database/QueryTests/FunctionsQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/FunctionsQueryTest.php
@@ -1,0 +1,181 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The Open Group Test Suite License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\QueryTests;
+
+use Cake\Database\Connection;
+use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
+use Cake\Database\Driver\Sqlite;
+use Cake\Database\Driver\Sqlserver;
+use Cake\Database\Expression\JsonPathExpression;
+use Cake\Database\Query\SelectQuery;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Tests FunctionExpression queries
+ */
+class FunctionsQueryTest extends TestCase
+{
+    protected array $fixtures = [
+        'core.Comments',
+    ];
+
+    /**
+     * @var \Cake\Database\Connection
+     */
+    protected Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = ConnectionManager::get('test');
+    }
+
+    protected function requireVersion(array $versions): void
+    {
+        $driver = $this->connection->getDriver();
+        $driverVersion = $driver->version();
+
+        foreach ($versions as $className => $version) {
+            $mariadb = $className === 'mariadb';
+            $className = $mariadb ? Mysql::class : $className;
+
+            if ($driver instanceof $className) {
+                if ($driver instanceof Mysql && $mariadb !== $driver->isMariadb()) {
+                    continue;
+                }
+
+                $this->skipIf(version_compare($driverVersion, $version, '<'), sprintf('The current database backend does not support the required function. Requires version %s.', $version));
+            }
+        }
+
+        $this->markTestSkipped('The current database backend does not support the required function.');
+    }
+
+    public function testJsonValue(): void
+    {
+        $this->requireVersion([
+            'mariadb' => '10.2.3',
+            Mysql::class => '8.0.21',
+            Postgres::class => '12',
+            Sqlserver::class => '13',
+            Sqlite::class => '3.19',
+        ]);
+
+        $query = new SelectQuery($this->connection);
+        $result = $query
+            ->select([
+                'value' => $query->func()->jsonValue(
+                    $this->quoteString(json_encode(['a' => 1])),
+                    '$.a',
+                ),
+            ])
+            // Set type because drivers like sqlite use non-standard functions that return the sqlite type not json string
+            ->setSelectTypeMap(['value' => 'integer'])
+            ->execute()->fetchAll('assoc');
+
+        $this->assertSame(1, $result[0]['value']);
+    }
+
+    public function testJsonValuePassing(): void
+    {
+        $this->requireVersion([
+            Postgres::class => '17',
+        ]);
+
+        $query = new SelectQuery($this->connection);
+        $result = $query
+            ->select([
+                'value' => $query->func()->jsonValue(
+                    $this->quoteString(json_encode(['a' => 1])),
+                    (new JsonPathExpression('$.a'))->passing(['x' => 1]),
+                ),
+            ])
+            ->execute()->fetchAll('assoc');
+
+        $this->assertSame('1', $result[0]['value']);
+    }
+
+    public function testJsonValueReturning(): void
+    {
+        $this->requireVersion([
+            Mysql::class => '8.0.21',
+            Postgres::class => '17',
+            Sqlserver::class => '17',
+        ]);
+
+        $query = new SelectQuery($this->connection);
+        $result = $query
+            ->select([
+                'value' => $query->func()->jsonValue(
+                    $this->quoteString(json_encode(['a' => 1])),
+                    (new JsonPathExpression('$.a'))->returning('float'),
+                ),
+            ])
+            ->execute()->fetchAll('assoc');
+
+        $this->assertSame(1.0, $result[0]['value']);
+    }
+
+    public function testJsonValueEmptyError(): void
+    {
+        $this->requireVersion([
+            Mysql::class => '8.0.21',
+            Postgres::class => '17',
+        ]);
+
+        $query = new SelectQuery($this->connection);
+        $result = $query
+            ->select([
+                'value' => $query->func()->jsonValue(
+                    $this->quoteString(json_encode(['a' => 1])),
+                    (new JsonPathExpression('$.a'))->onEmpty('NULL')->onError('DEFAULT', 2.0),
+                ),
+            ])
+            ->execute()->fetchAll('assoc');
+
+        $this->assertSame('1', $result[0]['value']);
+    }
+
+    public function testJsonExists(): void
+    {
+        $this->requireVersion([
+            'mariadb' => '10.2.3',
+            Mysql::class => '5.7.8',
+            Postgres::class => '12.0',
+            Sqlserver::class => '16',
+            Sqlite::class => '3.9',
+        ]);
+
+        $query = new SelectQuery($this->connection);
+        $result = $query
+            ->select([
+                 'present' => $query->func()->jsonExists(
+                     $this->quoteString(json_encode(['a' => 1])),
+                     '$.a',
+                 ),
+            ])
+            ->execute()->fetchAll('assoc');
+
+        $this->assertTrue((bool)$result[0]['present']);
+    }
+
+    private function quoteString(string $value): string
+    {
+        return sprintf("'%s'", $value);
+    }
+}


### PR DESCRIPTION
Add support for the full json path expression clauses for JSON_VALUE() and JSON_EXISTS() functions. These can be extended to support JSON_QUERY and possibly JSON_TABLE in the future.

https://www.postgresql.org/docs/current/functions-json.html#SQLJSON-QUERY-FUNCTIONS
