### PR TITLE
improve psalm taint handling

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="7.0.0-beta17@a7f96f911fc869c40c48ec977e21f01a8ca534bd">
-  <file src="src/Command/PluginLoadCommand.php">
-    <TaintedSSRF>
-      <code><![CDATA[$file]]></code>
-    </TaintedSSRF>
-  </file>
   <file src="src/Controller/ComponentRegistry.php">
     <OverriddenMethodAccess>
       <code><![CDATA[protected function getContainer(): ContainerInterface
@@ -34,11 +29,6 @@
       <code><![CDATA[$update = &$this->_config]]></code>
       <code><![CDATA[$update = &$this->_config]]></code>
     </UnsupportedPropertyReferenceUsage>
-  </file>
-  <file src="src/Core/PluginConfig.php">
-    <TaintedSSRF>
-      <code><![CDATA[$jsonPath]]></code>
-    </TaintedSSRF>
   </file>
   <file src="src/Datasource/EntityTrait.php">
     <UnsupportedPropertyReferenceUsage>

--- a/psalm.xml
+++ b/psalm.xml
@@ -27,10 +27,5 @@
         <MissingFile errorLevel="suppress"/>
         <UndefinedConstant errorLevel="suppress" />
         <UndefinedClass errorLevel="suppress" />
-
-        <!-- All the taint -->
-        <TaintedCallable errorLevel="suppress"/>
-        <TaintedFile errorLevel="suppress"/>
-        <TaintedHtml errorLevel="suppress"/>
     </issueHandlers>
 </psalm>

--- a/src/Core/Exception/CakeException.php
+++ b/src/Core/Exception/CakeException.php
@@ -68,6 +68,9 @@ class CakeException extends RuntimeException
      * Get the passed in attributes
      *
      * @return array
+     * @psalm-taint-escape html Exception attributes are developer-defined metadata (e.g. controller
+     *   name, validation rule names) used only in debug output — log files and CLI console — never
+     *   rendered unescaped into HTML responses.
      */
     public function getAttributes(): array
     {

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -53,6 +53,9 @@ class Hash
      * @return mixed The value fetched from the array, or $default if path doesn't exist, is null,
      *   or $data is empty.
      * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-get
+     * @psalm-taint-specialize Psalm tracks taint per call site instead of globally, preventing
+     *   false positives where taint from one caller (e.g. request body) bleeds into unrelated
+     *   callers of this generic utility (e.g. Configure::read, getParam).
      */
     public static function get(ArrayAccess|array $data, array|string|int|null $path, mixed $default = null): mixed
     {
@@ -297,6 +300,9 @@ class Hash
      * @return \ArrayAccess<array-key, mixed>|array The data with $values inserted.
      * @phpstan-return (T is array ? array : \ArrayAccess<array-key, mixed>)
      * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-insert
+     * @psalm-taint-specialize Psalm tracks taint per call site instead of globally, preventing
+     *   false positives where taint from one caller (e.g. ServerRequest::withData) bleeds into
+     *   unrelated callers of this generic utility (e.g. Configure::write).
      */
     public static function insert(ArrayAccess|array $data, string $path, mixed $values = null): ArrayAccess|array
     {
@@ -349,6 +355,10 @@ class Hash
      * @param array<string> $path The path to work on.
      * @param mixed $values The values to insert when doing inserts.
      * @return \ArrayAccess<array-key, mixed>|array
+     * @psalm-taint-specialize Psalm tracks taint per call site instead of globally. Without this,
+     *   the ArrayAccess|array $data parameter causes Psalm to dispatch taint through every
+     *   ArrayAccess::offsetSet implementation in the codebase (e.g. Validator) when this method
+     *   is called with tainted request data.
      */
     protected static function _simpleOp(
         string $op,
@@ -401,6 +411,9 @@ class Hash
      * @return \ArrayAccess<array-key, mixed>|array The modified array.
      * @phpstan-return (T is array ? array : \ArrayAccess<array-key, mixed>)
      * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-remove
+     * @psalm-taint-specialize Psalm tracks taint per call site instead of globally, preventing
+     *   false positives where taint from one caller (e.g. ServerRequest::withoutData) bleeds into
+     *   unrelated callers of this generic utility (e.g. Configure::delete).
      */
     public static function remove(ArrayAccess|array $data, string $path): ArrayAccess|array
     {
@@ -776,6 +789,10 @@ class Hash
      * @param mixed $merge Array to merge with. The argument and all trailing arguments will be array cast when merged
      * @return array Merged array
      * @link https://book.cakephp.org/5/en/core-libraries/hash.html#hash-merge
+     * @psalm-taint-specialize Psalm tracks taint per call site instead of globally, preventing
+     *   false positives where taint from one caller (e.g. ServerRequestFactory merging POST body
+     *   with uploaded files) bleeds into unrelated callers (e.g. InstanceConfigTrait merging
+     *   developer configuration, ServerRequest::addDetector merging detector definitions).
      */
     public static function merge(array $data, mixed $merge): array
     {


### PR DESCRIPTION
Psalm has a neat [Taint Security Feature](https://psalm.dev/docs/security_analysis/#) which tries to detect if user input is used unescaped.

But of course it needs to be told what a "trust boundary" is and when input/output data is considered trusted.

This makes it more clear where these places are and therefore removes the global ignore handlers we had previously.

I let Claude Sonnet 4.6 analyze those previously ignored errors and all of them were false positives.