### PR TITLE
Validate split packages against dev branches of sibling packages

### DIFF
--- a/contrib/validate-split-packages-phpstan.php
+++ b/contrib/validate-split-packages-phpstan.php
@@ -46,7 +46,14 @@ foreach ($phivePharsXml->phar as $phar) {
         break;
     }
 }
-$composerCommand = 'composer require --dev phpstan/phpstan:' . $phpstanVersion;
+// Prefer the dev branches of sibling cakephp packages over the latest tagged
+// release. The split packages require siblings as `5.4.*@dev`, which also matches
+// already-published RC/stable tags; composer prefers those tags, so it would
+// validate against released code that can lag behind the monorepo. Forcing dev
+// stability makes it resolve the `dev-<branch>` mirror instead, matching local src.
+$composerCommand = 'composer config minimum-stability dev'
+    . ' && composer config prefer-stable false'
+    . ' && composer require --dev phpstan/phpstan:' . $phpstanVersion;
 
 $issues = [];
 foreach ($packages as $path => $package) {


### PR DESCRIPTION
## Problem

The split-package PHPStan validation (`contrib/validate-split-packages-phpstan.php`, run in CI) currently fails on `5.next` with false positives:

- `Database` / `Http` / `ORM`: `missingType.generics` on `Connection`, `Client`, `Server`, `Table`, `BehaviorRegistry`
- `ORM`: `generics.variance` on `Query/SelectQuery`

These are not real bugs. The split packages require their cakephp siblings as `5.4.*@dev`. That constraint matches the already-published `5.4.0-RC1` tags as well as the `dev-5.next` branch, and composer prefers the RC tag. So the validation runs local `src/` against released sibling code that predates recent generics work:

- `EventDispatcherInterface`/`EventDispatcherTrait` dropped their class-level `@template TSubject`, and implementing classes dropped the matching `@implements`/`@use` annotations - but the published `cakephp/event` still declares the interface generic.
- `Database\Query\SelectQuery` became `@template-covariant` - but the published `cakephp/database` is still invariant.

Result: the published packages and the local source disagree on generic shapes, producing the errors above. They self-resolve only once the sibling packages are re-released.

## Fix

Force dev stability before installing in the validation script, so composer resolves the `dev-<branch>` mirror of each sibling instead of the lagging RC tag:

```php
$composerCommand = 'composer config minimum-stability dev'
    . ' && composer config prefer-stable false'
    . ' && composer require --dev phpstan/phpstan:' . $phpstanVersion;
```

The per-package cleanup already runs `git checkout composer.json`, so the config toggles do not persist.

Verified locally: the script now pulls `cakephp/event`, `cakephp/database`, `cakephp/core` at `dev-5.next` and exits `0` with no errors.