### PR TITLE
Add value types for registry array docblocks

### DIFF
--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -73,7 +73,7 @@ class Component implements EventListenerInterface
     /**
      * Other Components this component uses.
      *
-     * @var array
+     * @var array<int|string, string|array<string, mixed>>
      */
     protected array $components = [];
 

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -293,6 +293,12 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
                 $objectName = $config;
                 $config = [];
             }
+            if (!is_string($objectName)) {
+                continue;
+            }
+            if (!is_array($config)) {
+                $config = [];
+            }
 
             [$plugin, $name] = pluginSplit($objectName);
             if ($plugin) {

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -282,8 +282,8 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * Normalizes an object configuration array into associative form for making
      * lazy loading easier.
      *
-     * @param array $objects Array of child objects to normalize.
-     * @return array<string, array> Array of normalized objects.
+     * @param array<int|string, string|array<string, mixed>> $objects Array of child objects to normalize.
+     * @return array<string, array<string, mixed>> Array of normalized objects.
      */
     public function normalizeArray(array $objects): array
     {

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -49,7 +49,7 @@ class Helper implements EventListenerInterface
     /**
      * List of helpers used by this helper
      *
-     * @var array
+     * @var array<int|string, string|array<string, mixed>>
      */
     protected array $helpers = [];
 

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -34,7 +34,7 @@ class BreadcrumbsHelper extends Helper
     /**
      * Other helpers used by BreadcrumbsHelper.
      *
-     * @var array
+     * @var array<string>
      */
     protected array $helpers = ['Url'];
 

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -34,7 +34,7 @@ class BreadcrumbsHelper extends Helper
     /**
      * Other helpers used by BreadcrumbsHelper.
      *
-     * @var array<string>
+     * @var array<int|string, string|array<string, mixed>>
      */
     protected array $helpers = ['Url'];
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -66,7 +66,7 @@ class FormHelper extends Helper
     /**
      * Other helpers used by FormHelper
      *
-     * @var array
+     * @var array<string>
      */
     protected array $helpers = ['Url', 'Html'];
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -66,7 +66,7 @@ class FormHelper extends Helper
     /**
      * Other helpers used by FormHelper
      *
-     * @var array<string>
+     * @var array<int|string, string|array<string, mixed>>
      */
     protected array $helpers = ['Url', 'Html'];
 

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -38,7 +38,7 @@ class HtmlHelper extends Helper
     /**
      * List of helpers used by this helper
      *
-     * @var array
+     * @var array<string>
      */
     protected array $helpers = ['Url'];
 

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -38,7 +38,7 @@ class HtmlHelper extends Helper
     /**
      * List of helpers used by this helper
      *
-     * @var array<string>
+     * @var array<int|string, string|array<string, mixed>>
      */
     protected array $helpers = ['Url'];
 

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -48,7 +48,7 @@ class PaginatorHelper extends Helper
     /**
      * List of helpers used by this helper
      *
-     * @var array
+     * @var array<string>
      */
     protected array $helpers = ['Url', 'Number', 'Html', 'Form'];
 

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -48,7 +48,7 @@ class PaginatorHelper extends Helper
     /**
      * List of helpers used by this helper
      *
-     * @var array<string>
+     * @var array<int|string, string|array<string, mixed>>
      */
     protected array $helpers = ['Url', 'Number', 'Html', 'Form'];
 

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -42,7 +42,7 @@ class TextHelper extends Helper
     /**
      * helpers
      *
-     * @var array
+     * @var array<string>
      */
     protected array $helpers = ['Html'];
 

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -42,7 +42,7 @@ class TextHelper extends Helper
     /**
      * helpers
      *
-     * @var array<string>
+     * @var array<int|string, string|array<string, mixed>>
      */
     protected array $helpers = ['Html'];
 

--- a/tests/test_app/TestApp/Controller/Component/AppleComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/AppleComponent.php
@@ -28,7 +28,7 @@ class AppleComponent extends Component
     /**
      * components property
      *
-     * @var array
+     * @var array<int|string, string|array<string, mixed>>
      */
     protected array $components = ['Orange'];
 

--- a/tests/test_app/TestApp/Controller/Component/ConfiguredComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/ConfiguredComponent.php
@@ -31,7 +31,7 @@ class ConfiguredComponent extends Component
     /**
      * components property
      *
-     * @var array
+     * @var array<int|string, string|array<string, mixed>>
      */
     protected array $components = [];
 

--- a/tests/test_app/TestApp/Controller/Component/MutuallyReferencingOneComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/MutuallyReferencingOneComponent.php
@@ -27,7 +27,7 @@ class MutuallyReferencingOneComponent extends Component
     /**
      * components property
      *
-     * @var array
+     * @var array<int|string, string|array<string, mixed>>
      */
     protected array $components = ['MutuallyReferencingTwo'];
 }

--- a/tests/test_app/TestApp/Controller/Component/MutuallyReferencingTwoComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/MutuallyReferencingTwoComponent.php
@@ -27,7 +27,7 @@ class MutuallyReferencingTwoComponent extends Component
     /**
      * components property
      *
-     * @var array
+     * @var array<int|string, string|array<string, mixed>>
      */
     protected array $components = ['MutuallyReferencingOne'];
 }

--- a/tests/test_app/TestApp/Controller/Component/OrangeComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/OrangeComponent.php
@@ -28,7 +28,7 @@ class OrangeComponent extends Component
     /**
      * components property
      *
-     * @var array
+     * @var array<int|string, string|array<string, mixed>>
      */
     protected array $components = ['Banana'];
 

--- a/tests/test_app/TestApp/Controller/Component/ParamTestComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/ParamTestComponent.php
@@ -27,7 +27,7 @@ class ParamTestComponent extends Component
     /**
      * components property
      *
-     * @var array
+     * @var array<int|string, string|array<string, mixed>>
      */
     protected array $components = ['Banana' => ['config' => 'value']];
 }

--- a/tests/test_app/TestApp/Controller/Component/SomethingWithFlashComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/SomethingWithFlashComponent.php
@@ -27,7 +27,7 @@ class SomethingWithFlashComponent extends Component
     /**
      * components property
      *
-     * @var array
+     * @var array<int|string, string|array<string, mixed>>
      */
     protected array $components = ['Flash'];
 }

--- a/tests/test_app/TestApp/Controller/PaginatorTestController.php
+++ b/tests/test_app/TestApp/Controller/PaginatorTestController.php
@@ -10,7 +10,7 @@ class PaginatorTestController extends Controller
     /**
      * components property
      *
-     * @var array
+     * @var array<int|string, string|array<string, mixed>>
      */
     protected array $components = ['Paginator'];
 }


### PR DESCRIPTION
### Summary
- add value types to `Helper::$helpers` and `Component::$components`
- document the accepted input and normalized output shape of `ObjectRegistry::normalizeArray()`

These arrays accept shorthand string entries and named config arrays before normalization. After normalization they are keyed by object alias with config arrays. The more precise PHPDoc avoids static analysis issues for subclasses that document their helper/component declarations.
