### PR TITLE
add structarmed base setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,10 @@ jobs:
           RECTOR_CACHE_DIR: ${{ runner.temp }}/rector
         run: composer rector-setup && composer rector-check
 
+      - name: Run StructArmed
+        if: always()
+        run: vendor/bin/structarmed analyze
+
   split-packages-stan:
     name: Static Analysis for Split Packages
     runs-on: ubuntu-24.04

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "cakephp/validation": "self.version"
     },
     "require-dev": {
+        "boundwize/structarmed" : "^0.7",
         "cakephp/cakephp-codesniffer": "^5.3",
         "http-interop/http-factory-tests": "^2.0",
         "mikey179/vfsstream": "^1.6.12",
@@ -132,7 +133,8 @@
         "cs-fix": "phpcbf",
         "stan": [
             "tools/phpstan analyse",
-            "tools/psalm"
+            "tools/psalm",
+            "vendor/bin/structarmed analyze"
         ],
         "stan-tests": "tools/phpstan analyze -c tests/phpstan.neon",
         "stan-baseline": "tools/phpstan --generate-baseline",

--- a/structarmed.php
+++ b/structarmed.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Preset\Preset;
+use Boundwize\StructArmed\Preset\Presets\Psr4Preset;
+
+return Architecture::define()
+    ->skip([
+        Psr4Preset::CLASSES_MUST_MATCH_COMPOSER => [
+            __DIR__ . '/tests/test_app/',
+        ],
+    ])
+    ->withPreset(Preset::PSR4());

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -2069,16 +2069,15 @@ SQL;
     {
         $this->_needsConnection();
 
-        $this->pdo = Mockery::mock(PDOMocked::class);
+        $this->pdo = Mockery::mock(PDO::class);
         $this->pdo->shouldReceive('quote')
             ->andReturnUsing(function ($value) {
                 return "'{$value}'";
             });
 
-        $driver = Mockery::mock(Mysql::class)
+        $driver = Mockery::mock(Mysql::class, [[]])
             ->makePartial()
             ->shouldAllowMockingProtectedMethods();
-        $driver->__construct();
 
         $driver->shouldReceive('createPdo')
             ->andReturn($this->pdo);
@@ -2091,10 +2090,3 @@ SQL;
         return $driver;
     }
 }
-
-// phpcs:disable
-class PDOMocked extends PDO
-{
-    public function quoteIdentifier(): void {}
-}
-// phpcs:enable

--- a/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
+++ b/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         2.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Error;
+namespace Cake\Test\TestCase\Error\Renderer;
 
 use Cake\Controller\Controller;
 use Cake\Controller\ErrorController;

--- a/tests/TestCase/Http/MimeTypeTest.php
+++ b/tests/TestCase/Http/MimeTypeTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         5.2.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Http\Test\TestCase;
+namespace Cake\Test\TestCase\Http;
 
 use Cake\Http\MimeType;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/ORM/Association/BelongsToManySaveAssociatedOnlyEntitiesAppendTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManySaveAssociatedOnlyEntitiesAppendTest.php
@@ -68,8 +68,17 @@ class BelongsToManySaveAssociatedOnlyEntitiesAppendTest extends TestCase
     public function testSaveAssociatedOnlyEntitiesAppend(): void
     {
         $connection = ConnectionManager::get('test');
-        /** @var \Cake\Test\TestCase\ORM\Association\MockedTable&\Mockery\MockInterface $table */
-        $table = Mockery::mock(new MockedTable(['table' => 'tags', 'connection' => $connection]))
+        /** @var \Cake\ORM\Table&\Mockery\MockInterface $table */
+        $table = Mockery::mock(new class (['alias' => 'Tags', 'table' => 'tags', 'connection' => $connection]) extends Table
+        {
+            public function saveAssociated()
+            {
+            }
+
+            public function schema()
+            {
+            }
+        })
             ->makePartial();
         $table->setPrimaryKey('id');
 
@@ -88,17 +97,9 @@ class BelongsToManySaveAssociatedOnlyEntitiesAppendTest extends TestCase
             ],
         ]);
 
