### PR TITLE
Move result projection onto Table (Table::projectAs/list); drop SelectQuery::reshape()

### DIFF
--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -563,6 +563,38 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
     }
 
     /**
+     * Reshape each result via a formatter, rebinding the result type.
+     *
+     * Unlike `formatResults()` (which is typed to preserve the existing result
+     * shape), `reshape()` is for transforms that change the shape of each row
+     * and lets the static type follow that change. The callback receives the
+     * result set and must return an iterable of the new shape; the returned
+     * query is typed `SelectQuery<TNew>`, so `first()`/`firstOrFail()`/`all()`
+     * resolve to the new shape instead of the entity.
+     *
+     * Named `reshape()` rather than `map()` to avoid confusion with the
+     * collection `map()`, which applies per element and returns a collection;
+     * this operates on the whole result set and returns the query.
+     *
+     * ```
+     * $rows = $articles->find()
+     *     ->reshape(fn($results) => $results->map(fn($row) => $row->toArray()))
+     *     ->all();
+     * ```
+     *
+     * @template TNew of \Cake\Datasource\EntityInterface|array
+     * @param \Closure(\Cake\Datasource\ResultSetInterface<array-key, TSubject>, \Cake\ORM\Query\SelectQuery<TSubject>): iterable<TNew> $callback The reshaping callback.
+     * @return \Cake\ORM\Query\SelectQuery<TNew>
+     * @since 5.4.0
+     */
+    public function reshape(Closure $callback): SelectQuery
+    {
+        $this->formatResults($callback, self::OVERWRITE);
+
+        return $this;
+    }
+
+    /**
      * Returns the list of previously registered format routines.
      *
      * @return array<\Closure>

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -563,38 +563,6 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
     }
 
     /**
-     * Reshape each result via a formatter, rebinding the result type.
-     *
-     * Unlike `formatResults()` (which is typed to preserve the existing result
-     * shape), `reshape()` is for transforms that change the shape of each row
-     * and lets the static type follow that change. The callback receives the
-     * result set and must return an iterable of the new shape; the returned
-     * query is typed `SelectQuery<TNew>`, so `first()`/`firstOrFail()`/`all()`
-     * resolve to the new shape instead of the entity.
-     *
-     * Named `reshape()` rather than `map()` to avoid confusion with the
-     * collection `map()`, which applies per element and returns a collection;
-     * this operates on the whole result set and returns the query.
-     *
-     * ```
-     * $rows = $articles->find()
-     *     ->reshape(fn($results) => $results->map(fn($row) => $row->toArray()))
-     *     ->all();
-     * ```
-     *
-     * @template TNew of \Cake\Datasource\EntityInterface|array
-     * @param \Closure(\Cake\Datasource\ResultSetInterface<array-key, TSubject>, \Cake\ORM\Query\SelectQuery<TSubject>): iterable<TNew> $callback The reshaping callback.
-     * @return \Cake\ORM\Query\SelectQuery<TNew>
-     * @since 5.4.0
-     */
-    public function reshape(Closure $callback): SelectQuery
-    {
-        $this->formatResults($callback, self::OVERWRITE);
-
-        return $this;
-    }
-
-    /**
      * Returns the list of previously registered format routines.
      *
      * @return array<\Closure>
@@ -1583,6 +1551,10 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * When DTO projection is enabled, results will be hydrated into
      * the specified DTO class instead of entity objects.
      *
+     * @deprecated 5.4.0 Use {@see \Cake\ORM\Table::projectAs()} instead. The
+     *   terminal repository method returns a concrete `list<T>` of DTOs, while
+     *   this fluent toggle keeps the query typed as a collection of entities
+     *   and so lies about the projected result shape. Removed in 6.0.
      * @param class-string $dtoClass The DTO class name
      * @return $this
      */

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1569,6 +1569,89 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
+     * Project query results into DTO instances and return them as a list.
+     *
+     * Terminal repository counterpart to the fluent
+     * {@see \Cake\ORM\Query\SelectQuery::projectAs()}. The honest return type
+     * (`list<T>`) lives here on the repository instead of being a generic that
+     * the chainable query cannot truthfully carry. Stack finders on `$query`
+     * first when needed, then hand it here to execute the projection.
+     *
+     * Rows are mapped from the raw selected columns (the same projection path
+     * as the fluent `SelectQuery::projectAs()`), so entity visibility and
+     * accessors do not affect the DTO data.
+     *
+     * ```
+     * $dtos = $articles->projectAs(ArticleDto::class);
+     *
+     * $dtos = $articles->projectAs(
+     *     ArticleDto::class,
+     *     $articles->find()->where(['published' => true])->contain('Authors'),
+     * );
+     * ```
+     *
+     * @template T of object
+     * @param class-string<T> $class The DTO class to map each row into.
+     * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface>|null $query
+     *   A pre-built query, or null to start from `find()`.
+     * @return list<T>
+     * @since 5.4.0
+     */
+    public function projectAs(string $class, ?SelectQuery $query = null): array
+    {
+        $query ??= $this->find();
+
+        $results = [];
+        foreach ($query->projectAs($class)->all() as $dto) {
+            if ($dto instanceof $class) {
+                $results[] = $dto;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Execute a key/value list query and return the resulting array.
+     *
+     * Terminal repository counterpart to the `list` finder
+     * ({@see \Cake\ORM\Table::findList()}). Returns the combined array directly
+     * instead of a query whose static type still claims to be a collection of
+     * entities. Build and stack finders on `$query` first when needed.
+     *
+     * ```
+     * $options = $articles->list();
+     *
+     * $options = $articles->list(
+     *     $articles->find()->where(['published' => true]),
+     *     valueField: 'title',
+     * );
+     * ```
+     *
+     * @param \Cake\ORM\Query\SelectQuery<TEntity|array>|null $query
+     *   A pre-built query, or null to start from `find()`.
+     * @param \Closure|array<string>|string|null $keyField The path to the key field, defaults to the primary key.
+     * @param \Closure|array<string>|string|null $valueField The path to the value field, defaults to the display field.
+     * @param \Closure|array<string>|string|null $groupField The path to the field to group on.
+     * @param string $valueSeparator The separator used to join composite value fields.
+     * @return array<array-key, mixed>
+     * @since 5.4.0
+     */
+    public function list(
+        ?SelectQuery $query = null,
+        Closure|array|string|null $keyField = null,
+        Closure|array|string|null $valueField = null,
+        Closure|array|string|null $groupField = null,
+        string $valueSeparator = ' ',
+    ): array {
+        $query ??= $this->find();
+
+        return $this->findList($query, $keyField, $valueField, $groupField, $valueSeparator)
+            ->all()
+            ->toArray();
+    }
+
+    /**
      * Out of an options array, check if the keys described in `$keys` are arrays
      * and change the values for closures that will concatenate the each of the
      * properties in the value array when passed a row.

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -2148,56 +2148,6 @@ class SelectQueryTest extends TestCase
     }
 
     /**
-     * Tests that reshape() reshapes rows and registers a single overwrite formatter.
-     *
-     * @return void
-     */
-    public function testReshape(): void
-    {
-        $table = $this->getTableLocator()->get('Authors');
-        $query = $table->find()->where(['id' => 1]);
-        $returned = $query->reshape(function (ResultSetInterface $results) {
-            $out = [];
-            foreach ($results as $row) {
-                $out[] = ['authorId' => $row['id']];
-            }
-
-            return $out;
-        });
-
-        $this->assertSame($query, $returned);
-        $this->assertCount(1, $query->getResultFormatters());
-
-        $first = $query->all()->first();
-        $this->assertSame(['authorId' => 1], $first);
-    }
-
-    /**
-     * Tests that reshape() replaces previously registered formatters (overwrite semantics).
-     *
-     * @return void
-     */
-    public function testReshapeOverwritesFormatters(): void
-    {
-        $table = $this->getTableLocator()->get('Authors');
-        $query = $table->find();
-        $query->formatResults(function (ResultSetInterface $results) {
-            return $results;
-        });
-        $this->assertCount(1, $query->getResultFormatters());
-
-        $query->reshape(function (ResultSetInterface $results) {
-            $out = [];
-            foreach ($results as $row) {
-                $out[] = ['id' => $row['id']];
-            }
-
-            return $out;
-        });
-        $this->assertCount(1, $query->getResultFormatters());
-    }
-
-    /**
      * Tests that results formatters do receive the query object.
      */
     public function testResultFormatterReceivesTheQueryObject(): void

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -2148,6 +2148,56 @@ class SelectQueryTest extends TestCase
     }
 
     /**
+     * Tests that reshape() reshapes rows and registers a single overwrite formatter.
+     *
+     * @return void
+     */
+    public function testReshape(): void
+    {
+        $table = $this->getTableLocator()->get('Authors');
+        $query = $table->find()->where(['id' => 1]);
+        $returned = $query->reshape(function (ResultSetInterface $results) {
+            $out = [];
+            foreach ($results as $row) {
+                $out[] = ['authorId' => $row['id']];
+            }
+
+            return $out;
+        });
+
+        $this->assertSame($query, $returned);
+        $this->assertCount(1, $query->getResultFormatters());
+
+        $first = $query->all()->first();
+        $this->assertSame(['authorId' => 1], $first);
+    }
+
+    /**
+     * Tests that reshape() replaces previously registered formatters (overwrite semantics).
+     *
+     * @return void
+     */
+    public function testReshapeOverwritesFormatters(): void
+    {
+        $table = $this->getTableLocator()->get('Authors');
+        $query = $table->find();
+        $query->formatResults(function (ResultSetInterface $results) {
+            return $results;
+        });
+        $this->assertCount(1, $query->getResultFormatters());
+
+        $query->reshape(function (ResultSetInterface $results) {
+            $out = [];
+            foreach ($results as $row) {
+                $out[] = ['id' => $row['id']];
+            }
+
+            return $out;
+        });
+        $this->assertCount(1, $query->getResultFormatters());
+    }
+
+    /**
      * Tests that results formatters do receive the query object.
      */
     public function testResultFormatterReceivesTheQueryObject(): void

--- a/tests/TestCase/ORM/ResultSetFactoryTest.php
+++ b/tests/TestCase/ORM/ResultSetFactoryTest.php
@@ -273,6 +273,36 @@ class ResultSetFactoryTest extends TestCase
     }
 
     /**
+     * Test Table::projectAs() returns a concrete list of DTOs from a default query.
+     */
+    public function testTableProjectAs(): void
+    {
+        DtoMapper::clearCache();
+
+        $results = $this->table->projectAs(SimpleArticleDto::class);
+
+        $this->assertIsList($results);
+        $this->assertCount(3, $results);
+        $this->assertContainsOnlyInstancesOf(SimpleArticleDto::class, $results);
+        $this->assertSame(1, $results[0]->id);
+    }
+
+    /**
+     * Test Table::projectAs() with a pre-built query.
+     */
+    public function testTableProjectAsWithQuery(): void
+    {
+        DtoMapper::clearCache();
+
+        $query = $this->table->find()->where(['id' => 1]);
+        $results = $this->table->projectAs(SimpleArticleDto::class, $query);
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(SimpleArticleDto::class, $results[0]);
+        $this->assertSame('First Article', $results[0]->title);
+    }
+
+    /**
      * Test projectAs() with multiple results.
      */
     public function testProjectAsMultipleResults(): void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1428,6 +1428,58 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests the terminal list() repository method returns the combined array directly.
+     */
+    public function testList(): void
+    {
+        $table = new Table([
+            'table' => 'users',
+            'connection' => $this->connection,
+        ]);
+        $table->setDisplayField('username');
+
+        $expected = [
+            1 => 'mariano',
+            2 => 'nate',
+            3 => 'larry',
+            4 => 'garrett',
+        ];
+        $this->assertSame($expected, $table->list($table->find()->orderBy('id')));
+    }
+
+    /**
+     * Tests list() builds a default query when none is passed and honors field options.
+     */
+    public function testListDefaultQueryAndOptions(): void
+    {
+        $table = new Table([
+            'table' => 'users',
+            'connection' => $this->connection,
+        ]);
+        $table->setDisplayField('username');
+
+        $result = $table->list();
+        ksort($result);
+        $expected = [
+            1 => 'mariano',
+            2 => 'nate',
+            3 => 'larry',
+            4 => 'garrett',
+        ];
+        ksort($expected);
+        $this->assertSame($expected, $result);
+
+        $grouped = $table->list(
+            $table->find()
+                ->select(['id', 'username', 'odd' => new QueryExpression('id % 2')])
+                ->orderBy('id'),
+            groupField: 'odd',
+        );
+        $this->assertSame(['mariano', 'larry'], array_values($grouped[1]));
+        $this->assertSame(['nate', 'garrett'], array_values($grouped[0]));
+    }
+
+    /**
      * Tests find('threaded')
      */
     public function testFindThreadedNoHydration(): void


### PR DESCRIPTION
Draft. Part of the find()-honesty discussion in #19482.

## Problem

`$x = $table->find('auth')->first()` is statically typed as the entity even when a finder reshapes each row via `formatResults(..., OVERWRITE)`. The static type lies at runtime, and the reshape is invisible at the assignment site.

## Direction (revised)

Rather than adding result-reshaping methods to `SelectQuery`, this keeps `SelectQuery` a query builder (it returns entities or arrays) and puts shape-changing transforms on the `Table` (repository), where the honest return type can be a concrete array. This follows the same trajectory as `disableHydration()` -> `Table::unhydratedFind()`/`UnhydratedSelectQuery`.

It also avoids the overwrite-formatter stacking limitation: the terminal repository methods consume a query and return an array instead of mutating a chainable formatter.

## What this adds

- `Table::projectAs(class-string $class, ?SelectQuery $query = null): array` returns a concrete `list<T>` of DTOs. Delegates to the existing query projection path, so rows are mapped from the raw selected columns (entity visibility/accessors do not affect the DTO data).
- `Table::list(?SelectQuery $query = null, ...): array` is the terminal counterpart to the `list` finder and returns the combined array directly.
- Removes `SelectQuery::reshape()` (never released).
- Soft-deprecates `SelectQuery::projectAs()` (doc-only) in favor of `Table::projectAs()`.

```php
$dtos = $articles->projectAs(ArticleDto::class);

$options = $articles->list(
    $articles->find()->where(['published' => true]),
    valueField: 'title',
);
```

## Out of scope (need design discussion first, see #19482)

- A shared bound so `createFromArray()`-style DTOs are type-tracked too.
- Removing `SelectQuery::formatResults()`/`projectAs()` in 6.0, which needs an internal result-decorator pipeline first (`find('list')`/`find('threaded')`/associations still use `formatResults()` internally).