### PR TITLE
4.x - Strip CRLF from message headers in SmtpTransport

### DIFF
--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -544,16 +544,22 @@ class SmtpTransport extends AbstractTransport
     {
         $this->_smtpSend('DATA', '354');
 
-        $headers = $message->getHeadersString([
-            'from',
-            'sender',
-            'replyTo',
-            'readReceipt',
-            'to',
-            'cc',
-            'subject',
-            'returnPath',
-        ]);
+        $headers = $message->getHeadersString(
+            [
+                'from',
+                'sender',
+                'replyTo',
+                'readReceipt',
+                'to',
+                'cc',
+                'subject',
+                'returnPath',
+            ],
+            "\r\n",
+            function (string $val): string {
+                return str_replace("\r\n", '', $val);
+            },
+        );
         $message = $this->_prepareMessage($message);
 
         $this->_smtpSend($headers . "\r\n\r\n" . $message . "\r\n\r\n\r\n.");

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1456,7 +1456,7 @@ class View implements EventDispatcherInterface
         }
         $found = false;
         foreach ($this->_paths($plugin) as $path) {
-            if (str_starts_with($absolute, $path)) {
+            if (strpos($absolute, $path) === 0) {
                 $found = true;
                 break;
             }

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -111,4 +111,45 @@ class MailTransportTest extends TestCase
         $this->assertStringContainsString('Subject: ', $result['headers']);
         $this->assertStringContainsString('To: ', $result['headers']);
     }
+
+    /**
+     * test send strips crlf from headers
+     */
+    public function testSendHeadersStripCrlf(): void
+    {
+        $eol = "\r\n";
+        $date = date(DATE_RFC2822);
+
+        $message = new Message();
+        $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
+        $message->setTo('cake@cakephp.org', 'CakePHP');
+        $message->setSubject('injected headers');
+        $message->setMessageId('<abc0123@example.com>');
+
+        $message->setHeaders([
+            'X-inject' => "line one\r\nline two",
+        ]);
+        $message->setBody(['text' => "First Line\nSecond Line"]);
+
+        $data = "From: CakePHP Test <noreply@cakephp.org>{$eol}";
+        $data .= 'X-inject: line oneline two' . $eol;
+        $data .= 'Date: ' . $date . $eol;
+        $data .= 'Message-ID: <abc0123@example.com>' . $eol;
+        $data .= "MIME-Version: 1.0{$eol}";
+        $data .= "Content-Type: text/plain; charset=UTF-8{$eol}";
+        $data .= 'Content-Transfer-Encoding: 8bit';
+
+        $this->MailTransport->expects($this->once())->method('_mail')
+            ->with(
+                'CakePHP <cake@cakephp.org>',
+                'injected headers',
+                implode($eol, ['First Line', 'Second Line', '', '']),
+                $data,
+                '-f',
+            );
+
+        $result = $this->MailTransport->send($message);
+        $this->assertStringContainsString('Subject: ', $result['headers']);
+        $this->assertStringContainsString('To: ', $result['headers']);
+    }
 }

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -117,7 +117,7 @@ class MailTransportTest extends TestCase
      */
     public function testSendHeadersStripCrlf(): void
     {
-        $eol = "\r\n";
+        $eol = version_compare(PHP_VERSION, '8.0', '>=') ? "\r\n" : "\n";
         $date = date(DATE_RFC2822);
 
         $message = new Message();

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -680,6 +680,56 @@ class SmtpTransportTest extends TestCase
     }
 
     /**
+     * test send strips crlf from headers
+     */
+    public function testSendHeadersStripCrlf(): void
+    {
+        $eol = "\r\n";
+        $date = date(DATE_RFC2822);
+
+        $message = new Message();
+        $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
+        $message->setTo('cake@cakephp.org', 'CakePHP');
+        $message->setSubject('injected headers');
+        $message->setMessageId('<abc0123@example.com>');
+
+        $message->setHeaders([
+            'X-inject' => "line one\r\nline two",
+        ]);
+        $message->setBody(['text' => 'oh no']);
+
+        $data = "From: CakePHP Test <noreply@cakephp.org>{$eol}";
+        $data .= 'To: CakePHP <cake@cakephp.org>' . $eol;
+        $data .= 'X-inject: line oneline two' . $eol;
+        $data .= 'Date: ' . $date . $eol;
+        $data .= 'Message-ID: <abc0123@example.com>' . $eol;
+        $data .= 'Subject: injected headers' . $eol;
+        $data .= "MIME-Version: 1.0{$eol}";
+        $data .= "Content-Type: text/plain; charset=UTF-8{$eol}";
+        $data .= 'Content-Transfer-Encoding: 8bit' . $eol;
+        $data .= "\r\n";
+        $data .= "oh no\r\n";
+        $data .= "\r\n\r\n";
+        $data .= "\r\n\r\n.\r\n";
+
+        $this->socket->expects($this->any())
+            ->method('read')
+            ->will($this->onConsecutiveCalls(
+                "354 OK\r\n",
+                "250 OK\r\n",
+            ));
+
+        $this->socket->expects($this->exactly(2))
+            ->method('write')
+            ->withConsecutive(
+                ["DATA\r\n"],
+                [$data],
+            );
+
+        $this->SmtpTransport->sendData($message);
+    }
+
+    /**
      * testQuit method
      */
     public function testQuit(): void

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -679,8 +679,8 @@ class ViewTest extends TestCase
      */
     public function testElementPathEscape(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('it is not within any view template path.');
+        $this->expectException(MissingElementException::class);
+        $this->expectExceptionMessage('The following paths were searched');
         $this->View->element('../../../check');
     }
 


### PR DESCRIPTION
Strip CRLF bytes from message headers when delivering mail by SmtpTransport. This prevents header injection should userland code supply user data into messages headers.

Thank you to Himanshu Anand for reporting this issue.

Backport of #19512 to 4.x