### PR TITLE
Route internal trigger_error() calls through triggerWarning()

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -28,6 +28,7 @@ use Cake\Core\StaticConfigTrait;
 use Closure;
 use Psr\SimpleCache\CacheInterface;
 use RuntimeException;
+use function Cake\Core\triggerWarning;
 
 /**
  * Cache provides a consistent interface to Caching in your application. It allows you
@@ -159,7 +160,7 @@ class Cache
         } catch (RuntimeException $e) {
             if (!array_key_exists('fallback', $config)) {
                 $registry->set($name, new NullEngine());
-                trigger_error($e->getMessage(), E_USER_WARNING);
+                triggerWarning($e->getMessage());
 
                 return;
             }

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -34,6 +34,7 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
 use SplFileObject;
+use function Cake\Core\triggerWarning;
 
 /**
  * File Storage engine for cache. Filestorage is the slowest cache storage
@@ -426,18 +427,18 @@ class FileEngine extends CacheEngine
             try {
                 $this->File = $path->openFile('c+');
             } catch (Exception $e) {
-                trigger_error($e->getMessage(), E_USER_WARNING);
+                triggerWarning($e->getMessage());
 
                 return false;
             }
             unset($path);
 
             if (!$exists && !chmod($this->File->getPathname(), (int)$this->config['mask'])) {
-                trigger_error(sprintf(
+                triggerWarning(sprintf(
                     'Could not apply permission mask `%s` on cache file `%s`',
                     $this->File->getPathname(),
                     $this->config['mask'],
-                ), E_USER_WARNING);
+                ));
             }
         }
 
@@ -463,10 +464,10 @@ class FileEngine extends CacheEngine
         $isWritableDir = ($dir->isDir() && $dir->isWritable());
         if (!$success || ($this->init && !$isWritableDir)) {
             $this->init = false;
-            trigger_error(sprintf(
+            triggerWarning(sprintf(
                 '%s is not writable',
                 $this->config['path'],
-            ), E_USER_WARNING);
+            ));
         }
 
         return $success;

--- a/src/Cache/Engine/PhpEngine.php
+++ b/src/Cache/Engine/PhpEngine.php
@@ -30,6 +30,7 @@ use DateInterval;
 use LogicException;
 use SplFileInfo;
 use Throwable;
+use function Cake\Core\triggerWarning;
 
 /**
  * PHP Cache Engine
@@ -130,11 +131,11 @@ class PhpEngine extends CacheEngine
         try {
             $exported = VarExporter::export($value);
         } catch (Throwable $e) {
-            trigger_error(sprintf(
+            triggerWarning(sprintf(
                 'PhpEngine failed to export value for key `%s`: %s',
                 $key,
                 $e->getMessage(),
-            ), E_USER_WARNING);
+            ));
 
             $this->dispatchEvent(CacheAfterSetEvent::NAME, [
                 'key' => $key, 'value' => $value, 'success' => false, 'ttl' => $duration,
@@ -194,11 +195,11 @@ class PhpEngine extends CacheEngine
             $value = require $path;
         } catch (Throwable $e) {
             // Corrupt cache file
-            trigger_error(sprintf(
+            triggerWarning(sprintf(
                 'PhpEngine failed to read cache file `%s`: %s',
                 $path,
                 $e->getMessage(),
-            ), E_USER_WARNING);
+            ));
             $this->deleteFile($path);
 
             $this->dispatchEvent(CacheAfterGetEvent::NAME, ['key' => $key, 'value' => null, 'success' => false]);
@@ -460,10 +461,10 @@ class PhpEngine extends CacheEngine
         $isWritableDir = ($dir->isDir() && $dir->isWritable());
         if (!$success || ($this->init && !$isWritableDir)) {
             $this->init = false;
-            trigger_error(sprintf(
+            triggerWarning(sprintf(
                 '%s is not writable',
                 $this->config['path'],
-            ), E_USER_WARNING);
+            ));
         }
 
         return $success;

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -329,7 +329,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
 
         $trace = debug_backtrace();
         $parts = explode('\\', static::class);
-        trigger_error(
+        triggerWarning(
             sprintf(
                 'Undefined property `%s::$%s` in `%s` on line %s',
                 array_pop($parts),

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -304,14 +304,15 @@ if (!function_exists('Cake\Core\env')) {
 
 if (!function_exists('Cake\Core\triggerWarning')) {
     /**
-     * Triggers an E_USER_WARNING.
+     * Triggers a user-level PHP error/warning/notice.
      *
      * @param string $message The warning message.
+     * @param int $level The error level to trigger. Defaults to `E_USER_WARNING`.
      * @return void
      */
