### PR TITLE
Narrow ValidationSet callable types to Closure

### DIFF
--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -19,6 +19,7 @@ namespace Cake\Validation;
 use ArrayAccess;
 use ArrayIterator;
 use Cake\Core\Exception\CakeException;
+use Closure;
 use Countable;
 use IteratorAggregate;
 use Traversable;
@@ -42,23 +43,23 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Denotes whether the field name key must be present in data array
      *
-     * @var callable|string|bool
+     * @var \Closure|string|bool
      */
-    protected $validatePresent = false;
+    protected Closure|string|bool $validatePresent = false;
 
     /**
      * Denotes if a field is allowed to be empty
      *
-     * @var callable|string|bool
+     * @var \Closure|string|bool
      */
-    protected $allowEmpty = false;
+    protected Closure|string|bool $allowEmpty = false;
 
     /**
      * Returns whether a field can be left out.
      *
-     * @return callable|string|bool
+     * @return \Closure|string|bool
      */
-    public function isPresenceRequired(): callable|string|bool
+    public function isPresenceRequired(): Closure|string|bool
     {
         return $this->validatePresent;
     }
@@ -66,10 +67,10 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Sets whether a field is required to be present in data array.
      *
-     * @param callable|string|bool $validatePresent Valid values are true, false, 'create', 'update' or a callable.
+     * @param \Closure|string|bool $validatePresent Valid values are true, false, 'create', 'update' or a Closure.
      * @return $this
      */
-    public function requirePresence(callable|string|bool $validatePresent): static
+    public function requirePresence(Closure|string|bool $validatePresent): static
     {
         $this->validatePresent = $validatePresent;
 
@@ -79,9 +80,9 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Returns whether a field can be left empty.
      *
-     * @return callable|string|bool
+     * @return \Closure|string|bool
      */
-    public function isEmptyAllowed(): callable|string|bool
+    public function isEmptyAllowed(): Closure|string|bool
     {
         return $this->allowEmpty;
     }
@@ -89,11 +90,11 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Sets whether a field value is allowed to be empty.
      *
-     * @param callable|string|bool $allowEmpty Valid values are true, false,
-     * 'create', 'update' or a callable.
+     * @param \Closure|string|bool $allowEmpty Valid values are true, false,
+     * 'create', 'update' or a Closure.
      * @return $this
      */
-    public function allowEmpty(callable|string|bool $allowEmpty): static
+    public function allowEmpty(Closure|string|bool $allowEmpty): static
     {
         $this->allowEmpty = $allowEmpty;
 


### PR DESCRIPTION
Aligns `ValidationSet` with `Validator` on the type of the empty/presence "when" value.

## Background

Reported in cakephp/cakephp#19541: `Validator::allowEmptyFor()` (and the whole `allowEmpty*` / `notEmpty*` / `requirePresence` surface) types the `$when` / `$mode` argument as `Closure|string|bool`, but `ValidationSet::allowEmpty()` / `requirePresence()` still type it as `callable|string|bool`. `Validator` was migrated to `Closure` in 5.0; `ValidationSet` was the last class that kept the old `callable` type, so the two disagreed.

The mismatch was harmless at runtime (`Closure` is a `callable`, and `Validator` only ever hands `ValidationSet` a `Closure`), but the inconsistency is real and worth closing. Since narrowing a public parameter type is a BC break, this targets `6.x` rather than `5.next`.

## Changes

- `ValidationSet::allowEmpty()` / `requirePresence()` params narrowed to `Closure|string|bool`.
- `isEmptyAllowed()` / `isPresenceRequired()` return types narrowed to `Closure|string|bool`.
- Backing `$allowEmpty` / `$validatePresent` properties narrowed and given native type hints (now expressible as a property type).

## Backwards compatibility

Breaking for a major: external callers passing an array or string callable directly into `ValidationSet::allowEmpty()` / `requirePresence()` must switch to first-class callable syntax `$this->method(...)` or `Closure::fromCallable(...)`. No framework call site is affected. A note for the 6.x migration guide (cakephp/docs) is a follow-up.

Fixes #19541
