### PR TITLE
Initialize typed schema properties absent in legacy serialized data

### DIFF
--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -73,6 +73,38 @@ class Column
     }
 
     /**
+     * Re-initializes nullable properties that may be absent when unserializing
+     * column data produced by an older CakePHP version.
+     *
+     * Nullable column attributes were added incrementally (e.g. `geometryType`
+     * and `fixed` after `Column` first shipped). A serialized payload created
+     * before a given promoted property existed does not contain it, and PHP does
+     * not apply the promoted default on the unserialize path. Reading such a
+     * property would otherwise fail with "Typed property ...::$fixed must not be
+     * accessed before initialization". This surfaces via the schema metadata
+     * cache and the Migrations plugin's `schema-dump-*.lock` files.
+     *
+     * @return void
+     */
+    public function __wakeup(): void
+    {
+        $this->null ??= null;
+        $this->length ??= null;
+        $this->generated ??= null;
+        $this->precision ??= null;
+        $this->increment ??= null;
+        $this->after ??= null;
+        $this->onUpdate ??= null;
+        $this->comment ??= null;
+        $this->unsigned ??= null;
+        $this->collate ??= null;
+        $this->srid ??= null;
+        $this->geometryType ??= null;
+        $this->baseType ??= null;
+        $this->fixed ??= null;
+    }
+
+    /**
      * Sets the column name.
      *
      * @param string $name Name

--- a/src/Database/Schema/Index.php
+++ b/src/Database/Schema/Index.php
@@ -74,6 +74,29 @@ class Index
     }
 
     /**
+     * Re-initializes nullable properties that may be absent when unserializing
+     * index data produced by an older CakePHP version.
+     *
+     * Nullable index attributes were added incrementally (e.g. `include` in 5.3,
+     * `accessMethod` in 5.4). A serialized payload created before a given property
+     * existed does not contain it, and PHP does not apply the promoted default on
+     * the unserialize path. Reading such a property would otherwise fail with
+     * "Typed property ...::$accessMethod must not be accessed before
+     * initialization". This most commonly surfaces via the Migrations plugin's
+     * `schema-dump-*.lock` files during `migrations diff`.
+     *
+     * @return void
+     */
+    public function __wakeup(): void
+    {
+        $this->length ??= null;
+        $this->order ??= null;
+        $this->include ??= null;
+        $this->where ??= null;
+        $this->accessMethod ??= null;
+    }
+
+    /**
      * Sets the index columns.
      *
      * @param array<string>|string $columns Columns

--- a/tests/TestCase/Database/Schema/ColumnTest.php
+++ b/tests/TestCase/Database/Schema/ColumnTest.php
@@ -8,12 +8,39 @@ use Cake\Database\Schema\PostgresSchemaDialect;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Database\TypeFactory;
 use Cake\TestSuite\TestCase;
+use Closure;
 use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use TestApp\Database\Type\IntType;
 
 class ColumnTest extends TestCase
 {
+    /**
+     * Unserializing column data created by an older CakePHP version (where a
+     * promoted property such as `fixed` or `geometryType` did not yet exist)
+     * must not throw "must not be accessed before initialization".
+     *
+     * @link https://github.com/cakephp/cakephp/issues/19562
+     * @return void
+     */
+    public function testUnserializeLegacyDataWithoutNewProperties(): void
+    {
+        $column = new Column('created', 'string');
+        // Simulate a legacy serialized payload: remove properties added after
+        // Column first shipped so they are absent from the serialized data.
+        Closure::bind(function (): void {
+            unset($this->fixed, $this->geometryType);
+        }, $column, Column::class)();
+
+        $restored = unserialize(serialize($column));
+
+        $this->assertInstanceOf(Column::class, $restored);
+        $this->assertNull($restored->getFixed());
+        $result = $restored->toArray();
+        $this->assertNull($result['fixed']);
+        $this->assertArrayNotHasKey('geometryType', $result);
+    }
+
     public function testSetName(): void
     {
         $column = new Column('body', 'string');

--- a/tests/TestCase/Database/Schema/IndexTest.php
+++ b/tests/TestCase/Database/Schema/IndexTest.php
@@ -5,6 +5,7 @@ namespace Cake\Test\TestCase\Database\Schema;
 
 use Cake\Database\Schema\Index;
 use Cake\TestSuite\TestCase;
+use Closure;
 
 /**
  * Tests for the Index class.
@@ -123,6 +124,30 @@ class IndexTest extends TestCase
         $index->setAccessMethod(Index::GIN);
         $result = $index->toArray();
         $this->assertSame(Index::GIN, $result['accessMethod']);
+    }
+
+    /**
+     * Unserializing index data created by an older CakePHP version (where a
+     * nullable property such as `accessMethod` did not yet exist) must not throw
+     * "must not be accessed before initialization" when the property is read.
+     *
+     * @link https://github.com/cakephp/cakephp/issues/19562
+     * @return void
+     */
+    public function testUnserializeLegacyDataWithoutAccessMethod(): void
+    {
+        $index = new Index('title_idx', ['title']);
+        // Simulate a legacy serialized payload: remove the property so it is
+        // absent from the serialized data, exactly like a pre-5.4 dump.
+        Closure::bind(function (): void {
+            unset($this->accessMethod);
+        }, $index, Index::class)();
+
+        $restored = unserialize(serialize($index));
+
+        $this->assertInstanceOf(Index::class, $restored);
+        $this->assertNull($restored->getAccessMethod());
+        $this->assertArrayNotHasKey('accessMethod', $restored->toArray());
     }
 
     public function testSetAttributes(): void


### PR DESCRIPTION
Fixes #19562

## Problem

`migrations diff` (BakeMigrationDiffCommand) fails with:

```
Typed property Cake\Database\Schema\Index::$accessMethod must not be accessed before initialization
```

The schema value objects (`Index`, `Column`, ...) use promoted constructor properties, and their nullable attributes were added incrementally across minor releases:

* `Index::$accessMethod` was added in 5.4 (#19369)
* `Column::$geometryType` (#19117) and `Column::$fixed` (#19207) were added after `Column` first shipped (#18748)

Both the schema metadata cache and the Migrations plugin's `schema-dump-*.lock` file store these objects via `serialize()`. When a payload was written by an older version, it does not contain the newer property. PHP does **not** apply a promoted default on the unserialize path (it skips the constructor and, unlike a declaration-level default, a promoted default is not applied), so the property stays uninitialized. The first read (`toArray()`, a getter) then throws the error above.

This is why the reporter sees it only after upgrading to 5.4.0 with an existing lock file, and why the driver (MariaDB/PostgreSQL) is irrelevant.

## Fix

Add `__wakeup()` to `Index` and `Column` to re-initialize the nullable properties that may be absent from older serialized data. `__wakeup()` runs after unserialize has populated the present properties, so only the genuinely-missing ones are defaulted; already-present values are untouched (`??=`).

Scope note: `ForeignKey::$deferrable` uses a non-promoted declaration default, which PHP *does* apply on unserialize, so it is unaffected. `Constraint`, `CheckConstraint` and `UniqueKey` have not gained promoted properties since they shipped, so they have no version gap yet; they would need the same treatment if a nullable promoted property is ever appended.

## Tests

Added regression tests for both objects that serialize an instance with the newer property removed (reproducing a legacy payload) and assert `toArray()` no longer throws. Both fail on `5.x` without the fix (with the exact "must not be accessed before initialization" error) and pass with it.
