### PR TITLE
Drop generic annotation from PluginApplicationInterface param

### DIFF
--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -331,7 +331,7 @@ class BasePlugin implements PluginInterface
     /**
      * Register declarative and imperative application events.
      *
-     * @param \Cake\Core\PluginApplicationInterface<mixed> $app The host application
+     * @param \Cake\Core\PluginApplicationInterface $app The host application
      * @return void
      */
     protected function registerEvents(PluginApplicationInterface $app): void


### PR DESCRIPTION
## Summary

`PluginApplicationInterface` lost its `@template TSubject` in ba510db081 ("Simplify generics template for event subject"). #19437 was opened before that simplification landed and reintroduced `PluginApplicationInterface<mixed>` in `BasePlugin::registerEvents()` when it merged afterwards.

phpstan now reports `generics.notGeneric` on every `5.next` run:

> PHPDoc tag `@param` for parameter $app contains generic type Cake\Core\PluginApplicationInterface<mixed> but interface Cake\Core\PluginApplicationInterface is not generic.

Fix: drop the `<mixed>` so the annotation matches the (non-generic) interface.