### PR TITLE
Add HTTP/3 protocol mapping to curl adapter

### DIFF
--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -181,6 +181,9 @@ class Curl implements AdapterInterface
                     ? CURL_HTTP_VERSION_2_0
                     : throw new HttpException('libcurl 7.33 or greater required for HTTP/2 support')
                 ),
+            '3', '3.0' => defined('CURL_HTTP_VERSION_3')
+                ? CURL_HTTP_VERSION_3
+                : throw new HttpException('PHP 8.4 or greater with libcurl 7.66 or greater is required for HTTP/3 support'),
             default => CURL_HTTP_VERSION_NONE,
         };
     }

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -414,4 +414,32 @@ class CurlTest extends TestCase
         $result = $this->curl->buildOptions($request, $options);
         $this->assertSame(CURL_HTTP_VERSION_2TLS, $result[CURLOPT_HTTP_VERSION]);
     }
+
+    /**
+     * Test converting HTTP/3 protocol version into curl options.
+     */
+    public function testBuildOptionsHttp3ProtocolVersion(): void
+    {
+        $this->skipIf(
+            !defined('CURL_HTTP_VERSION_3'),
+            'Requires PHP 8.4 and libcurl 7.66',
+        );
+
+        $request = $this->getMockBuilder(Request::class)
+            ->setConstructorArgs(['https://localhost/things', 'GET'])
+            ->onlyMethods(['getProtocolVersion'])
+            ->getMock();
+
+        $request
+            ->expects($this->once())
+            ->method('getProtocolVersion')
+            ->willReturn('3');
+
+        $result = $this->curl->buildOptions($request, []);
+
+        $this->assertSame(
+            CURL_HTTP_VERSION_3,
+            $result[CURLOPT_HTTP_VERSION],
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Add support for mapping PSR-7 HTTP protocol versions `3` and `3.0` to `CURL_HTTP_VERSION_3` in the curl HTTP client adapter.

The adapter now throws an `HttpException` with a descriptive message when the required curl constant is not available.

## Changes

* Map protocol versions `3` and `3.0` to `CURL_HTTP_VERSION_3`
* Preserve the existing fallback behavior for unsupported or unspecified protocol versions
* Add test coverage for the HTTP/3 protocol mapping

## Testing

The HTTP/3 adapter test passes locally with PHP 8.6.0-dev and an HTTP/3-enabled curl build:

```bash
../php-src/sapi/cli/php -d zend.assertions=1 \
    vendor/bin/phpunit \
    tests/TestCase/Http/Client/Adapter/CurlTest.php
```

## Notes

This change covers protocol-version mapping in the curl adapter. It does not perform a live HTTP/3 integration test.

CakePHP's default `Request` implementation currently relies on Laminas Diactoros, which rejects protocol version `3` in `withProtocolVersion()`. The test therefore uses a partial mock that returns `3` from `getProtocolVersion()`.

A full test-suite run with PHP 8.6.0-dev also reports an unrelated failure in:

```text
Cake\Test\TestCase\View\Helper\TimeHelperTest::testTimeAgoInWordsOutputTimezone
```

No date, time, view helper, or internationalization files are changed by this pull request.
