### PR TITLE
Add Datasource and split package architecture rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -44,6 +44,7 @@ phpunit.xml.dist export-ignore
 psalm.xml export-ignore
 psalm-baseline.xml export-ignore
 rector.php export-ignore
+structarmed.php export-ignore
 
 tests/composer.lock export-ignore
 tests/phpstan.neon export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,10 @@ jobs:
           RECTOR_CACHE_DIR: ${{ runner.temp }}/rector
         run: composer rector-setup && composer rector-check
 
+      - name: Run StructArmed
+        if: always()
+        run: vendor/bin/structarmed analyze src
+
   split-packages-stan:
     name: Static Analysis for Split Packages
     runs-on: ubuntu-24.04

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "cakephp/validation": "self.version"
     },
     "require-dev": {
+        "boundwize/structarmed": "^0.7",
         "cakephp/cakephp-codesniffer": "^5.3",
         "http-interop/http-factory-tests": "^2.0",
         "mikey179/vfsstream": "^1.6.12",
@@ -132,8 +133,10 @@
         "cs-fix": "phpcbf",
         "stan": [
             "tools/phpstan analyse",
-            "tools/psalm"
+            "tools/psalm",
+            "@structarmed"
         ],
+        "structarmed": "vendor/bin/structarmed analyze src",
         "stan-tests": "tools/phpstan analyze -c tests/phpstan.neon",
         "stan-baseline": "tools/phpstan --generate-baseline",
         "stan-setup": "phive install",

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -18,7 +18,6 @@ namespace Cake\Datasource;
 
 use Cake\Collection\Collection;
 use Cake\Datasource\Exception\MissingPropertyException;
-use Cake\ORM\Entity;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
@@ -803,7 +802,7 @@ trait EntityTrait
             return static::$_accessors[$class][$type][$property] = '';
         }
 
