### PR TITLE
Strip CRLF from message headers in SmtpTransport

### DIFF
--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -557,16 +557,22 @@ class SmtpTransport extends AbstractTransport
     {
         $this->_smtpSend('DATA', '354');
 
-        $headers = $message->getHeadersString([
-            'from',
-            'sender',
-            'replyTo',
-            'readReceipt',
-            'to',
-            'cc',
-            'subject',
-            'returnPath',
-        ]);
+        $headers = $message->getHeadersString(
+            [
+                'from',
+                'sender',
+                'replyTo',
+                'readReceipt',
+                'to',
+                'cc',
+                'subject',
+                'returnPath',
+            ],
+            "\r\n",
+            function (string $val): string {
+                return str_replace("\r\n", '', $val);
+            },
+        );
         $message = $this->_prepareMessage($message);
 
         $this->_smtpSend($headers . "\r\n\r\n" . $message . "\r\n\r\n\r\n.");

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -114,4 +114,45 @@ class MailTransportTest extends TestCase
         $this->assertStringContainsString('Subject: ', $result['headers']);
         $this->assertStringContainsString('To: ', $result['headers']);
     }
+
+    /**
+     * test send strips crlf from headers
+     */
+    public function testSendHeadersStripCrlf(): void
+    {
+        $eol = "\r\n";
+        $date = date(DATE_RFC2822);
+
+        $message = new Message();
+        $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
+        $message->setTo('cake@cakephp.org', 'CakePHP');
+        $message->setSubject('injected headers');
+        $message->setMessageId('<abc0123@example.com>');
+
+        $message->setHeaders([
+            'X-inject' => "line one\r\nline two",
+        ]);
+        $message->setBody(['text' => "First Line\nSecond Line"]);
+
+        $data = "From: CakePHP Test <noreply@cakephp.org>{$eol}";
+        $data .= 'X-inject: line oneline two' . $eol;
+        $data .= 'Date: ' . $date . $eol;
+        $data .= 'Message-ID: <abc0123@example.com>' . $eol;
+        $data .= "MIME-Version: 1.0{$eol}";
+        $data .= "Content-Type: text/plain; charset=UTF-8{$eol}";
+        $data .= 'Content-Transfer-Encoding: 8bit';
+
+        $this->MailTransport->expects($this->once())->method('_mail')
+            ->with(
+                'CakePHP <cake@cakephp.org>',
+                'injected headers',
+                implode($eol, ['First Line', 'Second Line', '', '']),
+                $data,
+                '-f',
+            );
+
+        $result = $this->MailTransport->send($message);
+        $this->assertStringContainsString('Subject: ', $result['headers']);
+        $this->assertStringContainsString('To: ', $result['headers']);
+    }
 }

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -601,6 +601,52 @@ class SmtpTransportTest extends TestCase
     }
 
     /**
+     * test send strips crlf from headers
+     */
+    public function testSendHeadersStripCrlf(): void
+    {
+        $eol = "\r\n";
+        $date = date(DATE_RFC2822);
+
+        $message = new Message();
+        $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
+        $message->setTo('cake@cakephp.org', 'CakePHP');
+        $message->setSubject('injected headers');
+        $message->setMessageId('<abc0123@example.com>');
+
+        $message->setHeaders([
+            'X-inject' => "line one\r\nline two",
+        ]);
+        $message->setBody(['text' => 'oh no']);
+
+        $data = "From: CakePHP Test <noreply@cakephp.org>{$eol}";
+        $data .= 'To: CakePHP <cake@cakephp.org>' . $eol;
+        $data .= 'X-inject: line oneline two' . $eol;
+        $data .= 'Date: ' . $date . $eol;
+        $data .= 'Message-ID: <abc0123@example.com>' . $eol;
+        $data .= 'Subject: injected headers' . $eol;
+        $data .= "MIME-Version: 1.0{$eol}";
+        $data .= "Content-Type: text/plain; charset=UTF-8{$eol}";
+        $data .= 'Content-Transfer-Encoding: 8bit' . $eol;
+        $data .= "\r\n";
+        $data .= "oh no\r\n";
+        $data .= "\r\n\r\n";
+        $data .= "\r\n\r\n.\r\n";
+
+        $this->socket->shouldReceive('read')
+            ->andReturn(
+                "354 OK\r\n",
+                "250 OK\r\n",
+            )
+            ->twice();
+
+        $this->socket->shouldReceive('write')->with("DATA\r\n")->once();
+        $this->socket->shouldReceive('write')->with($data)->once();
+
+        $this->SmtpTransport->sendData($message);
+    }
+
+    /**
      * testQuit method
      */
     public function testQuit(): void


### PR DESCRIPTION
Strip CRLF bytes from message headers when delivering mail by SmtpTransport. This prevents header injection should userland code supply user data into messages headers. I've extended the test coverage for this scenario as well.

Thank you to Himanshu Anand for reporting this issue.