### PR TITLE
fix postgres eager loading alias bug

### DIFF
--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -22,6 +22,7 @@ use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\ExpressionInterface;
+use Cake\Database\PostgresCompiler;
 use Cake\Database\ValueBinder;
 use Cake\ORM\Association;
 use Cake\ORM\Query\SelectQuery;
@@ -312,7 +313,7 @@ class SelectLoader
             if (is_int($aliasedField)) {
                 $filter[] = $field;
                 if (count($joinFields) < $keyCount) {
-                    $joinFields[] = $this->_rewriteJoinIdentifier($field, $aliasedTable);
+                    $joinFields[] = $this->_rewriteJoinIdentifier($query, $field, $aliasedTable);
                 }
             } else {
                 $filter[$aliasedField] = $field;
@@ -339,25 +340,34 @@ class SelectLoader
      * while the outer join condition must reference the alias assigned to the
      * derived table itself.
      *
+     * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array> $query Target table's query
      * @param mixed $field The original selected field.
      * @param string $aliasedTable The alias assigned to the joined subquery.
      * @return mixed
      */
-    protected function _rewriteJoinIdentifier(mixed $field, string $aliasedTable): mixed
+    protected function _rewriteJoinIdentifier(SelectQuery $query, mixed $field, string $aliasedTable): mixed
     {
         if (!is_string($field)) {
             return $field;
         }
 
-        $identifier = preg_replace(
-            '/^' . preg_quote($this->sourceAlias, '/') . '\./',
-            $aliasedTable . '.' . $this->sourceAlias . '__',
-            $field,
-        );
+        $identifier = $field;
+        $selectAlias = null;
+        if (preg_match('/^' . preg_quote($this->sourceAlias, '/') . '\.(.+)$/', $field, $matches)) {
+            $selectAlias = $this->sourceAlias . '__' . $matches[1];
+            $identifier = $aliasedTable . '.' . $selectAlias;
+        }
 
-        return new IdentifierExpression(
-            $identifier ?? $field,
-        );
+        $driver = $query->getDriver();
+        if (
+            $selectAlias !== null &&
+            !$driver->isAutoQuotingEnabled() &&
+            $driver->newCompiler() instanceof PostgresCompiler
+        ) {
+            $identifier = $aliasedTable . '.' . $driver->quoteIdentifier($selectAlias);
+        }
+
+        return new IdentifierExpression($identifier);
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM\Association;
 
 use Cake\Database\Connection;
+use Cake\Database\Driver\Postgres;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Expression\OrderByExpression;
@@ -323,6 +324,47 @@ class HasManyTest extends TestCase
 
         $expected = new OrderByExpression(['id' => 'ASC']);
         $this->assertOrderClause($expected, $query);
+    }
+
+    /**
+     * Test that subquery joins quote PostgreSQL select aliases when auto quoting is disabled.
+     */
+    public function testSubqueryEagerLoaderQuotesPostgresSelectAliasInJoin(): void
+    {
+        $driver = new class (['quoteIdentifiers' => false]) extends Postgres {
+            public function enabled(): bool
+            {
+                return true;
+            }
+        };
+        $connection = new Connection(['driver' => $driver]);
+        $this->author->setConnection($connection);
+        $this->article->setConnection($connection);
+
+        $config = [
+            'sourceTable' => $this->author,
+            'targetTable' => $this->article,
+            'strategy' => Association::STRATEGY_SUBQUERY,
+        ];
+        $association = new HasMany('Articles', $config);
+
+        $query = $this->author->selectQuery();
+        $fetchQuery = new class ($this->article) extends SelectQuery {
+            public function all(): ResultSetInterface
+            {
+                return new ResultSet([]);
+            }
+        };
+        $this->article->shouldReceive('find')
+            ->with('all')
+            ->andReturn($fetchQuery);
+
+        $association->eagerLoader(['keys' => [], 'query' => $query]);
+        $sql = $fetchQuery->sql();
+
+        $this->assertStringContainsString('AS "Authors__id"', $sql);
+        $this->assertStringContainsString('Authors."Authors__id"', $sql);
+        $this->assertStringNotContainsString('Authors.Authors__id', $sql);
     }
 
     /**


### PR DESCRIPTION
Closes #19551 

Fix PostgreSQL subquery eager loading for hasMany / belongsToMany associations when quoteIdentifiers is disabled by quoting the derived-table select alias in the generated join condition.

PostgreSQL always treats quoted select aliases as case-sensitive. The subquery loader emitted aliases like:
```
AS "Authors__id"
```

but referenced them in the join condition as:
```
Authors.Authors__id
```

With auto-quoting disabled, PostgreSQL folds that to lowercase and fails with `column authors.authors__id does not exist`.