### PR TITLE
Clarify ServerRequest::referer() $local docblock

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -430,8 +430,10 @@ class ServerRequest implements ServerRequestInterface
     /**
      * Returns the referer that referred this request.
      *
-     * @param bool $local Attempt to return a local address.
-     *   Local addresses do not contain hostnames.
+     * @param bool $local When true, return the referer as a host-stripped local path,
+     *   or null if the referer is not on the same origin as this application.
+     *   When false, return the raw referer URL as-is. In both cases null is returned
+     *   when no referer is available.
      * @return string|null The referring address for this request or null.
      */
     public function referer(bool $local = true): ?string


### PR DESCRIPTION
Doc-only fix for #19486.

`ServerRequest::referer()`'s `$local` param was documented as "Attempt to return a local address", implying a soft fallback. The behavior is actually a hard contract: when `$local` is true and the referer is not same-origin, the method returns `null` rather than the raw referer.

This rewords the docblock to describe both modes accurately:
- `$local = true` -> host-stripped local path, or `null` if not same-origin
- `$local = false` -> raw referer URL as-is
- `null` in both modes when no referer is present

No behavior change. The null-on-non-local return is intentional (avoids handing a foreign URL to callers that may redirect with it); callers wanting the raw value should use `referer(false)`.
