### PR TITLE
Keep the ORDER BY intact when building a subquery strategy filter

### DIFF
--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -463,10 +463,15 @@ class SelectLoader
         $order = $query->clause('order');
         if ($order) {
             $columns = $query->clause('select');
-            $order->iterateParts(function ($direction, $field) use (&$fields, $columns): void {
+            // iterateParts() rebuilds the expression from the callback's return value, so each part
+            // has to be handed back. Returning nothing would strip the ORDER BY from $query itself,
+            // which is the caller's query, not a clone of it.
+            $order->iterateParts(function ($direction, $field) use (&$fields, $columns) {
                 if (isset($columns[$field])) {
                     $fields[$field] = $columns[$field];
                 }
+
+                return $direction;
             });
         }
 

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -1896,7 +1896,7 @@ class QueryRegressionTest extends TestCase
             ->toArray();
 
         $this->assertCount(2, $results);
-        $this->assertSame([4, 3], array_map(fn (EntityInterface $author) => $author->id, $results));
+        $this->assertSame([4, 3], array_map(fn(EntityInterface $author) => $author->id, $results));
 
         // Second hasMany in the contain list: empty before the fix.
         $this->assertCount(1, $results[0]->comments);

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -1896,7 +1896,7 @@ class QueryRegressionTest extends TestCase
             ->toArray();
 
         $this->assertCount(2, $results);
-        $this->assertSame([4, 3], array_map(fn ($author) => $author->id, $results));
+        $this->assertSame([4, 3], array_map(fn (EntityInterface $author) => $author->id, $results));
 
         // Second hasMany in the contain list: empty before the fix.
         $this->assertCount(1, $results[0]->comments);

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -23,6 +23,7 @@ use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\I18n\DateTime;
+use Cake\ORM\Association;
 use Cake\ORM\Entity;
 use Cake\ORM\Query\SelectQuery;
 use Cake\TestSuite\TestCase;
@@ -1848,5 +1849,63 @@ class QueryRegressionTest extends TestCase
         $this->assertCount(1, $result);
         $this->assertEquals('First Article', $result[0]->title);
         $this->assertNotEmpty($result[0]->user);
+    }
+
+    /**
+     * The subquery strategy must not strip the ORDER BY from the query it is given.
+     *
+     * The loader for the first association would otherwise leave the caller's query without an
+     * ORDER BY, so every subsequent loader builds its filtering subquery unordered, pages on the
+     * wrong rows and returns no results at all.
+     */
+    public function testSubqueryStrategyDoesNotMutateOrder(): void
+    {
+        $authors = $this->getTableLocator()->get('Authors');
+        $authors->hasMany('Articles', ['strategy' => Association::STRATEGY_SUBQUERY]);
+
+        $query = $authors->find()
+            ->contain(['Articles'])
+            ->orderBy(['Authors.id' => 'DESC'])
+            ->limit(2);
+
+        $this->assertCount(1, $query->clause('order'));
+        $query->all()->toArray();
+        $this->assertCount(1, $query->clause('order'), 'The ORDER BY was removed from the query.');
+    }
+
+    /**
+     * Every hasMany in the contain list must be loaded, not just the first one.
+     *
+     * Ordering by id DESC with a limit of 2 pages onto authors 4 and 3. An unordered subquery
+     * would instead filter on authors 1 and 2, so author 4's comment goes missing.
+     */
+    public function testSubqueryStrategyWithMultipleHasMany(): void
+    {
+        $authors = $this->getTableLocator()->get('Authors');
+        $authors->hasMany('Articles', ['strategy' => Association::STRATEGY_SUBQUERY]);
+        $authors->hasMany('Comments', [
+            'foreignKey' => 'user_id',
+            'strategy' => Association::STRATEGY_SUBQUERY,
+        ]);
+
+        $results = $this->getTableLocator()->get('Authors')->find()
+            ->contain(['Articles', 'Comments'])
+            ->orderBy(['Authors.id' => 'DESC'])
+            ->limit(2)
+            ->all()
+            ->toArray();
+
+        $this->assertCount(2, $results);
+        $this->assertSame([4, 3], array_map(fn ($author) => $author->id, $results));
+
+        // Second hasMany in the contain list: empty before the fix.
+        $this->assertCount(1, $results[0]->comments);
+        $this->assertSame(4, $results[0]->comments[0]->user_id);
+        $this->assertEmpty($results[0]->articles);
+
+        // First hasMany in the contain list: loaded correctly either way.
+        $this->assertCount(1, $results[1]->articles);
+        $this->assertSame('Second Article', $results[1]->articles[0]->title);
+        $this->assertEmpty($results[1]->comments);
     }
 }