-        $table->shouldReceive('saveAssociated')->never();
+        $table->shouldReceive('save')->never();
 
         $association = new BelongsToMany('Tags', $config);
         $association->saveAssociated($entity);
     }
 }
-
-// phpcs:disable
-class MockedTable extends Table
-{
-    public function saveAssociated() {}
-    public function schema() {}
-}
-// phpcs:enable

--- a/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
+++ b/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
@@ -51,7 +51,8 @@ class TableGetWithCustomFinderTest extends TestCase
     public function testGetWithCustomFinder($options): void
     {
         $queryFactory = Mockery::mock(QueryFactory::class);
-        $table = new GetWithCustomFinderTable([
+        $table = new class ([
+            'alias' => 'sometable',
             'connection' => $this->connection,
             'schema' => [
                 'id' => ['type' => 'integer'],
@@ -59,7 +60,12 @@ class TableGetWithCustomFinderTest extends TestCase
                 '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['bar']]],
             ],
             'queryFactory' => $queryFactory,
-        ]);
+        ]) extends Table {
+            public function findCustom($query)
+            {
+                return $query;
+            }
+        };
 
         $query = Mockery::mock(new SelectQuery($table))->makePartial();
         $queryFactory->shouldReceive('select')->once()->with($table)->andReturn($query);
@@ -82,13 +88,3 @@ class TableGetWithCustomFinderTest extends TestCase
         $this->assertSame($entity, $result);
     }
 }
-
-// phpcs:disable
-class GetWithCustomFinderTable extends Table
-{
-    public function findCustom($query)
-    {
-        return $query;
-    }
-}
-// phpcs:enable

--- a/tests/TestCase/ORM/TableImplementedEventsTest.php
+++ b/tests/TestCase/ORM/TableImplementedEventsTest.php
@@ -25,7 +25,40 @@ class TableImplementedEventsTest extends TestCase
      */
     public function testImplementedEvents(): void
     {
-        $table = new ImplementedEventsTable();
+        $table = new class extends Table
+        {
+            public function buildValidator(): void
+            {
+            }
+
+            public function beforeMarshal(): void
+            {
+            }
+
+            public function beforeFind(): void
+            {
+            }
+
+            public function beforeSave(): void
+            {
+            }
+
+            public function afterSave(): void
+            {
+            }
+
+            public function beforeDelete(): void
+            {
+            }
+
+            public function afterDelete(): void
+            {
+            }
+
+            public function afterRules(): void
+            {
+            }
+        };
         $result = $table->implementedEvents();
         $expected = [
             'Model.beforeMarshal' => 'beforeMarshal',
@@ -42,7 +75,10 @@ class TableImplementedEventsTest extends TestCase
 
     public function testImplementedEventsWithTableEventsTrait(): void
     {
-        $table = new ImplementedAllEventsTable();
+        $table = new class extends Table
+        {
+            use TableEventsTrait;
+        };
         $result = $table->implementedEvents();
         $expected = [
             'Model.beforeMarshal' => 'beforeMarshal',
@@ -61,22 +97,3 @@ class TableImplementedEventsTest extends TestCase
         $this->assertEquals($expected, $result, 'Events do not match.');
     }
 }
-
-// phpcs:disable
-class ImplementedEventsTable extends Table
-{
-    public function buildValidator(): void {}
-    public function beforeMarshal(): void {}
-    public function beforeFind(): void {}
-    public function beforeSave(): void {}
-    public function afterSave(): void {}
-    public function beforeDelete(): void {}
-    public function afterDelete(): void {}
-    public function afterRules(): void {}
-}
-
-class ImplementedAllEventsTable extends Table
-{
-    use TableEventsTrait;
-}
-// phpcs:enable

--- a/tests/TestCase/ORM/TableValidationWithBadDefinerTest.php
+++ b/tests/TestCase/ORM/TableValidationWithBadDefinerTest.php
@@ -25,23 +25,15 @@ class TableValidationWithBadDefinerTest extends TestCase
      */
     public function testValidationWithBadDefiner(): void
     {
-        $table = new ValidationWithBadDefinerTable();
+        $table = new class extends Table {
+            public function validationBad($validator): string
+            {
+                return '';
+            }
+        };
         $this->expectException(AssertionError::class);
-        $this->expectExceptionMessage(sprintf(
-            'The `%s::validationBad()` validation method must return an instance of `Cake\Validation\Validator`.',
-            $table::class,
-        ));
+        $this->expectExceptionMessage('The `Cake\ORM\Table@anonymous');
 
         $table->getValidator('bad');
     }
 }
-
-// phpcs:disable
-class ValidationWithBadDefinerTable extends Table
-{
-    public function validationBad($validator): string
-    {
-        return '';
-    }
-}
-// phpcs:enable

--- a/tests/TestCase/ORM/TableValidationWithDefinerTest.php
+++ b/tests/TestCase/ORM/TableValidationWithDefinerTest.php
@@ -24,19 +24,15 @@ class TableValidationWithDefinerTest extends TestCase
      */
     public function testValidationWithDefinerTest(): void
     {
-        $table = new ValidationWithDefinerTable();
+        $table = new class extends Table
+        {
+            public function validationForOtherStuff($validator)
+            {
+                return $validator;
+            }
+        };
         $other = $table->getValidator('forOtherStuff');
         $this->assertNotSame($other, $table->getValidator());
         $this->assertSame($table, $other->getProvider('table'));
     }
 }
