### PR TITLE
Move InstanceConfigTrait into TranslateStrategyTrait from individual classes.

### DIFF
--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -19,7 +19,6 @@ namespace Cake\ORM\Behavior\Translate;
 use ArrayObject;
 use Cake\Collection\Collection;
 use Cake\Collection\CollectionInterface;
-use Cake\Core\InstanceConfigTrait;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\ORM\Locator\LocatorAwareTrait;
@@ -41,7 +40,6 @@ use Cake\ORM\Table;
  */
 class EavStrategy implements TranslateStrategyInterface
 {
-    use InstanceConfigTrait;
     use LocatorAwareTrait;
     use TranslateStrategyTrait;
 

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -18,7 +18,6 @@ namespace Cake\ORM\Behavior\Translate;
 
 use ArrayObject;
 use Cake\Collection\CollectionInterface;
-use Cake\Core\InstanceConfigTrait;
 use Cake\Database\Expression\FieldInterface;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
@@ -35,7 +34,6 @@ use function Cake\Core\pluginSplit;
  */
 class ShadowTableStrategy implements TranslateStrategyInterface
 {
-    use InstanceConfigTrait;
     use LocatorAwareTrait;
     use TranslateStrategyTrait {
         buildMarshalMap as private _buildMarshalMap;

--- a/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
+++ b/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Behavior\Translate;
 
+use Cake\Core\InstanceConfigTrait;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\I18n\I18n;
@@ -29,6 +30,8 @@ use Cake\ORM\Table;
  */
 trait TranslateStrategyTrait
 {
+    use InstanceConfigTrait;
+
     /**
      * Table instance
      *

--- a/src/View/StringTemplateTrait.php
+++ b/src/View/StringTemplateTrait.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\View;
 
+use Cake\Core\InstanceConfigTrait;
 use function Cake\Core\deprecationWarning;
 
 /**
@@ -28,6 +29,8 @@ use function Cake\Core\deprecationWarning;
  */
 trait StringTemplateTrait
 {
+    use InstanceConfigTrait;
+
     /**
      * StringTemplate instance.
      *


### PR DESCRIPTION
This makes LSPs like intelephense stop complaining about the use of $this->_config in TranslateStrategyTrait.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