### PR DESCRIPTION
_subqueryFields() collects the ORDER BY fields through iterateParts(), which rebuilds the expression from whatever the callback returns. The callback returned nothing, so every part was dropped - and since it runs against the caller's query rather than a clone, the query itself was left without an ORDER BY.

The loader of the first contained association therefore stripped the order, and every following association built its filtering subquery unordered. With a limit in place those subqueries paged onto the wrong rows, so any hasMany after the first one silently returned no results at all.

### The bug

On a query with both an `ORDER BY` and a `LIMIT` (i.e. any paginated query) that contains
two or more `hasMany` associations, the **second and later ones come back empty** — silently,
no error, even though the rows are there.

```php
$query = $articles->find()
    ->contain(['Comments', 'Attachments'])   // both hasMany
    ->orderBy(['published' => 'DESC'])
    ->limit(3);

foreach ($query->all() as $article) {
    count($article->comments);      // correct
    count($article->attachments);   // 0 — but the rows exist
}
```

Swapping the contain order moves the breakage to the other association.

### Why

`_subqueryFields()` collects the ordered fields through `iterateParts()`, which rebuilds the
expression from whatever the callback returns. The callback was typed `: void`, so it returned
`null` for every part and the parts were all dropped. It runs against the **caller's** query, not
a clone of it, so the query is left without an `ORDER BY`:

```php
$q = $articles->find()->contain(['Comments'])->orderBy(['published' => 'DESC'])->limit(3);
$q->clause('order')->count();   // 1
$q->all();
$q->clause('order')->count();   // 0  <-- gone
```

`_buildSubquery()` clones the query before calling `_subqueryFields()`, so the first
association's loader still gets its order — it is every *subsequent* loader, cloning the
now-orderless query, that builds an unordered filtering subquery. With a `LIMIT` in place those
subqueries page onto the wrong parent rows, which do not overlap the rows actually being
hydrated, so the association resolves to nothing:

```sql
-- 1st hasMany loader
... INNER JOIN (SELECT Articles.id FROM articles Articles GROUP BY Articles.id ORDER BY published DESC LIMIT 3) ...
-- 2nd hasMany loader: no ORDER BY -> wrong three rows
... INNER JOIN (SELECT Articles.id FROM articles Articles GROUP BY Articles.id LIMIT 3) ...
```

The mutation itself is old (present since at least 4.5) but was harmless while `hasMany`
defaulted to `select` and `_buildSubquery()` discarded the order anyway. Two changes on `5.next`
made it reachable: `HasMany::$_strategy` now defaults to `STRATEGY_SUBQUERY`, and
`_buildSubquery()` now preserves `LIMIT` + `ORDER BY` together, so the subquery genuinely depends
on that order still being present. `BelongsToMany` defaults to the subquery strategy too, so a
contained `belongsToMany` participates in the same way.

Worth noting it is invisible whenever the result set fits on a single page (an unordered
`LIMIT n` over `<= n` rows still returns every row), so it tends to survive development and only
surfaces on production-sized data.

### The fix

Hand each part back, so collecting the fields stops being destructive.


