### PR TITLE
Set default value for `exportMask` config of Debugger.

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -62,7 +62,15 @@ class Debugger
      * @var array<string, mixed>
      */
     protected array $_defaultConfig = [
-        'outputMask' => [],
+        'outputMask' => [
+            'password' => '********',
+            'login' => '********',
+            'host' => '********',
+            'database' => '********',
+            'port' => '********',
+            'prefix' => '********',
+            'schema' => '********',
+        ],
         'exportFormatter' => null,
         'editor' => 'phpstorm',
         'editorBasePath' => null,
@@ -661,7 +669,7 @@ class Debugger
     /**
      * Export an array type object. Filters out keys used in datasource configuration.
      *
-     * The following keys are replaced with ***'s
+     * By default the following keys are replaced with ***'s
      *
      * - password
      * - login

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -65,6 +65,9 @@ class DebuggerTest extends TestCase
         Log::drop('stderr');
         Log::drop('stdout');
         Debugger::configInstance('exportFormatter', TextFormatter::class);
+        // The instances need to be initialized for the tests to pass
+        Debugger::getInstance(TestDebugger::class);
+        Debugger::getInstance(Debugger::class);
     }
 
     /**
@@ -659,9 +662,14 @@ eos;
     public function testSetOutputMask(): void
     {
         Debugger::setOutputMask(['password' => '[**********]']);
-        $this->assertEquals(['password' => '[**********]'], Debugger::outputMask());
+        $result = Debugger::outputMask();
+        $this->assertEquals('[**********]', $result['password']);
+        $this->assertEquals('********', $result['login']);
+        $this->assertEquals('********', $result['host']);
         Debugger::setOutputMask(['serial' => 'XXXXXX']);
-        $this->assertEquals(['password' => '[**********]', 'serial' => 'XXXXXX'], Debugger::outputMask());
+        $result = Debugger::outputMask();
+        $this->assertEquals('[**********]', $result['password']);
+        $this->assertEquals('XXXXXX', $result['serial']);
         Debugger::setOutputMask([], false);
         $this->assertSame([], Debugger::outputMask());
     }
@@ -701,6 +709,71 @@ eos;
         $result = Debugger::exportVar($object);
         $expected = "object(TestApp\\Error\\Thing\\SecurityThing)id:0{password=>'[**********]'}";
         $this->assertSame($expected, preg_replace('/\s+/', '', $result));
+    }
+
+    /**
+     * Tests that default outputMask keys are masked by default.
+     */
+    public function testDefaultOutputMaskMasksPassword(): void
+    {
+        $result = Debugger::exportVar(['password' => 'supersecret']);
+        $this->assertStringContainsString('********', $result);
+        $this->assertStringNotContainsString('supersecret', $result);
+    }
+
+    /**
+     * Tests that all default outputMask keys are present.
+     */
+    public function testDefaultOutputMaskContainsAllKeys(): void
+    {
+        $mask = Debugger::outputMask();
+        $this->assertArrayHasKey('password', $mask);
+        $this->assertArrayHasKey('login', $mask);
+        $this->assertArrayHasKey('host', $mask);
+        $this->assertArrayHasKey('database', $mask);
+        $this->assertArrayHasKey('port', $mask);
+        $this->assertArrayHasKey('prefix', $mask);
+        $this->assertArrayHasKey('schema', $mask);
+        $this->assertSame('********', $mask['password']);
+        $this->assertSame('********', $mask['login']);
+        $this->assertSame('********', $mask['host']);
+        $this->assertSame('********', $mask['database']);
+        $this->assertSame('********', $mask['port']);
+        $this->assertSame('********', $mask['prefix']);
+        $this->assertSame('********', $mask['schema']);
+    }
+
+    /**
+     * Tests that custom masks merge with defaults.
+     */
+    public function testCustomMaskMergesWithDefaults(): void
+    {
+        Debugger::setOutputMask(['api_key' => 'SECRET']);
+        $mask = Debugger::outputMask();
+        $this->assertSame('SECRET', $mask['api_key']);
+        $this->assertSame('********', $mask['password']);
+        $this->assertSame('********', $mask['host']);
+    }
+
+    /**
+     * Tests that non-default array keys are not masked.
+     */
+    public function testNonDefaultKeysAreNotMasked(): void
+    {
+        $result = Debugger::exportVar(['username' => 'admin', 'email' => 'test@example.com']);
+        $this->assertStringContainsString('admin', $result);
+        $this->assertStringContainsString('test@example.com', $result);
+    }
+
+    /**
+     * Tests that default mask works on object properties.
+     */
+    public function testDefaultMaskOnObjectProperties(): void
+    {
+        $object = new SecurityThing();
+        $result = Debugger::exportVar($object);
+        $this->assertStringContainsString('********', $result);
+        $this->assertStringNotContainsString('pass1234', $result);
     }
 
     /**


### PR DESCRIPTION
This makes the code now match the docblock of Debugger::exportArray() which states that values for keys like login, password etc. are replaced by ***s

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
