### PR TITLE
add a safety step before releasing to check obvious PHP syntax problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,9 @@ help:
 	@echo "test"
 	@echo "  Run the tests for CakePHP."
 	@echo ""
+	@echo "lint-src"
+	@echo "  Run php -l against every PHP file in src/."
+	@echo ""
 	@echo "All other tasks are not intended to be run directly."
 .PHONY: help
 
@@ -64,6 +67,10 @@ help:
 test: install
 	vendor/bin/phpunit
 .PHONY: test
+
+lint-src:
+	@contrib/lint-php-src src
+.PHONY: lint-src
 
 
 # Utility target for checking required parameters
@@ -199,5 +206,5 @@ clean-component-%:
 .PHONY: components-clean
 
 # Top level alias for doing a release.
-release: guard-VERSION tag-release components-tag package publish
+release: guard-VERSION lint-src tag-release components-tag package publish
 .PHONY: release

--- a/contrib/lint-php-src
+++ b/contrib/lint-php-src
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -u
+
+target="${1:-src}"
+php_bin="${PHP_BIN:-php}"
+
+if [[ ! -d "$target" ]]; then
+	echo "PHP syntax check target does not exist: $target"
+	exit 1
+fi
+
+if ! php_version="$("$php_bin" -r 'echo PHP_VERSION;' 2>/dev/null)"; then
+	echo "Could not determine PHP version using $php_bin."
+	exit 1
+fi
+
+echo "Checking PHP syntax in $target/ with PHP $php_version"
+
+while IFS= read -r -d '' file; do
+	if ! output="$("$php_bin" -l "$file" 2>&1)"; then
+		echo "$output"
+		echo "Fix the errors above before continuing."
+		exit 1
+	fi
+done < <(find "$target" -type f -name '*.php' -print0)
+
+echo "No obvious PHP errors found"


### PR DESCRIPTION
Since the last CakePHP 5.1 had a PHP syntax error in there for some weird reason this adds a safety step in the Makefile to check for obvious PHP syntax.

Output will look like this if errors are found.

```
kevin•CakePHP/Org/cakephp(5.x⚡)» make lint-src                     
Checking PHP syntax in src/ with PHP 8.5.6

Parse error: syntax error, unexpected token "===", expecting "function" in src/Routing/Route/Route.php on line 200

Errors parsing src/Routing/Route/Route.php
Fix the errors above before continuing.
make: *** [lint-src] Error 1
```