### PR TITLE
Add maskRegex and maskPartialRegex

### DIFF
--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1279,4 +1279,99 @@ class Text
             return str_repeat($maskCharacter, mb_strlen($matches[0]));
         }, $string);
     }
+
+    /**
+     * Masks all occurrences of given regex pattern(s) within a string using a repeated character.
+     *
+     * Each occurrence of the provided pattern(s) will be replaced by a sequence of the masking character.
+     *
+     * @param string $string The input string.
+     * @param string[]|string $patterns One or more regex patterns
+     * @param string $maskCharacter Single masking character.
+     * @return string
+     */
+    public static function maskRegex(string $string, array|string $patterns, string $maskCharacter = '*'): string
+    {
+        if (!is_array($patterns)) {
+            $patterns = [$patterns];
+        }
+
+        $patterns = array_unique(array_filter($patterns, fn($n) => $n !== ''));
+
+        if ($string === '' || $patterns === []) {
+            return $string;
+        }
+
+        if (mb_strlen($maskCharacter) !== 1) {
+            throw new InvalidArgumentException('Mask character must be a single character.');
+        }
+
+        foreach ($patterns as $regex) {
+            $string = (string)preg_replace_callback($regex, function ($matches) use ($maskCharacter) {
+                return str_repeat($maskCharacter, mb_strlen($matches[0]));
+            }, $string);
+        }
+
+        return $string;
+    }
+
+    /**
+     * Masks occurrences of given regex pattern(s) within a string, optionally preserving leading/trailing characters of
+     * each match.
+     *
+     * Each occurrence of the provided pattern(s) will have its interior replaced by a sequence of the masking
+     * character, while the first $showLeading and last $showTrailing characters of the match are left unchanged. If
+     * $showLeading + $showTrailing >= match length, the match is returned as-is.
+     *
+     * Examples:
+     * - maskPartialRegex('Card used: 4242424242424242', '/\d{16}/', 0, 4) => Credit card used: ************4242
+     * - maskPartialRegex('Secret Codeword', '/\b\w+\b/', 1, 1) => S****t C********d
+     *
+     * @param string $string The input string.
+     * @param string[]|string $patterns One or more regex patterns.
+     * @param int $showLeading Number of leading characters of each match to leave unmasked.
+     * @param int $showTrailing Number of trailing characters of each match to leave unmasked.
+     * @param string $maskCharacter Single masking character.
+     * @throws \InvalidArgumentException If $maskCharacter is not exactly a single character.
+     * @return string
+     */
+    public static function maskPartialRegex(string $string, array|string $patterns, int $showLeading = 0, int $showTrailing = 0, string $maskCharacter = '*'): string
+    {
+        if (!is_array($patterns)) {
+            $patterns = [$patterns];
+        }
+
+        $patterns = array_unique(array_filter($patterns, fn($n) => $n !== ''));
+
+        if ($string === '' || $patterns === []) {
+            return $string;
+        }
+
+        if (mb_strlen($maskCharacter) !== 1) {
+            throw new InvalidArgumentException('Mask character must be a single character.');
+        }
+
+        if ($showLeading < 0 || $showTrailing < 0) {
+            throw new InvalidArgumentException('Leading and trailing character counts must be non-negative.');
+        }
+
+        foreach ($patterns as $regex) {
+            $string = (string)preg_replace_callback($regex, function ($matches) use ($maskCharacter, $showLeading, $showTrailing) {
+                $match = $matches[0];
+                $matchLen = mb_strlen($match);
+                $middleLen = $matchLen - $showLeading - $showTrailing;
+
+                if ($middleLen <= 0) {
+                    return $match;
+                }
+
+                $leading = $showLeading > 0 ? mb_substr($match, 0, $showLeading) : '';
+                $trailing = $showTrailing > 0 ? mb_substr($match, -$showTrailing) : '';
+
+                return $leading . str_repeat($maskCharacter, $middleLen) . $trailing;
+            }, $string);
+        }
+
+        return $string;
+    }
 }

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1335,7 +1335,7 @@ class Text
      * @param string $maskCharacter Single masking character.
      * @return string
      * @throws \InvalidArgumentException If $maskCharacter is not exactly a single character, or if $showLeading/$showTrailing are negative.