-    function triggerWarning(string $message): void
+    function triggerWarning(string $message, int $level = E_USER_WARNING): void
     {
-        trigger_error($message, E_USER_WARNING);
+        trigger_error($message, $level);
     }
 }
 

--- a/src/Core/functions_global.php
+++ b/src/Core/functions_global.php
@@ -166,14 +166,15 @@ if (!function_exists('env')) {
 
 if (!function_exists('triggerWarning')) {
     /**
-     * Triggers an E_USER_WARNING.
+     * Triggers a user-level PHP error/warning/notice.
      *
      * @param string $message The warning message.
+     * @param int $level The error level to trigger. Defaults to `E_USER_WARNING`.
      * @return void
      */
-    function triggerWarning(string $message): void
+    function triggerWarning(string $message, int $level = E_USER_WARNING): void
     {
-        cakeTriggerWarning($message);
+        cakeTriggerWarning($message, $level);
     }
 }
 

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -43,6 +43,7 @@ use ReflectionProperty;
 use Throwable;
 use function Cake\Core\h;
 use function Cake\Core\pr;
+use function Cake\Core\triggerWarning;
 
 /**
  * Provide custom logging and error handling.
@@ -865,7 +866,7 @@ class Debugger
     {
         $salt = Security::getSalt();
         if ($salt === '__SALT__' || strlen($salt) < 32) {
-            trigger_error(
+            triggerWarning(
                 'Please change the value of `Security.salt` in `ROOT/config/app_local.php` ' .
                 'to a random value of at least 32 characters.',
                 E_USER_NOTICE,

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 use function Cake\Core\env;
+use function Cake\Core\triggerWarning;
 
 /**
  * Entry point to CakePHP's exception handling.
@@ -373,6 +374,6 @@ class ExceptionTrap
             $exception->getFile(),
             $exception->getLine(),
         );
-        trigger_error($message, E_USER_WARNING);
+        triggerWarning($message);
     }
 }

--- a/src/Error/functions_global.php
+++ b/src/Error/functions_global.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
+use function Cake\Core\triggerWarning;
 
 if (!function_exists('debug')) {
     /**
@@ -132,9 +133,8 @@ if (!function_exists('breakpoint')) {
         if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') && class_exists(\Psy\Shell::class)) {
             return 'extract(\Psy\Shell::debug(get_defined_vars(), isset($this) ? $this : null));';
         }
-        trigger_error(
+        triggerWarning(
             'psy/psysh must be installed and you must be in a CLI environment to use the breakpoint function',
-            E_USER_WARNING,
         );
 
         return null;

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -25,6 +25,7 @@ use Cake\Http\Cookie\CookieInterface;
 use Laminas\Diactoros\RelativeStream;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Link\LinkInterface;
+use function Cake\Core\triggerWarning;
 
 /**
  * Emits a Response to the PHP Server API.
@@ -55,7 +56,7 @@ class ResponseEmitter
         $line = 0;
         if (headers_sent($file, $line)) {
             $message = "Unable to emit headers. Headers sent in file={$file} line={$line}";
-            trigger_error($message, E_USER_WARNING);
+            triggerWarning($message);
         }
 
         $this->emitStatusLine($response);

--- a/src/Lock/Lock.php
+++ b/src/Lock/Lock.php
@@ -24,6 +24,7 @@ use Cake\Lock\Engine\RedisLockEngine;
 use Cake\Lock\Exception\InvalidArgumentException;
 use Closure;
 use RuntimeException;
+use function Cake\Core\triggerWarning;
 
 /**
  * Lock provides a consistent interface to distributed locking.
@@ -135,7 +136,7 @@ class Lock
             $registry->load($name, $config);
         } catch (RuntimeException $e) {
             $registry->set($name, new NullLockEngine());
-            trigger_error($e->getMessage(), E_USER_WARNING);
+            triggerWarning($e->getMessage());
         }
     }
 

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -19,6 +19,7 @@ namespace Cake\Log\Engine;
 use Cake\Log\Formatter\DefaultFormatter;
 use Cake\Utility\Text;
 use Stringable;
+use function Cake\Core\triggerWarning;
 
 /**
  * File Storage stream for Logging. Writes logs to different files
@@ -145,10 +146,10 @@ class FileLog extends BaseLog
 
         if (!$selfError && !$exists && !chmod($pathname, (int)$mask)) {
             $selfError = true;
-            trigger_error(vsprintf(
+            triggerWarning(vsprintf(
                 'Could not apply permission mask `%s` on log file `%s`',
                 [$mask, $pathname],
-            ), E_USER_WARNING);
+            ));
             $selfError = false;
         }
     }

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -31,6 +31,7 @@ use Cake\Utility\Inflector;
 use Closure;
 use InvalidArgumentException;
 use function Cake\Core\pluginSplit;
+use function Cake\Core\triggerWarning;
 
 /**
  * An Association is a relationship established between two tables and is used
@@ -575,9 +576,8 @@ abstract class Association
         ) {
             $msg = 'Association property name `%s` clashes with field of same name of table `%s`.' .
                 ' You should specify an alterate name using the `propertyName` option or `setProperty()` method.';
-            trigger_error(
+            triggerWarning(
                 sprintf($msg, $this->propertyName, $this->sourceTable->getTable()),
-                E_USER_WARNING,
             );
         }
 

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -32,6 +32,7 @@ use Exception;
 use ReflectionException;
 use ReflectionMethod;
 use Stringable;
+use function Cake\Core\triggerWarning;
 
 /**
  * Cell base.
@@ -266,12 +267,12 @@ abstract class Cell implements EventDispatcherInterface, Stringable
         try {
             return $this->render();
         } catch (Exception $e) {
-            trigger_error(sprintf(
+            triggerWarning(sprintf(
                 'Could not render cell - %s [%s, line %d]',
                 $e->getMessage(),
                 $e->getFile(),
                 $e->getLine(),
-            ), E_USER_WARNING);
+            ));
 
             return '';
         /** @phpstan-ignore-next-line */

--- a/tests/TestCase/Core/FunctionsGlobalTest.php
+++ b/tests/TestCase/Core/FunctionsGlobalTest.php
@@ -339,4 +339,16 @@ class FunctionsGlobalTest extends TestCase
             $this->assertTrue(true);
         });
     }
