### PR TITLE
Remove stale PHPStan ignores from Database split package config

### DIFF
--- a/src/Database/phpstan.neon.dist
+++ b/src/Database/phpstan.neon.dist
@@ -11,3 +11,8 @@ parameters:
 		- '#Unsafe usage of new static\(\).#'
 		-
 			identifier: missingType.iterableValue
+		-
+			message: '#^Dead catch \- InvalidArgumentException is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
+			path: Type/DateTimeType.php
+			reportUnmatched: false

--- a/src/Database/phpstan.neon.dist
+++ b/src/Database/phpstan.neon.dist
@@ -10,12 +10,4 @@ parameters:
 	ignoreErrors:
 		- '#Unsafe usage of new static\(\).#'
 		-
-			identifier: notIdentical.alwaysTrue
-		-
 			identifier: missingType.iterableValue
-
-		-
-			message: '#^Dead catch \- InvalidArgumentException is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
-			path: Type/DateTimeType.php


### PR DESCRIPTION
## Problem

The **Static Analysis for Split Packages** job in the CI workflow is red on `5.x`. The actual git subtree split (the **Split Packages** workflow) succeeds on every push - this is a separate validation job that runs PHPStan against each split package using the package's own per-package `phpstan.neon.dist`, simulating the standalone split repo's CI.

```
##[error]Ignored error pattern notIdentical.alwaysTrue was not matched in reported errors.
 [ERROR] Found 1 error
```

## Cause

`src/Database/phpstan.neon.dist` carries two `ignoreErrors` entries that no longer match any reported error when PHPStan analyzes the isolated `cakephp/database` package. With PHPStan's default `reportUnmatchedIgnoredErrors: true`, an unmatched ignore is a hard failure.

- `notIdentical.alwaysTrue` - the always-true comparison it covered is gone.
- `catch.neverThrown` (Type/DateTimeType.php) - the dead-catch finding is dependency-version dependent (it hinges on whether PHPStan resolves the marshal target to Chronos, which throws, or native `DateTimeImmutable`, which does not). With the dependency versions resolved today it is no longer reported, so the ignore is unmatched too.

## Fix

Drop both stale entries. Verified by reproducing the split job locally (`composer require --dev phpstan/phpstan:2.2.0 && vendor/bin/phpstan analyze ./` inside `src/Database/`): green after removal.

## Note

`catch.neverThrown` is inherently fragile - a future Chronos/dependency release could make PHPStan flag that catch as dead again, which would re-surface as an unreported error in the split job. If that recurs, the proper handling is `treatPhpDocTypesAsCertain`/type-level fixes rather than re-adding the bare ignore.
