### PR TITLE
Include passed parameters in MissingRouteException for failed named routes

### DIFF
--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -294,10 +294,17 @@ class RouteCollection
                 if ($out) {
                     return $out;
                 }
+                $message = sprintf(
+                    'A named route was found for `%s`, but matching failed. Passed parameters: `%s`.',
+                    $name,
+                    (string)json_encode($url),
+                );
+
                 throw new MissingRouteException([
                     'url' => $name,
                     'context' => $context,
-                    'message' => "A named route was found for `{$name}`, but matching failed.",
+                    // Escape `%` so the message survives CakeException's vsprintf() pass unchanged.
+                    'message' => str_replace('%', '%%', $message),
                 ]);
             }
             throw new MissingRouteException(['url' => $name, 'context' => $context]);

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -666,7 +666,9 @@ class RouteCollectionTest extends TestCase
     public function testMatchNamedError(): void
     {
         $this->expectException(MissingRouteException::class);
-        $this->expectExceptionMessage('A named route was found for `fail`, but matching failed');
+        $this->expectExceptionMessage(
+            'A named route was found for `fail`, but matching failed. Passed parameters: `{"controller":"Articles"}`.',
+        );
         $context = [
             '_base' => '/',
             '_scheme' => 'http',
@@ -675,7 +677,7 @@ class RouteCollectionTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/b');
         $routes->connect('/{lang}/articles', ['controller' => 'Articles'], ['_name' => 'fail']);
 
-        $this->collection->match(['_name' => 'fail'], $context);
+        $this->collection->match(['_name' => 'fail', 'controller' => 'Articles'], $context);
     }
 
     /**


### PR DESCRIPTION
Fixes #19493.

When a named route is found but matching fails (a passed parameter does not satisfy the route's regex patterns), the `MissingRouteException` only stated that matching failed, with no hint about which value was wrong.

The exception message now appends the passed parameters, so the offending value is visible.

Before:

```
A named route was found for `article:view`, but matching failed.
```

After:

```
A named route was found for `article:view`, but matching failed. Passed parameters: `{"id":"foo/bar"}`.
```

The parameters are json-encoded; any percent signs are escaped so the message survives CakeException's vsprintf() formatting unchanged.

Scope kept to the named-route failure branch only, as discussed in the issue.

Didn't use varexport() since that would make this multi-line.