### PR TITLE
unify array structure for marshalling and containing

### DIFF
--- a/src/ORM/AssociationsNormalizerTrait.php
+++ b/src/ORM/AssociationsNormalizerTrait.php
@@ -23,6 +23,34 @@ namespace Cake\ORM;
 trait AssociationsNormalizerTrait
 {
     /**
+     * List of option names accepted inside an association's options array.
+     *
+     * Unknown string keys are treated as nested association aliases so that
+     * contain-style associated arrays also work with lowercase aliases.
+     *
+     * @var array<string, int>
+     */
+    protected array $associationOptions = [
+        'associated' => 1,
+        'association' => 1,
+        'atomic' => 1,
+        'checkExisting' => 1,
+        'checkRules' => 1,
+        'fields' => 1,
+        'forceNew' => 1,
+        'ids' => 1,
+        'isMerge' => 1,
+        'junctionProperty' => 1,
+        'onlyIds' => 1,
+        'patchableFields' => 1,
+        'sourceTable' => 1,
+        'strictFields' => 1,
+        'validate' => 1,
+        '_cleanOnSuccess' => 1,
+        '_primary' => 1,
+    ];
+
+    /**
      * Returns an array out of the original passed associations list where dot notation
      * is transformed into nested arrays so that they can be parsed by other routines.
      *
@@ -30,6 +58,10 @@ trait AssociationsNormalizerTrait
      * - Dot notation: ['First.Second']
      * - Nested arrays: ['First' => ['Second', 'Third']]
      * - Mixed with options: ['First' => ['Second', 'onlyIds' => true]]
+     *
+     * Known option names are parsed as options. Unknown string keys are parsed as
+     * association aliases. If an association alias collides with an option name,
+     * use dot notation or the explicit `associated` option.
      *
      * @param array|string $associations The array of included associations.
      * @return array An array having dot notation transformed into nested arrays
@@ -45,9 +77,7 @@ trait AssociationsNormalizerTrait
                 $options = [];
             }
 
-            // Handle nested array format like contain()
-            // Only transform if the array looks like it contains associations (not just a simple array value)
-            if (is_array($options) && !isset($options['associated']) && $this->shouldExtractAssociations($options)) {
+            if (is_array($options) && !isset($options['associated'])) {
                 [$nestedAssociations, $actualOptions] = $this->extractAssociations($options);
                 if ($nestedAssociations) {
                     $actualOptions['associated'] = $this->normalizeAssociations($nestedAssociations);
@@ -84,66 +114,15 @@ trait AssociationsNormalizerTrait
     }
 
     /**
-     * Determines if an array should have associations extracted from it.
-     *
-     * Returns true if the array appears to be mixing association names with options,
-     * or if it contains nested association structures (like contain() format).
-     * Returns false for simple arrays that should be kept as-is.
-     *
-     * Uses CakePHP naming conventions to detect associations vs options:
-     * - Association names start with uppercase (CamelCase): Users, Articles
-     * - Option keys start with lowercase (camelCase): onlyIds, conditions
-     * - Special data keys start with underscore: _joinData, _ids
-     *
-     * @param array $options The options array to check.
-     * @return bool
-     */
-    protected function shouldExtractAssociations(array $options): bool
-    {
-        // Empty arrays should not be transformed
-        if (!$options) {
-            return false;
-        }
-
-        $hasOptionKey = false;
-        $hasStringKeys = false;
-        $hasNestedArrayValues = false;
-        $hasMultipleItems = count($options) > 1;
-
-        foreach ($options as $key => $value) {
-            if (is_string($key)) {
-                $hasStringKeys = true;
-                // Option keys start with lowercase letter (camelCase convention)
-                if (preg_match('/^[a-z]/', $key)) {
-                    $hasOptionKey = true;
-                }
-            }
-            // Check if value is an array (potential nested association)
-            if (is_array($value)) {
-                $hasNestedArrayValues = true;
-            }
-        }
-
-        // Only extract associations if:
-        // 1. We have an option key (mixing associations and options)
-        // 2. We have string keys AND nested array values (contain-like format with nested associations)
-        // 3. We have multiple items (likely a list of associations like ['Users', 'Comments'])
-        return $hasOptionKey || ($hasStringKeys && $hasNestedArrayValues) || $hasMultipleItems;
-    }
-
-    /**
      * Extracts association names from options array, separating them from actual options.
      *
-     * Uses CakePHP naming conventions to distinguish associations from options:
-     * - Association names start with uppercase (CamelCase): Users, Articles
-     * - Special data keys start with underscore: _joinData, _ids (treated as associations)
-     * - Option keys start with lowercase (camelCase): onlyIds, conditions
+     * This allows a contain-style nested array format in the shared `associated`
+     * option:
      *
-     * This allows the same nested array format as contain():
-     * - ['Users', 'Comments'] → associations
-     * - ['Users' => [...], 'Comments'] → associations
-     * - ['onlyIds' => true, 'validate' => false] → options only
-     * - ['Users', 'onlyIds' => true] → mixed
+     * - ['Users', 'Comments'] contains nested associations
+     * - ['Users' => [...], 'Comments'] contains nested associations
+     * - ['onlyIds' => true, 'validate' => false] contains options
+     * - ['Users', 'onlyIds' => true] contains associations and options
      *
      * @param array $options The options array that may contain nested associations.
      * @return array An array with two elements: [associations, options]
@@ -154,21 +133,17 @@ trait AssociationsNormalizerTrait
         $actualOptions = [];
 
         foreach ($options as $key => $value) {
-            // Numeric keys are always association names (string values like 'Users')
             if (is_int($key)) {
                 $associations[] = $value;
                 continue;
             }
 
-            // String keys starting with uppercase or underscore are associations/data keys
-            // This follows CakePHP conventions: CamelCase for models, _prefix for special data
-            if (preg_match('/^[A-Z_]/', $key)) {
-                $associations[$key] = $value;
+            if (isset($this->associationOptions[$key])) {
+                $actualOptions[$key] = $value;
                 continue;
             }
 
-            // Everything else (lowercase start) is an option key
-            $actualOptions[$key] = $value;
+            $associations[$key] = $value;
         }
 
         return [$associations, $actualOptions];

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -178,12 +178,16 @@ class Marshaller
      *  ```
      *  $result = $marshaller->one($data, [
      *    'associated' => [
-     *      'Tags' => [
-     *        'associated' => ['DeeperAssoc1', 'DeeperAssoc2']
-     *      ]
+     *      'Tags' => ['DeeperAssoc1', 'DeeperAssoc2']
      *    ]
      *  ]);
      *  ```
+     *
+     * ```
+     * $result = $marshaller->one($data, [
+     *   'associated' => ['Tags' => ['_joinData' => ['Users']]]
+     * ]);
+     * ```
      *
      * @param array<string, mixed> $data The data to hydrate.
      * @param array<string, mixed> $options List of options
@@ -553,9 +557,7 @@ class Marshaller
      * ```
      * $result = $marshaller->merge($entity, $data, [
      *   'associated' => [
-     *     'Tags' => [
-     *       'associated' => ['DeeperAssoc1', 'DeeperAssoc2']
-     *     ]
+     *     'Tags' => ['DeeperAssoc1', 'DeeperAssoc2']
      *   ]
      * ]);
      * ```

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2040,7 +2040,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * $companies->save($entity, [
      *   'associated' => [
      *     'Employees' => [
-     *       'associated' => ['Addresses'],
+     *       'Addresses',
      *       'checkRules' => false
      *     ]
      *   ]
@@ -2984,7 +2984,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * ```
      * $article = $this->Articles->newEntity(
      *   $this->request->getData(),
-     *   ['associated' => ['Tags', 'Comments.Users']]
+     *   ['associated' => ['Tags', 'Comments' => ['Users']]]
      * );
      * ```
      *
@@ -3102,6 +3102,12 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *   'associated' => [
      *     'Tags' => ['patchableFields' => ['*' => true]]
      *   ]
+     * ]);
+     * ```
+     *
+     * ```
+     * $article = $this->Articles->patchEntity($article, $this->request->getData(), [
+     *   'associated' => ['Tags' => ['_joinData' => ['Users']]]
      * ]);
      * ```
      *

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -373,8 +373,12 @@ class AssociationCollectionTest extends TestCase
         $this->assertSame([], $this->associations->normalizeKeys([]));
         $this->assertSame([], $this->associations->normalizeKeys(false));
 
+        $assocs = ['a', 'b', 'd' => ['associated' => ['something']]];
+        $expected = ['a' => [], 'b' => [], 'd' => ['associated' => ['something']]];
+        $this->assertSame($expected, $this->associations->normalizeKeys($assocs));
+
         $assocs = ['a', 'b', 'd' => ['something']];
-        $expected = ['a' => [], 'b' => [], 'd' => ['something']];
+        $expected = ['a' => [], 'b' => [], 'd' => ['associated' => ['something' => []]]];
         $this->assertSame($expected, $this->associations->normalizeKeys($assocs));
 
         $belongsTo = new BelongsTo('', new Table());

--- a/tests/TestCase/ORM/AssociationsNormalizerTraitTest.php
+++ b/tests/TestCase/ORM/AssociationsNormalizerTraitTest.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         6.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\ORM;
+
+use Cake\ORM\AssociationsNormalizerTrait;
+use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests AssociationsNormalizerTrait.
+ */
+class AssociationsNormalizerTraitTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: array|string, 1: array}>
+     */
+    public static function normalizeAssociationsProvider(): array
+    {
+        $expected = [
+            'First' => [
+                'associated' => [
+                    'Second' => [],
+                    'Third' => [],
+                    'Fourth' => [],
+                ],
+            ],
+        ];
+
+        return [
+            'dot notation' => [
+                ['First.Second', 'First.Third', 'First.Fourth'],
+                $expected,
+            ],
+            'contain style list' => [
+                ['First' => ['Second', 'Third', 'Fourth']],
+                $expected,
+            ],
+            'single nested child' => [
+                ['First' => ['Second']],
+                [
+                    'First' => [
+                        'associated' => [
+                            'Second' => [],
+                        ],
+                    ],
+                ],
+            ],
+            'deeper contain style' => [
+                ['First' => ['Second' => ['Third']]],
+                [
+                    'First' => [
+                        'associated' => [
+                            'Second' => [
+                                'associated' => [
+                                    'Third' => [],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'mixed options and associations' => [
+                ['Comments' => ['fields' => ['id', 'body'], 'Users']],
+                [
+                    'Comments' => [
+                        'fields' => ['id', 'body'],
+                        'associated' => [
+                            'Users' => [],
+                        ],
+                    ],
+                ],
+            ],
+            'options only' => [
+                ['Tags' => ['onlyIds' => true]],
+                [
+                    'Tags' => [
+                        'onlyIds' => true,
+                    ],
+                ],
+            ],
+            'lowercase aliases' => [
+                ['authors' => ['supervisors' => ['tags']]],
+                [
+                    'authors' => [
+                        'associated' => [
+                            'supervisors' => [
+                                'associated' => [
+                                    'tags' => [],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array|string $associations
+     * @param array $expected
+     */
+    #[DataProvider('normalizeAssociationsProvider')]
+    public function testNormalizeAssociations(array|string $associations, array $expected): void
+    {
+        $normalizer = new class {
+            use AssociationsNormalizerTrait {
+                normalizeAssociations as public;
+            }
+        };
+
+        $this->assertSame($expected, $normalizer->normalizeAssociations($associations));
+    }
+}

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -832,7 +832,7 @@ class MarshallerTest extends TestCase
             ],
         ];
         $marshaller = new Marshaller($this->tags);
-        $tag = $marshaller->one($data, ['associated' => ['Articles' => [ 'associated' => ['Users', 'Comments']]]]);
+        $tag = $marshaller->one($data, ['associated' => ['Articles' => ['associated' => ['Users', 'Comments']]]]);
 
         $this->assertNotEmpty($tag->articles);
         $this->assertCount(1, $tag->articles);
@@ -853,6 +853,47 @@ class MarshallerTest extends TestCase
         $this->assertInstanceOf(Entity::class, $tag->articles[0]->comments[0]);
         $this->assertTrue($tag->articles[0]->comments[0]->isNew());
         $this->assertTrue($tag->articles[0]->comments[1]->isNew());
+
+        $tag = $marshaller->one($data, ['associated' => ['Articles' => ['Users', 'Comments']]]);
+
+        $this->assertInstanceOf(Entity::class, $tag->articles[0]->user);
+        $this->assertSame('newuser', $tag->articles[0]->user->username);
+        $this->assertCount(2, $tag->articles[0]->comments);
+    }
+
+    /**
+     * Test marshalling contain-style nested associations mixed with options.
+     */
+    public function testOneContainStyleNestedAssociationsWithOptions(): void
+    {
+        $data = [
+            'title' => 'My title',
+            'body' => 'My content',
+            'comments' => [
+                [
+                    'comment' => 'First comment',
+                    'article_id' => 1,
+                    'user' => [
+                        'username' => 'mark',
+                    ],
+                ],
+            ],
+        ];
+        $marshaller = new Marshaller($this->articles);
+        $article = $marshaller->one($data, [
+            'associated' => [
+                'Comments' => [
+                    'fields' => ['comment', 'user'],
+                    'Users',
+                ],
+            ],
+        ]);
+
+        $this->assertCount(1, $article->comments);
+        $this->assertSame('First comment', $article->comments[0]->comment);
+        $this->assertNull($article->comments[0]->article_id);
+        $this->assertInstanceOf(Entity::class, $article->comments[0]->user);
+        $this->assertSame('mark', $article->comments[0]->user->username);
     }
 
     /**
@@ -2282,6 +2323,19 @@ class MarshallerTest extends TestCase
         $this->assertSame(
             $data['tags'][1]['_joinData']['user']['username'],
             $result->tags[1]->_joinData->user->username,
+        );
+
+        $article = $this->articles->get(1, ...['associated' => 'Tags']);
+        $result = $marshall->merge($article, $data, ['associated' => [
+            'Tags' => [
+                '_joinData' => ['Users'],
+            ],
+        ]]);
+
+        $this->assertInstanceOf(Entity::class, $result->tags[0]->_joinData->user);
+        $this->assertSame(
+            $data['tags'][0]['_joinData']['user']['username'],
+            $result->tags[0]->_joinData->user->username,
         );
     }
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -4230,6 +4230,69 @@ class TableTest extends TestCase
         ]));
     }
 
+    /**
+     * Tests that deep save options accept contain-style nested association arrays.
+     */
+    public function testSaveDeepAssociationContainStyleOptions(): void
+    {
+        $articles = $this->getMockBuilder(Table::class)
+            ->onlyMethods(['insert'])
+            ->setConstructorArgs([['table' => 'articles', 'connection' => $this->connection]])
+            ->getMock();
+        $authors = $this->getMockBuilder(Table::class)
+            ->onlyMethods(['insert'])
+            ->setConstructorArgs([['table' => 'authors', 'connection' => $this->connection]])
+            ->getMock();
+        $supervisors = $this->getMockBuilder(Table::class)
+            ->onlyMethods(['insert'])
+            ->setConstructorArgs([[
+                'table' => 'authors',
+                'alias' => 'supervisors',
+                'connection' => $this->connection,
+            ]])
+            ->getMock();
+
+        $articles->belongsTo('authors', ['targetTable' => $authors]);
+        $authors->hasOne('supervisors', ['targetTable' => $supervisors]);
+
+        $entity = new Entity([
+            'title' => 'bar',
+            'author' => new Entity([
+                'name' => 'Juan',
+                'supervisor' => new Entity(['name' => 'Marc']),
+            ]),
+        ]);
+        $entity->setNew(true);
+        $entity->author->setNew(true);
+        $entity->author->supervisor->setNew(true);
+
+        $articles->expects($this->once())
+            ->method('insert')
+            ->with($entity, ['title' => 'bar'])
+            ->willReturn($entity);
+
+        $authors->expects($this->once())
+            ->method('insert')
+            ->with($entity->author, ['name' => 'Juan'])
+            ->willReturn($entity->author);
+
+        $supervisors->expects($this->once())
+            ->method('insert')
+            ->with($entity->author->supervisor, ['name' => 'Marc'])
+            ->willReturn($entity->author->supervisor);
+
+        $this->assertSame($entity, $articles->save($entity, [
+            'associated' => [
+                'authors' => [
+                    'supervisors' => [
+                        'atomic' => false,
+                        'associated' => false,
+                    ],
+                ],
+            ],
+        ]));
+    }
+
     public function testBelongsToFluentInterface(): void
     {
         /** @var \TestApp\Model\Table\ArticlesTable $articles */


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/pull/17547

It was always confusing, that we had different array structures for containing associations and marshaling request data into an entity for deeper levels.

This PR unifies those 2 array structures and makes it possible to write it either way.

This way users have the option to use whatever they prefer to use.

The question that is open up for discussion though is - do we want to keep both or do we want to decide on 1 structure and enforce it?