### PR TITLE
[Security] Add allowedClasses config to RedisEngine to prevent PHP Object Injection

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -78,6 +78,14 @@ class FileEngine extends CacheEngine
         'path' => null,
         'prefix' => 'cake_',
         'serialize' => true,
+        /**
+         * Controls the `allowed_classes` option passed to `unserialize()`.
+         * Set to `false` to disallow all object unserialization (safest for
+         * caches that only store scalar/array values), or provide an array of
+         * fully-qualified class names to allow only those classes.
+         * Defaults to `true` (allow all) for backwards compatibility.
+         */
+        'allowedClasses' => true,
     ];
 
     /**
@@ -221,7 +229,10 @@ class FileEngine extends CacheEngine
         $data = trim($data);
 
         if ($data !== '' && !empty($this->_config['serialize'])) {
-            $data = unserialize($data);
+            $allowedClasses = $this->getConfig('allowedClasses');
+            $data = $allowedClasses !== true
+                ? unserialize($data, ['allowed_classes' => $allowedClasses])
+                : unserialize($data);
             $this->dispatchEvent(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => $data, 'success' => true]);
 
             return $data;

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -78,14 +78,6 @@ class FileEngine extends CacheEngine
         'path' => null,
         'prefix' => 'cake_',
         'serialize' => true,
-        /**
-         * Controls the `allowed_classes` option passed to `unserialize()`.
-         * Set to `false` to disallow all object unserialization (safest for
-         * caches that only store scalar/array values), or provide an array of
-         * fully-qualified class names to allow only those classes.
-         * Defaults to `true` (allow all) for backwards compatibility.
-         */
-        'allowedClasses' => true,
     ];
 
     /**
@@ -229,10 +221,7 @@ class FileEngine extends CacheEngine
         $data = trim($data);
 
         if ($data !== '' && !empty($this->_config['serialize'])) {
-            $allowedClasses = $this->getConfig('allowedClasses');
-            $data = $allowedClasses !== true
-                ? unserialize($data, ['allowed_classes' => $allowedClasses])
-                : unserialize($data);
+            $data = unserialize($data);
             $this->dispatchEvent(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => $data, 'success' => true]);
 
             return $data;

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -86,6 +86,12 @@ class RedisEngine extends CacheEngine
      * - `clearUsesFlushDb` Enable clear() and clearBlocking() to use FLUSHDB. This will be
      *   faster than standard clear()/clearBlocking() but will ignore prefixes and will
      *   cause dataloss if other applications are sharing a redis database.
+     * - `allowedClasses` Controls the `allowed_classes` option passed to `unserialize()`
+     *   when reading values back. Set to `false` to disallow all object unserialization
+     *   (safest when the cache only stores scalar/array values), or provide an array of
+     *   fully qualified class names to allow only those classes. Useful for hardening
+     *   against PHP object injection when a cache backend is shared across applications.
+     *   Defaults to `true` (allow all) for backwards compatibility.
      *
      * @var array<string, mixed>
      */
@@ -108,13 +114,6 @@ class RedisEngine extends CacheEngine
         'nodes' => [],
         'failover' => null,
         'clearUsesFlushDb' => false,
-        /**
-         * Controls the `allowed_classes` option passed to `unserialize()`.
-         * Set to `false` to disallow all object unserialization (safest for
-         * caches that only store scalar/array values), or provide an array of
-         * fully-qualified class names to allow only those classes.
-         * Defaults to `true` (allow all) for backwards compatibility.
-         */
         'allowedClasses' => true,
     ];
 

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -108,6 +108,14 @@ class RedisEngine extends CacheEngine
         'nodes' => [],
         'failover' => null,
         'clearUsesFlushDb' => false,
