### PR TITLE
Fix implementation of DefinitionAggregrate

### DIFF
--- a/src/Container/Definition/DefinitionAggregate.php
+++ b/src/Container/Definition/DefinitionAggregate.php
@@ -12,7 +12,7 @@ class DefinitionAggregate implements DefinitionAggregateInterface
     use ContainerAwareTrait;
 
     /**
-     * @var array<\Cake\Container\Definition\DefinitionInterface>
+     * @var array<string, \Cake\Container\Definition\DefinitionInterface>
      */
     protected array $definitions = [];
 
@@ -21,9 +21,11 @@ class DefinitionAggregate implements DefinitionAggregateInterface
      */
     public function __construct(array $definitions = [])
     {
-        $this->definitions = array_filter($definitions, static function ($definition) {
-            return $definition instanceof DefinitionInterface;
-        });
+        foreach ($definitions as $definition) {
+            if ($definition instanceof DefinitionInterface) {
+                $this->definitions[$definition->getAlias()] = $definition;
+            }
+        }
     }
 
     /**
@@ -35,7 +37,8 @@ class DefinitionAggregate implements DefinitionAggregateInterface
             $definition = new Definition($id, $definition);
         }
 
-        $this->definitions[] = $definition->setAlias($id);
+        $definition = $definition->setAlias($id);
+        $this->definitions[$definition->getAlias()] = $definition;
 
         return $definition;
     }
@@ -55,15 +58,7 @@ class DefinitionAggregate implements DefinitionAggregateInterface
      */
     public function has(string $id): bool
     {
-        $id = Definition::normaliseAlias($id);
-
-        foreach ($this->getIterator() as $definition) {
-            if ($id === $definition->getAlias()) {
-                return true;
-            }
-        }
-
-        return false;
+        return isset($this->definitions[Definition::normaliseAlias($id)]);
     }
 
     /**
@@ -87,13 +82,11 @@ class DefinitionAggregate implements DefinitionAggregateInterface
     {
         $id = Definition::normaliseAlias($id);
 
-        foreach ($this->getIterator() as $definition) {
-            if ($id === $definition->getAlias()) {
-                return $definition->setContainer($this->getContainer());
-            }
+        if (!isset($this->definitions[$id])) {
+            throw new NotFoundException(sprintf('Alias (%s) is not being handled as a definition.', $id));
         }
 
-        throw new NotFoundException(sprintf('Alias (%s) is not being handled as a definition.', $id));
+        return $this->definitions[$id]->setContainer($this->getContainer());
     }
 
     /**
@@ -145,7 +138,7 @@ class DefinitionAggregate implements DefinitionAggregateInterface
     }
 
     /**
-     * @inheritDoc
+     * @return \Generator<string, \Cake\Container\Definition\DefinitionInterface>
      */
     public function getIterator(): Generator
     {

--- a/tests/TestCase/Container/Definition/DefinitionAggregateTest.php
+++ b/tests/TestCase/Container/Definition/DefinitionAggregateTest.php
@@ -8,6 +8,7 @@ use Cake\Container\Definition\Definition;
 use Cake\Container\Definition\DefinitionAggregate;
 use Cake\Container\Definition\DefinitionInterface;
 use Cake\Container\Exception\NotFoundException;
+use Cake\Test\TestCase\Container\Asset\Bar;
 use Cake\Test\TestCase\Container\Asset\Foo;
 use Mockery;
 use PHPUnit\Framework\TestCase;
@@ -24,6 +25,9 @@ class DefinitionAggregateTest extends TestCase
             ->once()
             ->with('alias')
             ->andReturnSelf();
+        $definition
+            ->shouldReceive('getAlias')
+            ->andReturn('alias');
 
         $aggregate = (new DefinitionAggregate())->setContainer($container);
         $definition = $aggregate->add('alias', $definition);
@@ -59,9 +63,21 @@ class DefinitionAggregateTest extends TestCase
             $definitions[] = $aggregate->add('alias' . $i, Foo::class);
         }
 
-        foreach ($aggregate->getIterator() as $key => $definition) {
-            self::assertSame($definitions[$key], $definition);
-        }
+        $iterated = iterator_to_array($aggregate->getIterator(), false);
+        self::assertSame($definitions, $iterated);
+    }
+
+    public function testAggregateAddsSameIdTwiceWithDifferentDefinition(): void
+    {
+        $container = new Container();
+        $aggregate = (new DefinitionAggregate())->setContainer($container);
+
+        $aggregate->add('alias', Foo::class);
+        $returned = $aggregate->add('alias', Bar::class);
+
+        self::assertInstanceOf(Definition::class, $returned);
+        self::assertSame(Bar::class, $returned->getConcrete());
+        self::assertInstanceOf(Bar::class, $aggregate->resolve('alias'));
     }
 
     public function testAggregateIteratesAndResolvesDefinition(): void
@@ -126,6 +142,9 @@ class DefinitionAggregateTest extends TestCase
         $container = new Container();
 
         $definition1
+            ->shouldReceive('getAlias')
+            ->andReturn('definition1');
+        $definition1
             ->shouldReceive('setContainer')
             ->once()
             ->with($container)
@@ -142,6 +161,9 @@ class DefinitionAggregateTest extends TestCase
             ->once()
             ->andReturn('definition1');
 
+        $definition2
+            ->shouldReceive('getAlias')
+            ->andReturn('definition2');
         $definition2
             ->shouldReceive('setContainer')
             ->once()


### PR DESCRIPTION
- The definition lookups are now O(1) instead of O(n) iteration.
- Calling add() multiple times with same id but different definition resolves to the last definition set instead of the 1st.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