-
-// phpcs:disable
-class ValidationWithDefinerTable extends Table
-{
-    public function validationForOtherStuff($validator)
-    {
-        return $validator;
-    }
-}
-// phpcs:enable

--- a/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         4.3.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\TestSuite;
+namespace Cake\Test\TestCase\TestSuite\Fixture;
 
 use Cake\Core\Exception\CakeException;
 use Cake\Database\Connection;

--- a/tests/TestCase/TestSuite/Fixture/TransactionStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TransactionStrategyTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         4.3.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\TestSuite;
+namespace Cake\Test\TestCase\TestSuite\Fixture;
 
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\TransactionStrategy;

--- a/tests/TestCase/TestSuite/Fixture/TruncateStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TruncateStrategyTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         4.3.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\TestSuite;
+namespace Cake\Test\TestCase\TestSuite\Fixture;
 
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\TruncateStrategy;

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -3205,10 +3205,3 @@ class ValidatorTest extends TestCase
         );
     }
 }
-
-// phpcs:disable
-class stdMock extends stdClass
-{
-    public function isCool() {}
-}
-// phpcs:enable


### PR DESCRIPTION
Fellow rector maintainer @samsonasik provided a PR for our upgrade tool to get his new tool into our ugprade tool.

https://github.com/cakephp/upgrade/pull/398#issuecomment-4529283488

This is basically the same PR just for the core which showcases 1 part of this new tool - checking namespace definitions and PSR-4 Autoloading standards.

In particular this fixes wrongly defined namespaces in testfile classes as the namespace did not match the folder structure according to PSR-4.

---

Additionally this tool can also provide a sort of "namespace guard-rail" tool (as can be seen e.g. [by this config](https://github.com/codeigniter4/CodeIgniter4/blob/develop/structarmed.php)) so that we can define which namespaces can access other namespaces (or not).

I think this can definitely be usefull if we set it up properly and get a better understand which sub-parts of the framework use which other sub-parts. We of course already kind of do that via our split packages and the entries inside our `composer.json` but stil lthis is another layer we could add as a nice 

---

Primarily for the changes in this PR I got rid of all those small - not PSR-4 valid - sub classes inside each test file and replaced them with anonymouse classes.

Also there were - of course - a few classes, which had the wrong namespace defined.