### PR TITLE
Handle %2f in routing more consistently

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -22,6 +22,7 @@ use Cake\Http\Exception\BadRequestException;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
 use UnitEnum;
+use function Cake\Routing\urldecode_segments;
 
 /**
  * A single Route used by the Router to connect requests to
@@ -468,8 +469,8 @@ class Route
         [$url, $ext] = $this->_parseExtension($url);
 
         $urldecode = $this->options['_urldecode'] ?? true;
-        if ($urldecode) {
-            $url = urldecode($url);
+        if ($urldecode && str_contains($url, '%')) {
+            $url = urldecode_segments($url);
         }
 
         if (!preg_match($compiledRoute, $url, $route)) {

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -22,7 +22,7 @@ use Cake\Http\Exception\BadRequestException;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
 use UnitEnum;
-use function Cake\Routing\urldecode_segments;
+use function Cake\Routing\urldecodeSegments;
 
 /**
  * A single Route used by the Router to connect requests to
@@ -470,7 +470,7 @@ class Route
 
         $urldecode = $this->options['_urldecode'] ?? true;
         if ($urldecode && str_contains($url, '%')) {
-            $url = urldecode_segments($url);
+            $url = urldecodeSegments($url);
         }
 
         if (!preg_match($compiledRoute, $url, $route)) {

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -136,15 +136,10 @@ class RouteCollection
     public function parseRequest(ServerRequestInterface $request): array
     {
         $uri = $request->getUri();
+
         $urlPath = $uri->getPath();
         if (str_contains($urlPath, '%')) {
-            // decode urlencoded segments, but don't decode %2f aka /
-            $parts = explode('/', $urlPath);
-            $parts = array_map(
-                fn(string $part) => str_replace('/', '%2f', urldecode($part)),
-                $parts,
-            );
-            $urlPath = implode('/', $parts);
+            $urlPath = urldecode_segments($urlPath);
         }
         if ($urlPath !== '/') {
             $urlPath = rtrim($urlPath, '/');

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -139,7 +139,7 @@ class RouteCollection
 
         $urlPath = $uri->getPath();
         if (str_contains($urlPath, '%')) {
-            $urlPath = urldecode_segments($urlPath);
+            $urlPath = urldecodeSegments($urlPath);
         }
         if ($urlPath !== '/') {
             $urlPath = rtrim($urlPath, '/');

--- a/src/Routing/functions.php
+++ b/src/Routing/functions.php
@@ -57,3 +57,20 @@ function url(UriInterface|array|string|null $url = null, bool $full = false): st
 {
     return Router::url($url, $full);
 }
+
+/**
+ * urldecode all of the segments in a path, but skip over %2f
+ * because applications can use %2f in a segment.
+ *
+ * @internal
+ */
+function urldecode_segments(string $url): string
+{
+    $parts = explode('/', $url);
+    $parts = array_map(
+        fn(string $part) => str_replace('/', '%2f', urldecode($part)),
+        $parts,
+    );
+
+    return implode('/', $parts);
+}

--- a/src/Routing/functions.php
+++ b/src/Routing/functions.php
@@ -64,7 +64,7 @@ function url(UriInterface|array|string|null $url = null, bool $full = false): st
  *
  * @internal
  */
-function urldecode_segments(string $url): string
+function urldecodeSegments(string $url): string
 {
     $parts = explode('/', $url);
     $parts = array_map(

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1182,6 +1182,28 @@ class RouteTest extends TestCase
     }
 
     /**
+     * Test that segments are urldecoded into parsed route, but not %2f
+     * as applications use %2f for encoded data that path prefix matching
+     * doesn't treat as /
+     */
+    public function testParseUrlDecodeButNot2f(): void
+    {
+        $route = new Route(
+            '/{controller}/{slug}',
+            ['action' => 'view'],
+        );
+        $route->compile();
+        $result = $route->parse('/posts/foo', 'GET');
+        $this->assertSame('foo', $result['slug']);
+
+        $result = $route->parse('/posts/foo%20bar', 'GET');
+        $this->assertSame('foo bar', $result['slug']);
+
+        $result = $route->parse('/posts%2ffoo', 'GET');
+        $this->assertNull($result, 'encoded / should not count as real / ');
+    }
+
+    /**
      * Test numerically indexed defaults, get appended to pass
      */
     public function testParseWithPassDefaults(): void

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Routing;
 use BadMethodCallException;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Core\Plugin;
+use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Route\InflectedRoute;
 use Cake\Routing\Route\RedirectRoute;
@@ -957,7 +958,7 @@ class RouteBuilderTest extends TestCase
     /**
      * Test using name prefixes.
      */
-    public function testNamePrefixes(): void
+    public function testScopeNamePrefixes(): void
     {
         $routes = new RouteBuilder($this->collection, '/api', [], ['namePrefix' => 'api:']);
         $routes->scope('/v1', ['version' => 1, '_namePrefix' => 'v1:'], function (RouteBuilder $routes): void {
@@ -971,6 +972,41 @@ class RouteBuilderTest extends TestCase
         $all = $this->collection->named();
         $this->assertArrayHasKey('api:v1:ping', $all);
         $this->assertArrayHasKey('web:pong', $all);
+    }
+
+    /**
+     * Test that if an application has scoped middleware on a path prefix,
+     * and fallback routes, that URL decoding in Route::parse() would
+     * decode the %2f that was not accepted in the scope path prefix check.
+     */
+    public function testScopeMiddlewarePathMatch(): void
+    {
+        $gate = function () {
+            return new Response(['body' => 'no', 'status' => 403]);
+        };
+
+        $routes = new RouteBuilder($this->collection, '/');
+        $routes->registerMiddleware('gate', $gate);
+        $routes->scope('/admin', function (RouteBuilder $routes): void {
+            $routes->applyMiddleware('gate');
+            $routes->connect('/secret', ['controller' => 'Admin', 'action' => 'secret']);
+        });
+        $routes->fallbacks(DashedRoute::class);
+
+        // No encoded / is a standard request.
+        $result = $this->collection->parseRequest(new ServerRequest([
+            'url' => '/admin/secret',
+        ]));
+        $this->assertEquals(['gate'], $result['_route']->getMiddleware());
+        $this->assertEquals('/admin/secret', $result['_route']->template);
+
+        // Encoded / will not match path prefix. It will match /controller though
+        $result = $this->collection->parseRequest(new ServerRequest([
+            'url' => '/admin%2Fsecret',
+        ]));
+        $this->assertEquals('/{controller}', $result['_route']->template);
+        $this->assertEquals('Admin%2fsecret', $result['controller']);
+        $this->assertEquals('index', $result['action']);
     }
 
     /**


### PR DESCRIPTION
Currently path prefix matching does not treat %2f as /, and `Route` has an option for it. In the past we've made changes in this area (#18050, #16110) to make urldecoding optional, and to intentionally decode urlencoding in path segments to support non-ascii applications.

We got a report on the security list for a potential issue where *if* an application enforced authorization within path prefixed scopes, and had fallback routes enabled, then one could potentially bypass the scoped middleware and hit the fallback routes which inconsistently handle %2f.

These changes align the behavior of urldecoding between RouteCollection and Route with a new shared internal function. I thought a function was better than exposing a static method on a public class.

Thanks to Rotem Reiss for reporting this issue.