### PR TITLE
CLI: exempt commands with positional arguments from the sibling-subcommand check

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -31,6 +31,7 @@ use Cake\Event\EventManagerInterface;
 use Cake\Routing\Router;
 use Cake\Routing\RoutingApplicationInterface;
 use Cake\Utility\Inflector;
+use Throwable;
 
 /**
  * Run CLI commands for the provided application.
@@ -169,24 +170,6 @@ class CommandRunner implements EventDispatcherInterface
             $name = 'help';
         }
 
-        // If the matched command also has sibling subcommands (e.g. `i18n` exists alongside
-        // `i18n init` / `i18n extract`), an unknown next token is almost always a typo for a
-        // subcommand. Reject it instead of letting it fall through as a positional argument.
-        if (
-            $name !== null
-            && $commands->has($name)
-            && isset($argv[0])
-            && !str_starts_with($argv[0], '-')
-            && $this->hasCommandsWithPrefix($commands, $name)
-        ) {
-            $candidate = $name . ' ' . $argv[0];
-            if (!$commands->has($candidate)) {
-                $io->error($this->unknownSubcommandMessage($commands, $name, $argv[0]));
-
-                return CommandInterface::CODE_ERROR;
-            }
-        }
-
         try {
             $name = $this->resolveName($commands, $io, $name);
         } catch (MissingOptionException $e) {
@@ -196,6 +179,28 @@ class CommandRunner implements EventDispatcherInterface
         }
 
         $command = $this->getCommand($io, $commands, $name);
+
+        // If the matched command also has sibling subcommands (e.g. `i18n` exists alongside
+        // `i18n init` / `i18n extract`), an unknown next token is almost always a typo for a
+        // subcommand. Reject it instead of letting it fall through as a positional argument.
+        //
+        // Commands that declare their own positional arguments are exempt: there the next token
+        // is a legitimate argument (e.g. `bake template Articles` alongside `bake template all`),
+        // not a mistyped subcommand, and only the command's own parser can tell the two apart.
+        if (
+            isset($argv[0])
+            && !str_starts_with($argv[0], '-')
+            && $this->hasCommandsWithPrefix($commands, $name)
+            && !$this->commandHasArguments($command)
+        ) {
+            $candidate = $name . ' ' . $argv[0];
+            if (!$commands->has($candidate)) {
+                $io->error($this->unknownSubcommandMessage($commands, $name, $argv[0]));
+
+                return CommandInterface::CODE_ERROR;
+            }
+        }
+
         $result = $this->runCommand($command, $argv, $io);
 
         if ($result === null) {
@@ -364,6 +369,30 @@ class CommandRunner implements EventDispatcherInterface
         }
 
         return false;
+    }
+
+    /**
+     * Check whether a command declares its own positional arguments.
+     *
+     * A command that accepts positional arguments treats a trailing token as a real argument,
+     * so it must not be rejected as a mistyped subcommand by the sibling-subcommand check.
+     *
+     * @param \Cake\Console\CommandInterface $command The resolved command instance to inspect.
+     * @return bool
+     */
+    protected function commandHasArguments(CommandInterface $command): bool
+    {
+        if (!$command instanceof BaseCommand) {
+            return false;
+        }
+
+        try {
+            $parser = $command->getOptionParser();
+        } catch (Throwable) {
+            return false;
+        }
+
+        return $parser->arguments() !== [];
     }
 
     /**

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -191,7 +191,7 @@ class CommandRunner implements EventDispatcherInterface
             isset($argv[0])
             && !str_starts_with($argv[0], '-')
             && $this->hasCommandsWithPrefix($commands, $name)
-            && !$this->commandHasArguments($command)
+            && $this->isArgumentlessCommand($command)
         ) {
             $candidate = $name . ' ' . $argv[0];
             if (!$commands->has($candidate)) {
@@ -372,15 +372,17 @@ class CommandRunner implements EventDispatcherInterface
     }
 
     /**
-     * Check whether a command declares its own positional arguments.
+     * Check whether a command is known to accept no positional arguments.
      *
-     * A command that accepts positional arguments treats a trailing token as a real argument,
-     * so it must not be rejected as a mistyped subcommand by the sibling-subcommand check.
+     * Only returns true when the command's option parser can be inspected and declares zero
+     * arguments. When the parser cannot be determined, it errs on the side of caution and
+     * returns false, so a potentially valid command is run rather than rejected by the
+     * sibling-subcommand check as a mistyped subcommand.
      *
      * @param \Cake\Console\CommandInterface $command The resolved command instance to inspect.
      * @return bool
      */
