### PR TITLE
6.x fix psalm + fix testsuite using old unhydrated API

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="7.0.0-beta17@a7f96f911fc869c40c48ec977e21f01a8ca534bd">
+<files psalm-version="7.0.0-beta19@7e751c06a756fa64dc4c759c09fe4a173afcb433">
+  <file src="src/Controller/Component/FlashComponent.php">
+    <MethodSignatureMismatch>
+      <code><![CDATA[public function configShallow(array|string $key, mixed $value = null): static]]></code>
+      <code><![CDATA[public function setConfig(array|string $key, mixed $value = null, bool $merge = true): static]]></code>
+    </MethodSignatureMismatch>
+  </file>
   <file src="src/Controller/ComponentRegistry.php">
     <OverriddenMethodAccess>
       <code><![CDATA[protected function getContainer(): ContainerInterface
@@ -25,6 +31,23 @@
     </OverriddenMethodAccess>
   </file>
   <file src="src/Core/InstanceConfigTrait.php">
+    <MethodSignatureMismatch>
+      <code><![CDATA[public function configShallow(array|string $key, mixed $value = null): static]]></code>
+      <code><![CDATA[public function configShallow(array|string $key, mixed $value = null): static]]></code>
+      <code><![CDATA[public function configShallow(array|string $key, mixed $value = null): static]]></code>
+      <code><![CDATA[public function configShallow(array|string $key, mixed $value = null): static]]></code>
+      <code><![CDATA[public function configShallow(array|string $key, mixed $value = null): static]]></code>
+      <code><![CDATA[public function deleteConfig(string $key): static]]></code>
+      <code><![CDATA[public function deleteConfig(string $key): static]]></code>
+      <code><![CDATA[public function deleteConfig(string $key): static]]></code>
+      <code><![CDATA[public function deleteConfig(string $key): static]]></code>
+      <code><![CDATA[public function deleteConfig(string $key): static]]></code>
+      <code><![CDATA[public function setConfig(array|string $key, mixed $value = null, bool $merge = true): static]]></code>
+      <code><![CDATA[public function setConfig(array|string $key, mixed $value = null, bool $merge = true): static]]></code>
+      <code><![CDATA[public function setConfig(array|string $key, mixed $value = null, bool $merge = true): static]]></code>
+      <code><![CDATA[public function setConfig(array|string $key, mixed $value = null, bool $merge = true): static]]></code>
+      <code><![CDATA[public function setConfig(array|string $key, mixed $value = null, bool $merge = true): static]]></code>
+    </MethodSignatureMismatch>
     <UnsupportedPropertyReferenceUsage>
       <code><![CDATA[$update = &$this->config]]></code>
       <code><![CDATA[$update = &$this->config]]></code>
@@ -45,6 +68,16 @@
       <code><![CDATA[SelectQuery]]></code>
     </MethodSignatureMismatch>
   </file>
+  <file src="src/ORM/Query/UnhydratedSelectQuery.php">
+    <MethodSignatureMismatch>
+      <code><![CDATA[UnhydratedSelectQuery]]></code>
+      <code><![CDATA[UnhydratedSelectQuery]]></code>
+      <code><![CDATA[UnhydratedSelectQuery]]></code>
+      <code><![CDATA[UnhydratedSelectQuery]]></code>
+      <code><![CDATA[UnhydratedSelectQuery]]></code>
+      <code><![CDATA[UnhydratedSelectQuery]]></code>
+    </MethodSignatureMismatch>
+  </file>
   <file src="src/TestSuite/TestCase.php">
     <NoValue>
       <code><![CDATA[return $this->capturedError;]]></code>
@@ -52,5 +85,13 @@
     <UndefinedVariable>
       <code><![CDATA[$previousHandler]]></code>
     </UndefinedVariable>
+  </file>
+  <file src="src/Validation/Validator.php">
+    <TaintedCallable>
+      <code><![CDATA[$callable]]></code>
+      <code><![CDATA[$callable]]></code>
+      <code><![CDATA[$callable]]></code>
+      <code><![CDATA[$callable]]></code>
+    </TaintedCallable>
   </file>
 </files>

--- a/src/Http/Session/DatabaseSession.php
+++ b/src/Http/Session/DatabaseSession.php
@@ -115,10 +115,9 @@ class DatabaseSession implements SessionHandlerInterface
         $pkField = $this->table->getPrimaryKey();
         assert(is_string($pkField));
         $result = $this->table
-            ->find('all')
+            ->unhydratedFind()
             ->select(['data'])
             ->where([$pkField => $id])
-            ->disableHydration()
             ->first();
 
         if (!$result) {

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -526,10 +526,9 @@ class EavStrategy implements TranslateStrategyInterface
     {
         $association = $this->table->getAssociation($this->translationTable->getAlias());
 
-        $query = $association->find()
+        $query = $association->unhydratedSelectQuery()
             ->select(['id', 'num' => 0])
-            ->where(current($ruleSet))
-            ->disableHydration();
+            ->where(current($ruleSet));
 
         unset($ruleSet[0]);
         foreach ($ruleSet as $i => $conditions) {

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -814,11 +814,10 @@ class TreeBehavior extends Behavior
         $primaryKey = $this->getPrimaryKey();
         $order = $config['recoverOrder'] ?: $primaryKey;
 
-        $nodes = $this->scope($this->table->selectQuery())
+        $nodes = $this->scope($this->table->unhydratedSelectQuery())
             ->select($primaryKey)
             ->where([$parent . ' IS' => $parentId])
             ->orderBy($order)
-            ->disableHydration()
             ->all();
 
         foreach ($nodes as $node) {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1961,11 +1961,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function exists(ExpressionInterface|Closure|array|string|null $conditions): bool
     {
         return (bool)count(
-            $this->find('all')
+            $this->unhydratedFind()
             ->select(['existing' => 1])
             ->where($conditions)
             ->limit(1)
-            ->disableHydration()
             ->toArray(),
         );
     }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -174,9 +174,8 @@ class TranslateBehaviorEavTest extends TestCase
         $entity = $table->newEntity(['author_id' => 2, 'title' => 'Title 4', 'body' => 'Body 4']);
         $table->save($entity);
 
-        $results = $table->find('all', locale: 'cze')
+        $results = $table->unhydratedFind('all', locale: 'cze')
             ->select(['id', 'title', 'body'])
-            ->disableHydration()
             ->orderByAsc('Articles.id')
             ->toArray();
         $expected = [


### PR DESCRIPTION
Psalm seems to have quite the track record for method signature mismatches.
https://github.com/vimeo/psalm/issues?q=is%3Aissue%20state%3Aopen%20trait%20MethodSignatureMismatch

So we'll just ignore them for now and re-evaluate later.

---

Our Testsuite found a few places where we still used the old `disableHydration()` method which are now fixed