### PR TITLE
Add lightweight findUnhydrated() alternative for comparison

### DIFF
--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1519,15 +1519,14 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * Disabling hydration will cause array results to be returned for the query
      * instead of entities.
      *
-     * @return static<array<string,mixed>>
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     * @deprecated 5.4.0 Use {@see \Cake\ORM\Table::findUnhydrated()} instead.
+     * @return $this
      */
     public function disableHydration()
     {
         $this->_dirty();
         $this->_hydrate = false;
 
-        /** @phpstan-ignore return.type */
         return $this;
     }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1365,6 +1365,26 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
+     * Returns a new unhydrated query object for this table.
+     *
+     * This is a lightweight typed wrapper around `find()->disableHydration()`.
+     * It keeps finder dispatch unchanged while giving static analysis an
+     * explicit non-hydrated entry point.
+     *
+     * @since 5.4.0
+     * @param string $type The type of query to perform
+     * @param mixed ...$args Arguments that match up to finder-specific parameters
+     * @return \Cake\ORM\Query\SelectQuery<array<string, mixed>> The query builder
+     */
+    public function findUnhydrated(string $type = 'all', mixed ...$args): SelectQuery
+    {
+        /** @var \Cake\ORM\Query\SelectQuery<array<string, mixed>> $query */
+        $query = $this->callFinder($type, $this->selectQuery()->disableHydration(), ...$args);
+
+        return $query;
+    }
+
+    /**
      * Returns the query as passed.
      *
      * By default findAll() applies no query clauses, you can override this

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1316,6 +1316,28 @@ class TableTest extends TestCase
         $this->assertSame(2, $author->id);
     }
 
+    public function testFindUnhydrated(): void
+    {
+        $row = $this->getTableLocator()->get('Authors')
+            ->findUnhydrated()
+            ->where(['id' => 2])
+            ->first();
+
+        $this->assertIsArray($row);
+        $this->assertSame(2, $row['id']);
+    }
+
+    public function testFindUnhydratedTypedParameters(): void
+    {
+        $row = $this->getTableLocator()->get('Authors')->findUnhydrated('WithIdArgument', 2)->first();
+        $this->assertIsArray($row);
+        $this->assertSame(2, $row['id']);
+
+        $row = $this->getTableLocator()->get('Authors')->findUnhydrated('WithIdArgument', id: 2)->first();
+        $this->assertIsArray($row);
+        $this->assertSame(2, $row['id']);
+    }
+
     /**
      * https://github.com/cakephp/cakephp/issues/18716
      */


### PR DESCRIPTION
## Summary

This is the lightweight alternative discussed in https://github.com/cakephp/cakephp/pull/19441#issuecomment-4528928110, prepared as a separate draft PR on top of `5.next` for direct comparison with #19441.

It intentionally keeps the change small:

- Add `Table::findUnhydrated()` as a typed wrapper around `selectQuery()->disableHydration()`.
- Change `SelectQuery::disableHydration()` to `@return $this` and mark it deprecated in favor of `findUnhydrated()`.
- Add focused `TableTest` coverage for unhydrated rows and finder argument dispatch.

## Comparison To #19441

Unlike #19441, this draft does **not** add `UnhydratedSelectQuery`, a new `QueryFactory` seam, or finder contract enforcement. It is meant only to show the smaller shape that was proposed in review so behavior, ergonomics, and tradeoffs can be compared side by side.
