### PR TITLE
chore: Bump to StructArmed ^0.15 and enable MustBeFinalRule on tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
 
       - name: Run StructArmed
         if: always()
-        run: vendor/bin/structarmed analyze src tests
+        run: vendor/bin/structarmed analyze src/ tests/
 
   split-packages-stan:
     name: Static Analysis for Split Packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
 
       - name: Run StructArmed
         if: always()
-        run: vendor/bin/structarmed analyze src
+        run: vendor/bin/structarmed analyze src tests
 
   split-packages-stan:
     name: Static Analysis for Split Packages

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "cakephp/validation": "self.version"
     },
     "require-dev": {
-        "boundwize/structarmed": "^0.14",
+        "boundwize/structarmed": "^0.15",
         "cakephp/cakephp-codesniffer": "^5.3",
         "http-interop/http-factory-tests": "^2.0",
         "mikey179/vfsstream": "^1.6.12",
@@ -136,7 +136,7 @@
             "tools/psalm",
             "@structarmed"
         ],
-        "structarmed": "vendor/bin/structarmed analyze src",
+        "structarmed": "vendor/bin/structarmed analyze src tests",
         "stan-tests": "tools/phpstan analyze -c tests/phpstan.neon",
         "stan-baseline": "tools/phpstan --generate-baseline",
         "stan-setup": "phive install",

--- a/structarmed.php
+++ b/structarmed.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule;
 
 return Architecture::define()
     ->layerPattern('Cache', '/^Cake\\\\Cache\\\\.*$/')
@@ -53,4 +54,10 @@ return Architecture::define()
         'Utility' => ['Core', 'I18n'],
         'Validation' => ['Event', 'ORM', '+Utility'],
         'View' => ['+Cache', 'Form', '+ORM', '+Routing'],
-    ]);
+    ])
+
+    ->rule(
+        'tests_must_be_final',
+        new MustBeFinalRule(layer: 'tests')
+    )
+    ->layerPattern('tests', '/^Cake\\\\Test\\\\TestCase\\\\.*Test$/');

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -35,7 +35,7 @@ use TestPlugin\Cache\Engine\TestPluginCacheEngine;
 /**
  * CacheTest class
  */
