### PR TITLE
Update PHP version requirement to <8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4.0,<9",
+        "php": ">=7.4.0,<8.4",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -679,7 +679,7 @@ class ViewTest extends TestCase
      */
     public function testElementPathEscape(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(MissingElementException::class);
         $this->expectExceptionMessage('it is not within any view template path.');
         $this->View->element('../../../check');
     }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -680,7 +680,7 @@ class ViewTest extends TestCase
     public function testElementPathEscape(): void
     {
         $this->expectException(MissingElementException::class);
-        $this->expectExceptionMessage('it is not within any view template path.');
+        $this->expectExceptionMessage('The following paths were searched');
         $this->View->element('../../../check');
     }
 


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/19504

diactoros 2.26's constraint ~8.0||~8.1||~8.2||~8.3

Given that we are not releasing a new minor 4.6 and that it is currently due to the unfortunate releasing of laminas not possible to pull needed dependencies on PHP 8.4+, it seems reasonable to communicate that as such.