### PR TITLE
Fix assertLogMessageContains() to support partial matches

### DIFF
--- a/src/TestSuite/LogTestTrait.php
+++ b/src/TestSuite/LogTestTrait.php
@@ -153,7 +153,10 @@ trait LogTestTrait
                     continue;
                 }
                 $loggedMessage = substr($message, strlen($levelPrefix));
-                if ($contains ? str_contains($loggedMessage, $expectedMessage) : $loggedMessage === $expectedMessage) {
+                $matches = $contains
+                    ? str_contains($loggedMessage, $expectedMessage)
+                    : $loggedMessage === $expectedMessage;
+                if ($matches) {
                     $messageFound = true;
                     break;
                 }

--- a/src/TestSuite/LogTestTrait.php
+++ b/src/TestSuite/LogTestTrait.php
@@ -136,7 +136,7 @@ trait LogTestTrait
         bool $contains = false,
     ): void {
         $messageFound = false;
-        $expectedMessage = sprintf('%s: %s', $level, $expectedMessage);
+        $levelPrefix = $level . ': ';
         foreach (Log::configured() as $engineName) {
             $engineObj = Log::engine($engineName);
             if (!$engineObj instanceof ArrayLog) {
@@ -149,14 +149,18 @@ trait LogTestTrait
                 continue;
             }
             foreach ($messages as $message) {
-                if ($contains && str_contains($message, $expectedMessage) || $message === $expectedMessage) {
+                if (!str_starts_with($message, $levelPrefix)) {
+                    continue;
+                }
+                $loggedMessage = substr($message, strlen($levelPrefix));
+                if ($contains ? str_contains($loggedMessage, $expectedMessage) : $loggedMessage === $expectedMessage) {
                     $messageFound = true;
                     break;
                 }
             }
         }
         if (!$messageFound) {
-            $failMsg = "Could not find the message `{$expectedMessage}` in logs. " . $failMsg;
+            $failMsg = "Could not find the message `{$expectedMessage}` for level `{$level}` in logs. " . $failMsg;
             $this->fail($failMsg);
         }
         $this->assertTrue(true);

--- a/tests/TestCase/TestSuite/LogTestTraitTest.php
+++ b/tests/TestCase/TestSuite/LogTestTraitTest.php
@@ -95,12 +95,47 @@ class LogTestTraitTest extends TestCase
     }
 
     /**
+     * Test expecting log messages contains with a partial match in the middle of the message
+     */
+    public function testExpectLogContainsPartial(): void
+    {
+        $this->setupLog('error');
+        Log::error('This message contains 42, which is the only relevant value to the test.');
+        $this->assertLogMessageContains('error', '42');
+        $this->assertLogMessageContains('error', 'relevant value to the test.');
+    }
+
+    /**
+     * Test that partial matches still require the expected level
+     */
+    public function testExpectLogContainsWrongLevelFails(): void
+    {
+        $this->setupLog(['debug', 'error']);
+        Log::error('This message contains 42.');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->assertLogMessageContains('debug', '42');
+    }
+
+    /**
+     * Test that the expected message does not match inside the level prefix
+     */
+    public function testExpectLogContainsDoesNotMatchLevelPrefix(): void
+    {
+        $this->setupLog('error');
+        Log::error('Some message');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->assertLogMessageContains('error', 'error');
+    }
+
+    /**
      * Test expecting log message without setup
      */
     public function testExpectLogWithoutSetup(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Could not find the message `debug: ` in logs.');
+        $this->expectExceptionMessage('Could not find the message `` for level `debug` in logs.');
         $this->assertLogMessage('debug', '');
     }
 


### PR DESCRIPTION
Fixes #19533

`LogTestTrait::_expectLogMessage()` prepended the level prefix to the expected message before the `str_contains()` check, so `assertLogMessageContains('error', '42')` compared:

```php
str_contains(
    'error: This message contains 42, which is the only relevant value to the test.',
    'error: 42'
)
```

Partial matches therefore only worked when the expected string happened to sit at the very start of the logged message.

Now the level prefix is validated separately (message must start with `level: `) and stripped before comparing against the actual logged message, for both exact and partial matching. This also prevents the expected string from accidentally matching inside the level prefix itself.

The failure message now reports the level and the expected message separately instead of the misleading concatenated form.