+        /**
+         * Controls the `allowed_classes` option passed to `unserialize()`.
+         * Set to `false` to disallow all object unserialization (safest for
+         * caches that only store scalar/array values), or provide an array of
+         * fully-qualified class names to allow only those classes.
+         * Defaults to `true` (allow all) for backwards compatibility.
+         */
+        'allowedClasses' => true,
     ];
 
     /**
@@ -667,6 +675,11 @@ class RedisEngine extends CacheEngine
     {
         if (preg_match('/^[-]?\d+$/', $value)) {
             return (int)$value;
+        }
+
+        $allowedClasses = $this->getConfig('allowedClasses');
+        if ($allowedClasses !== true) {
+            return unserialize($value, ['allowed_classes' => $allowedClasses]);
         }
 
         return unserialize($value);

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -136,6 +136,7 @@ class RedisClusterEngineTest extends TestCase
             'unix_socket' => false,
             'clearUsesFlushDb' => false,
             'failover' => null,
+            'allowedClasses' => true,
         ];
         $this->assertEquals($expecting, $config);
     }

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -16,12 +16,14 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Cache\Engine;
 
+use __PHP_Incomplete_Class;
 use Cake\Cache\Cache;
 use Cake\Cache\Engine\RedisEngine;
 use Cake\TestSuite\TestCase;
 use DateInterval;
 use Mockery;
 use Redis;
+use stdClass;
 use function Cake\Core\env;
 
 /**
@@ -123,6 +125,7 @@ class RedisEngineTest extends TestCase
             'nodes' => [],
             'clearUsesFlushDb' => false,
             'failover' => null,
+            'allowedClasses' => true,
         ];
         $this->assertEquals($expecting, $config);
     }
@@ -157,6 +160,7 @@ class RedisEngineTest extends TestCase
             'nodes' => [],
             'clearUsesFlushDb' => false,
             'failover' => null,
+            'allowedClasses' => true,
         ];
         $this->assertEquals($expecting, $config);
     }
@@ -198,6 +202,7 @@ class RedisEngineTest extends TestCase
             'nodes' => [],
             'clearUsesFlushDb' => false,
             'failover' => null,
+            'allowedClasses' => true,
         ];
         $this->assertEquals($expecting, $config);
     }
@@ -537,6 +542,80 @@ class RedisEngineTest extends TestCase
         $this->assertNull($result);
 
         Cache::delete('test', 'redis');
+    }
+
+    /**
+     * Objects are unserialized normally with the default `allowedClasses` of `true`.
+     */
+    public function testAllowedClassesDefaultAllowsObjects(): void
+    {
+        $this->_configCache();
+
+        $data = new stdClass();
+        $data->foo = 'bar';
+        $this->assertTrue(Cache::write('object', $data, 'redis'));
+
+        $result = Cache::read('object', 'redis');
+        $this->assertInstanceOf(stdClass::class, $result);
+        $this->assertSame('bar', $result->foo);
+
+        Cache::delete('object', 'redis');
+    }
+
+    /**
+     * Setting `allowedClasses` to `false` blocks object unserialization,
+     * yielding an incomplete class instance instead of the original object.
+     */
+    public function testAllowedClassesFalseBlocksObjects(): void
+    {
+        $this->_configCache(['allowedClasses' => false]);
+
+        $data = new stdClass();
+        $data->foo = 'bar';
+        $this->assertTrue(Cache::write('object', $data, 'redis'));
+
+        $result = Cache::read('object', 'redis');
+        $this->assertInstanceOf(__PHP_Incomplete_Class::class, $result);
+
+        Cache::delete('object', 'redis');
+    }
+
+    /**
+     * An array of `allowedClasses` permits only the listed classes; others
+     * are returned as incomplete class instances.
+     */
+    public function testAllowedClassesWhitelist(): void
+    {
+        $this->_configCache(['allowedClasses' => [stdClass::class]]);
+
+        $allowed = new stdClass();
+        $allowed->foo = 'bar';
+        $this->assertTrue(Cache::write('allowed', $allowed, 'redis'));
+        $this->assertInstanceOf(stdClass::class, Cache::read('allowed', 'redis'));
+
+        $blocked = new DateInterval('PT1S');
+        $this->assertTrue(Cache::write('blocked', $blocked, 'redis'));
+        $this->assertInstanceOf(__PHP_Incomplete_Class::class, Cache::read('blocked', 'redis'));
+
+        Cache::delete('allowed', 'redis');
+        Cache::delete('blocked', 'redis');
+    }
+
+    /**
+     * Integers keep round-tripping correctly regardless of `allowedClasses`.
+     */
+    public function testAllowedClassesPreservesScalars(): void
+    {
+        $this->_configCache(['allowedClasses' => false]);
+
+        $this->assertTrue(Cache::write('int', 42, 'redis'));
+        $this->assertSame(42, Cache::read('int', 'redis'));
+
+        $this->assertTrue(Cache::write('array', ['a' => 1, 'b' => 2], 'redis'));
+        $this->assertSame(['a' => 1, 'b' => 2], Cache::read('array', 'redis'));
+
+        Cache::delete('int', 'redis');
+        Cache::delete('array', 'redis');
     }
 
     /**


### PR DESCRIPTION
## Summary

`RedisEngine::unserialize()` and `FileEngine`'s inline `unserialize()` call both deserialize cached data without restricting the `allowed_classes` option. An attacker who can write to the cache backend can inject a crafted PHP serialized payload containing a gadget chain and trigger **PHP Object Injection**.

## Attack scenario

1. Attacker gains write access to the Redis/file cache backend (misconfigured Redis without auth, lateral movement, SSRF, or cache poisoning via the application).
2. Attacker writes a serialized payload that instantiates an exploitable gadget chain available in the application's class space (e.g., Monolog, Guzzle, or any other library that implements `__wakeup`/`__destruct`).
3. On the next cache read, `unserialize()` instantiates the gadget class and executes attacker-controlled code.

## Fix

Add an `allowedClasses` configuration option to both engines (defaulting to `true` for full backwards compatibility). Applications that only cache scalar/array values can harden their deployment by setting `'allowedClasses' => false`; applications caching specific object types can enumerate only those classes.

```php
// In config/app.php Cache configuration:
'MyCache' => [
    'className' => 'Redis',
    // ...
    'allowedClasses' => false, // prevent PHP Object Injection
],
```

## Files changed

- `src/Cache/Engine/RedisEngine.php` — add `allowedClasses` default config + honour it in `unserialize()`
- `src/Cache/Engine/FileEngine.php` — same

## Severity

**High** (requires write access to cache backend, but cache backends are frequently shared across tenants or exposed via misconfigured infrastructure).