### PR TITLE
Respect curl.cainfo php.ini setting in Curl adapter

### DIFF
--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -128,7 +128,11 @@ class Curl implements AdapterInterface
         }
 
         if (empty($options['ssl_cafile'])) {
-            $options['ssl_cafile'] = CaBundle::getBundledCaBundlePath();
+            // Respect an explicitly configured `curl.cainfo` (php.ini) before
+            // falling back to the CA bundle shipped with composer/ca-bundle.
+            // This lets enterprise/containerized environments that inject a
+            // custom CA via php.ini work without passing `ssl_cafile` per call.
+            $options['ssl_cafile'] = ini_get('curl.cainfo') ?: CaBundle::getBundledCaBundlePath();
         }
         if (!empty($options['ssl_verify_host'])) {
             // Value of 1 or true is deprecated. Only 2 or 0 should be used now.

--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -128,10 +128,7 @@ class Curl implements AdapterInterface
         }
 
         if (empty($options['ssl_cafile'])) {
-            // Respect an explicitly configured `curl.cainfo` (php.ini) before
-            // falling back to the CA bundle shipped with composer/ca-bundle.
-            // This lets enterprise/containerized environments that inject a
-            // custom CA via php.ini work without passing `ssl_cafile` per call.
+            // Respect a configured curl.cainfo (php.ini) before the bundled CA file.
             $options['ssl_cafile'] = ini_get('curl.cainfo') ?: CaBundle::getBundledCaBundlePath();
         }
         if (!empty($options['ssl_verify_host'])) {

--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -128,7 +128,6 @@ class Curl implements AdapterInterface
         }
 
         if (empty($options['ssl_cafile'])) {
-            // Respect a configured curl.cainfo (php.ini) before the bundled CA file.
             $options['ssl_cafile'] = ini_get('curl.cainfo') ?: CaBundle::getBundledCaBundlePath();
         }
         if (!empty($options['ssl_verify_host'])) {

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -43,7 +43,9 @@ class CurlTest extends TestCase
         $this->skipIf(!function_exists('curl_init'), 'Skipping as ext/curl is not installed.');
 
         $this->curl = new Curl();
-        $this->caFile = CaBundle::getBundledCaBundlePath();
+        // Mirror the adapter default: an explicit `curl.cainfo` (php.ini) wins,
+        // otherwise the bundled CA file is used.
+        $this->caFile = ini_get('curl.cainfo') ?: CaBundle::getBundledCaBundlePath();
     }
 
     /**
@@ -120,6 +122,21 @@ class CurlTest extends TestCase
             CURLOPT_CAINFO => $this->caFile,
         ];
         $this->assertSame($expected, $result);
+    }
+
+    /**
+     * An explicitly passed `ssl_cafile` must take precedence over both the
+     * `curl.cainfo` php.ini setting and the bundled CA file.
+     */
+    public function testBuildOptionsExplicitCafileWins(): void
+    {
+        $options = [
+            'ssl_cafile' => '/custom/ca-bundle.pem',
+        ];
+        $request = new Request('http://localhost/things', 'GET');
+        $result = $this->curl->buildOptions($request, $options);
+
+        $this->assertSame('/custom/ca-bundle.pem', $result[CURLOPT_CAINFO]);
     }
 
     /**


### PR DESCRIPTION
Fixes #19506.

When no `ssl_cafile` option is passed, `Curl::buildOptions()` hardcoded `CaBundle::getBundledCaBundlePath()` and ignored an explicitly configured `curl.cainfo` in php.ini. In enterprise/containerized environments that inject a custom CA globally (corporate proxies, internal CAs), this caused `cURL Error (60) SSL certificate problem` even though native `curl_exec()` on the same host succeeds.

### Change

- When `ssl_cafile` is not provided, prefer `ini_get('curl.cainfo')` and fall back to the bundled CA file when it is empty.
- An explicitly passed `ssl_cafile` option still takes highest priority.

Precedence: explicit `ssl_cafile` option > `curl.cainfo` (php.ini) > bundled composer/ca-bundle.

### Note on testing

`curl.cainfo` is `PHP_INI_SYSTEM`, so it cannot be toggled at runtime with `ini_set()` inside a test. The added `testBuildOptionsExplicitCafileWins` locks the option-precedence path; the existing `buildOptions` tests reference the same `ini_get('curl.cainfo') ?: <bundle>` default (mirrored in `setUp()`), so they stay correct on hosts where `curl.cainfo` is set.