+
+    /**
+     * Test triggerWarning() with an explicit error level.
+     */
+    public function testTriggerWarningCustomLevel(): void
+    {
+        $error = $this->captureError(E_ALL, function (): void {
+            triggerWarning('This is just a notice', E_USER_NOTICE);
+        });
+        $this->assertSame(E_USER_NOTICE, $error->getCode());
+        $this->assertMatchesRegularExpression('/This is just a notice/', $error->getMessage());
+    }
 }

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -385,6 +385,19 @@ class FunctionsTest extends TestCase
         });
     }
 
+    /**
+     * Test triggerWarning() with an explicit error level.
+     */
+    public function testTriggerWarningCustomLevel(): void
+    {
+        $this->expectNoticeMessageMatches('/This is just a notice/', function (): void {
+            $this->withErrorReporting(E_ALL, function (): void {
+                triggerWarning('This is just a notice', E_USER_NOTICE);
+                $this->assertTrue(true);
+            });
+        });
+    }
+
     #[DataProvider('toStringProvider')]
     public function testToString(mixed $rawValue, ?string $expected): void
     {


### PR DESCRIPTION
## Summary
- Replaces the remaining scattered `trigger_error()` calls across `Cache`, `Lock`, `Http`, `View`, `Log`, `ORM`, `Controller`, and `Error` with `Cake\Core\triggerWarning()`, so error/warning emission goes through one central wrapper instead of the native PHP function directly.
- Extends `triggerWarning()` (both the namespaced `Cake\Core\triggerWarning()` and its global-namespace alias) with an optional `int $level = E_USER_WARNING` parameter, so the two call sites that intentionally used `E_USER_NOTICE` (`Controller::__get()` and `Debugger::checkSecurityKeys()`) keep their original severity while still going through the wrapper.
- The only remaining raw `trigger_error()` calls in `src/` are the two primitives inside `triggerWarning()`/`deprecationWarning()` themselves.

## Test plan
- [x] Added `testTriggerWarningCustomLevel` to both `FunctionsTest` and `FunctionsGlobalTest` covering the new `$level` parameter.
- [x] Ran all touched test suites individually (`Cache`, `Lock`, `Http`, `View`, `Log`, `ORM`, `Controller`, `Error`, `Core/Functions*`) - all green.
- [x] `phpcs` and `phpstan` clean on every touched file (pre-existing, unrelated findings verified via diff against `6.x`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)