### PR TITLE
Allow HTTP/3 protocol version in ServerRequest

### DIFF
--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -181,6 +181,9 @@ class Curl implements AdapterInterface
                     ? CURL_HTTP_VERSION_2_0
                     : throw new HttpException('libcurl 7.33 or greater required for HTTP/2 support')
                 ),
+            '3', '3.0' => defined('CURL_HTTP_VERSION_3')
+                ? CURL_HTTP_VERSION_3
+                : throw new HttpException('PHP 8.4 or greater with libcurl 7.66 or greater is required for HTTP/3 support'),
             default => CURL_HTTP_VERSION_NONE,
         };
     }

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1395,7 +1395,7 @@ class ServerRequest implements ServerRequestInterface
      */
     public function withProtocolVersion(string $version): static
     {
-        if (!preg_match('/^(1\.[01]|2)$/', $version)) {
+        if (!preg_match('/^(1\.[01]|[23])\z/', $version)) {
             throw new InvalidArgumentException(sprintf('Unsupported protocol version `%s` provided.', $version));
         }
         $new = clone $this;

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -414,4 +414,32 @@ class CurlTest extends TestCase
         $result = $this->curl->buildOptions($request, $options);
         $this->assertSame(CURL_HTTP_VERSION_2TLS, $result[CURLOPT_HTTP_VERSION]);
     }
+
+    /**
+     * Test converting HTTP/3 protocol version into curl options.
+     */
+    public function testBuildOptionsHttp3ProtocolVersion(): void
+    {
+        $this->skipIf(
+            !defined('CURL_HTTP_VERSION_3'),
+            'Requires PHP 8.4 and libcurl 7.66',
+        );
+
+        $request = $this->getMockBuilder(Request::class)
+            ->setConstructorArgs(['https://localhost/things', 'GET'])
+            ->onlyMethods(['getProtocolVersion'])
+            ->getMock();
+
+        $request
+            ->expects($this->once())
+            ->method('getProtocolVersion')
+            ->willReturn('3');
+
+        $result = $this->curl->buildOptions($request, []);
+
+        $this->assertSame(
+            CURL_HTTP_VERSION_3,
+            $result[CURLOPT_HTTP_VERSION],
+        );
+    }
 }

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -592,14 +592,33 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test withProtocolVersion()
+     *
+     * @param string $version Protocol version.
      */
-    public function testWithProtocolVersion(): void
+    #[DataProvider('protocolVersionProvider')]
+    public function testWithProtocolVersion(string $version): void
     {
         $request = new ServerRequest();
-        $new = $request->withProtocolVersion('1.0');
+        $new = $request->withProtocolVersion($version);
+
         $this->assertNotSame($new, $request);
         $this->assertSame('1.1', $request->getProtocolVersion());
-        $this->assertSame('1.0', $new->getProtocolVersion());
+        $this->assertSame($version, $new->getProtocolVersion());
+    }
+
+    /**
+     * Data provider for testWithProtocolVersion().
+     *
+     * @return array<string, array{string}>
+     */
+    public static function protocolVersionProvider(): array
+    {
+        return [
+            'HTTP 1.0' => ['1.0'],
+            'HTTP 1.1' => ['1.1'],
+            'HTTP 2' => ['2'],
+            'HTTP 3' => ['3'],
+        ];
     }
 
     /**


### PR DESCRIPTION
Update `ServerRequest::withProtocolVersion()` to accept HTTP/3 protocol version `3`.

`ServerRequest::getProtocolVersion()` can already return `3` when the `SERVER_PROTOCOL` environment value is HTTP/3. However, `withProtocolVersion('3')` currently throws an `InvalidArgumentException`.

This change makes protocol version handling consistent and allows `ServerRequest` to represent HTTP/3 requests through the PSR-7 API.