### PR TITLE
Update supported version list

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -6,7 +6,12 @@ We support fixing security issues on the following releases:
 
 | Version | Supported          | Security fixes until
 | ------- | ------------------ | --------------------
-| 5.0     | :white_check_mark: | The release of 5.2
+| 5.4     | :white_check_mark: | The release of 5.6
+| 5.3     | :white_check_mark: | The release of 5.5
+| 5.2     | :white_check_mark: | The release of 5.4
+| 5.1     | :x:                | The release of 5.3
+| 5.0     | :x:                | The release of 5.2
+| 4.6     | :white_check_mark: | The release of 6.0
 | 4.5     | :white_check_mark: | 36 Months after the release of 5.0 (09 Sep 2026)
 | 4.4     | :white_check_mark: | 36 Months after the release of 5.0 (09 Sep 2026)
 | 4.3     | :white_check_mark: | 36 Months after the release of 5.0 (09 Sep 2026)
@@ -32,3 +37,4 @@ the CakePHP team will take the following actions:
 * Prepare a post describing the vulnerability, and the possible exploits.
 * Release new versions of all affected versions.
 * Prominently feature the problem in the release announcement
+

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,24 +2,7 @@
 
 ## Supported Versions
 
-We support fixing security issues on the following releases:
-
-| Version | Supported          | Security fixes until
-| ------- | ------------------ | --------------------
-| 5.4     | :white_check_mark: | The release of 5.6
-| 5.3     | :white_check_mark: | The release of 5.5
-| 5.2     | :white_check_mark: | The release of 5.4
-| 5.1     | :x:                | The release of 5.3
-| 5.0     | :x:                | The release of 5.2
-| 4.6     | :white_check_mark: | The release of 6.0
-| 4.5     | :white_check_mark: | 36 Months after the release of 5.0 (09 Sep 2026)
-| 4.4     | :white_check_mark: | 36 Months after the release of 5.0 (09 Sep 2026)
-| 4.3     | :white_check_mark: | 36 Months after the release of 5.0 (09 Sep 2026)
-| 4.2     | :x:                | No longer supported
-| 4.1     | :x:                | No longer supported
-| 4.0     | :x:                | No longer supported
-| 3.10.x  | :x:                | No longer supported
-| 2.10.x  | :x:                | No longer supported
+The supported version list can be found in [GitHub wiki](https://github.com/cakephp/cakephp/wiki#supported-versions).
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
When I was doing the last round of security releases, I noticed that our policy document is missing several versions and needs to be updated as time has passed.

I've also moved 4.3 to dropped support. Looking at the recent usage data, there is a low minority of usage for this release, with the bulk of the 4.3 usage coming from 4.4 and 4.6.