- */
+     */
     public static function maskPartialRegex(string $string, array|string $patterns, int $showLeading = 0, int $showTrailing = 0, string $maskCharacter = '*'): string
     {
         if (!is_array($patterns)) {

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1296,7 +1296,7 @@ class Text
             $patterns = [$patterns];
         }
 
-        $patterns = array_unique(array_filter($patterns, fn($n) => $n !== ''));
+        $patterns = array_unique(array_filter($patterns, fn(string $n) => $n !== ''));
 
         if ($string === '' || $patterns === []) {
             return $string;
@@ -1341,7 +1341,7 @@ class Text
             $patterns = [$patterns];
         }
 
-        $patterns = array_unique(array_filter($patterns, fn($n) => $n !== ''));
+        $patterns = array_unique(array_filter($patterns, fn(string $n) => $n !== ''));
 
         if ($string === '' || $patterns === []) {
             return $string;

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1333,9 +1333,9 @@ class Text
      * @param int $showLeading Number of leading characters of each match to leave unmasked.
      * @param int $showTrailing Number of trailing characters of each match to leave unmasked.
      * @param string $maskCharacter Single masking character.
-     * @throws \InvalidArgumentException If $maskCharacter is not exactly a single character.
      * @return string
-     */
+     * @throws \InvalidArgumentException If $maskCharacter is not exactly a single character, or if $showLeading/$showTrailing are negative.
+ */
     public static function maskPartialRegex(string $string, array|string $patterns, int $showLeading = 0, int $showTrailing = 0, string $maskCharacter = '*'): string
     {
         if (!is_array($patterns)) {

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1286,8 +1286,9 @@ class Text
      * Each occurrence of the provided pattern(s) will be replaced by a sequence of the masking character.
      *
      * @param string $string The input string.
-     * @param string[]|string $patterns One or more regex patterns
+     * @param string[]|string $patterns One or more regex patterns.
      * @param string $maskCharacter Single masking character.
+     * @throws \InvalidArgumentException If $maskCharacter is not exactly a single character.
      * @return string
      */
     public static function maskRegex(string $string, array|string $patterns, string $maskCharacter = '*'): string

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1325,8 +1325,8 @@ class Text
      * $showLeading + $showTrailing >= match length, the match is returned as-is.
      *
      * Examples:
-     * - maskPartialRegex('Card used: 4242424242424242', '/\d{16}/', 0, 4) => Credit card used: ************4242
-     * - maskPartialRegex('Secret Codeword', '/\b\w+\b/', 1, 1) => S****t C********d
+     * - maskPartialRegex('Card used: 4242424242424242', '/\d{16}/', 0, 4) => Card used: ************4242
+     * - maskPartialRegex('Secret Codeword', '/\b\w+\b/', 1, 1) => S****t C*******d
      *
      * @param string $string The input string.
      * @param string[]|string $patterns One or more regex patterns.

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -2061,4 +2061,141 @@ HTML;
         $this->expectException(InvalidArgumentException::class);
         Text::maskValue($string, $needles, $maskCharacter);
     }
+
+    /**
+     * Data provider for testMaskRegex()
+     *
+     * @return array<string, array>
+     */
+    public static function maskRegexProvider(): array
+    {
+        return [
+            'empty string' => ['', '/\d+/', '*', ''],
+            'empty pattern array' => ['hello', [], '*', 'hello'],
+            'empty pattern string' => ['hello', '', '*', 'hello'],
+            'no match' => ['hello world', '/\d+/', '*', 'hello world'],
+            'single match' => ['my pin is 1234', '/\d+/', '*', 'my pin is ****'],
+            'multiple matches' => ['a1 b22 c333', '/\d+/', '*', 'a* b** c***'],
+            'string pattern' => ['foo bar', '/\b\w+\b/', '*', '*** ***'],
+            'array of patterns applied sequentially' => ['hello 123 world', ['/\d+/', '/[a-z]+/'], '*', '***** *** *****'],
+            'custom mask character' => ['token: abc123', '/[a-z0-9]+/', 'x', 'xxxxx: xxxxxx'],
+            'multibyte string' => ['私は123です', '/\d+/', 'x', '私はxxxです'],
+            'multibyte mask character' => ['secret123', '/\d+/', 'ক', 'secretককক'],
+        ];
+    }
+
+    /**
+     * testMaskRegex method
+     *
+     * @param string $string Input string
+     * @param array|string $patterns Regex patterns
+     * @param string $maskCharacter Mask character
+     * @param string $expected Expected output
+     */
+    #[DataProvider('maskRegexProvider')]
+    public function testMaskRegex(string $string, array|string $patterns, string $maskCharacter, string $expected): void
+    {
+        $result = Text::maskRegex($string, $patterns, $maskCharacter);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider for testMaskRegexThrowsOnInvalidMaskCharacter()
+     *
+     * @return array<string, array>
+     */
+    public static function maskRegexInvalidCharacterProvider(): array
+    {
+        return [
+            'empty mask character' => ['hello', '/\w+/', ''],
+            'multi-character mask' => ['hello', '/\w+/', '**'],
+        ];
+    }
+
+    /**
+     * testMaskRegexThrowsOnInvalidMaskCharacter method
+     *
+     * @param string $string
+     * @param string $patterns
+     * @param string $maskCharacter
+     */
+    #[DataProvider('maskRegexInvalidCharacterProvider')]
+    public function testMaskRegexThrowsOnInvalidMaskCharacter(string $string, string $patterns, string $maskCharacter): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Text::maskRegex($string, $patterns, $maskCharacter);
+    }
+
+    /**
+     * Data provider for testMaskPartialRegex()
+     *
+     * @return array<string, array>
+     */
+    public static function maskPartialRegexProvider(): array
+    {
+        return [
+            'empty string' => ['', '/\d+/', 0, 0, '*', ''],
+            'empty pattern array' => ['secret', [], 0, 0, '*', 'secret'],
+            'empty pattern string' => ['secret', '', 0, 0, '*', 'secret'],
+            'no showLeading or showTrailing masks fully' => ['pin: 1234', '/\d+/', 0, 0, '*', 'pin: ****'],
+            'showLeading only' => ['card: 4242424242424242', '/\d{16}/', 2, 0, '*', 'card: 42**************'],
+            'showTrailing only' => ['card: 4242424242424242', '/\d{16}/', 0, 4, '*', 'card: ************4242'],
+            'showLeading and showTrailing' => ['Secret Codeword', '/\b\w+\b/', 1, 1, '*', 'S****t C******d'],
+            'showLeading + showTrailing equals match length' => ['ab', '/\w+/', 1, 1, '*', 'ab'],
+            'showLeading + showTrailing exceeds match length' => ['a', '/\w+/', 1, 1, '*', 'a'],
+            'multiple matches each partially masked' => ['hello world', '/\b\w+\b/', 2, 1, '*', 'he**o wo**d'],
+            'string pattern' => ['hello', '/\b\w+\b/', 1, 0, '*', 'h****'],
+            'array of patterns applied sequentially' => ['abc 123', ['/[a-z]+/', '/\d+/'], 1, 1, '*', 'a*c 1*3'],
+            'custom mask character' => ['secret', '/\w+/', 2, 1, '-', 'se---t'],
+            'multibyte string' => ['こんにちは', '/.+/u', 1, 1, '*', 'こ***は'],
+        ];
+    }
+
+    /**
+     * testMaskPartialRegex method
+     *
+     * @param string $string Input string
+     * @param array|string $patterns Regex patterns
+     * @param int $showLeading Number of leading chars to leave unmasked
+     * @param int $showTrailing Number of trailing chars to leave unmasked
+     * @param string $maskCharacter Mask character
+     * @param string $expected Expected output
+     */
+    #[DataProvider('maskPartialRegexProvider')]
+    public function testMaskPartialRegex(string $string, array|string $patterns, int $showLeading, int $showTrailing, string $maskCharacter, string $expected): void
+    {
+        $result = Text::maskPartialRegex($string, $patterns, $showLeading, $showTrailing, $maskCharacter);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider for testMaskPartialRegexThrowsOnInvalidInput()
+     *
+     * @return array<string, array>
+     */
+    public static function maskPartialRegexInvalidInputProvider(): array
+    {
+        return [
+            'empty mask character' => ['hello', '/\w+/', 0, 0, ''],
+            'multi-character mask' => ['hello', '/\w+/', 0, 0, '**'],
+            'negative showLeading' => ['hello', '/\w+/', -1, 0, '*'],
+            'negative showTrailing' => ['hello', '/\w+/', 0, -1, '*'],
+        ];
+    }
+
+    /**
+     * testMaskPartialRegexThrowsOnInvalidInput method
+     *
+     * @param string $string
+     * @param string $patterns
+     * @param int $showLeading
+     * @param int $showTrailing
+     * @param string $maskCharacter
+     */
+    #[DataProvider('maskPartialRegexInvalidInputProvider')]
+    public function testMaskPartialRegexThrowsOnInvalidInput(string $string, string $patterns, int $showLeading, int $showTrailing, string $maskCharacter): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Text::maskPartialRegex($string, $patterns, $showLeading, $showTrailing, $maskCharacter);
+    }
 }


### PR DESCRIPTION
Add `Text::maskRegex()` and `Text::maskPartialRegex()` static methods to `Cake\Utility\Text` for masking portions of strings by regex instead of by specific substrings.

See issue #19525 