### PR TITLE
Drop CakePHP 1.x pipe-delimited cookie format support

### DIFF
--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -803,7 +803,6 @@ class Cookie implements CookieInterface
 
     /**
      * Explode method to return array from string set in CookieComponent::_flatten()
-     * Maintains reading backwards compatibility with 1.x CookieComponent::_flatten().
      *
      * @param string $string A string containing JSON encoded data, or a bare string.
      * @return array|string Map of key and values
@@ -816,15 +815,6 @@ class Cookie implements CookieInterface
             return json_decode($string, true) ?? $string;
         }
 
-        $array = [];
-        foreach (explode(',', $string) as $pair) {
-            $key = explode('|', $pair);
-            if (!isset($key[1])) {
-                return $key[0];
-            }
-            $array[$key[0]] = $key[1];
-        }
-
-        return $array;
+        return $string;
     }
 }

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -159,7 +159,6 @@ trait CookieCryptTrait
 
     /**
      * Explode method to return array from string set in CookieComponent::_implode()
-     * Maintains reading backwards compatibility with 1.x CookieComponent::_implode().
      *
      * @param string $string A string containing JSON encoded data, or a bare string.
      * @return array|string Map of key and values
@@ -170,15 +169,7 @@ trait CookieCryptTrait
         if ($first === '{' || $first === '[') {
             return json_decode($string, true) ?? $string;
         }
-        $array = [];
-        foreach (explode(',', $string) as $pair) {
-            $key = explode('|', $pair);
-            if (!isset($key[1])) {
-                return $key[0];
-            }
-            $array[$key[0]] = $key[1];
-        }
 
-        return $array;
+        return $string;
     }
 }

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -415,17 +415,6 @@ class CookieTest extends TestCase
     }
 
     /**
-     * Test reading complex data serialized in 1.x and early 2.x
-     */
-    public function testReadLegacyComplexData(): void
-    {
-        $data = 'key|value,key2|value2';
-        $cookie = new Cookie('cakephp', $data);
-        $this->assertSame('value', $cookie->read('key'));
-        $this->assertNull($cookie->read('nope'));
-    }
-
-    /**
      * Test that toHeaderValue() collapses data.
      */
     public function testToHeaderValueCollapsesComplexData(): void


### PR DESCRIPTION
I think its long overdue that we remove this 😁 