-    protected function commandHasArguments(CommandInterface $command): bool
+    protected function isArgumentlessCommand(CommandInterface $command): bool
     {
         if (!$command instanceof BaseCommand) {
             return false;
@@ -392,7 +394,7 @@ class CommandRunner implements EventDispatcherInterface
             return false;
         }
 
-        return $parser->arguments() !== [];
+        return $parser->arguments() === [];
     }
 
     /**

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -27,6 +27,7 @@ use Cake\Console\CommandFactoryInterface;
 use Cake\Console\CommandInterface;
 use Cake\Console\CommandRunner;
 use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
@@ -208,6 +209,51 @@ class CommandRunnerTest extends TestCase
         $this->assertSame(0, $result);
         $messages = implode("\n", $output->messages());
         $this->assertStringNotContainsString('Unknown command', $messages);
+    }
+
+    /**
+     * Test that a command declaring its own positional arguments is not subject to the
+     * unknown-subcommand check, even when a sibling subcommand sharing its prefix exists.
+     *
+     * For example, given `widget` (which takes a `name` argument), `widget all` is also
+     * registered: `bin/cake widget Articles` must run the `widget` command with `Articles`
+     * as its argument, not be rejected as a mistyped `widget` subcommand.
+     */
+    public function testRunPositionalArgumentNotTreatedAsUnknownSubcommand(): void
+    {
+        $parent = new class extends Command {
+            public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+            {
+                return $parser->addArgument('name', ['help' => 'A name.', 'required' => false]);
+            }
+
+            public function execute(Arguments $args, ConsoleIo $io): int
+            {
+                $io->out('ran widget with ' . (string)$args->getArgument('name'));
+
+                return static::CODE_SUCCESS;
+            }
+        };
+        $sibling = new class extends Command {
+            public function execute(Arguments $args, ConsoleIo $io): int
+            {
+                return static::CODE_SUCCESS;
+            }
+        };
+
+        $output = new StubConsoleOutput();
+        $app = $this->makeAppWithCommands([
+            'help' => HelpCommand::class,
+            'widget' => $parent,
+            'widget all' => $sibling,
+        ]);
+        $runner = new CommandRunner($app);
+        $result = $runner->run(['cake', 'widget', 'Articles'], $this->getMockIo($output));
+
+        $this->assertSame(CommandInterface::CODE_SUCCESS, $result);
+        $messages = implode("\n", $output->messages());
+        $this->assertStringNotContainsString('Unknown command', $messages);
+        $this->assertStringContainsString('ran widget with Articles', $messages);
     }
 
     /**

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -229,7 +229,7 @@ class CommandRunnerTest extends TestCase
 
             public function execute(Arguments $args, ConsoleIo $io): int
             {
-                $io->out('ran widget with ' . (string)$args->getArgument('name'));
+                $io->out('ran widget with ' . $args->getArgument('name'));
 
                 return static::CODE_SUCCESS;
             }


### PR DESCRIPTION
Fixes the core half of #19491 (Cluster A).

## Problem

The sibling-subcommand guard added in #19425 rejects an unknown token after a command that has registered subcommands, on the assumption that the token is a mistyped subcommand:

```
Unknown command `cake bake template authors`.
Available subcommands: `bake template all`.
```

That assumption holds for parent commands that take no arguments (`i18n`, `cache`), but it is wrong for commands that declare their own positional arguments. There the trailing token is a legitimate argument, not a subcommand.

Bake is the concrete victim: `BakePlugin` registers both `bake template` and `bake template all` (and the same for `controller`, `model`, `fixture`). `TemplateCommand` accepts a `name` argument, so `bake template Articles` is a valid invocation, yet the guard refuses it because `bake template all` shares the prefix. Only `--flag`-first invocations slipped through, which is why some tests stayed green.

The original change already documented the intended exemption ("Commands without siblings, commands with declared positional arguments, and option-like tokens are unaffected") - the positional-argument part was just never implemented.

## Fix

A token can only be told apart from a subcommand by the matched command's own option parser. So resolve and instantiate the command first, then skip the guard when its parser declares positional arguments:

```php
$command = $this->getCommand($io, $commands, $name);

if (
    isset($argv[0])
    && !str_starts_with($argv[0], '-')
    && $this->hasCommandsWithPrefix($commands, $name)
    && !$this->commandHasArguments($command)
) {
    // ... reject unknown subcommand
}
```

`commandHasArguments()` reads the resolved command's option parser and returns whether it defines any positional arguments. The command is now instantiated once and reused for both the check and execution.

Typo protection for argument-less parent commands (`cake i18n nonsense`) is preserved.

## Notes

- This is the core-side fix only. Cluster B in the issue (uninitialized typed property in Bake's `*AllCommand::buildOptionParser()`) is a Bake bug and is fixed separately in the bake plugin.
- New regression test: a command declaring a positional argument alongside a sibling subcommand runs with its argument instead of erroring. Existing guard tests (argument-less parent still errors; option-like token unaffected) continue to pass.