-class CacheTest extends TestCase
+final class CacheTest extends TestCase
 {
     /**
      * setUp method

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -291,7 +291,7 @@ final class CacheTest extends TestCase
      */
     public function testConfigWithLibAndPluginEngines(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         $this->loadPlugins(['TestPlugin']);
 
         $config = ['engine' => 'TestAppCache', 'path' => CACHE, 'prefix' => 'cake_test_'];
@@ -598,7 +598,7 @@ final class CacheTest extends TestCase
      */
     public function testDrop(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         $result = Cache::drop('some_config_that_does_not_exist');
         $this->assertFalse($result, 'Drop should not succeed when config is missing.');
@@ -722,7 +722,7 @@ final class CacheTest extends TestCase
      */
     public function testWriteTriggerCacheWriteException(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         Cache::setConfig('test_trigger', [
             'engine' => 'TestAppCache',
             'prefix' => '',

--- a/tests/TestCase/Cache/Engine/ApcuEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ApcuEngineTest.php
@@ -24,7 +24,7 @@ use DateInterval;
 /**
  * ApcuEngineTest class
  */
-class ApcuEngineTest extends TestCase
+final class ApcuEngineTest extends TestCase
 {
     use EngineEventsTrait;
 

--- a/tests/TestCase/Cache/Engine/ApcuEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ApcuEngineTest.php
@@ -44,7 +44,7 @@ final class ApcuEngineTest extends TestCase
      */
     public static function setUpBeforeClass(): void
     {
-        static::$useRequestTime = ini_get('apc.use_request_time');
+        self::$useRequestTime = ini_get('apc.use_request_time');
         ini_set('apc.use_request_time', '0');
     }
 
@@ -53,7 +53,7 @@ final class ApcuEngineTest extends TestCase
      */
     public static function teardownAfterClass(): void
     {
-        ini_set('apc.use_request_time', static::$useRequestTime ? '1' : '0');
+        ini_set('apc.use_request_time', self::$useRequestTime ? '1' : '0');
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/ArrayEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ArrayEngineTest.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\TestCase;
 /**
  * ArrayEngineTest class
  */
-class ArrayEngineTest extends TestCase
+final class ArrayEngineTest extends TestCase
 {
     use EngineEventsTrait;
 

--- a/tests/TestCase/Cache/Engine/CacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/CacheEngineTest.php
@@ -8,7 +8,7 @@ use DateInterval;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Cache\Engine\TestAppCacheEngine;
 
-class CacheEngineTest extends TestCase
+final class CacheEngineTest extends TestCase
 {
     public static function durationProvider(): array
     {

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -25,7 +25,7 @@ use DateInterval;
 /**
  * FileEngineTest class
  */
-class FileEngineTest extends TestCase
+final class FileEngineTest extends TestCase
 {
     use EngineEventsTrait;
 

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -28,7 +28,7 @@ use function Cake\Core\env;
 /**
  * MemcachedEngineTest class
  */
-class MemcachedEngineTest extends TestCase
+final class MemcachedEngineTest extends TestCase
 {
     use EngineEventsTrait;
 

--- a/tests/TestCase/Cache/Engine/NullEngineTest.php
+++ b/tests/TestCase/Cache/Engine/NullEngineTest.php
@@ -23,7 +23,7 @@ use Exception;
 /**
  * ArrayEngineTest class
  */
-class NullEngineTest extends TestCase
+final class NullEngineTest extends TestCase
 {
     /**
      * setUp method

--- a/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisClusterEngineTest.php
@@ -13,7 +13,7 @@ use Mockery;
 /**
  * RedisClusterEngineTest class
  */
-class RedisClusterEngineTest extends TestCase
+final class RedisClusterEngineTest extends TestCase
 {
     use LogTestTrait;
 

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -29,7 +29,7 @@ use function Cake\Core\env;
 /**
  * RedisEngineTest class
  */
-class RedisEngineTest extends TestCase
+final class RedisEngineTest extends TestCase
 {
     use EngineEventsTrait;
 

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -45,7 +45,7 @@ use function Cake\Collection\collection;
 /**
  * Collection Test
  */
-class CollectionTest extends TestCase
+final class CollectionTest extends TestCase
 {
     /**
      * Tests that it is possible to convert an array into a collection

--- a/tests/TestCase/Collection/FunctionsGlobalTest.php
+++ b/tests/TestCase/Collection/FunctionsGlobalTest.php
@@ -24,7 +24,7 @@ require_once CAKE . 'Collection/functions_global.php';
 /**
  * FunctionsGlobalTest class
  */
-class FunctionsGlobalTest extends TestCase
+final class FunctionsGlobalTest extends TestCase
 {
     /**
      * Tests that the collection() method is a shortcut for new Collection

--- a/tests/TestCase/Collection/FunctionsTest.php
+++ b/tests/TestCase/Collection/FunctionsTest.php
@@ -23,7 +23,7 @@ use function Cake\Collection\collection;
 /**
  * FunctionsTest class
  */
-class FunctionsTest extends TestCase
+final class FunctionsTest extends TestCase
 {
     /**
      * Tests that the collection() method is a shortcut for new Collection

--- a/tests/TestCase/Collection/Iterator/BufferedIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/BufferedIteratorTest.php
@@ -24,7 +24,7 @@ use NoRewindIterator;
 /**
  * BufferedIterator Test
  */
-class BufferedIteratorTest extends TestCase
+final class BufferedIteratorTest extends TestCase
 {
     /**
      * Tests that items are cached once iterated over them

--- a/tests/TestCase/Collection/Iterator/ExtractIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/ExtractIteratorTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * ExtractIterator Test
  */
-class ExtractIteratorTest extends TestCase
+final class ExtractIteratorTest extends TestCase
 {
     /**
      * Tests it is possible to extract a column in the first level of an array

--- a/tests/TestCase/Collection/Iterator/FilterIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/FilterIteratorTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * FilterIterator test
  */
-class FilterIteratorTest extends TestCase
+final class FilterIteratorTest extends TestCase
 {
     /**
      * Tests that the iterator works correctly

--- a/tests/TestCase/Collection/Iterator/InsertIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/InsertIteratorTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * InsertIterator Test
  */
-class InsertIteratorTest extends TestCase
+final class InsertIteratorTest extends TestCase
 {
     /**
      * Test insert simple path

--- a/tests/TestCase/Collection/Iterator/MapReduceTest.php
+++ b/tests/TestCase/Collection/Iterator/MapReduceTest.php
@@ -23,7 +23,7 @@ use LogicException;
 /**
  * Tests MapReduce class
  */
-class MapReduceTest extends TestCase
+final class MapReduceTest extends TestCase
 {
     /**
      * Tests the creation of an inversed index of words to documents using

--- a/tests/TestCase/Collection/Iterator/ReplaceIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/ReplaceIteratorTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * ReplaceIterator Test
  */
-class ReplaceIteratorTest extends TestCase
+final class ReplaceIteratorTest extends TestCase
 {
     /**
      * Tests that the iterator works correctly

--- a/tests/TestCase/Collection/Iterator/SortIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/SortIteratorTest.php
@@ -32,7 +32,7 @@ use const SORT_NUMERIC;
 /**
  * SortIterator Test
  */
-class SortIteratorTest extends TestCase
+final class SortIteratorTest extends TestCase
 {
     /**
      * Tests sorting numbers with an identity callbacks

--- a/tests/TestCase/Collection/Iterator/TreeIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/TreeIteratorTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * TreeIterator Test
  */
-class TreeIteratorTest extends TestCase
+final class TreeIteratorTest extends TestCase
 {
     /**
      * Tests the printer function with defaults

--- a/tests/TestCase/Command/CacheCommandsTest.php
+++ b/tests/TestCase/Command/CacheCommandsTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Cache Commands tests.
  */
-class CacheCommandsTest extends TestCase
+final class CacheCommandsTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 

--- a/tests/TestCase/Command/CompletionCommandTest.php
+++ b/tests/TestCase/Command/CompletionCommandTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
 /**
  * CompletionCommandTest
  */
-class CompletionCommandTest extends TestCase
+final class CompletionCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 

--- a/tests/TestCase/Command/CompletionCommandTest.php
+++ b/tests/TestCase/Command/CompletionCommandTest.php
@@ -35,7 +35,7 @@ final class CompletionCommandTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
         Configure::write('Plugins.autoload', ['TestPlugin', 'TestPluginTwo']);
     }
 

--- a/tests/TestCase/Command/CounterCacheCommandTest.php
+++ b/tests/TestCase/Command/CounterCacheCommandTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 /**
  * CounterCacheCommandTest class
  */
-class CounterCacheCommandTest extends TestCase
+final class CounterCacheCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 

--- a/tests/TestCase/Command/I18nCommandTest.php
+++ b/tests/TestCase/Command/I18nCommandTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * I18nCommand test.
  */
-class I18nCommandTest extends TestCase
+final class I18nCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 

--- a/tests/TestCase/Command/I18nExtractCommandTest.php
+++ b/tests/TestCase/Command/I18nExtractCommandTest.php
@@ -233,7 +233,7 @@ final class I18nExtractCommandTest extends TestCase
      */
     public function testExtractExcludePlugins(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         $this->exec(
             'i18n extract ' .
             '--extract-core=no ' .

--- a/tests/TestCase/Command/I18nExtractCommandTest.php
+++ b/tests/TestCase/Command/I18nExtractCommandTest.php
@@ -24,7 +24,7 @@ use Cake\Utility\Filesystem;
 /**
  * I18nExtractCommandTest
  */
-class I18nExtractCommandTest extends TestCase
+final class I18nExtractCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -26,7 +26,7 @@ use SplFileInfo;
 /**
  * PluginAssetsCommandsTest class
  */
-class PluginAssetsCommandsTest extends TestCase
+final class PluginAssetsCommandsTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 

--- a/tests/TestCase/Command/PluginListCommandTest.php
+++ b/tests/TestCase/Command/PluginListCommandTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
 /**
  * PluginListCommandTest class.
  */
-class PluginListCommandTest extends TestCase
+final class PluginListCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
     use PluginConfigFileTrait;

--- a/tests/TestCase/Command/PluginLoadCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadCommandTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 /**
  * PluginLoadCommandTest class.
  */
-class PluginLoadCommandTest extends TestCase
+final class PluginLoadCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
     use PluginConfigFileTrait;

--- a/tests/TestCase/Command/PluginLoadedCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadedCommandTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 /**
  * PluginLoadedCommand test.
  */
-class PluginLoadedCommandTest extends TestCase
+final class PluginLoadedCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 

--- a/tests/TestCase/Command/PluginUnloadCommandTest.php
+++ b/tests/TestCase/Command/PluginUnloadCommandTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * PluginUnloadCommandTest class
  */
-class PluginUnloadCommandTest extends TestCase
+final class PluginUnloadCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
     use PluginConfigFileTrait;

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -26,7 +26,7 @@ use Cake\TestSuite\TestCase;
 /**
  * RoutesCommandTest
  */
-class RoutesCommandTest extends TestCase
+final class RoutesCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 

--- a/tests/TestCase/Command/SchemaCacheCommandsTest.php
+++ b/tests/TestCase/Command/SchemaCacheCommandsTest.php
@@ -27,7 +27,7 @@ use Mockery;
 /**
  * SchemaCacheCommands test.
  */
-class SchemaCacheCommandsTest extends TestCase
+final class SchemaCacheCommandsTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 

--- a/tests/TestCase/Command/ServerCommandTest.php
+++ b/tests/TestCase/Command/ServerCommandTest.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\TestCase;
 /**
  * ServerShell test.
  */
-class ServerCommandTest extends TestCase
+final class ServerCommandTest extends TestCase
 {
     /**
      * @var \Cake\Command\ServerCommand

--- a/tests/TestCase/Command/VersionCommandTest.php
+++ b/tests/TestCase/Command/VersionCommandTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * VersionCommandTest class.
  */
-class VersionCommandTest extends TestCase
+final class VersionCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 

--- a/tests/TestCase/Console/ArgumentsTest.php
+++ b/tests/TestCase/Console/ArgumentsTest.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Arguments test case.
  */
-class ArgumentsTest extends TestCase
+final class ArgumentsTest extends TestCase
 {
     /**
      * Get all arguments

--- a/tests/TestCase/Console/BaseCommandTest.php
+++ b/tests/TestCase/Console/BaseCommandTest.php
@@ -26,7 +26,7 @@ use Mockery;
 /**
  * Test that BaseCommand hydrates $args and $io properties.
  */
-class BaseCommandTest extends TestCase
+final class BaseCommandTest extends TestCase
 {
     /**
      * Test that $this->args is available inside execute()

--- a/tests/TestCase/Console/Command/HelpCommandTest.php
+++ b/tests/TestCase/Console/Command/HelpCommandTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 /**
  * HelpCommand test.
  */
-class HelpCommandTest extends TestCase
+final class HelpCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -32,7 +32,7 @@ use TestPlugin\Command\SampleCommand as PluginSampleCommand;
 /**
  * Test case for the CommandCollection
  */
-class CommandCollectionTest extends TestCase
+final class CommandCollectionTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/TestCase/Console/CommandFactoryTest.php
+++ b/tests/TestCase/Console/CommandFactoryTest.php
@@ -22,7 +22,7 @@ use stdClass;
 use TestApp\Command\DemoCommand;
 use TestApp\Command\DependencyCommand;
 
-class CommandFactoryTest extends TestCase
+final class CommandFactoryTest extends TestCase
 {
     public function testCreateCommand(): void
     {

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -53,7 +53,7 @@ use TestApp\Command\SampleCommand;
  * Test case for the CommandCollection
  */
 #[AllowMockObjectsWithoutExpectations]
-class CommandRunnerTest extends TestCase
+final class CommandRunnerTest extends TestCase
 {
     /**
      * @var string

--- a/tests/TestCase/Console/CommandScannerTest.php
+++ b/tests/TestCase/Console/CommandScannerTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Test case for the CommandScanner
  */
-class CommandScannerTest extends TestCase
+final class CommandScannerTest extends TestCase
 {
     /**
      * @inheritDoc

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -43,7 +43,7 @@ use TestApp\Command\NonInteractiveCommand;
 /**
  * Test case for Console\Command
  */
-class CommandTest extends TestCase
+final class CommandTest extends TestCase
 {
     /**
      * test orm locator is setup

--- a/tests/TestCase/Console/ConsoleInputArgumentTest.php
+++ b/tests/TestCase/Console/ConsoleInputArgumentTest.php
@@ -25,7 +25,7 @@ use SimpleXMLElement;
 /**
  * ConsoleInputArgumentTest
  */
-class ConsoleInputArgumentTest extends TestCase
+final class ConsoleInputArgumentTest extends TestCase
 {
     public static function dataProperties(): array
     {

--- a/tests/TestCase/Console/ConsoleInputOptionTest.php
+++ b/tests/TestCase/Console/ConsoleInputOptionTest.php
@@ -25,7 +25,7 @@ use SimpleXMLElement;
 /**
  * ConsoleInputOptionTest
  */
-class ConsoleInputOptionTest extends TestCase
+final class ConsoleInputOptionTest extends TestCase
 {
     /**
      * @var \Cake\Console\ConsoleInputOption|\PHPUnit\Framework\MockObject\MockObject

--- a/tests/TestCase/Console/ConsoleInputTest.php
+++ b/tests/TestCase/Console/ConsoleInputTest.php
@@ -24,7 +24,7 @@ use function Cake\Core\env;
 /**
  * ConsoleInput test.
  */
-class ConsoleInputTest extends TestCase
+final class ConsoleInputTest extends TestCase
 {
     /**
      * @var \Cake\Console\ConsoleInput

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -58,7 +58,7 @@ final class ConsoleIoTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         $this->out = Mockery::mock(ConsoleOutput::class)->shouldIgnoreMissing();
         $this->err = Mockery::mock(ConsoleOutput::class)->shouldIgnoreMissing();

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -30,7 +30,7 @@ use PHPUnit\Framework\Attributes\TestWith;
 /**
  * ConsoleIo test.
  */
-class ConsoleIoTest extends TestCase
+final class ConsoleIoTest extends TestCase
 {
     /**
      * @var \Cake\Console\ConsoleIo

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -29,7 +29,7 @@ use LogicException;
 /**
  * ConsoleOptionParserTest
  */
-class ConsoleOptionParserTest extends TestCase
+final class ConsoleOptionParserTest extends TestCase
 {
     private ConsoleIo $io;
 

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -27,7 +27,7 @@ use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
  * ConsoleOutputTest
  */
 #[AllowMockObjectsWithoutExpectations]
-class ConsoleOutputTest extends TestCase
+final class ConsoleOutputTest extends TestCase
 {
     /**
      * @var \Cake\Console\ConsoleOutput|\PHPUnit\Framework\MockObject\MockObject

--- a/tests/TestCase/Console/HelpFormatterTest.php
+++ b/tests/TestCase/Console/HelpFormatterTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
 /**
  * HelpFormatterTest
  */
-class HelpFormatterTest extends TestCase
+final class HelpFormatterTest extends TestCase
 {
     /**
      * test that the console max width is respected when generating help.

--- a/tests/TestCase/Console/Helper/BannerHelperTest.php
+++ b/tests/TestCase/Console/Helper/BannerHelperTest.php
@@ -25,7 +25,7 @@ use InvalidArgumentException;
 /**
  * BannerHelper test.
  */
-class BannerHelperTest extends TestCase
+final class BannerHelperTest extends TestCase
 {
     /**
      * @var \Cake\Console\Helper\BannerHelper

--- a/tests/TestCase/Console/Helper/ProgressHelperTest.php
+++ b/tests/TestCase/Console/Helper/ProgressHelperTest.php
@@ -25,7 +25,7 @@ use InvalidArgumentException;
 /**
  * ProgressHelper test.
  */
-class ProgressHelperTest extends TestCase
+final class ProgressHelperTest extends TestCase
 {
     /**
      * @var \Cake\Console\Helper\ProgressHelper

--- a/tests/TestCase/Console/Helper/TableHelperTest.php
+++ b/tests/TestCase/Console/Helper/TableHelperTest.php
@@ -25,7 +25,7 @@ use UnexpectedValueException;
 /**
  * TableHelper test.
  */
-class TableHelperTest extends TestCase
+final class TableHelperTest extends TestCase
 {
     /**
      * @var \Cake\Console\TestSuite\StubConsoleOutput

--- a/tests/TestCase/Console/Helper/TreeHelperTest.php
+++ b/tests/TestCase/Console/Helper/TreeHelperTest.php
@@ -28,7 +28,7 @@ use TestApp\Model\Enum\Priority;
 /**
  * TreeHelper test.
  */
-class TreeHelperTest extends TestCase
+final class TreeHelperTest extends TestCase
 {
     /**
      * @var \Cake\Console\Helper\TreeHelper

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -41,7 +41,7 @@ final class HelperRegistryTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
         $io = new ConsoleIo(
             new StubConsoleOutput(),
             new StubConsoleOutput(),

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -28,7 +28,7 @@ use TestPlugin\Console\Helper\ExampleHelper;
 /**
  * HelperRegistryTest
  */
-class HelperRegistryTest extends TestCase
+final class HelperRegistryTest extends TestCase
 {
     /**
      * @var \Cake\Console\HelperRegistry

--- a/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
-class ConsoleIntegrationTestTraitTest extends TestCase
+final class ConsoleIntegrationTestTraitTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
 

--- a/tests/TestCase/Container/Argument/ArgumentResolverTest.php
+++ b/tests/TestCase/Container/Argument/ArgumentResolverTest.php
@@ -17,7 +17,7 @@ use ReflectionFunctionAbstract;
 use ReflectionNamedType;
 use ReflectionParameter;
 
-class ArgumentResolverTest extends TestCase
+final class ArgumentResolverTest extends TestCase
 {
     public function testResolverResolvesFromContainer(): void
     {

--- a/tests/TestCase/Container/Argument/TypedArgumentTest.php
+++ b/tests/TestCase/Container/Argument/TypedArgumentTest.php
@@ -8,7 +8,7 @@ use Cake\Container\Argument\LiteralArgument;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-class TypedArgumentTest extends TestCase
+final class TypedArgumentTest extends TestCase
 {
     public function testLiteralArgumentSetsAndGetsArgument(): void
     {

--- a/tests/TestCase/Container/ContainerTest.php
+++ b/tests/TestCase/Container/ContainerTest.php
@@ -15,7 +15,7 @@ use Cake\Test\TestCase\Container\Asset\BarInterface;
 use Cake\Test\TestCase\Container\Asset\Foo;
 use PHPUnit\Framework\TestCase;
 
-class ContainerTest extends TestCase
+final class ContainerTest extends TestCase
 {
     public function testContainerAddsAndGets(): void
     {

--- a/tests/TestCase/Container/Definition/DefinitionAggregateTest.php
+++ b/tests/TestCase/Container/Definition/DefinitionAggregateTest.php
@@ -13,7 +13,7 @@ use Cake\Test\TestCase\Container\Asset\Foo;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
-class DefinitionAggregateTest extends TestCase
+final class DefinitionAggregateTest extends TestCase
 {
     public function testAggregateAddsDefinition(): void
     {

--- a/tests/TestCase/Container/Definition/DefinitionTest.php
+++ b/tests/TestCase/Container/Definition/DefinitionTest.php
@@ -13,7 +13,7 @@ use Cake\Test\TestCase\Container\Asset\FooCallable;
 use Error;
 use PHPUnit\Framework\TestCase;
 
-class DefinitionTest extends TestCase
+final class DefinitionTest extends TestCase
 {
     public function testDefinitionResolvesClosureWithDefinedArgs(): void
     {

--- a/tests/TestCase/Container/Inflector/InflectorAggregateTest.php
+++ b/tests/TestCase/Container/Inflector/InflectorAggregateTest.php
@@ -10,7 +10,7 @@ use Cake\Container\Inflector\InflectorAggregate;
 use DateTimeZone;
 use PHPUnit\Framework\TestCase;
 
-class InflectorAggregateTest extends TestCase
+final class InflectorAggregateTest extends TestCase
 {
     public function testAggregateAddsInflector(): void
     {

--- a/tests/TestCase/Container/Inflector/InflectorTest.php
+++ b/tests/TestCase/Container/Inflector/InflectorTest.php
@@ -9,7 +9,7 @@ use Cake\Test\TestCase\Container\Asset\Bar;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
-class InflectorTest extends TestCase
+final class InflectorTest extends TestCase
 {
     public function testInflectorSetsExpectedMethodCalls(): void
     {

--- a/tests/TestCase/Container/ReflectionContainerTest.php
+++ b/tests/TestCase/Container/ReflectionContainerTest.php
@@ -14,7 +14,7 @@ use Cake\Test\TestCase\Container\Asset\ProFoo;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-class ReflectionContainerTest extends TestCase
+final class ReflectionContainerTest extends TestCase
 {
     private function getContainer(array $items = []): Container
     {

--- a/tests/TestCase/Container/ServiceProvider/ServiceProviderAggregateTest.php
+++ b/tests/TestCase/Container/ServiceProvider/ServiceProviderAggregateTest.php
@@ -11,7 +11,7 @@ use Cake\Container\ServiceProvider\ServiceProviderAggregate;
 use Cake\Container\ServiceProvider\ServiceProviderInterface;
 use PHPUnit\Framework\TestCase;
 
-class ServiceProviderAggregateTest extends TestCase
+final class ServiceProviderAggregateTest extends TestCase
 {
     protected function getServiceProvider(): ServiceProviderInterface
     {

--- a/tests/TestCase/Container/ServiceProvider/ServiceProviderTest.php
+++ b/tests/TestCase/Container/ServiceProvider/ServiceProviderTest.php
@@ -8,7 +8,7 @@ use Cake\Container\ServiceProvider\BootableServiceProviderInterface;
 use Cake\Container\ServiceProvider\ServiceProviderInterface;
 use PHPUnit\Framework\TestCase;
 
-class ServiceProviderTest extends TestCase
+final class ServiceProviderTest extends TestCase
 {
     protected function getServiceProvider(): ServiceProviderInterface
     {

--- a/tests/TestCase/Controller/Component/CheckHttpCacheComponentTest.php
+++ b/tests/TestCase/Controller/Component/CheckHttpCacheComponentTest.php
@@ -43,7 +43,7 @@ final class CheckHttpCacheComponentTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
         $request = (new ServerRequest())
             ->withHeader('If-Modified-Since', '2012-01-01 00:00:00')
             ->withHeader('If-None-Match', '*');

--- a/tests/TestCase/Controller/Component/CheckHttpCacheComponentTest.php
+++ b/tests/TestCase/Controller/Component/CheckHttpCacheComponentTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
 /**
  * CheckHttpCacheComponentTest class
  */
-class CheckHttpCacheComponentTest extends TestCase
+final class CheckHttpCacheComponentTest extends TestCase
 {
     /**
      * @var \Cake\Controller\Component\CheckHTtpCacheComponent

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -27,7 +27,7 @@ use Exception;
 /**
  * FlashComponentTest class
  */
-class FlashComponentTest extends TestCase
+final class FlashComponentTest extends TestCase
 {
     /**
      * @var \Cake\Controller\Component\FlashComponent

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -50,7 +50,7 @@ final class FlashComponentTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
         $this->Controller = new Controller(new ServerRequest(['session' => new Session()]));
         $ComponentRegistry = new ComponentRegistry($this->Controller);
         $this->Flash = new FlashComponent($ComponentRegistry);

--- a/tests/TestCase/Controller/Component/FormProtectionComponentTest.php
+++ b/tests/TestCase/Controller/Component/FormProtectionComponentTest.php
@@ -31,7 +31,7 @@ use Cake\Utility\Security;
 /**
  * FormProtectionComponentTest class
  */
-class FormProtectionComponentTest extends TestCase
+final class FormProtectionComponentTest extends TestCase
 {
     /**
      * @var \Cake\Controller\Controller

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -36,7 +36,7 @@ use TestApp\Service\TestService;
 use TestPlugin\Controller\Component\OtherComponent;
 use Traversable;
 
-class ComponentRegistryTest extends TestCase
+final class ComponentRegistryTest extends TestCase
 {
     /**
      * @var \Cake\Controller\ComponentRegistry

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -34,7 +34,7 @@ use TestApp\Controller\ComponentTestController;
 /**
  * ComponentTest class
  */
-class ComponentTest extends TestCase
+final class ComponentTest extends TestCase
 {
     /**
      * setUp method

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -42,7 +42,7 @@ final class ComponentTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -37,7 +37,7 @@ use TestPlugin\Controller\TestPluginController;
 /**
  * Test case for ControllerFactory.
  */
-class ControllerFactoryTest extends TestCase
+final class ControllerFactoryTest extends TestCase
 {
     /**
      * @var \Cake\Controller\ControllerFactory

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -55,7 +55,7 @@ final class ControllerFactoryTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
         $this->container = new Container();
         $this->factory = new ControllerFactory($this->container);
     }

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -78,7 +78,7 @@ final class ControllerTest extends TestCase
     {
         parent::setUp();
 
-        static::setAppNamespace();
+        self::setAppNamespace();
         Router::reload();
     }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -59,7 +59,7 @@ use TestPlugin\Model\Table\TestPluginCommentsTable;
 /**
  * ControllerTest class
  */
-class ControllerTest extends TestCase
+final class ControllerTest extends TestCase
 {
     /**
      * fixtures property

--- a/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
  *
  * @deprecated
  */
-class AuthSecurityExceptionTest extends TestCase
+final class AuthSecurityExceptionTest extends TestCase
 {
     /**
      * @var \Cake\Controller\Exception\AuthSecurityException

--- a/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
  *
  * @deprecated
  */
-class SecurityExceptionTest extends TestCase
+final class SecurityExceptionTest extends TestCase
 {
     /**
      * @var \Cake\Controller\Exception\SecurityException

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -28,7 +28,7 @@ use TestApp\Core\TestApp;
 /**
  * AppTest class
  */
-class AppTest extends TestCase
+final class AppTest extends TestCase
 {
     /**
      * tearDown method

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -53,7 +53,7 @@ final class AppTest extends TestCase
     #[DataProvider('classNameProvider')]
     public function testClassName($class, $type, $suffix = '', $existsInBase = false, $expected = false): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         $i = 0;
         TestApp::$existsInBaseCallback = function ($name, $namespace) use ($existsInBase, $class, $expected, &$i) {
             if ($i++ === 0) {
@@ -98,7 +98,7 @@ final class AppTest extends TestCase
     #[DataProvider('shortNameProvider')]
     public function testShortName($class, $type, $suffix = '', $expected = false): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         $return = TestApp::shortName($class, $type, $suffix);
         $this->assertSame($expected, $return);
@@ -109,7 +109,7 @@ final class AppTest extends TestCase
      */
     public function testShortNameWithNestedAppNamespace(): void
     {
-        static::setAppNamespace('TestApp/Nested');
+        self::setAppNamespace('TestApp/Nested');
 
         $return = TestApp::shortName(
             'TestApp/Nested/Controller/PagesController',
@@ -118,7 +118,7 @@ final class AppTest extends TestCase
         );
         $this->assertSame('Pages', $return);
 
-        static::setAppNamespace();
+        self::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/Core/Attribute/ConfigureTest.php
+++ b/tests/TestCase/Core/Attribute/ConfigureTest.php
@@ -10,7 +10,7 @@ use Cake\TestSuite\TestCase;
 use League\Container\ReflectionContainer;
 use TypeError;
 
-class ConfigureTest extends TestCase
+final class ConfigureTest extends TestCase
 {
     /**
      * @return void

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -292,7 +292,7 @@ final class BasePluginTest extends TestCase
 
     public function testEventsAreRegistered(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/cakes']);
         $request = $request->withAttribute('params', [
             'controller' => 'Cakes',
@@ -329,7 +329,7 @@ final class BasePluginTest extends TestCase
 
     public function testConsoleEventsAreRegistered(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         $basePlugin = new class extends BasePlugin
         {
             public function events(EventManagerInterface $eventManager): EventManagerInterface
@@ -365,7 +365,7 @@ final class BasePluginTest extends TestCase
 
     public function testEventListenersAreRegistered(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         $plugin = new class extends BasePlugin
         {
@@ -405,7 +405,7 @@ final class BasePluginTest extends TestCase
      */
     public function testEventListenersResolvedThroughContainerWithDependencyInjection(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         $plugin = new class extends BasePlugin
         {
@@ -475,7 +475,7 @@ final class BasePluginTest extends TestCase
 
     public function testEventListenersResolvedThroughContainer(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         $plugin = new class extends BasePlugin
         {

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -53,7 +53,7 @@ use TestPlugin\TestPluginPlugin as TestPlugin;
 /**
  * BasePluginTest class
  */
-class BasePluginTest extends TestCase
+final class BasePluginTest extends TestCase
 {
     /**
      * tearDown method

--- a/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * IniConfigTest
  */
-class IniConfigTest extends TestCase
+final class IniConfigTest extends TestCase
 {
     /**
      * Test data to serialize and unserialize.

--- a/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * JsonConfigTest
  */
-class JsonConfigTest extends TestCase
+final class JsonConfigTest extends TestCase
 {
     /**
      * @var string

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * PhpConfigTest
  */
-class PhpConfigTest extends TestCase
+final class PhpConfigTest extends TestCase
 {
     /**
      * @var string

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -26,7 +26,7 @@ use Exception;
 /**
  * ConfigureTest
  */
-class ConfigureTest extends TestCase
+final class ConfigureTest extends TestCase
 {
     /**
      * setUp method

--- a/tests/TestCase/Core/FunctionsGlobalTest.php
+++ b/tests/TestCase/Core/FunctionsGlobalTest.php
@@ -27,7 +27,7 @@ require_once CAKE . 'Core/functions_global.php';
 /**
  * Test cases for functions in Core\functions_global.php
  */
-class FunctionsGlobalTest extends TestCase
+final class FunctionsGlobalTest extends TestCase
 {
     /**
      * Test cases for env()

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -37,7 +37,7 @@ use function Cake\Core\triggerWarning;
 /**
  * Test cases for functions in Core\functions.php
  */
-class FunctionsTest extends TestCase
+final class FunctionsTest extends TestCase
 {
     public function testPathCombine(): void
     {

--- a/tests/TestCase/Core/InstanceConfigTraitTest.php
+++ b/tests/TestCase/Core/InstanceConfigTraitTest.php
@@ -23,7 +23,7 @@ use InvalidArgumentException;
 use TestApp\Config\ReadOnlyTestInstanceConfig;
 use TestApp\Config\TestInstanceConfig;
 
-class InstanceConfigTraitTest extends TestCase
+final class InstanceConfigTraitTest extends TestCase
 {
     /**
      * @var \TestApp\Config\TestInstanceConfig

--- a/tests/TestCase/Core/PluginCollectionTest.php
+++ b/tests/TestCase/Core/PluginCollectionTest.php
@@ -30,7 +30,7 @@ use TestPlugin\TestPluginPlugin as TestPlugin;
 /**
  * PluginCollection Test
  */
-class PluginCollectionTest extends TestCase
+final class PluginCollectionTest extends TestCase
 {
     public function testConstructor(): void
     {

--- a/tests/TestCase/Core/PluginConfigTest.php
+++ b/tests/TestCase/Core/PluginConfigTest.php
@@ -20,7 +20,7 @@ use Cake\Core\Configure;
 use Cake\Core\PluginConfig;
 use Cake\TestSuite\TestCase;
 
-class PluginConfigTest extends TestCase
+final class PluginConfigTest extends TestCase
 {
     protected string $pluginsListPath;
 

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -24,7 +24,7 @@ use TestPlugin\TestPluginPlugin as TestPlugin;
 /**
  * PluginTest class
  */
-class PluginTest extends TestCase
+final class PluginTest extends TestCase
 {
     /**
      * Setup

--- a/tests/TestCase/Core/Retry/CommandRetryTest.php
+++ b/tests/TestCase/Core/Retry/CommandRetryTest.php
@@ -23,7 +23,7 @@ use TestApp\Database\Retry\TestRetryStrategy;
 /**
  * Tests for the CommandRetry class
  */
-class CommandRetryTest extends TestCase
+final class CommandRetryTest extends TestCase
 {
     /**
      * Simple retry test

--- a/tests/TestCase/Core/ServiceConfigTest.php
+++ b/tests/TestCase/Core/ServiceConfigTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * ServiceConfigTest
  */
-class ServiceConfigTest extends TestCase
+final class ServiceConfigTest extends TestCase
 {
     public function testGet(): void
     {

--- a/tests/TestCase/Core/ServiceProviderTest.php
+++ b/tests/TestCase/Core/ServiceProviderTest.php
@@ -25,7 +25,7 @@ use TestApp\ServiceProvider\PersonServiceProvider;
 /**
  * ServiceProviderTest
  */
-class ServiceProviderTest extends TestCase
+final class ServiceProviderTest extends TestCase
 {
     public function testBootstrapHook(): void
     {

--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -27,7 +27,7 @@ use TypeError;
 /**
  * StaticConfigTraitTest class
  */
-class StaticConfigTraitTest extends TestCase
+final class StaticConfigTraitTest extends TestCase
 {
     /**
      * @var object

--- a/tests/TestCase/Database/ColumnSchemaAwareTypeTest.php
+++ b/tests/TestCase/Database/ColumnSchemaAwareTypeTest.php
@@ -10,7 +10,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use TestApp\Database\Type\ColumnSchemaAwareType;
 
-class ColumnSchemaAwareTypeTest extends TestCase
+final class ColumnSchemaAwareTypeTest extends TestCase
 {
     /**
      * @var \Cake\Database\Connection

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -54,7 +54,7 @@ use function Cake\Core\namespaceSplit;
 /**
  * Tests Connection class
  */
-class ConnectionTest extends TestCase
+final class ConnectionTest extends TestCase
 {
     /**
      * @var array<string>

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -95,7 +95,7 @@ final class ConnectionTest extends TestCase
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
 
-        static::setAppNamespace();
+        self::setAppNamespace();
     }
 
     protected function tearDown(): void

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -31,7 +31,7 @@ use ReflectionClass;
 /**
  * Tests MySQL driver
  */
-class MysqlTest extends TestCase
+final class MysqlTest extends TestCase
 {
     /**
      * setup

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -29,7 +29,7 @@ use PDO;
 /**
  * Tests Postgres driver
  */
-class PostgresTest extends TestCase
+final class PostgresTest extends TestCase
 {
     /**
      * Test connecting to Postgres with default configuration

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -30,7 +30,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Tests Sqlite driver
  */
-class SqliteTest extends TestCase
+final class SqliteTest extends TestCase
 {
     protected function tearDown(): void
     {

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -34,7 +34,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Tests Sqlserver driver
  */
-class SqlserverTest extends TestCase
+final class SqlserverTest extends TestCase
 {
     /**
      * @var bool

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -41,7 +41,7 @@ use TestApp\Database\Driver\StubDriver;
 /**
  * Tests Driver class
  */
-class DriverTest extends TestCase
+final class DriverTest extends TestCase
 {
     /**
      * @var \TestApp\Database\Driver\StubDriver

--- a/tests/TestCase/Database/Exception/QueryExceptionTest.php
+++ b/tests/TestCase/Database/Exception/QueryExceptionTest.php
@@ -25,7 +25,7 @@ use PDOException;
 /**
  * Tests QueryException class
  */
-class QueryExceptionTest extends TestCase
+final class QueryExceptionTest extends TestCase
 {
     /**
      * Test exception with string query

--- a/tests/TestCase/Database/Expression/AggregateExpressionTest.php
+++ b/tests/TestCase/Database/Expression/AggregateExpressionTest.php
@@ -24,7 +24,7 @@ use Cake\Database\ValueBinder;
 /**
  * Tests FunctionExpression class
  */
-class AggregateExpressionTest extends FunctionExpressionTest
+final class AggregateExpressionTest extends FunctionExpressionTest
 {
     /**
      * @var string The expression class to test with

--- a/tests/TestCase/Database/Expression/BetweenExpressionTest.php
+++ b/tests/TestCase/Database/Expression/BetweenExpressionTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests BetweenExpression class
  */
-class BetweenExpressionTest extends TestCase
+final class BetweenExpressionTest extends TestCase
 {
     /**
      * Tests that BETWEEN expression is generated correctly

--- a/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
@@ -42,7 +42,7 @@ use TestApp\Database\Type\CustomExpressionType;
 use TestApp\View\Object\TestObjectWithToString;
 use TypeError;
 
-class CaseStatementExpressionTest extends TestCase
+final class CaseStatementExpressionTest extends TestCase
 {
     // region Type handling
 

--- a/tests/TestCase/Database/Expression/CommonTableExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CommonTableExpressionTest.php
@@ -22,7 +22,7 @@ use Cake\Database\ValueBinder;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 
-class CommonTableExpressionTest extends TestCase
+final class CommonTableExpressionTest extends TestCase
 {
     /**
      * @var \Cake\Database\Connection

--- a/tests/TestCase/Database/Expression/ComparisonExpressionTest.php
+++ b/tests/TestCase/Database/Expression/ComparisonExpressionTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests Comparison class
  */
-class ComparisonExpressionTest extends TestCase
+final class ComparisonExpressionTest extends TestCase
 {
     /**
      * Test sql generation using IdentifierExpression

--- a/tests/TestCase/Database/Expression/DistinctComparisonExpressionTest.php
+++ b/tests/TestCase/Database/Expression/DistinctComparisonExpressionTest.php
@@ -22,7 +22,7 @@ use Cake\Database\Expression\QueryExpression;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
 
-class DistinctComparisonExpressionTest extends TestCase
+final class DistinctComparisonExpressionTest extends TestCase
 {
     public function testSqlWithIdentifierValue(): void
     {

--- a/tests/TestCase/Database/Expression/IdentifierExpressionTest.php
+++ b/tests/TestCase/Database/Expression/IdentifierExpressionTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests IdentifierExpression class
  */
-class IdentifierExpressionTest extends TestCase
+final class IdentifierExpressionTest extends TestCase
 {
     /**
      * Tests getting and setting the field

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Tests QueryExpression class
  */
-class QueryExpressionTest extends TestCase
+final class QueryExpressionTest extends TestCase
 {
     /**
      * Test setConjunction()/getConjunction() works.

--- a/tests/TestCase/Database/Expression/StringExpressionTest.php
+++ b/tests/TestCase/Database/Expression/StringExpressionTest.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests StringExpression class
  */
-class StringExpressionTest extends TestCase
+final class StringExpressionTest extends TestCase
 {
     public function testCollation(): void
     {

--- a/tests/TestCase/Database/Expression/TupleComparisonTest.php
+++ b/tests/TestCase/Database/Expression/TupleComparisonTest.php
@@ -25,7 +25,7 @@ use InvalidArgumentException;
 /**
  * Tests TupleComparison class
  */
-class TupleComparisonTest extends TestCase
+final class TupleComparisonTest extends TestCase
 {
     /**
      * Tests generating a function with no arguments

--- a/tests/TestCase/Database/Expression/WindowExpressionTest.php
+++ b/tests/TestCase/Database/Expression/WindowExpressionTest.php
@@ -27,7 +27,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests WindowExpression class
  */
-class WindowExpressionTest extends TestCase
+final class WindowExpressionTest extends TestCase
 {
     /**
      * Tests an empty window expression

--- a/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
@@ -28,7 +28,7 @@ use TestApp\Database\Type\UuidValue;
  * Tests for Expression objects casting values to other expressions
  * using the type classes
  */
-class ExpressionTypeCastingIntegrationTest extends TestCase
+final class ExpressionTypeCastingIntegrationTest extends TestCase
 {
     protected array $fixtures = ['core.OrderedUuidItems'];
 

--- a/tests/TestCase/Database/ExpressionTypeCastingTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingTest.php
@@ -29,7 +29,7 @@ use TestApp\Database\Type\TestType;
  * Tests for Expression objects casting values to other expressions
  * using the type classes
  */
-class ExpressionTypeCastingTest extends TestCase
+final class ExpressionTypeCastingTest extends TestCase
 {
     /**
      * Setups a mock for FunctionsBuilder

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -28,7 +28,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Tests FunctionsBuilder class
  */
-class FunctionsBuilderTest extends TestCase
+final class FunctionsBuilderTest extends TestCase
 {
     /**
      * @var \Cake\Database\FunctionsBuilder

--- a/tests/TestCase/Database/Log/LoggedQueryTest.php
+++ b/tests/TestCase/Database/Log/LoggedQueryTest.php
@@ -27,7 +27,7 @@ use RuntimeException;
 /**
  * Tests LoggedQuery class
  */
-class LoggedQueryTest extends TestCase
+final class LoggedQueryTest extends TestCase
 {
     protected $driver;
 

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -26,7 +26,7 @@ use Stringable;
 /**
  * Tests QueryLogger class
  */
-class QueryLoggerTest extends TestCase
+final class QueryLoggerTest extends TestCase
 {
     /**
      * Tear down

--- a/tests/TestCase/Database/NullSafeComparisonTest.php
+++ b/tests/TestCase/Database/NullSafeComparisonTest.php
@@ -16,7 +16,7 @@ use Cake\TestSuite\TestCase;
 use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class NullSafeComparisonTest extends TestCase
+final class NullSafeComparisonTest extends TestCase
 {
     public static function dialectProvider(): array
     {

--- a/tests/TestCase/Database/Query/DeleteQueryTest.php
+++ b/tests/TestCase/Database/Query/DeleteQueryTest.php
@@ -28,7 +28,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests DeleteQuery class
  */
-class DeleteQueryTest extends TestCase
+final class DeleteQueryTest extends TestCase
 {
     use QueryAssertsTrait;
 

--- a/tests/TestCase/Database/Query/InsertQueryTest.php
+++ b/tests/TestCase/Database/Query/InsertQueryTest.php
@@ -29,7 +29,7 @@ use InvalidArgumentException;
 /**
  * Tests InsertQuery class
  */
-class InsertQueryTest extends TestCase
+final class InsertQueryTest extends TestCase
 {
     use QueryAssertsTrait;
 

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -50,7 +50,7 @@ use function Cake\Collection\collection;
 /**
  * Tests SelectQuery class
  */
-class SelectQueryTest extends TestCase
+final class SelectQueryTest extends TestCase
 {
     use QueryAssertsTrait;
 

--- a/tests/TestCase/Database/Query/UpdateQueryTest.php
+++ b/tests/TestCase/Database/Query/UpdateQueryTest.php
@@ -37,7 +37,7 @@ use Mockery;
 /**
  * Tests UpdateQuery class
  */
-class UpdateQueryTest extends TestCase
+final class UpdateQueryTest extends TestCase
 {
     use QueryAssertsTrait;
 

--- a/tests/TestCase/Database/QueryCompilerTest.php
+++ b/tests/TestCase/Database/QueryCompilerTest.php
@@ -28,7 +28,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests Query class
  */
-class QueryCompilerTest extends TestCase
+final class QueryCompilerTest extends TestCase
 {
     use QueryAssertsTrait;
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -27,7 +27,7 @@ use InvalidArgumentException;
 /**
  * Tests Query class
  */
-class QueryTest extends TestCase
+final class QueryTest extends TestCase
 {
     use QueryAssertsTrait;
 

--- a/tests/TestCase/Database/QueryTests/AggregatesQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/AggregatesQueryTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests AggregateExpression queries
  */
-class AggregatesQueryTest extends TestCase
+final class AggregatesQueryTest extends TestCase
 {
     protected array $fixtures = [
         'core.Comments',

--- a/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
@@ -30,7 +30,7 @@ use Cake\Test\Fixture\ProductsFixture;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class CaseExpressionQueryTest extends TestCase
+final class CaseExpressionQueryTest extends TestCase
 {
     protected array $fixtures = [
         ArticlesFixture::class,

--- a/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
@@ -28,7 +28,7 @@ use Cake\Database\ValueBinder;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 
-class CommonTableExpressionQueryTest extends TestCase
+final class CommonTableExpressionQueryTest extends TestCase
 {
     /**
      * @inheritDoc

--- a/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
@@ -39,7 +39,7 @@ use PDOException;
  *
  * @see \Cake\Database\Driver\TupleComparisonTranslatorTrait::_transformTupleComparison()
  */
-class TupleComparisonQueryTest extends TestCase
+final class TupleComparisonQueryTest extends TestCase
 {
     /**
      * @inheritDoc

--- a/tests/TestCase/Database/QueryTests/WindowQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/WindowQueryTest.php
@@ -29,7 +29,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests WindowExpression class
  */
-class WindowQueryTest extends TestCase
+final class WindowQueryTest extends TestCase
 {
     protected array $fixtures = [
         'core.Comments',

--- a/tests/TestCase/Database/Schema/CollectionTest.php
+++ b/tests/TestCase/Database/Schema/CollectionTest.php
@@ -27,7 +27,7 @@ use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 /**
  * Test case for Collection
  */
-class CollectionTest extends TestCase
+final class CollectionTest extends TestCase
 {
     /**
      * @var \Cake\Database\Connection

--- a/tests/TestCase/Database/Schema/ColumnTest.php
+++ b/tests/TestCase/Database/Schema/ColumnTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use TestApp\Database\Type\IntType;
 
-class ColumnTest extends TestCase
+final class ColumnTest extends TestCase
 {
     public function testSetName(): void
     {

--- a/tests/TestCase/Database/Schema/ConstraintTest.php
+++ b/tests/TestCase/Database/Schema/ConstraintTest.php
@@ -9,7 +9,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests for the Constraint class.
  */
-class ConstraintTest extends TestCase
+final class ConstraintTest extends TestCase
 {
     public function testSetType(): void
     {

--- a/tests/TestCase/Database/Schema/ForeignKeyTest.php
+++ b/tests/TestCase/Database/Schema/ForeignKeyTest.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
 /**
  * Tests for the ForeignKey class.
  */
-class ForeignKeyTest extends TestCase
+final class ForeignKeyTest extends TestCase
 {
     public function testSetType(): void
     {

--- a/tests/TestCase/Database/Schema/IndexTest.php
+++ b/tests/TestCase/Database/Schema/IndexTest.php
@@ -9,7 +9,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests for the Index class.
  */
-class IndexTest extends TestCase
+final class IndexTest extends TestCase
 {
     public function testSetType(): void
     {

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -37,7 +37,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Test case for MySQL Schema Dialect.
  */
-class MysqlSchemaDialectTest extends TestCase
+final class MysqlSchemaDialectTest extends TestCase
 {
     protected PDO $pdo;
 

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -37,7 +37,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Postgres schema test case.
  */
-class PostgresSchemaDialectTest extends TestCase
+final class PostgresSchemaDialectTest extends TestCase
 {
     /**
      * Helper method for skipping tests that need a real connection.

--- a/tests/TestCase/Database/Schema/SchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SchemaDialectTest.php
@@ -27,7 +27,7 @@ use TestApp\Database\Schema\CompatDialect;
  * Test case for SchemaDialect methods
  * that can pass tests across all drivers
  */
-class SchemaDialectTest extends TestCase
+final class SchemaDialectTest extends TestCase
 {
     /**
      * @var array<string>

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -36,7 +36,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Test case for Sqlite Schema Dialect.
  */
-class SqliteSchemaDialectTest extends TestCase
+final class SqliteSchemaDialectTest extends TestCase
 {
     protected PDO $pdo;
 

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -33,7 +33,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * SQL Server schema test case.
  */
-class SqlserverSchemaDialectTest extends TestCase
+final class SqlserverSchemaDialectTest extends TestCase
 {
     /**
      * Helper method for skipping tests that need a real connection.

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -30,7 +30,7 @@ use TestApp\Database\Type\IntType;
 /**
  * Test case for Table
  */
-class TableSchemaTest extends TestCase
+final class TableSchemaTest extends TestCase
 {
     protected array $fixtures = [
         'core.Articles',

--- a/tests/TestCase/Database/Schema/UniqueKeyTest.php
+++ b/tests/TestCase/Database/Schema/UniqueKeyTest.php
@@ -9,7 +9,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests for the UniqueKey class.
  */
-class UniqueKeyTest extends TestCase
+final class UniqueKeyTest extends TestCase
 {
     public function testSetType(): void
     {

--- a/tests/TestCase/Database/SchemaCacheTest.php
+++ b/tests/TestCase/Database/SchemaCacheTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
 /**
  * SchemaCache test.
  */
-class SchemaCacheTest extends TestCase
+final class SchemaCacheTest extends TestCase
 {
     /**
      * Fixtures.

--- a/tests/TestCase/Database/Type/BinaryTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryTypeTest.php
@@ -25,7 +25,7 @@ use PDO;
 /**
  * Test for the Binary type.
  */
-class BinaryTypeTest extends TestCase
+final class BinaryTypeTest extends TestCase
 {
     /**
      * @var \Cake\Database\Type\BinaryType

--- a/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
@@ -26,7 +26,7 @@ use PDO;
 /**
  * Test for the Binary uuid type.
  */
-class BinaryUuidTypeTest extends TestCase
+final class BinaryUuidTypeTest extends TestCase
 {
     /**
      * @var \Cake\Database\Type\BinaryUuidType

--- a/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -25,7 +25,7 @@ use PDO;
 /**
  * Test for the Boolean type.
  */
-class BoolTypeTest extends TestCase
+final class BoolTypeTest extends TestCase
 {
     /**
      * @var \Cake\Database\Type\BoolType

--- a/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Test for the DateTime type.
  */
-class DateTimeFractionalTypeTest extends TestCase
+final class DateTimeFractionalTypeTest extends TestCase
 {
     /**
      * @var \Cake\Database\Type\DateTimeFractionalType

--- a/tests/TestCase/Database/Type/DateTimeTimezoneTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTimezoneTypeTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Test for the DateTimeTimezone type.
  */
-class DateTimeTimezoneTypeTest extends TestCase
+final class DateTimeTimezoneTypeTest extends TestCase
 {
     /**
      * @var \Cake\Database\Type\DateTimeTimezoneType

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -30,7 +30,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Test for the DateTime type.
  */
-class DateTimeTypeTest extends TestCase
+final class DateTimeTypeTest extends TestCase
 {
     /**
      * @var \Cake\Database\Type\DateTimeType

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Test for the Date type.
  */
-class DateTypeTest extends TestCase
+final class DateTypeTest extends TestCase
 {
     /**
      * @var \Cake\Database\Type\DateType

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -28,7 +28,7 @@ use PDO;
 /**
  * Test for the Decimal type.
  */
-class DecimalTypeTest extends TestCase
+final class DecimalTypeTest extends TestCase
 {
     /**
      * @var \Cake\Database\Type\DecimalType

--- a/tests/TestCase/Database/Type/EnumLabelTraitTest.php
+++ b/tests/TestCase/Database/Type/EnumLabelTraitTest.php
@@ -27,7 +27,7 @@ use TestApp\Model\Enum\ArticleStatusTraitLabeled;
 /**
  * Tests for EnumLabelTrait.
  */
-class EnumLabelTraitTest extends TestCase
+final class EnumLabelTraitTest extends TestCase
 {
     /**
      * Restore i18n state after each test so translator changes do not bleed between tests.

--- a/tests/TestCase/Database/Type/EnumTypeTest.php
+++ b/tests/TestCase/Database/Type/EnumTypeTest.php
@@ -33,7 +33,7 @@ use ValueError;
 /**
  * Test for the String type.
  */
-class EnumTypeTest extends TestCase
+final class EnumTypeTest extends TestCase
 {
     /**
      * @inheritDoc

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -26,7 +26,7 @@ use PDO;
 /**
  * Test for the Float type.
  */
-class FloatTypeTest extends TestCase
+final class FloatTypeTest extends TestCase
 {
     /**
      * @var \Cake\Database\Type\FloatType

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Test for the Integer type.
  */
-class IntegerTypeTest extends TestCase
+final class IntegerTypeTest extends TestCase
 {
     /**
      * @var \Cake\Database\Type\IntegerType

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -27,7 +27,7 @@ use stdClass;
 /**
  * Test for the String type.
  */
-class JsonTypeTest extends TestCase
+final class JsonTypeTest extends TestCase
 {
     /**
      * @var \Cake\Database\Type\JsonType

--- a/tests/TestCase/Database/Type/StringTypeTest.php
+++ b/tests/TestCase/Database/Type/StringTypeTest.php
@@ -26,7 +26,7 @@ use PDO;
 /**
  * Test for the String type.
  */
-class StringTypeTest extends TestCase
+final class StringTypeTest extends TestCase
 {
     /**
      * @var \Cake\Database\TypeInterface

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -31,7 +31,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Test for the Time type.
  */
-class TimeTypeTest extends TestCase
+final class TimeTypeTest extends TestCase
 {
     /**
      * @var \Cake\Database\Type\TimeType

--- a/tests/TestCase/Database/Type/UuidTypeTest.php
+++ b/tests/TestCase/Database/Type/UuidTypeTest.php
@@ -24,7 +24,7 @@ use PDO;
 /**
  * Test for the Uuid type.
  */
-class UuidTypeTest extends TestCase
+final class UuidTypeTest extends TestCase
 {
     /**
      * @var \Cake\Database\Type\UuidType

--- a/tests/TestCase/Database/TypeFactoryTest.php
+++ b/tests/TestCase/Database/TypeFactoryTest.php
@@ -29,7 +29,7 @@ use TestApp\Database\Type\FooType;
 /**
  * Tests TypeFactory class
  */
-class TypeFactoryTest extends TestCase
+final class TypeFactoryTest extends TestCase
 {
     /**
      * Original type map

--- a/tests/TestCase/Database/ValueBinderTest.php
+++ b/tests/TestCase/Database/ValueBinderTest.php
@@ -24,7 +24,7 @@ use Mockery;
 /**
  * Tests ValueBinder class
  */
-class ValueBinderTest extends TestCase
+final class ValueBinderTest extends TestCase
 {
     /**
      * test the bind method

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -30,7 +30,7 @@ use TestPlugin\Datasource\TestSource;
 /**
  * ConnectionManager Test
  */
-class ConnectionManagerTest extends TestCase
+final class ConnectionManagerTest extends TestCase
 {
     /**
      * tearDown method

--- a/tests/TestCase/Datasource/FactoryLocatorTest.php
+++ b/tests/TestCase/Datasource/FactoryLocatorTest.php
@@ -24,7 +24,7 @@ use TestApp\Datasource\StubFactory;
 /**
  * FactoryLocatorTest test case
  */
-class FactoryLocatorTest extends TestCase
+final class FactoryLocatorTest extends TestCase
 {
     /**
      * Test get factory

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -29,7 +29,7 @@ use UnexpectedValueException;
 /**
  * ModelAwareTrait test case
  */
-class ModelAwareTraitTest extends TestCase
+final class ModelAwareTraitTest extends TestCase
 {
     protected function tearDown(): void
     {

--- a/tests/TestCase/Datasource/Paging/NumericPaginatorSortFieldTest.php
+++ b/tests/TestCase/Datasource/Paging/NumericPaginatorSortFieldTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
 /**
  * NumericPaginator SortField Integration Test Case
  */
-class NumericPaginatorSortFieldTest extends TestCase
+final class NumericPaginatorSortFieldTest extends TestCase
 {
     /**
      * @var array<string>

--- a/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
+++ b/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
 use Mockery;
 use function Cake\Collection\collection;
 
-class PaginatedResultSetTest extends TestCase
+final class PaginatedResultSetTest extends TestCase
 {
     public function testItems(): void
     {

--- a/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
@@ -21,7 +21,7 @@ use Cake\Datasource\Paging\SimplePaginator;
 use Cake\Datasource\RepositoryInterface;
 use Cake\ORM\Entity;
 
-class SimplePaginatorTest extends NumericPaginatorTest
+final class SimplePaginatorTest extends NumericPaginatorTest
 {
     protected function setUp(): void
     {

--- a/tests/TestCase/Datasource/Paging/SortFieldTest.php
+++ b/tests/TestCase/Datasource/Paging/SortFieldTest.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\TestCase;
 /**
  * SortField Test Case
  */
-class SortFieldTest extends TestCase
+final class SortFieldTest extends TestCase
 {
     /**
      * Test constructor and getters

--- a/tests/TestCase/Datasource/Paging/SortableFieldsBuilderTest.php
+++ b/tests/TestCase/Datasource/Paging/SortableFieldsBuilderTest.php
@@ -24,7 +24,7 @@ use InvalidArgumentException;
 /**
  * SortableFieldsBuilder Test Case
  */
-class SortableFieldsBuilderTest extends TestCase
+final class SortableFieldsBuilderTest extends TestCase
 {
     /**
      * Test basic add() functionality

--- a/tests/TestCase/Datasource/QueryCacherTest.php
+++ b/tests/TestCase/Datasource/QueryCacherTest.php
@@ -25,7 +25,7 @@ use stdClass;
 /**
  * Query cacher test
  */
-class QueryCacherTest extends TestCase
+final class QueryCacherTest extends TestCase
 {
     /**
      * @var \Cake\Cache\CacheEngineInterface

--- a/tests/TestCase/Datasource/ResultSetDecoratorTest.php
+++ b/tests/TestCase/Datasource/ResultSetDecoratorTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests ResultSetDecorator class
  */
-class ResultSetDecoratorTest extends TestCase
+final class ResultSetDecoratorTest extends TestCase
 {
     /**
      * Tests the decorator can wrap a simple iterator

--- a/tests/TestCase/Datasource/RuleInvokerTest.php
+++ b/tests/TestCase/Datasource/RuleInvokerTest.php
@@ -21,7 +21,7 @@ use Cake\ORM\Entity;
 use Cake\ORM\Rule\ValidCount;
 use PHPUnit\Framework\TestCase;
 
-class RuleInvokerTest extends TestCase
+final class RuleInvokerTest extends TestCase
 {
     public function testInvoke(): void
     {

--- a/tests/TestCase/Datasource/RulesCheckerTest.php
+++ b/tests/TestCase/Datasource/RulesCheckerTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests the integration between the ORM and the domain checker
  */
-class RulesCheckerTest extends TestCase
+final class RulesCheckerTest extends TestCase
 {
     /**
      * Test adding rule for create and update

--- a/tests/TestCase/Error/Debug/ConsoleFormatterTest.php
+++ b/tests/TestCase/Error/Debug/ConsoleFormatterTest.php
@@ -29,7 +29,7 @@ use Cake\TestSuite\TestCase;
 /**
  * ConsoleFormatterTest
  */
-class ConsoleFormatterTest extends TestCase
+final class ConsoleFormatterTest extends TestCase
 {
     /**
      * Test dumping a graph that contains all possible nodes.

--- a/tests/TestCase/Error/Debug/HtmlFormatterTest.php
+++ b/tests/TestCase/Error/Debug/HtmlFormatterTest.php
@@ -30,7 +30,7 @@ use DomDocument;
 /**
  * HtmlFormatterTest
  */
-class HtmlFormatterTest extends TestCase
+final class HtmlFormatterTest extends TestCase
 {
     /**
      * Test dumping a graph that contains all possible nodes.

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -48,7 +48,7 @@ use TestApp\Utility\ThrowsDebugInfo;
  * !!! change line numbers which are used in the tests
  */
 #[AllowMockObjectsWithoutExpectations]
-class DebuggerTest extends TestCase
+final class DebuggerTest extends TestCase
 {
     /**
      * @var bool

--- a/tests/TestCase/Error/ErrorLoggerTest.php
+++ b/tests/TestCase/Error/ErrorLoggerTest.php
@@ -29,7 +29,7 @@ use TestApp\Log\Engine\TestAppLog;
 /**
  * ErrorLogger Test
  */
-class ErrorLoggerTest extends TestCase
+final class ErrorLoggerTest extends TestCase
 {
     /**
      * @var \Cake\Error\ErrorLogger

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -30,7 +30,7 @@ use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class ErrorTrapTest extends TestCase
+final class ErrorTrapTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -36,7 +36,7 @@ use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use RuntimeException;
 use Throwable;
 
-class ExceptionTrapTest extends TestCase
+final class ExceptionTrapTest extends TestCase
 {
     private string $memoryLimit;
 

--- a/tests/TestCase/Error/FunctionsTest.php
+++ b/tests/TestCase/Error/FunctionsTest.php
@@ -26,7 +26,7 @@ use function Cake\Error\stackTrace;
 /**
  * FunctionsTest class
  */
-class FunctionsTest extends TestCase
+final class FunctionsTest extends TestCase
 {
     /**
      * test debug()

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -44,7 +44,7 @@ use Throwable;
 /**
  * Test for ErrorHandlerMiddleware
  */
-class ErrorHandlerMiddlewareTest extends TestCase
+final class ErrorHandlerMiddlewareTest extends TestCase
 {
     /**
      * @var \Cake\Log\Engine\ArrayLog

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -58,7 +58,7 @@ final class ErrorHandlerMiddlewareTest extends TestCase
     {
         parent::setUp();
 
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         Log::reset();
         Log::setConfig('error_test', [

--- a/tests/TestCase/Error/PhpErrorTest.php
+++ b/tests/TestCase/Error/PhpErrorTest.php
@@ -20,7 +20,7 @@ use Cake\Error\PhpError;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class PhpErrorTest extends TestCase
+final class PhpErrorTest extends TestCase
 {
     public function testBasicGetters(): void
     {

--- a/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
+++ b/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
@@ -304,7 +304,7 @@ final class WebExceptionRendererTest extends TestCase
      */
     public function testCakeErrorHelpersNotLost(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         $exception = new NotFoundException();
         $renderer = new TestAppsExceptionRenderer($exception);
 

--- a/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
+++ b/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
@@ -62,7 +62,7 @@ use TestApp\Error\Renderer\TestAppsExceptionRenderer;
 use TestPlugin\Controller\ErrorController as PluginErrorController;
 use function Cake\Core\h;
 
-class WebExceptionRendererTest extends TestCase
+final class WebExceptionRendererTest extends TestCase
 {
     /**
      * @var bool

--- a/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
+++ b/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
@@ -26,7 +26,7 @@ use InvalidArgumentException;
 /**
  * Tests the Cake\Event\Event class functionality
  */
-class ConditionDecoratorTest extends TestCase
+final class ConditionDecoratorTest extends TestCase
 {
     /**
      * testCanTriggerIf

--- a/tests/TestCase/Event/Decorator/SubjectFilterDecoratorTest.php
+++ b/tests/TestCase/Event/Decorator/SubjectFilterDecoratorTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests the Cake\Event\Event class functionality
  */
-class SubjectFilterDecoratorTest extends TestCase
+final class SubjectFilterDecoratorTest extends TestCase
 {
     /**
      * testCanTrigger

--- a/tests/TestCase/Event/EventDispatcherTraitTest.php
+++ b/tests/TestCase/Event/EventDispatcherTraitTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * EventDispatcherTrait test case
  */
-class EventDispatcherTraitTest extends TestCase
+final class EventDispatcherTraitTest extends TestCase
 {
     /**
      * @var \Cake\Event\EventDispatcherTrait

--- a/tests/TestCase/Event/EventListTest.php
+++ b/tests/TestCase/Event/EventListTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests the Cake\Event\EvenList class functionality
  */
-class EventListTest extends TestCase
+final class EventListTest extends TestCase
 {
     /**
      * testAddEventAndFlush

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -30,7 +30,7 @@ use TestApp\TestCase\Event\EventTestListener;
 /**
  * Tests the Cake\Event\EventManager class functionality
  */
-class EventManagerTest extends TestCase
+final class EventManagerTest extends TestCase
 {
     /**
      * Test attach() with a listener interface.

--- a/tests/TestCase/Event/EventTest.php
+++ b/tests/TestCase/Event/EventTest.php
@@ -27,7 +27,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests the Cake\Event\Event class functionality
  */
-class EventTest extends TestCase
+final class EventTest extends TestCase
 {
     /**
      * Tests the name() method

--- a/tests/TestCase/ExceptionsTest.php
+++ b/tests/TestCase/ExceptionsTest.php
@@ -77,7 +77,7 @@ use Cake\View\Exception\MissingViewException;
 use Exception;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class ExceptionsTest extends TestCase
+final class ExceptionsTest extends TestCase
 {
     /**
      * Tests simple exceptions work.

--- a/tests/TestCase/Form/FormProtectorTest.php
+++ b/tests/TestCase/Form/FormProtectorTest.php
@@ -24,7 +24,7 @@ use Cake\Utility\Security;
 /**
  * FormProtectorTest class
  */
-class FormProtectorTest extends TestCase
+final class FormProtectorTest extends TestCase
 {
     /**
      * @var string

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -27,7 +27,7 @@ use TestApp\Form\FormSchema;
 /**
  * Form test case.
  */
-class FormTest extends TestCase
+final class FormTest extends TestCase
 {
     /**
      * Test setSchema() and getSchema()

--- a/tests/TestCase/Form/SchemaTest.php
+++ b/tests/TestCase/Form/SchemaTest.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Form schema test case.
  */
-class SchemaTest extends TestCase
+final class SchemaTest extends TestCase
 {
     /**
      * Test adding multiple fields.

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -59,7 +59,7 @@ final class BaseApplicationTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
         $this->app = new class (dirname(__DIR__, 2)) extends BaseApplication
         {
             public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
@@ -383,7 +383,7 @@ final class BaseApplicationTest extends TestCase
 
     public function testConsoleEventsAreRegistered(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         $app = new class (dirname(__DIR__, 2)) extends BaseApplication
         {
             public function routes(RouteBuilder $routes): void
@@ -415,7 +415,7 @@ final class BaseApplicationTest extends TestCase
 
     public function testEventListenersWithDependencyInjection(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         $app = new class (dirname(__DIR__, 2) . '/test_app/config') extends BaseApplication {
             public function eventListeners(): array

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -46,7 +46,7 @@ use TestPlugin\TestPluginPlugin as TestPlugin;
 /**
  * Base application test.
  */
-class BaseApplicationTest extends TestCase
+final class BaseApplicationTest extends TestCase
 {
     /**
      * @var \Cake\Http\BaseApplication

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -25,7 +25,7 @@ use Composer\CaBundle\CaBundle;
 /**
  * HTTP curl adapter test.
  */
-class CurlTest extends TestCase
+final class CurlTest extends TestCase
 {
     /**
      * @var \Cake\Http\Client\Adapter\Curl

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -28,7 +28,7 @@ use TestApp\Http\Client\Adapter\CakeStreamWrapper;
 /**
  * HTTP stream adapter test.
  */
-class StreamTest extends TestCase
+final class StreamTest extends TestCase
 {
     /**
      * @var \Cake\Http\Client\Adapter\Stream

--- a/tests/TestCase/Http/Client/Auth/DigestTest.php
+++ b/tests/TestCase/Http/Client/Auth/DigestTest.php
@@ -27,7 +27,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Digest authentication test
  */
-class DigestTest extends TestCase
+final class DigestTest extends TestCase
 {
     /**
      * @var \Cake\Http\Client

--- a/tests/TestCase/Http/Client/Auth/OauthTest.php
+++ b/tests/TestCase/Http/Client/Auth/OauthTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Oauth test.
  */
-class OauthTest extends TestCase
+final class OauthTest extends TestCase
 {
     private string $privateKeyString;
 

--- a/tests/TestCase/Http/Client/FormDataTest.php
+++ b/tests/TestCase/Http/Client/FormDataTest.php
@@ -22,7 +22,7 @@ use Laminas\Diactoros\UploadedFile;
 /**
  * Test case for FormData.
  */
-class FormDataTest extends TestCase
+final class FormDataTest extends TestCase
 {
     /**
      * Test getting the boundary.

--- a/tests/TestCase/Http/Client/RequestTest.php
+++ b/tests/TestCase/Http/Client/RequestTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * HTTP request test.
  */
-class RequestTest extends TestCase
+final class RequestTest extends TestCase
 {
     /**
      * test string ata, header and constructor

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * HTTP response test.
  */
-class ResponseTest extends TestCase
+final class ResponseTest extends TestCase
 {
     /**
      * Test parsing headers and reading with PSR7 methods.

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -33,7 +33,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * HTTP client test.
  */
-class ClientTest extends TestCase
+final class ClientTest extends TestCase
 {
     protected function tearDown(): void
     {

--- a/tests/TestCase/Http/ContentTypeNegotiationTest.php
+++ b/tests/TestCase/Http/ContentTypeNegotiationTest.php
@@ -7,7 +7,7 @@ use Cake\Http\ContentTypeNegotiation;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 
-class ContentTypeNegotiationTest extends TestCase
+final class ContentTypeNegotiationTest extends TestCase
 {
     public function testPreferredTypeNoAccept(): void
     {

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -27,7 +27,7 @@ use InvalidArgumentException;
 /**
  * Cookie collection test.
  */
-class CookieCollectionTest extends TestCase
+final class CookieCollectionTest extends TestCase
 {
     /**
      * Test constructor

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -27,7 +27,7 @@ use ValueError;
 /**
  * HTTP cookies test.
  */
-class CookieTest extends TestCase
+final class CookieTest extends TestCase
 {
     /**
      * Generate invalid cookie names.

--- a/tests/TestCase/Http/CorsBuilderTest.php
+++ b/tests/TestCase/Http/CorsBuilderTest.php
@@ -7,7 +7,7 @@ use Cake\Http\CorsBuilder;
 use Cake\Http\Response;
 use Cake\TestSuite\TestCase;
 
-class CorsBuilderTest extends TestCase
+final class CorsBuilderTest extends TestCase
 {
     /**
      * test allowOrigin() setting allow-origin

--- a/tests/TestCase/Http/FlashMessageTest.php
+++ b/tests/TestCase/Http/FlashMessageTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * FlashMessageTest class
  */
-class FlashMessageTest extends TestCase
+final class FlashMessageTest extends TestCase
 {
     /**
      * @var \Cake\Http\FlashMessage

--- a/tests/TestCase/Http/FlashMessageTest.php
+++ b/tests/TestCase/Http/FlashMessageTest.php
@@ -41,7 +41,7 @@ final class FlashMessageTest extends TestCase
     {
         parent::setUp();
 
-        static::setAppNamespace();
+        self::setAppNamespace();
         $this->Session = new Session();
         $this->Flash = new FlashMessage($this->Session);
     }

--- a/tests/TestCase/Http/HeaderUtilityTest.php
+++ b/tests/TestCase/Http/HeaderUtilityTest.php
@@ -8,7 +8,7 @@ use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 
-class HeaderUtilityTest extends TestCase
+final class HeaderUtilityTest extends TestCase
 {
     /**
      * Tests getting a parsed representation of a Link header

--- a/tests/TestCase/Http/Link/LinkProviderTest.php
+++ b/tests/TestCase/Http/Link/LinkProviderTest.php
@@ -25,7 +25,7 @@ use Psr\Link\LinkProviderInterface;
 /**
  * LinkProviderTest class
  */
-class LinkProviderTest extends TestCase
+final class LinkProviderTest extends TestCase
 {
     /**
      * Test that LinkProvider implements PSR-13 interfaces.

--- a/tests/TestCase/Http/Link/LinkTest.php
+++ b/tests/TestCase/Http/Link/LinkTest.php
@@ -24,7 +24,7 @@ use Psr\Link\LinkInterface;
 /**
  * LinkTest class
  */
-class LinkTest extends TestCase
+final class LinkTest extends TestCase
 {
     /**
      * Test that Link implements PSR-13 interfaces.

--- a/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
@@ -27,7 +27,7 @@ use TestApp\Http\TestRequestHandler;
 /**
  * Test for BodyParser
  */
-class BodyParserMiddlewareTest extends TestCase
+final class BodyParserMiddlewareTest extends TestCase
 {
     /**
      * Data provider for HTTP method tests.

--- a/tests/TestCase/Http/Middleware/CspMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CspMiddlewareTest.php
@@ -28,7 +28,7 @@ use TestApp\Http\TestRequestHandler;
 /**
  * Content Security Policy Middleware Test
  */
-class CspMiddlewareTest extends TestCase
+final class CspMiddlewareTest extends TestCase
 {
     /**
      * Provides the request handler

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -35,7 +35,7 @@ use TestApp\Http\TestRequestHandler;
 /**
  * Test for CsrfProtection
  */
-class CsrfProtectionMiddlewareTest extends TestCase
+final class CsrfProtectionMiddlewareTest extends TestCase
 {
     protected function createOldToken(): string
     {

--- a/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
@@ -29,7 +29,7 @@ use TestApp\Http\TestRequestHandler;
 /**
  * Test for EncryptedCookieMiddleware
  */
-class EncryptedCookieMiddlewareTest extends TestCase
+final class EncryptedCookieMiddlewareTest extends TestCase
 {
     use CookieCryptTrait;
 

--- a/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
@@ -49,7 +49,7 @@ final class EncryptedCookieMiddlewareTest extends TestCase
     {
         parent::setup();
 
-        static::$encryptedString = $this->_encrypt('secret data', 'aes');
+        self::$encryptedString = $this->_encrypt('secret data', 'aes');
 
         $this->middleware = new EncryptedCookieMiddleware(
             ['secret', 'ninja'],
@@ -113,9 +113,9 @@ final class EncryptedCookieMiddlewareTest extends TestCase
     {
         return [
             'empty' => [''],
-            'wrong prefix' => [substr_replace(static::$encryptedString, 'foo', 0, 3)],
-            'altered' => [str_replace('M', 'A', static::$encryptedString)],
-            'invalid chars' => [str_replace('M', 'M#', static::$encryptedString)],
+            'wrong prefix' => [substr_replace(self::$encryptedString, 'foo', 0, 3)],
+            'altered' => [str_replace('M', 'A', self::$encryptedString)],
+            'invalid chars' => [str_replace('M', 'M#', self::$encryptedString)],
         ];
     }
 

--- a/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
@@ -31,7 +31,7 @@ use UnexpectedValueException;
 /**
  * Test for HttpsEnforcerMiddleware
  */
-class HttpsEnforcerMiddlewareTest extends TestCase
+final class HttpsEnforcerMiddlewareTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
@@ -29,7 +29,7 @@ use stdClass;
 /**
  * RateLimitMiddleware test case
  */
-class RateLimitMiddlewareTest extends TestCase
+final class RateLimitMiddlewareTest extends TestCase
 {
     /**
      * @var \Psr\Http\Server\RequestHandlerInterface

--- a/tests/TestCase/Http/Middleware/SecurityHeadersMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SecurityHeadersMiddlewareTest.php
@@ -26,7 +26,7 @@ use TestApp\Http\TestRequestHandler;
 /**
  * Test for SecurityMiddleware
  */
-class SecurityHeadersMiddlewareTest extends TestCase
+final class SecurityHeadersMiddlewareTest extends TestCase
 {
     /**
      * Test adding the security headers

--- a/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
@@ -29,7 +29,7 @@ use TestApp\Http\TestRequestHandler;
 /**
  * Test for SessionCsrfProtection
  */
-class SessionCsrfProtectionMiddlewareTest extends TestCase
+final class SessionCsrfProtectionMiddlewareTest extends TestCase
 {
     /**
      * Data provider for HTTP method tests.

--- a/tests/TestCase/Http/MiddlewareApplicationTest.php
+++ b/tests/TestCase/Http/MiddlewareApplicationTest.php
@@ -25,7 +25,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * MiddlewareApplication test.
  */
-class MiddlewareApplicationTest extends TestCase
+final class MiddlewareApplicationTest extends TestCase
 {
     /**
      * Setup

--- a/tests/TestCase/Http/MiddlewareApplicationTest.php
+++ b/tests/TestCase/Http/MiddlewareApplicationTest.php
@@ -33,7 +33,7 @@ final class MiddlewareApplicationTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -28,7 +28,7 @@ use TestApp\Middleware\SampleMiddleware;
 /**
  * Test case for the MiddlewareQueue
  */
-class MiddlewareQueueTest extends TestCase
+final class MiddlewareQueueTest extends TestCase
 {
     /**
      * @var string

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -42,7 +42,7 @@ final class MiddlewareQueueTest extends TestCase
     {
         parent::setUp();
 
-        $this->previousNamespace = static::setAppNamespace('TestApp');
+        $this->previousNamespace = self::setAppNamespace('TestApp');
     }
 
     /**
@@ -51,7 +51,7 @@ final class MiddlewareQueueTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
-        static::setAppNamespace($this->previousNamespace);
+        self::setAppNamespace($this->previousNamespace);
     }
 
     public function testConstructorAddingMiddleware(): void

--- a/tests/TestCase/Http/MimeTypeTest.php
+++ b/tests/TestCase/Http/MimeTypeTest.php
@@ -19,7 +19,7 @@ namespace Cake\Test\TestCase\Http;
 use Cake\Http\MimeType;
 use Cake\TestSuite\TestCase;
 
-class MimeTypeTest extends TestCase
+final class MimeTypeTest extends TestCase
 {
     public function testGetMimeTypes(): void
     {

--- a/tests/TestCase/Http/RateLimit/SlidingWindowRateLimiterTest.php
+++ b/tests/TestCase/Http/RateLimit/SlidingWindowRateLimiterTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * SlidingWindowRateLimiter test case
  */
-class SlidingWindowRateLimiterTest extends TestCase
+final class SlidingWindowRateLimiterTest extends TestCase
 {
     /**
      * @var \Cake\Http\RateLimit\SlidingWindowRateLimiter

--- a/tests/TestCase/Http/RequestFactoryTest.php
+++ b/tests/TestCase/Http/RequestFactoryTest.php
@@ -23,7 +23,7 @@ use Laminas\Diactoros\Uri;
 /**
  * Test case for the request factory.
  */
-class RequestFactoryTest extends TestCase
+final class RequestFactoryTest extends TestCase
 {
     public function testCreateRequest(): void
     {

--- a/tests/TestCase/Http/Response/AbstractStreamResponseTest.php
+++ b/tests/TestCase/Http/Response/AbstractStreamResponseTest.php
@@ -28,7 +28,7 @@ use Throwable;
  * Tests for {@see \Cake\Http\Response\AbstractStreamResponse} that exercise
  * the shared streaming lifecycle independently of any concrete wire format.
  */
-class AbstractStreamResponseTest extends TestCase
+final class AbstractStreamResponseTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/TestCase/Http/Response/JsonStreamResponseTest.php
+++ b/tests/TestCase/Http/Response/JsonStreamResponseTest.php
@@ -23,7 +23,7 @@ use InvalidArgumentException;
 use JsonException;
 use Throwable;
 
-class JsonStreamResponseTest extends TestCase
+final class JsonStreamResponseTest extends TestCase
 {
     /**
      * @var bool|null

--- a/tests/TestCase/Http/ResponseEmitterTest.php
+++ b/tests/TestCase/Http/ResponseEmitterTest.php
@@ -29,7 +29,7 @@ require_once __DIR__ . '/server_mocks.php';
 /**
  * Response emitter test.
  */
-class ResponseEmitterTest extends TestCase
+final class ResponseEmitterTest extends TestCase
 {
     /**
      * @var \Cake\Http\ResponseEmitter

--- a/tests/TestCase/Http/ResponseFactoryTest.php
+++ b/tests/TestCase/Http/ResponseFactoryTest.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Test case for the response factory.
  */
-class ResponseFactoryTest extends TestCase
+final class ResponseFactoryTest extends TestCase
 {
     public function testCreateResponse(): void
     {

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -39,7 +39,7 @@ use Psr\Http\Message\StreamInterface;
 /**
  * ResponseTest
  */
-class ResponseTest extends TestCase
+final class ResponseTest extends TestCase
 {
     /**
      * SERVER variable backup.

--- a/tests/TestCase/Http/RunnerTest.php
+++ b/tests/TestCase/Http/RunnerTest.php
@@ -30,7 +30,7 @@ use Throwable;
 /**
  * Test case for runner.
  */
-class RunnerTest extends TestCase
+final class RunnerTest extends TestCase
 {
     /**
      * @var \Cake\Http\MiddlewareQueue

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -31,7 +31,7 @@ use Psr\Http\Message\UploadedFileInterface;
 /**
  * Test case for the server factory.
  */
-class ServerRequestFactoryTest extends TestCase
+final class ServerRequestFactoryTest extends TestCase
 {
     /**
      * Test fromGlobals reads super globals

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -36,7 +36,7 @@ use Psr\Http\Message\UriInterface;
 /**
  * ServerRequest Test
  */
-class ServerRequestTest extends TestCase
+final class ServerRequestTest extends TestCase
 {
     /**
      * Test custom detector with extra arguments.

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -41,7 +41,7 @@ require_once __DIR__ . '/server_mocks.php';
 /**
  * Server test case
  */
-class ServerTest extends TestCase
+final class ServerTest extends TestCase
 {
     /**
      * @var string

--- a/tests/TestCase/Http/Session/CacheSessionTest.php
+++ b/tests/TestCase/Http/Session/CacheSessionTest.php
@@ -26,7 +26,7 @@ use InvalidArgumentException;
 /**
  * CacheSessionTest
  */
-class CacheSessionTest extends TestCase
+final class CacheSessionTest extends TestCase
 {
     protected static $_sessionBackup;
 

--- a/tests/TestCase/Http/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Http/Session/DatabaseSessionTest.php
@@ -45,7 +45,7 @@ final class DatabaseSessionTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
         $this->storage = new DatabaseSession();
     }
 

--- a/tests/TestCase/Http/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Http/Session/DatabaseSessionTest.php
@@ -27,7 +27,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Database session test.
  */
-class DatabaseSessionTest extends TestCase
+final class DatabaseSessionTest extends TestCase
 {
     /**
      * @var array

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -31,7 +31,7 @@ use TestPlugin\Http\Session\TestPluginSession;
 /**
  * SessionTest class
  */
-class SessionTest extends TestCase
+final class SessionTest extends TestCase
 {
     /**
      * tearDown method

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -502,7 +502,7 @@ final class SessionTest extends TestCase
     #[RunInSeparateProcess]
     public function testUsingAppLibsHandler(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         $config = [
             'defaults' => 'cake',
             'handler' => [
@@ -525,7 +525,7 @@ final class SessionTest extends TestCase
     #[RunInSeparateProcess]
     public function testUsingPluginHandler(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         $this->loadPlugins(['TestPlugin']);
 
         $config = [
@@ -547,7 +547,7 @@ final class SessionTest extends TestCase
     #[RunInSeparateProcess]
     public function testEngineWithPreMadeInstance(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         $engine = new TestAppLibSession();
         $session = new Session(['handler' => ['engine' => $engine]]);
         $this->assertSame($engine, $session->engine());

--- a/tests/TestCase/Http/StreamFactoryTest.php
+++ b/tests/TestCase/Http/StreamFactoryTest.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Test case for the stream factory.
  */
-class StreamFactoryTest extends TestCase
+final class StreamFactoryTest extends TestCase
 {
     protected StreamFactory $factory;
 

--- a/tests/TestCase/Http/TestSuite/HttpClientTraitTest.php
+++ b/tests/TestCase/Http/TestSuite/HttpClientTraitTest.php
@@ -21,7 +21,7 @@ use Cake\Http\TestSuite\HttpClientTrait;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class HttpClientTraitTest extends TestCase
+final class HttpClientTraitTest extends TestCase
 {
     use HttpClientTrait;
 

--- a/tests/TestCase/Http/UploadedFileFactoryTest.php
+++ b/tests/TestCase/Http/UploadedFileFactoryTest.php
@@ -23,7 +23,7 @@ use Laminas\Diactoros\Stream;
 /**
  * Test case for the uploaded file factory.
  */
-class UploadedFileFactoryTest extends TestCase
+final class UploadedFileFactoryTest extends TestCase
 {
     protected UploadedFileFactory $factory;
 

--- a/tests/TestCase/Http/UriFactoryTest.php
+++ b/tests/TestCase/Http/UriFactoryTest.php
@@ -24,7 +24,7 @@ use Laminas\Diactoros\Uri;
 /**
  * Test case for the uri factory.
  */
-class UriFactoryTest extends TestCase
+final class UriFactoryTest extends TestCase
 {
     public function testCreateUri(): void
     {

--- a/tests/TestCase/I18n/DatePeriodTest.php
+++ b/tests/TestCase/I18n/DatePeriodTest.php
@@ -23,7 +23,7 @@ use DateInterval;
 use DatePeriod as PhpDatePeriod;
 use DateTimeImmutable;
 
-class DatePeriodTest extends TestCase
+final class DatePeriodTest extends TestCase
 {
     public function testDatePeriod(): void
     {

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -28,7 +28,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * DateTest class
  */
-class DateTest extends TestCase
+final class DateTest extends TestCase
 {
     /**
      * setup

--- a/tests/TestCase/I18n/DateTimePeriodTest.php
+++ b/tests/TestCase/I18n/DateTimePeriodTest.php
@@ -23,7 +23,7 @@ use DateInterval;
 use DatePeriod;
 use DateTimeImmutable;
 
-class DateTimePeriodTest extends TestCase
+final class DateTimePeriodTest extends TestCase
 {
     public function testDateTimePeriod(): void
     {

--- a/tests/TestCase/I18n/DateTimeTest.php
+++ b/tests/TestCase/I18n/DateTimeTest.php
@@ -28,7 +28,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * DateTimeTest class
  */
-class DateTimeTest extends TestCase
+final class DateTimeTest extends TestCase
 {
     /**
      * @var \Cake\Chronos\Chronos|null

--- a/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
+++ b/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
@@ -23,7 +23,7 @@ use Exception;
 /**
  * IcuFormatter tests
  */
-class IcuFormatterTest extends TestCase
+final class IcuFormatterTest extends TestCase
 {
     /**
      * Tests that empty values can be used as formatting strings

--- a/tests/TestCase/I18n/Formatter/SprintfFormatterTest.php
+++ b/tests/TestCase/I18n/Formatter/SprintfFormatterTest.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\TestCase;
 /**
  * SprintfFormatter tests
  */
-class SprintfFormatterTest extends TestCase
+final class SprintfFormatterTest extends TestCase
 {
     /**
      * Tests that variables are interpolated correctly

--- a/tests/TestCase/I18n/FunctionsTest.php
+++ b/tests/TestCase/I18n/FunctionsTest.php
@@ -29,7 +29,7 @@ use function Cake\I18n\toDateTime;
 /**
  * Test cases for functions in I18n\functions.php
  */
-class FunctionsTest extends TestCase
+final class FunctionsTest extends TestCase
 {
     #[DataProvider('toDateTimeProvider')]
     public function testToDateTime(mixed $rawValue, string $format, ?DateTime $expected): void

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -35,7 +35,7 @@ use function Cake\I18n\__xn;
 /**
  * I18nTest class
  */
-class I18nTest extends TestCase
+final class I18nTest extends TestCase
 {
     /**
      * Set Up

--- a/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * MessagesFileLoaderTest class
  */
-class MessagesFileLoaderTest extends TestCase
+final class MessagesFileLoaderTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/TestCase/I18n/Middleware/LocaleSelectorMiddlewareTest.php
+++ b/tests/TestCase/I18n/Middleware/LocaleSelectorMiddlewareTest.php
@@ -26,7 +26,7 @@ use TestApp\Http\TestRequestHandler;
 /**
  * Test for LocaleSelectorMiddleware
  */
-class LocaleSelectorMiddlewareTest extends TestCase
+final class LocaleSelectorMiddlewareTest extends TestCase
 {
     /**
      * @var string

--- a/tests/TestCase/I18n/NumberTest.php
+++ b/tests/TestCase/I18n/NumberTest.php
@@ -26,7 +26,7 @@ use NumberFormatter;
 /**
  * NumberTest class
  */
-class NumberTest extends TestCase
+final class NumberTest extends TestCase
 {
     /**
      * @var \Cake\I18n\Number

--- a/tests/TestCase/I18n/PackageTest.php
+++ b/tests/TestCase/I18n/PackageTest.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\TestCase;
 /**
  * PackageTest class
  */
-class PackageTest extends TestCase
+final class PackageTest extends TestCase
 {
     /**
      * Test adding messages.

--- a/tests/TestCase/I18n/Parser/MoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/MoFileParserTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests the MoFileLoader
  */
-class MoFileParserTest extends TestCase
+final class MoFileParserTest extends TestCase
 {
     /**
      * Locale folder path

--- a/tests/TestCase/I18n/Parser/PoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/PoFileParserTest.php
@@ -29,7 +29,7 @@ use function Cake\I18n\__x;
 /**
  * Tests the PoFileLoader
  */
-class PoFileParserTest extends TestCase
+final class PoFileParserTest extends TestCase
 {
     /**
      * Locale folder path

--- a/tests/TestCase/I18n/PluralRulesTest.php
+++ b/tests/TestCase/I18n/PluralRulesTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * PluralRules tests
  */
-class PluralRulesTest extends TestCase
+final class PluralRulesTest extends TestCase
 {
     /**
      * tearDown method

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -25,7 +25,7 @@ use DateTimeImmutable;
 use IntlDateFormatter;
 use InvalidArgumentException;
 
-class TimeTest extends TestCase
+final class TimeTest extends TestCase
 {
     /**
      * @var \Cake\Chronos\Chronos|null

--- a/tests/TestCase/I18n/TranslatorRegistryTest.php
+++ b/tests/TestCase/I18n/TranslatorRegistryTest.php
@@ -28,7 +28,7 @@ use InvalidArgumentException;
 use TestApp\Cache\Engine\RecordingCacheEngine;
 use TestApp\Cache\Engine\TestAppCacheEngine;
 
-class TranslatorRegistryTest extends TestCase
+final class TranslatorRegistryTest extends TestCase
 {
     /**
      * Test Package null initialization from cache

--- a/tests/TestCase/Lock/AcquiredLockTest.php
+++ b/tests/TestCase/Lock/AcquiredLockTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * AcquiredLockTest class
  */
-class AcquiredLockTest extends TestCase
+final class AcquiredLockTest extends TestCase
 {
     /**
      * Test constructor and getters.

--- a/tests/TestCase/Lock/Engine/FileLockEngineTest.php
+++ b/tests/TestCase/Lock/Engine/FileLockEngineTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * FileLockEngineTest class
  */
-class FileLockEngineTest extends TestCase
+final class FileLockEngineTest extends TestCase
 {
     /**
      * @var \Cake\Lock\Engine\FileLockEngine

--- a/tests/TestCase/Lock/Engine/MemcachedLockEngineTest.php
+++ b/tests/TestCase/Lock/Engine/MemcachedLockEngineTest.php
@@ -24,7 +24,7 @@ use function Cake\Core\env;
 /**
  * MemcachedLockEngineTest class
  */
-class MemcachedLockEngineTest extends TestCase
+final class MemcachedLockEngineTest extends TestCase
 {
     /**
      * @var \Cake\Lock\Engine\MemcachedLockEngine|null

--- a/tests/TestCase/Lock/Engine/NullLockEngineTest.php
+++ b/tests/TestCase/Lock/Engine/NullLockEngineTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * NullLockEngineTest class
  */
-class NullLockEngineTest extends TestCase
+final class NullLockEngineTest extends TestCase
 {
     /**
      * @var \Cake\Lock\Engine\NullLockEngine

--- a/tests/TestCase/Lock/Engine/RedisLockEngineTest.php
+++ b/tests/TestCase/Lock/Engine/RedisLockEngineTest.php
@@ -26,7 +26,7 @@ use function Cake\Core\env;
 /**
  * RedisLockEngineTest class
  */
-class RedisLockEngineTest extends TestCase
+final class RedisLockEngineTest extends TestCase
 {
     /**
      * @var \Cake\Lock\Engine\RedisLockEngine|null

--- a/tests/TestCase/Lock/LockTest.php
+++ b/tests/TestCase/Lock/LockTest.php
@@ -26,7 +26,7 @@ use Cake\TestSuite\TestCase;
 /**
  * LockTest class
  */
-class LockTest extends TestCase
+final class LockTest extends TestCase
 {
     /**
      * setUp method

--- a/tests/TestCase/Log/Engine/BaseLogTest.php
+++ b/tests/TestCase/Log/Engine/BaseLogTest.php
@@ -25,7 +25,7 @@ use Psr\Log\LogLevel;
 use TestApp\Log\Engine\TestBaseLog;
 use TestApp\Log\Formatter\ValidFormatter;
 
-class BaseLogTest extends TestCase
+final class BaseLogTest extends TestCase
 {
     private $testData = ['ä', 'ö', 'ü'];
 

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -24,7 +24,7 @@ use Mockery;
 /**
  * ConsoleLogTest class
  */
-class ConsoleLogTest extends TestCase
+final class ConsoleLogTest extends TestCase
 {
     /**
      * Test writing to ConsoleOutput

--- a/tests/TestCase/Log/Engine/FileLogTest.php
+++ b/tests/TestCase/Log/Engine/FileLogTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 /**
  * FileLogTest class
  */
-class FileLogTest extends TestCase
+final class FileLogTest extends TestCase
 {
     /**
      * testLogFileWriting method

--- a/tests/TestCase/Log/Engine/SyslogLogTest.php
+++ b/tests/TestCase/Log/Engine/SyslogLogTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * SyslogLogTest class
  */
-class SyslogLogTest extends TestCase
+final class SyslogLogTest extends TestCase
 {
     /**
      * Tests that the connection to the logger is open with the right arguments

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -48,7 +48,7 @@ final class LogTest extends TestCase
      */
     public function testImportingLoggers(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         $this->loadPlugins(['TestPlugin']);
 
         Log::setConfig('libtest', [
@@ -544,7 +544,7 @@ final class LogTest extends TestCase
      */
     public function testPassingScopeToEngine(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         Log::reset();
 

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -28,7 +28,7 @@ use TestPlugin\Log\Engine\TestPluginLog;
 /**
  * LogTest class
  */
-class LogTest extends TestCase
+final class LogTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/TestCase/Log/LogTraitTest.php
+++ b/tests/TestCase/Log/LogTraitTest.php
@@ -25,7 +25,7 @@ use Psr\Log\LogLevel;
 /**
  * Test case for LogTrait
  */
-class LogTraitTest extends TestCase
+final class LogTraitTest extends TestCase
 {
     protected function tearDown(): void
     {

--- a/tests/TestCase/Mailer/MailerAwareTraitTest.php
+++ b/tests/TestCase/Mailer/MailerAwareTraitTest.php
@@ -32,7 +32,7 @@ final class MailerAwareTraitTest extends TestCase
     public function testGetMailer(): void
     {
         $originalAppNamespace = Configure::read('App.namespace');
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         $stub = new Stub();
         $this->assertInstanceOf(TestMailer::class, $stub->getMailer('Test'));
@@ -41,7 +41,7 @@ final class MailerAwareTraitTest extends TestCase
         $mailer = $stub->getMailer('Test', ['from' => 'admad@cakephp.org']);
         $this->assertSame(['admad@cakephp.org' => 'admad@cakephp.org'], $mailer->getFrom());
 
-        static::setAppNamespace($originalAppNamespace);
+        self::setAppNamespace($originalAppNamespace);
     }
 
     /**

--- a/tests/TestCase/Mailer/MailerAwareTraitTest.php
+++ b/tests/TestCase/Mailer/MailerAwareTraitTest.php
@@ -24,7 +24,7 @@ use TestApp\Mailer\TestMailer;
 /**
  * MailerAwareTrait test case
  */
-class MailerAwareTraitTest extends TestCase
+final class MailerAwareTraitTest extends TestCase
 {
     /**
      * Test getMailer

--- a/tests/TestCase/Mailer/MailerDefaultProfileRestorationTest.php
+++ b/tests/TestCase/Mailer/MailerDefaultProfileRestorationTest.php
@@ -17,7 +17,7 @@ namespace Cake\Test\TestCase\Mailer;
 use Cake\Mailer\Mailer;
 use Cake\TestSuite\TestCase;
 
-class MailerDefaultProfileRestorationTest extends TestCase
+final class MailerDefaultProfileRestorationTest extends TestCase
 {
     public function testSendAction(): void
     {

--- a/tests/TestCase/Mailer/MailerSendActionTest.php
+++ b/tests/TestCase/Mailer/MailerSendActionTest.php
@@ -17,7 +17,7 @@ namespace Cake\Test\TestCase\Mailer;
 use Cake\Mailer\Mailer;
 use Cake\TestSuite\TestCase;
 
-class MailerSendActionTest extends TestCase
+final class MailerSendActionTest extends TestCase
 {
     public function testSendAction(): void
     {

--- a/tests/TestCase/Mailer/MailerSendWithUnsetTemplateDefaultsToActionNameTest.php
+++ b/tests/TestCase/Mailer/MailerSendWithUnsetTemplateDefaultsToActionNameTest.php
@@ -17,7 +17,7 @@ namespace Cake\Test\TestCase\Mailer;
 use Cake\Mailer\Mailer;
 use Cake\TestSuite\TestCase;
 
-class MailerSendWithUnsetTemplateDefaultsToActionNameTest extends TestCase
+final class MailerSendWithUnsetTemplateDefaultsToActionNameTest extends TestCase
 {
     public function testSendAction(): void
     {

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -30,7 +30,7 @@ use InvalidArgumentException;
 use TestApp\Mailer\TestMailer;
 use function Cake\Core\env;
 
-class MailerTest extends TestCase
+final class MailerTest extends TestCase
 {
     /**
      * @var array

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -30,7 +30,7 @@ use function Cake\Core\env;
 /**
  * MessageTest class
  */
-class MessageTest extends TestCase
+final class MessageTest extends TestCase
 {
     /**
      * @var \Cake\Mailer\Message

--- a/tests/TestCase/Mailer/Transport/DebugTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/DebugTransportTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Test case
  */
-class DebugTransportTest extends TestCase
+final class DebugTransportTest extends TestCase
 {
     /**
      * @var \Cake\Mailer\Transport\DebugTransport

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -28,7 +28,7 @@ use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
  * Test case
  */
 #[AllowMockObjectsWithoutExpectations]
-class MailTransportTest extends TestCase
+final class MailTransportTest extends TestCase
 {
     /**
      * @var \Cake\Mailer\Transport\MailTransport|\PHPUnit\Framework\MockObject\MockObject

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -29,7 +29,7 @@ use TestApp\Mailer\Transport\SmtpTestTransport;
 /**
  * Test case
  */
-class SmtpTransportTest extends TestCase
+final class SmtpTransportTest extends TestCase
 {
     /**
      * @var \TestApp\Mailer\Transport\SmtpTestTransport

--- a/tests/TestCase/Mailer/TransportFactoryTest.php
+++ b/tests/TestCase/Mailer/TransportFactoryTest.php
@@ -25,7 +25,7 @@ use InvalidArgumentException;
 /**
  * TransportFactory Test class
  */
-class TransportFactoryTest extends TestCase
+final class TransportFactoryTest extends TestCase
 {
     /**
      * @var array

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * SocketTest class
  */
-class SocketTest extends TestCase
+final class SocketTest extends TestCase
 {
     /**
      * @var \Cake\Network\Socket

--- a/tests/TestCase/ORM/Association/BelongsToManySaveAssociatedOnlyEntitiesAppendTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManySaveAssociatedOnlyEntitiesAppendTest.php
@@ -26,7 +26,7 @@ use Mockery;
 /**
  * Tests BelongsToManySaveAssociatedOnlyEntitiesAppendTest class
  */
-class BelongsToManySaveAssociatedOnlyEntitiesAppendTest extends TestCase
+final class BelongsToManySaveAssociatedOnlyEntitiesAppendTest extends TestCase
 {
     /**
      * @var \Cake\ORM\Table

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -45,7 +45,7 @@ use function Cake\Collection\collection;
 /**
  * Tests BelongsToMany class
  */
-class BelongsToManyTest extends TestCase
+final class BelongsToManyTest extends TestCase
 {
     /**
      * Fixtures

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -33,7 +33,7 @@ use Mockery;
 /**
  * Tests BelongsTo class
  */
-class BelongsToTest extends TestCase
+final class BelongsToTest extends TestCase
 {
     /**
      * Fixtures to use.

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -45,7 +45,7 @@ use function Cake\I18n\__;
 /**
  * Tests HasMany class
  */
-class HasManyTest extends TestCase
+final class HasManyTest extends TestCase
 {
     /**
      * Fixtures

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -32,7 +32,7 @@ use Mockery;
 /**
  * Tests HasOne class
  */
-class HasOneTest extends TestCase
+final class HasOneTest extends TestCase
 {
     /**
      * Fixtures to load

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -33,7 +33,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * AssociationCollection test case.
  */
-class AssociationCollectionTest extends TestCase
+final class AssociationCollectionTest extends TestCase
 {
     /**
      * @var AssociationCollection

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -25,7 +25,7 @@ use Mockery;
  * Tests the features related to proxying methods from the Association
  * class to the Table class
  */
-class AssociationProxyTest extends TestCase
+final class AssociationProxyTest extends TestCase
 {
     /**
      * Fixtures to be loaded

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -31,7 +31,7 @@ use TestPlugin\Model\Table\CommentsTable;
 /**
  * Tests Association class
  */
-class AssociationTest extends TestCase
+final class AssociationTest extends TestCase
 {
     /**
      * @var \TestApp\Model\Table\TestTable

--- a/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
+++ b/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
@@ -25,7 +25,7 @@ use TestApp\Model\Entity\NumberTree;
 /**
  * Behavior regression tests
  */
-class BehaviorRegressionTest extends TestCase
+final class BehaviorRegressionTest extends TestCase
 {
     /**
      * fixtures

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -29,7 +29,7 @@ use TestApp\Model\Table\PublishedPostsTable;
 /**
  * CounterCacheBehavior test case
  */
-class CounterCacheBehaviorTest extends TestCase
+final class CounterCacheBehaviorTest extends TestCase
 {
     /**
      * @var \TestApp\Model\Table\PublishedPostsTable

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -29,7 +29,7 @@ use UnexpectedValueException;
 /**
  * Behavior test case
  */
-class TimestampBehaviorTest extends TestCase
+final class TimestampBehaviorTest extends TestCase
 {
     /**
      * fixtures

--- a/tests/TestCase/ORM/Behavior/Translate/TranslateTraitTest.php
+++ b/tests/TestCase/ORM/Behavior/Translate/TranslateTraitTest.php
@@ -23,7 +23,7 @@ use TestApp\Model\Entity\TranslateTestEntity;
 /**
  * Translate behavior test case
  */
-class TranslateTraitTest extends TestCase
+final class TranslateTraitTest extends TestCase
 {
     /**
      * Tests that missing translation entries are created automatically

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -31,7 +31,7 @@ use TestApp\Model\Entity\TranslateBakedArticle;
 /**
  * TranslateBehavior test case
  */
-class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
+final class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
 {
     protected array $fixtures = [
         'core.Articles',

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Translate behavior test case
  */
-class TreeBehaviorTest extends TestCase
+final class TreeBehaviorTest extends TestCase
 {
     /**
      * fixtures

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -59,7 +59,7 @@ final class BehaviorRegistryTest extends TestCase
         $this->Table = new Table(['table' => 'articles']);
         $this->EventManager = $this->Table->getEventManager();
         $this->Behaviors = new BehaviorRegistry($this->Table);
-        static::setAppNamespace();
+        self::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -33,7 +33,7 @@ use TestPlugin\Model\Behavior\PersisterOneBehavior;
 /**
  * Test case for BehaviorRegistry.
  */
-class BehaviorRegistryTest extends TestCase
+final class BehaviorRegistryTest extends TestCase
 {
     /**
      * @var \Cake\ORM\BehaviorRegistry

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -27,7 +27,7 @@ use TestApp\Model\Behavior\TestBehavior;
 /**
  * Behavior test case
  */
-class BehaviorTest extends TestCase
+final class BehaviorTest extends TestCase
 {
     /**
      * Test the side effects of the constructor.

--- a/tests/TestCase/ORM/BindingKeyTest.php
+++ b/tests/TestCase/ORM/BindingKeyTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Integration tests for using the bindingKey in associations
  */
-class BindingKeyTest extends TestCase
+final class BindingKeyTest extends TestCase
 {
     /**
      * Fixture to be used

--- a/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
+++ b/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
@@ -9,7 +9,7 @@ use Cake\TestSuite\TestCase;
 use Mockery;
 use TestApp\Database\Type\ColumnSchemaAwareType;
 
-class ColumnSchemaAwareTypeIntegrationTest extends TestCase
+final class ColumnSchemaAwareTypeIntegrationTest extends TestCase
 {
     protected array $fixtures = [
         'core.ColumnSchemaAwareTypeValues',

--- a/tests/TestCase/ORM/DtoMapperTest.php
+++ b/tests/TestCase/ORM/DtoMapperTest.php
@@ -28,7 +28,7 @@ use TestApp\Dto\SimpleArticleDto;
 /**
  * DtoMapper test case.
  */
-class DtoMapperTest extends TestCase
+final class DtoMapperTest extends TestCase
 {
     protected DtoMapper $mapper;
 

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -29,7 +29,7 @@ use Mockery;
 /**
  * Tests EagerLoader
  */
-class EagerLoaderTest extends TestCase
+final class EagerLoaderTest extends TestCase
 {
     /**
      * @var \Cake\Datasource\ConnectionInterface

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -30,7 +30,7 @@ use TestApp\Model\Entity\VirtualUser;
 /**
  * Entity test case.
  */
-class EntityTest extends TestCase
+final class EntityTest extends TestCase
 {
     /**
      * Tests setting a single property in an entity without custom setters

--- a/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
+++ b/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
@@ -28,7 +28,7 @@ use UnexpectedValueException;
 /**
  * LocatorAwareTrait test case
  */
-class LocatorAwareTraitTest extends TestCase
+final class LocatorAwareTraitTest extends TestCase
 {
     /**
      * @var object|\Cake\ORM\Locator\LocatorAwareTrait

--- a/tests/TestCase/ORM/Locator/TableContainerTest.php
+++ b/tests/TestCase/ORM/Locator/TableContainerTest.php
@@ -23,7 +23,7 @@ use League\Container\Exception\NotFoundException;
 use TestApp\Model\Table\ArticlesTable;
 use TestApp\Model\Table\FakeTable;
 
-class TableContainerTest extends TestCase
+final class TableContainerTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/TestCase/ORM/Locator/TableContainerTest.php
+++ b/tests/TestCase/ORM/Locator/TableContainerTest.php
@@ -28,7 +28,7 @@ final class TableContainerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
     }
 
     public function testTableContainer(): void

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -41,7 +41,7 @@ use TestPluginTwo\Model\Table\CommentsTable as PluginTwoCommentsTable;
 /**
  * Test case for TableLocator
  */
-class TableLocatorTest extends TestCase
+final class TableLocatorTest extends TestCase
 {
     /**
      * TableLocator instance.

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -56,7 +56,7 @@ final class TableLocatorTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         $this->_locator = new TableLocator();
     }

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -34,7 +34,7 @@ use TestApp\Model\Table\GreedyCommentsTable;
 /**
  * Marshaller test case
  */
-class MarshallerTest extends TestCase
+final class MarshallerTest extends TestCase
 {
     protected array $fixtures = [
         'core.Articles',

--- a/tests/TestCase/ORM/Query/CaseExpressionQueryTest.php
+++ b/tests/TestCase/ORM/Query/CaseExpressionQueryTest.php
@@ -20,7 +20,7 @@ use Cake\Database\Driver\Postgres;
 use Cake\ORM\Query\SelectQuery;
 use Cake\TestSuite\TestCase;
 
-class CaseExpressionQueryTest extends TestCase
+final class CaseExpressionQueryTest extends TestCase
 {
     protected array $fixtures = [
         'core.Products',

--- a/tests/TestCase/ORM/Query/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/Query/CompositeKeysTest.php
@@ -32,7 +32,7 @@ use TestApp\Model\Entity\OpenArticleEntity;
 /**
  * Integration tests for table operations involving composite keys
  */
-class CompositeKeysTest extends TestCase
+final class CompositeKeysTest extends TestCase
 {
     /**
      * Fixture to be used

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -37,7 +37,7 @@ use function Cake\Collection\collection;
 /**
  * Contains regression test for the Query builder
  */
-class QueryRegressionTest extends TestCase
+final class QueryRegressionTest extends TestCase
 {
     /**
      * Fixture to be used

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -54,7 +54,7 @@ use TestApp\Model\Table\TagsTable;
 /**
  * Tests SelectQuery class
  */
-class SelectQueryTest extends TestCase
+final class SelectQueryTest extends TestCase
 {
     /**
      * Fixture to be used

--- a/tests/TestCase/ORM/Query/UnhydratedSelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/UnhydratedSelectQueryTest.php
@@ -29,7 +29,7 @@ use Cake\TestSuite\TestCase;
  * Tests the type-safe non-hydrated query path: Table::unhydratedFind() and
  * the UnhydratedSelectQuery class it returns.
  */
-class UnhydratedSelectQueryTest extends TestCase
+final class UnhydratedSelectQueryTest extends TestCase
 {
     /**
      * @var array<string>

--- a/tests/TestCase/ORM/ResultSetFactoryTest.php
+++ b/tests/TestCase/ORM/ResultSetFactoryTest.php
@@ -36,7 +36,7 @@ use TestApp\Dto\SimpleArticleDto;
 /**
  * ResultSetFactory test case.
  */
-class ResultSetFactoryTest extends TestCase
+final class ResultSetFactoryTest extends TestCase
 {
     /**
      * @var array<string>

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 /**
  * ResultSet test case.
  */
-class ResultSetTest extends TestCase
+final class ResultSetTest extends TestCase
 {
     /**
      * @var array<string>

--- a/tests/TestCase/ORM/Rule/ExistsInNullableTest.php
+++ b/tests/TestCase/ORM/Rule/ExistsInNullableTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Tests the ExistsInNullable rule
  */
-class ExistsInNullableTest extends TestCase
+final class ExistsInNullableTest extends TestCase
 {
     /**
      * Fixtures to be loaded

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -35,7 +35,7 @@ use TestApp\Model\Table\ArticlesTable;
 /**
  * Tests the LinkConstraint rule.
  */
-class LinkConstraintTest extends TestCase
+final class LinkConstraintTest extends TestCase
 {
     /**
      * Fixtures.

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -33,7 +33,7 @@ use stdClass;
 /**
  * Tests the integration between the ORM and the domain checker
  */
-class RulesCheckerIntegrationTest extends TestCase
+final class RulesCheckerIntegrationTest extends TestCase
 {
     /**
      * Fixtures to be loaded

--- a/tests/TestCase/ORM/TableComplexIdTest.php
+++ b/tests/TestCase/ORM/TableComplexIdTest.php
@@ -40,7 +40,7 @@ final class TableComplexIdTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/ORM/TableComplexIdTest.php
+++ b/tests/TestCase/ORM/TableComplexIdTest.php
@@ -23,7 +23,7 @@ use DateTime;
 /**
  * Integration tests for Table class with uuid primary keys.
  */
-class TableComplexIdTest extends TestCase
+final class TableComplexIdTest extends TestCase
 {
     /**
      * Fixtures

--- a/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
+++ b/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
@@ -32,7 +32,7 @@ final class TableGetWithCustomFinderTest extends TestCase
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
-        static::setAppNamespace();
+        self::setAppNamespace();
     }
 
     public static function providerForTestGetWithCustomFinder(): array

--- a/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
+++ b/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class TableGetWithCustomFinderTest extends TestCase
+final class TableGetWithCustomFinderTest extends TestCase
 {
     protected ConnectionInterface $connection;
 

--- a/tests/TestCase/ORM/TableImplementedEventsTest.php
+++ b/tests/TestCase/ORM/TableImplementedEventsTest.php
@@ -18,7 +18,7 @@ use Cake\ORM\Table;
 use Cake\ORM\TableEventsTrait;
 use Cake\TestSuite\TestCase;
 
-class TableImplementedEventsTest extends TestCase
+final class TableImplementedEventsTest extends TestCase
 {
     /**
      * Check that defining methods inside table classes will result in event listeners

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -25,7 +25,7 @@ use Mockery;
 /**
  * Test case for TableRegistry
  */
-class TableRegistryTest extends TestCase
+final class TableRegistryTest extends TestCase
 {
     /**
      * Original TableLocator.

--- a/tests/TestCase/ORM/TableRegressionTest.php
+++ b/tests/TestCase/ORM/TableRegressionTest.php
@@ -23,7 +23,7 @@ use InvalidArgumentException;
 /**
  * Contains regression test for the Table class
  */
-class TableRegressionTest extends TestCase
+final class TableRegressionTest extends TestCase
 {
     /**
      * Fixture to be used

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -80,7 +80,7 @@ use TestPlugin\Model\Table\CommentsTable;
  * Tests Table class
  */
 #[AllowMockObjectsWithoutExpectations]
-class TableTest extends TestCase
+final class TableTest extends TestCase
 {
     /**
      * @var string[]

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -127,7 +127,7 @@ final class TableTest extends TestCase
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         $this->usersTypeMap = new TypeMap([
             'Users.id' => 'integer',

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -42,7 +42,7 @@ final class TableUuidTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Integration tests for Table class with uuid primary keys.
  */
-class TableUuidTest extends TestCase
+final class TableUuidTest extends TestCase
 {
     /**
      * Fixtures

--- a/tests/TestCase/ORM/TableValidationWithBadDefinerTest.php
+++ b/tests/TestCase/ORM/TableValidationWithBadDefinerTest.php
@@ -18,7 +18,7 @@ use AssertionError;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 
-class TableValidationWithBadDefinerTest extends TestCase
+final class TableValidationWithBadDefinerTest extends TestCase
 {
     /**
      * Tests that a InvalidArgumentException is thrown if the custom validator does not return an Validator instance

--- a/tests/TestCase/ORM/TableValidationWithDefinerTest.php
+++ b/tests/TestCase/ORM/TableValidationWithDefinerTest.php
@@ -17,7 +17,7 @@ namespace Cake\Test\TestCase\ORM;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 
-class TableValidationWithDefinerTest extends TestCase
+final class TableValidationWithDefinerTest extends TestCase
 {
     /**
      * Tests that it is possible to define custom validator methods

--- a/tests/TestCase/Routing/AssetTest.php
+++ b/tests/TestCase/Routing/AssetTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
 /**
  * AssetTest class
  */
-class AssetTest extends TestCase
+final class AssetTest extends TestCase
 {
     /**
      * @var \Cake\Routing\RouteBuilder

--- a/tests/TestCase/Routing/AssetTest.php
+++ b/tests/TestCase/Routing/AssetTest.php
@@ -45,7 +45,7 @@ final class AssetTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        static::setAppNamespace();
+        self::setAppNamespace();
         $this->loadPlugins(['TestTheme']);
         $this->builder = Router::createRouteBuilder('/');
         $this->builder->fallbacks();

--- a/tests/TestCase/Routing/FunctionsGlobalTest.php
+++ b/tests/TestCase/Routing/FunctionsGlobalTest.php
@@ -21,7 +21,7 @@ use Cake\TestSuite\TestCase;
 
 require_once CAKE . 'Routing/functions_global.php';
 
-class FunctionsGlobalTest extends TestCase
+final class FunctionsGlobalTest extends TestCase
 {
     /**
      * Tests that the url() method is a shortcut Router::url()

--- a/tests/TestCase/Routing/FunctionsTest.php
+++ b/tests/TestCase/Routing/FunctionsTest.php
@@ -24,7 +24,7 @@ use function Cake\Routing\urlArray;
 /**
  * FunctionsTest class
  */
-class FunctionsTest extends TestCase
+final class FunctionsTest extends TestCase
 {
     /**
      * Tests that the url() method is a shortcut Router::url()

--- a/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
@@ -26,7 +26,7 @@ use TestApp\Http\TestRequestHandler;
 /**
  * Test for AssetMiddleware
  */
-class AssetMiddlewareTest extends TestCase
+final class AssetMiddlewareTest extends TestCase
 {
     /**
      * setup

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -38,7 +38,7 @@ use TestApp\Routing\Route\HeaderRedirectRoute;
 /**
  * Test for RoutingMiddleware
  */
-class RoutingMiddlewareTest extends TestCase
+final class RoutingMiddlewareTest extends TestCase
 {
     protected $log = [];
 

--- a/tests/TestCase/Routing/Route/DashedRouteTest.php
+++ b/tests/TestCase/Routing/Route/DashedRouteTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Test case for DashedRoute
  */
-class DashedRouteTest extends TestCase
+final class DashedRouteTest extends TestCase
 {
     /**
      * test that routes match their pattern.

--- a/tests/TestCase/Routing/Route/EntityRouteTest.php
+++ b/tests/TestCase/Routing/Route/EntityRouteTest.php
@@ -27,7 +27,7 @@ use TestApp\Model\Enum\Priority;
 /**
  * Test case for EntityRoute
  */
-class EntityRouteTest extends TestCase
+final class EntityRouteTest extends TestCase
 {
     /**
      * test that route keys take precedence to object properties.

--- a/tests/TestCase/Routing/Route/InflectedRouteTest.php
+++ b/tests/TestCase/Routing/Route/InflectedRouteTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 /**
  * Test case for InflectedRoute
  */
-class InflectedRouteTest extends TestCase
+final class InflectedRouteTest extends TestCase
 {
     /**
      * test that routes match their pattern.

--- a/tests/TestCase/Routing/Route/PluginShortRouteTest.php
+++ b/tests/TestCase/Routing/Route/PluginShortRouteTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
 /**
  * test case for PluginShortRoute
  */
-class PluginShortRouteTest extends TestCase
+final class PluginShortRouteTest extends TestCase
 {
     /**
      * setUp method

--- a/tests/TestCase/Routing/Route/RedirectRouteTest.php
+++ b/tests/TestCase/Routing/Route/RedirectRouteTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
 /**
  * test case for RedirectRoute
  */
-class RedirectRouteTest extends TestCase
+final class RedirectRouteTest extends TestCase
 {
     /**
      * @var \Cake\Routing\RouteBuilder

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -30,7 +30,7 @@ use TestApp\Routing\Route\ProtectedRoute;
 /**
  * Test case for Route
  */
-class RouteTest extends TestCase
+final class RouteTest extends TestCase
 {
     /**
      * setUp method

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -35,7 +35,7 @@ use TestApp\Routing\Route\DashedRoute;
 /**
  * RouteBuilder test case
  */
-class RouteBuilderTest extends TestCase
+final class RouteBuilderTest extends TestCase
 {
     /**
      * @var \Cake\Routing\RouteCollection

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -27,7 +27,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Routing\Route\AddQueryParamRoute;
 
-class RouteCollectionTest extends TestCase
+final class RouteCollectionTest extends TestCase
 {
     /**
      * @var \Cake\Routing\RouteCollection

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -3269,7 +3269,7 @@ final class RouterTest extends TestCase
         $this->assertSame('/FooBar', $result);
 
         // This is needed because tests/bootstrap.php sets App.namespace to 'App'
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         Router::defaultRouteClass('DashedRoute');
         $routes = Router::createRouteBuilder('/');

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -37,7 +37,7 @@ use function Cake\Routing\urlArray;
 /**
  * RouterTest class
  */
-class RouterTest extends TestCase
+final class RouterTest extends TestCase
 {
     /**
      * setUp method

--- a/tests/TestCase/TestSuite/AssertHtmlTest.php
+++ b/tests/TestCase/TestSuite/AssertHtmlTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 /**
  * This class helps in indirectly testing the functionality of TestCase::assertHtml
  */
-class AssertHtmlTest extends TestCase
+final class AssertHtmlTest extends TestCase
 {
     /**
      * Test whitespace after HTML tags

--- a/tests/TestCase/TestSuite/ConnectionHelperTest.php
+++ b/tests/TestCase/TestSuite/ConnectionHelperTest.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\ConnectionHelper;
 use Cake\TestSuite\TestCase;
 use TestApp\Database\Driver\TestDriver;
 
-class ConnectionHelperTest extends TestCase
+final class ConnectionHelperTest extends TestCase
 {
     protected function tearDown(): void
     {

--- a/tests/TestCase/TestSuite/Constraint/EventFiredTest.php
+++ b/tests/TestCase/TestSuite/Constraint/EventFiredTest.php
@@ -12,7 +12,7 @@ use Cake\TestSuite\TestCase;
 /**
  * EventFired Test
  */
-class EventFiredTest extends TestCase
+final class EventFiredTest extends TestCase
 {
     /**
      * tests EventFired constraint

--- a/tests/TestCase/TestSuite/Constraint/EventFiredWithTest.php
+++ b/tests/TestCase/TestSuite/Constraint/EventFiredWithTest.php
@@ -14,7 +14,7 @@ use stdClass;
 /**
  * EventFiredWith Test
  */
-class EventFiredWithTest extends TestCase
+final class EventFiredWithTest extends TestCase
 {
     /**
      * tests EventFiredWith constraint

--- a/tests/TestCase/TestSuite/EmailTraitTest.php
+++ b/tests/TestCase/TestSuite/EmailTraitTest.php
@@ -31,7 +31,7 @@ use PHPUnit\Framework\Constraint\LogicalNot;
 /**
  * Tests EmailTrait assertions
  */
-class EmailTraitTest extends TestCase
+final class EmailTraitTest extends TestCase
 {
     use EmailTrait;
 

--- a/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
@@ -31,7 +31,7 @@ use TestPlugin\Test\Fixture\ArticlesFixture as PluginArticlesFixture;
 use TestPlugin\Test\Fixture\Blog\CommentsFixture as PluginCommentsFixture;
 use UnexpectedValueException;
 
-class FixtureHelperTest extends TestCase
+final class FixtureHelperTest extends TestCase
 {
     protected array $fixtures = ['core.Articles'];
 

--- a/tests/TestCase/TestSuite/Fixture/SchemaLoaderTest.php
+++ b/tests/TestCase/TestSuite/Fixture/SchemaLoaderTest.php
@@ -26,7 +26,7 @@ use Cake\TestSuite\Fixture\SchemaLoader;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 
-class SchemaLoaderTest extends TestCase
+final class SchemaLoaderTest extends TestCase
 {
     /**
      * @var bool|null

--- a/tests/TestCase/TestSuite/Fixture/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TestFixtureTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\Fixture\TestFixture;
 use Cake\TestSuite\TestCase;
 use TestPlugin\Test\Fixture\TestableArticlesFixture;
 
-class TestFixtureTest extends TestCase
+final class TestFixtureTest extends TestCase
 {
     /**
      * Test that plugin fixtures automatically get their plugin prefix in the alias.

--- a/tests/TestCase/TestSuite/Fixture/TransactionStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TransactionStrategyTest.php
@@ -20,7 +20,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\TransactionStrategy;
 use Cake\TestSuite\TestCase;
 
-class TransactionStrategyTest extends TestCase
+final class TransactionStrategyTest extends TestCase
 {
     protected array $fixtures = ['core.Articles'];
 

--- a/tests/TestCase/TestSuite/Fixture/TruncateStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TruncateStrategyTest.php
@@ -20,7 +20,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\TruncateStrategy;
 use Cake\TestSuite\TestCase;
 
-class TruncateStrategyTest extends TestCase
+final class TruncateStrategyTest extends TestCase
 {
     protected array $fixtures = ['core.Articles'];
 

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -62,7 +62,7 @@ final class IntegrationTestTraitTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         Router::reload();
         $routesClosure = function (RouteBuilder $routes): void {

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -45,7 +45,7 @@ use TestApp\ReflectionDependency;
 /**
  * Self test of the IntegrationTestTrait
  */
-class IntegrationTestTraitTest extends TestCase
+final class IntegrationTestTraitTest extends TestCase
 {
     use IntegrationTestTrait;
 

--- a/tests/TestCase/TestSuite/LogTestTraitTest.php
+++ b/tests/TestCase/TestSuite/LogTestTraitTest.php
@@ -26,7 +26,7 @@ use TestApp\Log\Engine\TestAppLog;
 /**
  * Tests LogTrait assertions
  */
-class LogTestTraitTest extends TestCase
+final class LogTestTraitTest extends TestCase
 {
     use LogTestTrait;
 

--- a/tests/TestCase/TestSuite/PluginBootstrapTest.php
+++ b/tests/TestCase/TestSuite/PluginBootstrapTest.php
@@ -26,7 +26,7 @@ use function Cake\TestSuite\enablePluginLoadingForTests;
 /**
  * Tests for the global plugin loading function in src/TestSuite/functions.php
  */
-class PluginBootstrapTest extends TestCase
+final class PluginBootstrapTest extends TestCase
 {
     use IntegrationTestTrait;
 

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -47,7 +47,7 @@ use function Cake\Core\deprecationWarning;
  * TestCaseTest
  */
 #[AllowMockObjectsWithoutExpectations]
-class TestCaseTest extends TestCase
+final class TestCaseTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -379,7 +379,7 @@ final class TestCaseTest extends TestCase
     {
         $this->skipIf(version_compare(Version::id(), '12.0.0', '>='), 'This test is not compatible with PHPUnit 12');
 
-        static::setAppNamespace();
+        self::setAppNamespace();
         // No methods will be mocked if $methods argument of getMockForModel() is empty.
         $Posts = $this->getMockForModel('Posts');
         $entity = new Entity([]);
@@ -416,7 +416,7 @@ final class TestCaseTest extends TestCase
      */
     public function testGetMockForModelWithPlugin(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         $this->loadPlugins(['TestPlugin']);
         $TestPluginComment = $this->getMockForModel('TestPlugin.TestPluginComments');
 
@@ -478,7 +478,7 @@ final class TestCaseTest extends TestCase
      */
     public function testGetMockForModelSetTable(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         ConnectionManager::alias('test', 'custom_i18n_datasource');
 
         $I18n = $this->getMockForModel('CustomI18n', ['save']);
@@ -494,7 +494,7 @@ final class TestCaseTest extends TestCase
      */
     public function testMockModel(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         $entity = new Entity([]);
 
         $Posts = $this->mockModel('Posts');
@@ -531,7 +531,7 @@ final class TestCaseTest extends TestCase
      */
     public function testMockModelWithPlugin(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         $this->loadPlugins(['TestPlugin']);
         $TestPluginComment = $this->mockModel('TestPlugin.TestPluginComments');
 
@@ -591,7 +591,7 @@ final class TestCaseTest extends TestCase
      */
     public function testMockModelSetTable(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         ConnectionManager::alias('test', 'custom_i18n_datasource');
 
         $I18n = $this->mockModel('CustomI18n');

--- a/tests/TestCase/TestSuite/TestEmailTransportTest.php
+++ b/tests/TestCase/TestSuite/TestEmailTransportTest.php
@@ -22,7 +22,7 @@ use Cake\Mailer\TransportFactory;
 use Cake\TestSuite\TestCase;
 use Cake\TestSuite\TestEmailTransport;
 
-class TestEmailTransportTest extends TestCase
+final class TestEmailTransportTest extends TestCase
 {
     /**
      * setUp

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -37,7 +37,7 @@ use TestApp\Test\Fixture\LettersFixture;
 /**
  * Test case for TestFixture
  */
-class TestFixtureTest extends TestCase
+final class TestFixtureTest extends TestCase
 {
     /**
      * Fixtures for this test.

--- a/tests/TestCase/TestSuite/TestSessionTest.php
+++ b/tests/TestCase/TestSuite/TestSessionTest.php
@@ -19,7 +19,7 @@ namespace Cake\Test\TestCase\TestSuite;
 use Cake\TestSuite\TestCase;
 use Cake\TestSuite\TestSession;
 
-class TestSessionTest extends TestCase
+final class TestSessionTest extends TestCase
 {
     /**
      * @var array

--- a/tests/TestCase/Utility/Crypto/OpenSslTest.php
+++ b/tests/TestCase/Utility/Crypto/OpenSslTest.php
@@ -22,7 +22,7 @@ use Cake\Utility\Crypto\OpenSsl;
 /**
  * Openssl engine tests.
  */
-class OpenSslTest extends TestCase
+final class OpenSslTest extends TestCase
 {
     private OpenSsl $crypt;
 

--- a/tests/TestCase/Utility/FilesystemTest.php
+++ b/tests/TestCase/Utility/FilesystemTest.php
@@ -23,7 +23,7 @@ use org\bovigo\vfs\vfsStream;
 /**
  * Filesystem class
  */
-class FilesystemTest extends TestCase
+final class FilesystemTest extends TestCase
 {
     protected $vfs;
 

--- a/tests/TestCase/Utility/Fs/FinderTest.php
+++ b/tests/TestCase/Utility/Fs/FinderTest.php
@@ -26,7 +26,7 @@ use SplFileInfo;
 /**
  * FinderTest class
  */
-class FinderTest extends TestCase
+final class FinderTest extends TestCase
 {
     /**
      * Test virtual filesystem

--- a/tests/TestCase/Utility/Fs/Iterator/FilterIteratorTest.php
+++ b/tests/TestCase/Utility/Fs/Iterator/FilterIteratorTest.php
@@ -31,7 +31,7 @@ use SplFileInfo;
 /**
  * FilterIteratorTest class
  */
-class FilterIteratorTest extends TestCase
+final class FilterIteratorTest extends TestCase
 {
     /**
      * Test virtual filesystem

--- a/tests/TestCase/Utility/Fs/Iterator/PatternFilterIteratorTest.php
+++ b/tests/TestCase/Utility/Fs/Iterator/PatternFilterIteratorTest.php
@@ -29,7 +29,7 @@ use RecursiveIteratorIterator;
 /**
  * Tests for pattern-based filter iterators
  */
-class PatternFilterIteratorTest extends TestCase
+final class PatternFilterIteratorTest extends TestCase
 {
     /**
      * @var \org\bovigo\vfs\vfsStreamDirectory

--- a/tests/TestCase/Utility/Fs/PathTest.php
+++ b/tests/TestCase/Utility/Fs/PathTest.php
@@ -22,7 +22,7 @@ use Cake\Utility\Fs\Path;
 /**
  * Path test case
  */
-class PathTest extends TestCase
+final class PathTest extends TestCase
 {
     public function testNormalize(): void
     {

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -274,8 +274,8 @@ final class HashTest extends TestCase
     public static function articleDataSets(): array
     {
         return [
-            [static::articleData()],
-            [static::articleDataObject()],
+            [self::articleData()],
+            [self::articleDataObject()],
         ];
     }
 
@@ -1937,7 +1937,7 @@ final class HashTest extends TestCase
      */
     public function testInsertMulti(): void
     {
-        $data = static::articleData();
+        $data = self::articleData();
 
         $result = Hash::insert($data, '{n}.Article.insert', 'value');
         $this->assertSame('value', $result[0]['Article']['insert']);
@@ -1981,7 +1981,7 @@ final class HashTest extends TestCase
      */
     public function testInsertMultiWord(): void
     {
-        $data = static::articleData();
+        $data = self::articleData();
 
         $result = Hash::insert($data, '{n}.{s}.insert', 'value');
         $this->assertSame('value', $result[0]['Article']['insert']);
@@ -2189,7 +2189,7 @@ final class HashTest extends TestCase
      */
     public function testRemoveMulti(): void
     {
-        $data = static::articleData();
+        $data = self::articleData();
 
         $result = Hash::remove($data, '{n}.Article.title');
         $this->assertFalse(isset($result[0]['Article']['title']));
@@ -2318,7 +2318,7 @@ final class HashTest extends TestCase
         $result = Hash::combine([], '{n}.User.id', '{n}.User.Data');
         $this->assertEmpty($result);
 
-        $a = static::userData();
+        $a = self::userData();
 
         $result = Hash::combine($a, '{n}.User.id');
         $expected = [2 => null, 14 => null, 25 => null];
@@ -2351,7 +2351,7 @@ final class HashTest extends TestCase
         $result = Hash::combine([], null, '{n}.User.Data');
         $this->assertEmpty($result);
 
-        $a = static::userData();
+        $a = self::userData();
 
         $result = Hash::combine($a, null);
         $expected = [0 => null, 1 => null, 2 => null];
@@ -2407,7 +2407,7 @@ final class HashTest extends TestCase
      */
     public function testCombineWithGroupPath(): void
     {
-        $a = static::userData();
+        $a = self::userData();
 
         $result = Hash::combine($a, '{n}.User.id', '{n}.User.Data', '{n}.User.group_id');
         $expected = [
@@ -2511,7 +2511,7 @@ final class HashTest extends TestCase
      */
     public function testCombineWithFormatting(): void
     {
-        $a = static::userData();
+        $a = self::userData();
 
         $result = Hash::combine(
             $a,
@@ -2593,7 +2593,7 @@ final class HashTest extends TestCase
      */
     public function testFormat(): void
     {
-        $data = static::userData();
+        $data = self::userData();
 
         $result = Hash::format(
             $data,
@@ -2651,7 +2651,7 @@ final class HashTest extends TestCase
      */
     public function testMap(): void
     {
-        $data = static::articleData();
+        $data = self::articleData();
 
         $result = Hash::map($data, '{n}.Article.id', $this->mapCallback(...));
         $expected = [2, 4, 6, 8, 10];
@@ -2663,7 +2663,7 @@ final class HashTest extends TestCase
      */
     public function testApply(): void
     {
-        $data = static::articleData();
+        $data = self::articleData();
 
         $result = Hash::apply($data, '{n}.Article.id', 'array_sum');
         $this->assertSame(15, $result);
@@ -2674,7 +2674,7 @@ final class HashTest extends TestCase
      */
     public function testReduce(): void
     {
-        $data = static::articleData();
+        $data = self::articleData();
 
         $result = Hash::reduce($data, '{n}.Article.id', $this->reduceCallback(...));
         $this->assertSame(15, $result);

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -28,7 +28,7 @@ use stdClass;
 /**
  * HashTest
  */
-class HashTest extends TestCase
+final class HashTest extends TestCase
 {
     /**
      * Data provider

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Short description for class.
  */
-class InflectorTest extends TestCase
+final class InflectorTest extends TestCase
 {
     /**
      * A list of chars to test transliteration.

--- a/tests/TestCase/Utility/MergeVariablesTraitTest.php
+++ b/tests/TestCase/Utility/MergeVariablesTraitTest.php
@@ -23,7 +23,7 @@ use TestApp\Utility\Grandchild;
 /**
  * MergeVariablesTrait test case
  */
-class MergeVariablesTraitTest extends TestCase
+final class MergeVariablesTraitTest extends TestCase
 {
     /**
      * Test merging vars as a list.

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -25,7 +25,7 @@ use InvalidArgumentException;
 /**
  * SecurityTest class
  */
-class SecurityTest extends TestCase
+final class SecurityTest extends TestCase
 {
     /**
      * Test engine

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -27,7 +27,7 @@ use Transliterator;
 /**
  * TextTest class
  */
-class TextTest extends TestCase
+final class TextTest extends TestCase
 {
     /**
      * @var \Cake\Utility\Text

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -36,7 +36,7 @@ use TypeError;
 /**
  * XmlTest class
  */
-class XmlTest extends TestCase
+final class XmlTest extends TestCase
 {
     /**
      * setUp method

--- a/tests/TestCase/Validation/RulesProviderTest.php
+++ b/tests/TestCase/Validation/RulesProviderTest.php
@@ -25,7 +25,7 @@ use TestApp\Validation\CustomProvider;
  *
  * @deprecated
  */
-class RulesProviderTest extends TestCase
+final class RulesProviderTest extends TestCase
 {
     /**
      * Tests that RulesProvider proxies the method correctly and removes the

--- a/tests/TestCase/Validation/ValidationRuleTest.php
+++ b/tests/TestCase/Validation/ValidationRuleTest.php
@@ -25,7 +25,7 @@ use Error;
 /**
  * ValidationRuleTest
  */
-class ValidationRuleTest extends TestCase
+final class ValidationRuleTest extends TestCase
 {
     /**
      * Auxiliary method to test custom validators

--- a/tests/TestCase/Validation/ValidationSetTest.php
+++ b/tests/TestCase/Validation/ValidationSetTest.php
@@ -25,7 +25,7 @@ use Cake\Validation\ValidationSet;
 /**
  * ValidationSetTest
  */
-class ValidationSetTest extends TestCase
+final class ValidationSetTest extends TestCase
 {
     /**
      * testGetRule method

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -41,7 +41,7 @@ require_once __DIR__ . '/stubs.php';
 /**
  * Test Case for Validation Class
  */
-class ValidationTest extends TestCase
+final class ValidationTest extends TestCase
 {
     /**
      * tearDown method

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -32,7 +32,7 @@ use Traversable;
 /**
  * Tests Validator class
  */
-class ValidatorTest extends TestCase
+final class ValidatorTest extends TestCase
 {
     /**
      * tests getRequiredMessage

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -35,7 +35,7 @@ use TestApp\View\CustomJsonView;
  *
  * For testing both View\Cell & Utility\CellTrait
  */
-class CellTest extends TestCase
+final class CellTest extends TestCase
 {
     /**
      * @var \Cake\View\View

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -48,7 +48,7 @@ final class CellTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::setAppNamespace();
+        self::setAppNamespace();
         $this->clearPlugins();
         $this->loadPlugins(['TestPlugin', 'TestTheme']);
         $request = new ServerRequest();

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -22,7 +22,7 @@ use Cake\View\Form\ArrayContext;
 /**
  * Array context test case.
  */
-class ArrayContextTest extends TestCase
+final class ArrayContextTest extends TestCase
 {
     /**
      * setup method.

--- a/tests/TestCase/View/Form/ContextFactoryTest.php
+++ b/tests/TestCase/View/Form/ContextFactoryTest.php
@@ -24,7 +24,7 @@ use Cake\View\Form\ContextFactory;
 /**
  * ContextFactory test case.
  */
-class ContextFactoryTest extends TestCase
+final class ContextFactoryTest extends TestCase
 {
     public function testGetException(): void
     {

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -33,7 +33,7 @@ use TestApp\Model\Entity\Tag;
 /**
  * Entity context test case.
  */
-class EntityContextTest extends TestCase
+final class EntityContextTest extends TestCase
 {
     /**
      * Fixtures to use.

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -24,7 +24,7 @@ use Cake\View\Form\FormContext;
 /**
  * Form context test case.
  */
-class FormContextTest extends TestCase
+final class FormContextTest extends TestCase
 {
     /**
      * setup method.

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -22,7 +22,7 @@ use Cake\View\Helper\BreadcrumbsHelper;
 use Cake\View\View;
 use LogicException;
 
-class BreadcrumbsHelperTest extends TestCase
+final class BreadcrumbsHelperTest extends TestCase
 {
     /**
      * Instance of the BreadcrumbsHelper

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -27,7 +27,7 @@ use Cake\View\View;
  *
  * @property \Cake\View\Helper\FlashHelper $Flash
  */
-class FlashHelperTest extends TestCase
+final class FlashHelperTest extends TestCase
 {
     /**
      * @var \Cake\View\View

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -102,7 +102,7 @@ final class FormHelperTest extends TestCase
 
         Configure::write('Config.language', 'eng');
         Configure::write('App.base', '');
-        static::setAppNamespace('Cake\Test\TestCase\View\Helper');
+        self::setAppNamespace('Cake\Test\TestCase\View\Helper');
 
         $request = new ServerRequest([
             'webroot' => '',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -64,7 +64,7 @@ use TestApp\View\Form\StubContext;
  * @property \Cake\View\Helper\FormHelper $Form
  * @property \Cake\View\View $View
  */
-class FormHelperTest extends TestCase
+final class FormHelperTest extends TestCase
 {
     /**
      * Fixtures to be used

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -81,7 +81,7 @@ final class HtmlHelperTest extends TestCase
         $this->Html = new HtmlHelper($this->View);
 
         $this->loadPlugins(['TestTheme']);
-        static::setAppNamespace();
+        self::setAppNamespace();
         Configure::write('Asset.timestamp', false);
 
         $builder = Router::createRouteBuilder('/');

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -33,7 +33,7 @@ use function Cake\Core\h;
 /**
  * HtmlHelperTest class
  */
-class HtmlHelperTest extends TestCase
+final class HtmlHelperTest extends TestCase
 {
     /**
      * Regexp for CDATA start block

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -41,7 +41,7 @@ final class NumberHelperTest extends TestCase
         parent::setUp();
         $this->View = new View();
 
-        static::setAppNamespace();
+        self::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * NumberHelperTest class
  */
-class NumberHelperTest extends TestCase
+final class NumberHelperTest extends TestCase
 {
     /**
      * @var \Cake\View\View

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -32,7 +32,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * PaginatorHelperTest class
  */
-class PaginatorHelperTest extends TestCase
+final class PaginatorHelperTest extends TestCase
 {
     /**
      * @var \Cake\View\View

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -44,7 +44,7 @@ final class TextHelperTest extends TestCase
         parent::setUp();
         $this->View = new View();
         $this->Text = new TextHelper($this->View);
-        static::setAppNamespace();
+        self::setAppNamespace();
     }
 
     /**

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * TextHelperTest class
  */
-class TextHelperTest extends TestCase
+final class TextHelperTest extends TestCase
 {
     /**
      * @var \Cake\View\Helper\TextHelper

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -28,7 +28,7 @@ use IntlDateFormatter;
 /**
  * TimeHelperTest class
  */
-class TimeHelperTest extends TestCase
+final class TimeHelperTest extends TestCase
 {
     /**
      * @var \Cake\View\Helper\TimeHelper

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -30,7 +30,7 @@ use function Cake\Core\h;
 /**
  * UrlHelperTest class
  */
-class UrlHelperTest extends TestCase
+final class UrlHelperTest extends TestCase
 {
     /**
      * @var \Cake\View\Helper\UrlHelper

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -61,7 +61,7 @@ final class UrlHelperTest extends TestCase
         $this->View = new View($request);
         $this->Helper = new UrlHelper($this->View);
 
-        static::setAppNamespace();
+        self::setAppNamespace();
         $this->loadPlugins(['TestTheme']);
         $this->builder = Router::createRouteBuilder('/');
         $this->builder->fallbacks(DashedRoute::class);

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -30,7 +30,7 @@ use TestPlugin\View\Helper\OtherHelperHelper;
 /**
  * HelperRegistryTest
  */
-class HelperRegistryTest extends TestCase
+final class HelperRegistryTest extends TestCase
 {
     /**
      * @var \Cake\View\HelperRegistry

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -209,7 +209,7 @@ final class HelperRegistryTest extends TestCase
      */
     public function testReset(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         $instance = $this->Helpers->load('EventListenerTest');
         $this->assertSame(
@@ -230,7 +230,7 @@ final class HelperRegistryTest extends TestCase
      */
     public function testUnload(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
 
         $instance = $this->Helpers->load('EventListenerTest');
         $this->assertSame(

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -33,7 +33,7 @@ use TestPlugin\View\Helper\OtherHelperHelper;
 /**
  * HelperTest class
  */
-class HelperTest extends TestCase
+final class HelperTest extends TestCase
 {
     /**
      * @var \Cake\View\View

--- a/tests/TestCase/View/JsonViewTest.php
+++ b/tests/TestCase/View/JsonViewTest.php
@@ -30,7 +30,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * JsonViewTest
  */
-class JsonViewTest extends TestCase
+final class JsonViewTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -22,7 +22,7 @@ use Cake\View\StringTemplate;
 use InvalidArgumentException;
 use stdClass;
 
-class StringTemplateTest extends TestCase
+final class StringTemplateTest extends TestCase
 {
     /**
      * @var \Cake\View\StringTemplate

--- a/tests/TestCase/View/StringTemplateTraitTest.php
+++ b/tests/TestCase/View/StringTemplateTraitTest.php
@@ -23,7 +23,7 @@ use TestApp\View\TestStringTemplate;
 /**
  * StringTemplateTraitTest class
  */
-class StringTemplateTraitTest extends TestCase
+final class StringTemplateTraitTest extends TestCase
 {
     /**
      * @var \TestApp\View\TestStringTemplate

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -254,7 +254,7 @@ final class ViewBuilderTest extends TestCase
      */
     public function testBuildAppViewMissing(): void
     {
-        static::setAppNamespace('Nope');
+        self::setAppNamespace('Nope');
         $builder = new ViewBuilder();
         $view = $builder->build();
         $this->assertInstanceOf(View::class, $view);
@@ -265,7 +265,7 @@ final class ViewBuilderTest extends TestCase
      */
     public function testBuildAppViewPresent(): void
     {
-        static::setAppNamespace();
+        self::setAppNamespace();
         $builder = new ViewBuilder();
         $view = $builder->build();
         $this->assertInstanceOf(AppView::class, $view);

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -34,7 +34,7 @@ use TestApp\View\TestViewWithDefaultConfig;
 /**
  * View builder test case.
  */
-class ViewBuilderTest extends TestCase
+final class ViewBuilderTest extends TestCase
 {
     public function testSetVar(): void
     {

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -55,7 +55,7 @@ use function Cake\Core\env;
 /**
  * ViewTest class
  */
-class ViewTest extends TestCase
+final class ViewTest extends TestCase
 {
     /**
      * Fixtures used in this test.

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -24,7 +24,7 @@ use Cake\View\XmlView;
 /**
  * ViewVarsTrait test case
  */
-class ViewVarsTraitTest extends TestCase
+final class ViewVarsTraitTest extends TestCase
 {
     /**
      * @var \Cake\Controller\Controller

--- a/tests/TestCase/View/Widget/BasicWidgetTest.php
+++ b/tests/TestCase/View/Widget/BasicWidgetTest.php
@@ -24,7 +24,7 @@ use Cake\View\Widget\BasicWidget;
 /**
  * Basic input test.
  */
-class BasicWidgetTest extends TestCase
+final class BasicWidgetTest extends TestCase
 {
     /**
      * @var \Cake\View\Form\NullContext

--- a/tests/TestCase/View/Widget/ButtonWidgetTest.php
+++ b/tests/TestCase/View/Widget/ButtonWidgetTest.php
@@ -24,7 +24,7 @@ use Cake\View\Widget\ButtonWidget;
 /**
  * Basic input test.
  */
-class ButtonWidgetTest extends TestCase
+final class ButtonWidgetTest extends TestCase
 {
     /**
      * @var \Cake\View\Form\NullContext

--- a/tests/TestCase/View/Widget/CheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/CheckboxWidgetTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Checkbox test case
  */
-class CheckboxWidgetTest extends TestCase
+final class CheckboxWidgetTest extends TestCase
 {
     /**
      * @var \Cake\View\Form\NullContext

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * DateTimeWidget test case
  */
-class DateTimeWidgetTest extends TestCase
+final class DateTimeWidgetTest extends TestCase
 {
     /**
      * @var \Cake\View\Form\NullContext

--- a/tests/TestCase/View/Widget/FileWidgetTest.php
+++ b/tests/TestCase/View/Widget/FileWidgetTest.php
@@ -24,7 +24,7 @@ use Cake\View\Widget\FileWidget;
 /**
  * File input test.
  */
-class FileWidgetTest extends TestCase
+final class FileWidgetTest extends TestCase
 {
     /**
      * @var \Cake\View\Form\NullContext

--- a/tests/TestCase/View/Widget/LabelWidgetTest.php
+++ b/tests/TestCase/View/Widget/LabelWidgetTest.php
@@ -24,7 +24,7 @@ use Cake\View\Widget\LabelWidget;
 /**
  * Label test case.
  */
-class LabelWidgetTest extends TestCase
+final class LabelWidgetTest extends TestCase
 {
     /**
      * @var \Cake\View\Form\NullContext

--- a/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
@@ -26,7 +26,7 @@ use Cake\View\Widget\NestingLabelWidget;
 /**
  * MultiCheckbox test case.
  */
-class MultiCheckboxWidgetTest extends TestCase
+final class MultiCheckboxWidgetTest extends TestCase
 {
     /**
      * @var \Cake\View\Form\NullContext

--- a/tests/TestCase/View/Widget/RadioWidgetTest.php
+++ b/tests/TestCase/View/Widget/RadioWidgetTest.php
@@ -26,7 +26,7 @@ use Cake\View\Widget\RadioWidget;
 /**
  * Radio test case
  */
-class RadioWidgetTest extends TestCase
+final class RadioWidgetTest extends TestCase
 {
     /**
      * @var \Cake\View\Form\NullContext

--- a/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
+++ b/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
@@ -26,7 +26,7 @@ use Cake\View\Widget\SelectBoxWidget;
 /**
  * SelectBox test case
  */
-class SelectBoxWidgetTest extends TestCase
+final class SelectBoxWidgetTest extends TestCase
 {
     /**
      * @var \Cake\View\Form\NullContext

--- a/tests/TestCase/View/Widget/TextareaWidgetTest.php
+++ b/tests/TestCase/View/Widget/TextareaWidgetTest.php
@@ -24,7 +24,7 @@ use Cake\View\Widget\TextareaWidget;
 /**
  * Textarea input test.
  */
-class TextareaWidgetTest extends TestCase
+final class TextareaWidgetTest extends TestCase
 {
     /**
      * @var \Cake\View\Form\NullContext

--- a/tests/TestCase/View/Widget/WidgetLocatorTest.php
+++ b/tests/TestCase/View/Widget/WidgetLocatorTest.php
@@ -30,7 +30,7 @@ use TestApp\View\Widget\TestUsingViewWidget;
 /**
  * WidgetLocator test case
  */
-class WidgetLocatorTest extends TestCase
+final class WidgetLocatorTest extends TestCase
 {
     /**
      * @var \Cake\View\StringTemplate

--- a/tests/TestCase/View/XmlViewTest.php
+++ b/tests/TestCase/View/XmlViewTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * XmlViewTest
  */
-class XmlViewTest extends TestCase
+final class XmlViewTest extends TestCase
 {
     protected array $fixtures = ['core.Authors'];
 


### PR DESCRIPTION
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->

StructArmed 0.15.0 introduce `ExtendedClassAwareRuleInterface` that makes its `MustBeFinalRule` safely be used to skip if there is class that extend target class.

This PR bump StructArmed to `^0.15` and apply the `MustBeFinalRule` with single command to fix.

```bash
vendor/bin/structarmed analyze src tests --fix
```

to finalize tests classes.
