### PR TITLE
add command instances to the event manager by default

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -26,6 +26,7 @@ use Cake\Core\ContainerApplicationInterface;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
+use Cake\Event\EventListenerInterface;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerInterface;
 use Cake\Routing\Router;
@@ -440,6 +441,9 @@ class CommandRunner implements EventDispatcherInterface
     protected function runCommand(CommandInterface $command, array $argv, ConsoleIo $io): ?int
     {
         try {
+            if ($command instanceof EventListenerInterface) {
+                $this->getEventManager()->on($command);
+            }
             if ($command instanceof EventDispatcherInterface) {
                 $command->setEventManager($this->getEventManager());
             }

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -33,6 +33,7 @@ use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
 use Cake\Core\ConsoleHelpHeaderProviderInterface;
 use Cake\Event\Event;
+use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerInterface;
 use Cake\Http\BaseApplication;
@@ -592,6 +593,43 @@ class CommandRunnerTest extends TestCase
         $runner->run(['cake', '--version'], $this->getMockIo($output));
         $this->assertTrue($startedEventTriggered, 'Should have triggered Command.started event.');
         $this->assertTrue($finishedEventTriggered, 'Should have triggered Command.finished event.');
+    }
+
+    /**
+     * Test that run() invokes the command class' lifecycle hook methods.
+     */
+    public function testRunInvokesCommandLifecycleHooks(): void
+    {
+        $command = new class extends Command {
+            public function beforeExecute(EventInterface $event, Arguments $args, ConsoleIo $io): void
+            {
+                $io->out('beforeExecute run');
+            }
+
+            public function execute(Arguments $args, ConsoleIo $io): int
+            {
+                $io->out('execute run');
+
+                return static::CODE_SUCCESS;
+            }
+
+            public function afterExecute(EventInterface $event, Arguments $args, ConsoleIo $io, ?int $result): void
+            {
+                $io->out('afterExecute run');
+            }
+        };
+
+        $output = new StubConsoleOutput();
+        $app = $this->makeAppWithCommands(['lifecycle' => $command]);
+        $runner = new CommandRunner($app, 'cake');
+        $result = $runner->run(['cake', 'lifecycle'], $this->getMockIo($output));
+
+        $this->assertSame(CommandInterface::CODE_SUCCESS, $result);
+        $this->assertSame([
+            'beforeExecute run',
+            'execute run',
+            'afterExecute run',
+        ], $output->messages());
     }
 
     /**


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/pull/18899

Since 5.0 commands have their own lifecycle hooks, but they were only accessible if users either register a event listener globally like it is explained [here](https://book.cakephp.org/5.x/core-libraries/events.html#command-beforeexecute-command-afterexecute) or of the class is manually registered in the events manager like so
```
public function events(EventManagerInterface $eventManager): EventManagerInterface
{
    $eventManager->on(new LiveCycleCommand());

    return $eventManager;
}
```

This PR adds commands automatically to the events manager which makes the hooks inside the command class automatically usable.