### PR TITLE
Bump rector to ~2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -134,7 +134,7 @@
         "psalm-baseline": "tools/psalm --set-baseline=psalm-baseline.xml",
         "lowest": "validate-prefer-lowest",
         "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json",
-        "rector-setup": "cp composer.json composer.backup && composer require --dev rector/rector:\"~2.3.1\" && mv composer.backup composer.json",
+        "rector-setup": "cp composer.json composer.backup && composer require --dev rector/rector:\"~2.4.0\" && mv composer.backup composer.json",
         "rector-check": "vendor/bin/rector process --dry-run",
         "rector-fix": "vendor/bin/rector process",
         "test": "phpunit",

--- a/rector.php
+++ b/rector.php
@@ -127,4 +127,10 @@ return RectorConfig::configure()
         \Rector\Php73\Rector\FuncCall\ArrayKeyFirstLastRector::class,
         \Rector\Php80\Rector\FuncCall\ClassOnObjectRector::class,
         \Rector\CodeQuality\Rector\Ternary\SwitchNegatedTernaryRector::class,
+
+        // Newly aggressive in rector 2.4 - keep the bump behavior-neutral:
+        // adds declare(strict_types=1) to test fixtures/config (out of scope here),
+        \Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector::class,
+        // and rewrites `$x ?: []` in ways that can change behavior on undefined/empty values.
+        \Rector\DeadCode\Rector\Ternary\RemoveUselessTernaryRector::class,
     ]);


### PR DESCRIPTION
Bumps the pinned rector version from `~2.3.1` to `~2.4.0`.

rector 2.4 newly fires two rules on this codebase, so they are added to the skip list to keep the bump behavior-neutral (no production code changes):

- `SafeDeclareStrictTypesRector` — would add `declare(strict_types=1)` to ~90 test fixtures / test-app config files. Out of scope for a tooling bump (`src/` is already 100% strict-typed).
- `RemoveUselessTernaryRector` — rewrites `$x ?: []` (e.g. `return $_SESSION ?: [];`) in ways that can change behavior when the value is undefined/empty.

With those skipped, `rector process --dry-run` is clean against the bumped version. Adopting either of the above (e.g. strict_types in tests) can be a separate, deliberate change.
