### PR TITLE
Re-enable SimplifyUselessVariableRector with only_direct_assign

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -32,6 +32,10 @@ return RectorConfig::configure()
         SetList::TYPE_DECLARATION,
     ])
 
+    ->withConfiguredRule(\Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector::class, [
+        \Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector::ONLY_DIRECT_ASSIGN => true,
+    ])
+
     ->withSkip([
         __DIR__ . '/tests/test_app/templates',
         __DIR__ . '/tests/test_app/Plugin/TestPlugin/templates',
@@ -45,7 +49,6 @@ return RectorConfig::configure()
         \Rector\CodeQuality\Rector\Foreach_\UnusedForeachValueToArrayKeysRector::class,
         \Rector\CodeQuality\Rector\FuncCall\CompactToVariablesRector::class,
         \Rector\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector::class,
-        \Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector::class,
         \Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector::class,
         \Rector\CodeQuality\Rector\If_\ConsecutiveNullCompareReturnsToNullCoalesceQueueRector::class,
         \Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector::class,

--- a/src/Datasource/Paging/SortableFieldsBuilder.php
+++ b/src/Datasource/Paging/SortableFieldsBuilder.php
@@ -109,9 +109,8 @@ class SortableFieldsBuilder
     public static function fromCallable(Closure $factory): static
     {
         $builder = new static();
-        $builder = $factory($builder);
 
-        return $builder;
+        return $factory($builder);
     }
 
     /**

--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -71,9 +71,7 @@ class Curl implements AdapterInterface
             throw new NetworkException($message, $request);
         }
 
-        $responses = $this->createResponse($ch, $body);
-
-        return $responses;
+        return $this->createResponse($ch, $body);
     }
 
     /**

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -1501,11 +1501,9 @@ class SelectQueryTest extends TestCase
             ->select(['id'])
             ->from('comments')
             ->where(function (ExpressionInterface $exp) {
-                $or = $exp->or(function ($or) {
+                return $exp->or(function ($or) {
                     return $or->eq('id', 1)->eq('id', 2);
                 });
-
-                return $or;
             })
             ->execute();
         $rows = $result->fetchAll('assoc');

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -139,7 +139,8 @@ class DateTypeTest extends TestCase
     public static function marshalProvider(): array
     {
         $date = new Date('@1392387900');
-        $data = [
+
+        return [
             // invalid types.
             [null, null],
             [false, null],
@@ -211,8 +212,6 @@ class DateTypeTest extends TestCase
                 null,
             ],
         ];
-
-        return $data;
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -3560,11 +3560,9 @@ class RouterTest extends TestCase
      */
     protected function makeRequest($url, $method): ServerRequest
     {
-        $request = new ServerRequest([
+        return new ServerRequest([
             'url' => $url,
             'environment' => ['REQUEST_METHOD' => $method],
         ]);
-
-        return $request;
     }
 }


### PR DESCRIPTION
Re-enables `SimplifyUselessVariableRector`, which was previously skipped outright.

The `only_direct_assign` option restricts the rule to the safe `$x = expr; return $x;` case and avoids the riskier compound-assignment rewrites (e.g. turning `$a = '...'; $a .= '...'; return $a;` into a concat) — which is why it had been skipped.

Two existing spots get simplified as a result:

```php
// SortableFieldsBuilder::fromCallable()
-        $builder = $factory($builder);
-        return $builder;
+        return $factory($builder);

// Curl::send()
-        $responses = $this->createResponse($ch, $body);
-        return $responses;
+        return $this->createResponse($ch, $body);
```
