### PR TITLE
Fix parameter handling in FunctionsBuilder

### DIFF
--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -23,7 +23,11 @@ use InvalidArgumentException;
 /**
  * Contains methods related to generating FunctionExpression objects
  * with most commonly used SQL functions.
+ *
  * This acts as a factory for FunctionExpression objects.
+ *
+ * Supplying user-controlled data to parameters with the `ExpressionInterface|string`
+ * type is **unsafe**. These parameters are included in the final query without escaping.
  */
 class FunctionsBuilder
 {
@@ -40,7 +44,7 @@ class FunctionsBuilder
     /**
      * Returns a AggregateExpression representing a call to SQL SUM function.
      *
-     * @param \Cake\Database\ExpressionInterface|string $expression the function argument
+     * @param \Cake\Database\ExpressionInterface|string $expression the expression for the sum() function.
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\AggregateExpression
      */
@@ -57,7 +61,7 @@ class FunctionsBuilder
     /**
      * Returns a AggregateExpression representing a call to SQL AVG function.
      *
-     * @param \Cake\Database\ExpressionInterface|string $expression the function argument
+     * @param \Cake\Database\ExpressionInterface|string $expression the expression for the avg() function.
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\AggregateExpression
      */
@@ -69,7 +73,7 @@ class FunctionsBuilder
     /**
      * Returns a AggregateExpression representing a call to SQL MAX function.
      *
-     * @param \Cake\Database\ExpressionInterface|string $expression the function argument
+     * @param \Cake\Database\ExpressionInterface|string $expression the expression for the max() function
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\AggregateExpression
      */
@@ -81,7 +85,7 @@ class FunctionsBuilder
     /**
      * Returns a AggregateExpression representing a call to SQL MIN function.
      *
-     * @param \Cake\Database\ExpressionInterface|string $expression the function argument
+     * @param \Cake\Database\ExpressionInterface|string $expression the expression for the min() function.
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\AggregateExpression
      */
@@ -93,7 +97,7 @@ class FunctionsBuilder
     /**
      * Returns a AggregateExpression representing a call to SQL COUNT function.
      *
-     * @param \Cake\Database\ExpressionInterface|string $expression the function argument
+     * @param \Cake\Database\ExpressionInterface|string $expression the expression for the count() function.
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\AggregateExpression
      */
@@ -133,11 +137,12 @@ class FunctionsBuilder
      * is the default type name. Use `setReturnType()` to update it.
      *
      * @param \Cake\Database\ExpressionInterface|string $field Field or expression to cast.
-     * @param string $dataType The SQL data type
+     * @param string $dataType The SQL data type. Must be a simple alphanumeric string.
      * @return \Cake\Database\Expression\FunctionExpression
      */
     public function cast(ExpressionInterface|string $field, string $dataType): FunctionExpression
     {
+        $this->ensureSimpleString('dataType', $dataType);
         $expression = new FunctionExpression('CAST', $this->toLiteralParam($field));
 
         return $expression->setConjunction(' AS')->add([$dataType => 'literal']);
@@ -159,7 +164,7 @@ class FunctionsBuilder
     /**
      * Returns the specified date part from the SQL expression.
      *
-     * @param string $part Part of the date to return.
+     * @param string $part Part of the date to return. Must be a simple alphanumeric string.
      * @param \Cake\Database\ExpressionInterface|string $expression Expression to obtain the date part from.
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
@@ -175,13 +180,14 @@ class FunctionsBuilder
     /**
      * Returns the specified date part from the SQL expression.
      *
-     * @param string $part Part of the date to return.
+     * @param string $part Part of the date to return. Must be a simple alphanumeric string.
      * @param \Cake\Database\ExpressionInterface|string $expression Expression to obtain the date part from.
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
     public function extract(string $part, ExpressionInterface|string $expression, array $types = []): FunctionExpression
     {
+        $this->ensureSimpleString('part', $part);
         $expression = new FunctionExpression('EXTRACT', $this->toLiteralParam($expression), $types, 'integer');
 
         return $expression->setConjunction(' FROM')->add([$part => 'literal'], [], true);
@@ -192,7 +198,7 @@ class FunctionsBuilder
      *
      * @param \Cake\Database\ExpressionInterface|string $expression Expression to obtain the date part from.
      * @param string|int $value Value to be added. Use negative to subtract.
-     * @param string $unit Unit of the value e.g. hour or day.
+     * @param string $unit Unit of the value e.g. hour or day. Must be a simple alphanumeric string.
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
@@ -205,6 +211,7 @@ class FunctionsBuilder
         if (!is_numeric($value)) {
             $value = 0;
         }
+        $this->ensureSimpleString('unit', $unit);
         $interval = $value . ' ' . $unit;
         $expression = new FunctionExpression('DATE_ADD', $this->toLiteralParam($expression), $types, 'datetime');
 
@@ -387,5 +394,20 @@ class FunctionsBuilder
         }
 
         return [$expression];
+    }
+
+    /**
+     * Ensures that string values are simple ascii values with no whitespace
+     *
+     * @param string $parameterName The name of the parameter being checked.
+     * @param string $value The value to check
+     * @return void
+     */
+    protected function ensureSimpleString(string $parameterName, string $value): void
+    {
+        if (preg_match('/^[a-zA-Z0-9]+$/', $value)) {
+            return;
+        }
+        throw new InvalidArgumentException("Argument `{$parameterName}` must be an alphanumeric string");
     }
 }

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -21,6 +21,8 @@ use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\FunctionsBuilder;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests FunctionsBuilder class
@@ -172,6 +174,26 @@ class FunctionsBuilderTest extends TestCase
         $this->assertSame('string', $function->getReturnType());
     }
 
+    public static function invalidValues(): array
+    {
+        return [
+            ['words with spaces'],
+            ["' drop table users --"],
+            [' word '],
+        ];
+    }
+
+    /**
+     * Ensure that only alphanumeric values are accepted for types.
+     */
+    #[DataProvider('invalidValues')]
+    public function testCastInvalidValue(string $type): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('`dataType` must be an alphanumeric string');
+        $this->functions->cast('field', $type);
+    }
+
     /**
      * Tests generating a NOW(), CURRENT_TIME() and CURRENT_DATE() function
      */
@@ -209,6 +231,22 @@ class FunctionsBuilderTest extends TestCase
         $this->assertSame('integer', $function->getReturnType());
     }
 
+    #[DataProvider('invalidValues')]
+    public function testExtractInvalidValue(string $part): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('`part` must be an alphanumeric string');
+        $this->functions->extract($part, 'created');
+    }
+
+    #[DataProvider('invalidValues')]
+    public function testDatePartInvalidValue(string $part): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('`part` must be an alphanumeric string');
+        $this->functions->datePart($part, 'created');
+    }
+
     /**
      * Tests generating a DATE_ADD() function
      */
@@ -222,6 +260,14 @@ class FunctionsBuilderTest extends TestCase
         $function = $this->functions->dateAdd(new IdentifierExpression('created'), -3, 'day');
         $this->assertInstanceOf(FunctionExpression::class, $function);
         $this->assertSame('DATE_ADD(created, INTERVAL -3 day)', $function->sql(new ValueBinder()));
+    }
+
+    #[DataProvider('invalidValues')]
+    public function testDateAddInvalidValue(string $unit): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('`unit` must be an alphanumeric string');
+        $this->functions->dateAdd('created', -3, $unit);
     }
 
     /**


### PR DESCRIPTION
Several methods did not explicity label their parameters as unsafe, so it is possible for an application developer to mistakenly supply user controlled data into these parameters creating a SQL injection vector.

Thank you to Himanshu Anand for reporting this issue.