### PR TITLE
Remove legacy unsalted hex CSRF token support

### DIFF
--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -204,22 +204,6 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
     }
 
     /**
-     * Test if the token predates salted tokens.
-     *
-     * These tokens are hexadecimal values and equal
-     * to the token with checksum length. While they are vulnerable
-     * to BREACH they should rotate over time and support will be dropped
-     * in 5.x.
-     *
-     * @param string $token The token to test.
-     * @return bool
-     */
-    protected function isHexadecimalToken(string $token): bool
-    {
-        return preg_match('/^[a-f0-9]{' . static::TOKEN_WITH_CHECKSUM_LENGTH . '}$/', $token) === 1;
-    }
-
-    /**
      * Create a new token to be used for CSRF protection
      *
      * @return string
@@ -243,9 +227,6 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      */
     public function saltToken(string $token): string
     {
-        if ($this->isHexadecimalToken($token)) {
-            return $token;
-        }
         $decoded = base64_decode($token, true);
         if ($decoded === false) {
             throw new InvalidArgumentException('Invalid token data.');
@@ -265,17 +246,14 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
     /**
      * Remove the salt from a CSRF token.
      *
-     * If the token is not TOKEN_VALUE_LENGTH * 2 it is an old
-     * unsalted value that is supported for backwards compatibility.
+     * Returns the token unchanged if it isn't a validly-salted value
+     * (e.g. malformed or tampered-with input).
      *
      * @param string $token The token that could be salty.
      * @return string An unsalted token.
      */
     public function unsaltToken(string $token): string
     {
-        if ($this->isHexadecimalToken($token)) {
-            return $token;
-        }
         $decoded = base64_decode($token, true);
         if ($decoded === false || strlen($decoded) !== static::TOKEN_WITH_CHECKSUM_LENGTH * 2) {
             return $token;
@@ -300,13 +278,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
      */
     protected function verifyToken(string $token): bool
     {
-        // If we have a hexadecimal value we're in a compatibility mode from before
-        // tokens were salted on each request.
-        if ($this->isHexadecimalToken($token)) {
-            $decoded = $token;
-        } else {
-            $decoded = base64_decode($token, true);
-        }
+        $decoded = base64_decode($token, true);
         if (!$decoded || strlen($decoded) <= static::TOKEN_VALUE_LENGTH) {
             return false;
         }

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -24,7 +24,6 @@ use Cake\Http\Middleware\CsrfProtectionMiddleware;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
-use Cake\Utility\Security;
 use Laminas\Diactoros\Response as DiactorosResponse;
 use Laminas\Diactoros\Response\RedirectResponse;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -37,14 +36,6 @@ use TestApp\Http\TestRequestHandler;
  */
 class CsrfProtectionMiddlewareTest extends TestCase
 {
-    protected function createOldToken(): string
-    {
-        // Create an old style token. These tokens are hexadecimal with an hmac.
-        $random = Security::randomString(CsrfProtectionMiddleware::TOKEN_VALUE_LENGTH);
-
-        return $random . hash_hmac('sha1', $random, Security::getSalt());
-    }
-
     /**
      * Data provider for HTTP method tests.
      *
@@ -143,35 +134,6 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $this->assertTrue($cookie['secure']);
         $this->assertTrue($cookie['httponly']);
         $this->assertSame(CookieInterface::SAMESITE_LAX, $cookie['samesite']);
-    }
-
-    /**
-     * Test setting request attribute based on old cookie value.
-     */
-    public function testRequestAttributeCompatWithOldToken(): void
-    {
-        $middleware = new CsrfProtectionMiddleware();
-        $oldToken = $this->createOldToken();
-
-        $request = new ServerRequest([
-            'environment' => [
-                'REQUEST_METHOD' => 'GET',
-            ],
-            'cookies' => ['csrfToken' => $oldToken],
-        ]);
-
-        /** @var \Cake\Http\ServerRequest $updatedRequest */
-        $updatedRequest = null;
-        $handler = new TestRequestHandler(function ($request) use (&$updatedRequest) {
-            $updatedRequest = $request;
-
-            return new Response();
-        });
-        $response = $middleware->process($request, $handler);
-        $this->assertInstanceOf(Response::class, $response);
-
-        $requestAttr = $updatedRequest->getAttribute('csrfToken');
-        $this->assertSame($requestAttr, $oldToken, 'Request attribute should match the token.');
     }
 
     /**
@@ -344,33 +306,6 @@ class CsrfProtectionMiddlewareTest extends TestCase
             $this->assertSame('csrfToken', $cookie->getName(), 'Should automatically delete cookie with invalid CSRF token');
             $this->assertTrue($cookie->isExpired(), 'Should automatically delete cookie with invalid CSRF token');
         }
-    }
-
-    /**
-     * Test that request data works with the various http methods.
-     */
-    #[DataProvider('httpMethodProvider')]
-    public function testValidTokenRequestDataCompat(string $method): void
-    {
-        $middleware = new CsrfProtectionMiddleware();
-        $token = $this->createOldToken();
-
-        $request = new ServerRequest([
-            'environment' => [
-                'REQUEST_METHOD' => $method,
-            ],
-            'post' => ['_csrfToken' => $token],
-            'cookies' => ['csrfToken' => $token],
-        ]);
-
-        $handler = new TestRequestHandler(function ($request) {
-            $this->assertNull($request->getData('_csrfToken'));
-
-            return new Response();
-        });
-
-        // No exception means everything is OK
-        $middleware->process($request, $handler);
     }
 
     /**


### PR DESCRIPTION
Removes the old hexadecimal token based implementation