-        if (static::class === Entity::class) {
+        if (static::class === self::class) {
             return '';
         }
 

--- a/structarmed.php
+++ b/structarmed.php
@@ -5,7 +5,21 @@ use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Rule\Rules\Layer\MayNotDependOnRule;
 
 return Architecture::define()
+    ->layerPattern('Collection', '/^Cake\\\\Collection\\\\.*$/')
+    ->layerPattern('Database', '/^Cake\\\\Database\\\\.*$/')
     ->layerPattern('Datasource', '/^Cake\\\\Datasource\\\\.*$/')
+    ->rule(
+        'collection.must_not_depend_on_database',
+        new MayNotDependOnRule(from: 'Collection', to: 'Database', toPath: 'Cake/Database')
+    )
+    ->rule(
+        'collection.must_not_depend_on_orm',
+        new MayNotDependOnRule(from: 'Collection', to: 'ORM', toPath: 'Cake/ORM')
+    )
+    ->rule(
+        'database.must_not_depend_on_orm',
+        new MayNotDependOnRule(from: 'Database', to: 'ORM', toPath: 'Cake/ORM')
+    )
     ->rule(
         'datasource.must_not_depend_on_orm',
         new MayNotDependOnRule(from: 'Datasource', to: 'ORM', toPath: 'Cake/ORM')

--- a/structarmed.php
+++ b/structarmed.php
@@ -2,25 +2,55 @@
 declare(strict_types=1);
 
 use Boundwize\StructArmed\Architecture;
-use Boundwize\StructArmed\Rule\Rules\Layer\MayNotDependOnRule;
 
 return Architecture::define()
+    ->layerPattern('Cache', '/^Cake\\\\Cache\\\\.*$/')
     ->layerPattern('Collection', '/^Cake\\\\Collection\\\\.*$/')
+    ->layerPattern('Command', '/^Cake\\\\Command\\\\.*$/')
+    ->layerPattern('Console', '/^Cake\\\\Console\\\\.*$/')
+    ->layerPattern('Container', '/^Cake\\\\Container\\\\.*$/')
+    ->layerPattern('Controller', '/^Cake\\\\Controller\\\\.*$/')
+    ->layerPattern('Core', '/^Cake\\\\Core\\\\.*$/')
     ->layerPattern('Database', '/^Cake\\\\Database\\\\.*$/')
     ->layerPattern('Datasource', '/^Cake\\\\Datasource\\\\.*$/')
-    ->rule(
-        'collection.must_not_depend_on_database',
-        new MayNotDependOnRule(from: 'Collection', to: 'Database', toPath: 'Cake/Database')
-    )
-    ->rule(
-        'collection.must_not_depend_on_orm',
-        new MayNotDependOnRule(from: 'Collection', to: 'ORM', toPath: 'Cake/ORM')
-    )
-    ->rule(
-        'database.must_not_depend_on_orm',
-        new MayNotDependOnRule(from: 'Database', to: 'ORM', toPath: 'Cake/ORM')
-    )
-    ->rule(
-        'datasource.must_not_depend_on_orm',
-        new MayNotDependOnRule(from: 'Datasource', to: 'ORM', toPath: 'Cake/ORM')
-    );
+    ->layerPattern('Error', '/^Cake\\\\Error\\\\.*$/')
+    ->layerPattern('Event', '/^Cake\\\\Event\\\\.*$/')
+    ->layerPattern('Form', '/^Cake\\\\Form\\\\.*$/')
+    ->layerPattern('Http', '/^Cake\\\\Http\\\\.*$/')
+    ->layerPattern('I18n', '/^Cake\\\\I18n\\\\.*$/')
+    ->layerPattern('Lock', '/^Cake\\\\Lock\\\\.*$/')
+    ->layerPattern('Log', '/^Cake\\\\Log\\\\.*$/')
+    ->layerPattern('Mailer', '/^Cake\\\\Mailer\\\\.*$/')
+    ->layerPattern('Network', '/^Cake\\\\Network\\\\.*$/')
+    ->layerPattern('ORM', '/^Cake\\\\ORM\\\\.*$/')
+    ->layerPattern('Routing', '/^Cake\\\\Routing\\\\.*$/')
+    ->layerPattern('TestSuite', '/^Cake\\\\TestSuite\\\\.*$/')
+    ->layerPattern('Utility', '/^Cake\\\\Utility\\\\.*$/')
+    ->layerPattern('Validation', '/^Cake\\\\Validation\\\\.*$/')
+    ->layerPattern('View', '/^Cake\\\\View\\\\.*$/')
+    ->ruleset([
+        'Cache' => ['Core', 'Event', 'Log', 'Utility'],
+        'Collection' => [],
+        'Command' => ['Cache', 'Console', 'Core', 'Database', 'Datasource', 'Event', 'Http', 'I18n', 'Log', 'ORM', 'Routing', 'Utility'],
+        'Console' => ['Command', 'Core', 'Database', 'Error', 'Event', 'Log', 'Routing', 'Utility'],
+        'Container' => [],
+        'Controller' => ['Core', 'Datasource', 'Event', 'Form', 'Http', 'Log', 'ORM', 'Routing', 'Utility', 'View'],
+        'Core' => ['Cache', 'Console', 'Container', 'Event', 'Http', 'Routing', 'Utility'],
+        'Database' => ['Cache', 'Core', 'Datasource', 'Event', 'I18n', 'Log', 'Utility'],
+        'Datasource' => ['Cache', 'Collection', 'Core', 'Database', 'Event', 'Utility'],
+        'Error' => ['Console', 'Controller', 'Core', 'Database', 'Event', 'Http', 'I18n', 'Log', 'Routing', 'Utility', 'View'],
+        'Event' => ['Core'],
+        'Form' => ['Core', 'Event', 'Utility', 'Validation'],
+        'Http' => ['Cache', 'Console', 'Controller', 'Core', 'Datasource', 'Error', 'Event', 'I18n', 'Log', 'ORM', 'Routing', 'Utility'],
+        'I18n' => ['Cache', 'Core', 'Utility'],
+        'Lock' => ['Core', 'Event', 'Log', 'Utility'],
+        'Log' => ['Console', 'Core', 'Event', 'Utility'],
+        'Mailer' => ['Core', 'Datasource', 'Event', 'Http', 'Log', 'Network', 'ORM', 'Utility', 'View'],
+        'Network' => ['Core', 'Utility', 'Validation'],
+        'ORM' => ['Collection', 'Core', 'Database', 'Datasource', 'Event', 'I18n', 'Utility', 'Validation'],
+        'Routing' => ['Core', 'Http', 'I18n', 'Utility'],
+        'TestSuite' => ['Collection', 'Controller', 'Core', 'Database', 'Datasource', 'Error', 'Event', 'Form', 'Http', 'Log', 'Mailer', 'ORM', 'Routing', 'Utility'],
+        'Utility' => ['Core', 'I18n'],
+        'Validation' => ['Core', 'Event', 'I18n', 'ORM', 'Utility'],
+        'View' => ['Cache', 'Collection', 'Core', 'Database', 'Datasource', 'Event', 'Form', 'Http', 'I18n', 'Log', 'ORM', 'Routing', 'Utility', 'Validation'],
+    ]);

--- a/structarmed.php
+++ b/structarmed.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Rule\Rules\Layer\MayNotDependOnRule;
+
+return Architecture::define()
+    ->layerPattern('Datasource', '/^Cake\\\\Datasource\\\\.*$/')
+    ->rule(
+        'datasource.must_not_depend_on_orm',
+        new MayNotDependOnRule(from: 'Datasource', to: 'ORM', toPath: 'Cake/ORM')
+    );


### PR DESCRIPTION
This draft narrows the original StructArmed proposal down to one architecture rule with an immediate framework win. Refs https://github.com/cakephp/cakephp/pull/19466

The concrete rule in this branch is:

- `Cake\Datasource` must not depend on `Cake\ORM`

To make that pass on `5.next`, this branch also removes the current direct dependency in `Cake\Datasource\EntityTrait` by changing the base-entity check from `static::class === Entity::class` to `static::class === self::class`, which preserves the existing runtime behavior for `Cake\ORM\Entity` and its subclasses without reaching back into `Cake\ORM`.

The goal of this draft is to discuss whether this tool is worth keeping for dependency-direction rules that PHPCS does not express well.

## Why start here

- It is a real architectural boundary: `Datasource` is a lower-level package than `ORM`.
- It gives the tool a clear job beyond token/style checks.
- It keeps the initial scope small enough to evaluate on its own merits.

## What this branch includes

- `boundwize/structarmed` as a dev dependency
- a minimal `structarmed.php` config with one namespace-based layer and one custom rule
- CI execution for `vendor/bin/structarmed analyze src`
- local script integration via `composer structarmed` and `composer stan`
- removal of the current `Datasource -> ORM` dependency in `EntityTrait`

## Proposed RFC plan

If this narrow rule is acceptable, the next steps would be discussion-first and incremental:

1. Keep `Datasource -> not ORM` as the first enforced rule.
2. Add only a few one-way dependency rules with clear package/layer value.
3. Prefer baseline mode only where existing intentional violations cannot be removed yet.
4. Expand from namespace rules into split-package dependency rules once there is agreement on the matrix.
5. Consider a second phase for `@internal` or `Internal` namespace boundaries if there is appetite for stricter API separation.

## Candidate follow-up rules for discussion

These are not part of this PR. They are listed here to show the intended direction if the tool stays.

Hard candidates:
- `Cake\Collection` must not depend on `Cake\Database` or `Cake\ORM`
- `Cake\Utility` must not depend on `Cake\Database` or `Cake\ORM`
- `Cake\ORM` must not depend on `Cake\Controller` or `Cake\View`

Rules that likely need discussion or exceptions first:
- `Cake\Http` must not depend on `Cake\ORM`
- `Cake\Command` must not depend on `Cake\ORM`
- broader split-package graph enforcement

## Open question

If maintainers do not want generic architecture tooling in the framework, this draft should probably stop at the `EntityTrait` cleanup and drop the tooling entirely. If the framework does want architecture checks, this seems like a concrete low-risk entry point.

## Full Possible Rule Matrix

  Foundational layers:

  - Cake\Core
  - Cake\Utility
  - Cake\Collection
  - Cake\Event
  - Cake\Error
  - Cake\Log
  - Cake\I18n

  Data layers:

  - Cake\Database
  - Cake\Datasource

  Domain/data-access:

  - Cake\ORM

  Transport/runtime:

  - Cake\Http
  - Cake\Routing
  - Cake\Console
  - Cake\Command

  Presentation:

  - Cake\View
  - Cake\Controller

  Rules:

  1. Cake\Database must not depend on Cake\ORM, Cake\Controller, Cake\View, Cake\Http
  2. Cake\Collection must not depend on Cake\Database, Cake\ORM, Cake\Http, Cake\View, Cake\Controller
  3. Cake\Utility must not depend on Cake\Database, Cake\ORM, Cake\Http, Cake\View, Cake\Controller
  4. Cake\Datasource may depend on Cake\Database, but not on Cake\ORM, Cake\Controller, Cake\View
  5. Cake\ORM may depend on Cake\Database, Cake\Datasource, Cake\Collection, Cake\Event, Cake\I18n, Cake\Utility, but not on
     Cake\Controller or Cake\View
  6. Cake\Http must not depend on Cake\View or Cake\ORM
  7. Cake\Routing must not depend on Cake\View or Cake\ORM
  8. Cake\Console and Cake\Command must not depend on Cake\View or Cake\Controller
  9. Cake\View may depend on Cake\Http/Cake\Routing, but not on Cake\Controller
  10. Cake\Controller may depend on Cake\Http, Cake\Routing, Cake\View, but should not depend directly on Cake\Database

  Split-Package Rules
  If the package split is important, add package-level rules too:

  - cakephp/database must not import from cakephp/orm
  - cakephp/collection must not import from cakephp/database or above
  - cakephp/datasource must not import from cakephp/orm
  - cakephp/orm may import from database, datasource, collection
  - cakephp/view must not import from controller
  - cakephp/http must not import from view

  Internal API Rules
  Add a second phase for internal boundaries:

  - namespaces containing Internal
  - classes tagged `@internal`

  Rules:

  - external namespaces cannot import Internal namespaces
  - only approved sibling namespaces may reference `@internal` classes

