### PR TITLE
Fix unsafe RateLimitMiddleware defaults

### DIFF
--- a/src/Http/Middleware/RateLimitMiddleware.php
+++ b/src/Http/Middleware/RateLimitMiddleware.php
@@ -23,7 +23,6 @@ use Cake\Http\RateLimit\FixedWindowRateLimiter;
 use Cake\Http\RateLimit\RateLimiterInterface;
 use Cake\Http\RateLimit\SlidingWindowRateLimiter;
 use Cake\Http\RateLimit\TokenBucketRateLimiter;
-use Cake\Http\ServerRequest;
 use Closure;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/src/Http/Middleware/RateLimitMiddleware.php
+++ b/src/Http/Middleware/RateLimitMiddleware.php
@@ -93,8 +93,10 @@ class RateLimitMiddleware implements MiddlewareInterface
      * - `identifierCallback`: Closure|null to generate custom identifier, overrides `identifier` option
      * - `limitCallback`: Closure|null to determine dynamic limits based on request/identifier
      * - `ipHeader`: Header name(s) to check for client IP (default: 'remote_addr'). If your application
-     *    is behind a load balancer or CDN, you may need to use `x-forwarded-for` to get the original
-     *    client IP.
+     *    is behind a load balancer or CDN, set this to the forwarded header (e.g. `x-forwarded-for`) to
+     *    get the original client IP. The left-most entry of a comma-separated chain is used. WARNING:
+     *    forwarded headers are client-supplied and trivially spoofable unless a trusted proxy overwrites
+     *    them. Only opt in when a proxy you control sets the header; otherwise rate limits can be bypassed.
      * - `includeRetryAfter`: Whether to include Retry-After header (default: true)
      * - `keyGenerator`: Closure|null to generate custom cache keys for rate limiting
      * - `tokenHeaders`: Array of headers to check for API tokens (default: ['Authorization', 'X-API-Key'])
@@ -278,17 +280,23 @@ class RateLimitMiddleware implements MiddlewareInterface
     {
         $params = $request->getServerParams();
 
-        if (is_array($this->config['ipHeader'])) {
-            foreach ($this->config['ipHeader'] as $header) {
-                $value = $request->getHeaderLine($header);
-                if ($value !== '') {
-                    return $value;
+        foreach ((array)$this->config['ipHeader'] as $header) {
+            // 'remote_addr' is a sentinel for the connecting IP, not an HTTP header.
+            if (strtolower($header) === 'remote_addr') {
+                if (!empty($params['REMOTE_ADDR'])) {
+                    return $params['REMOTE_ADDR'];
                 }
+
+                continue;
             }
-        } elseif (is_string($this->config['ipHeader'])) {
-            $value = $request->getHeaderLine($this->config['ipHeader']);
+
+            $value = $request->getHeaderLine($header);
             if ($value !== '') {
-                return $value;
+                // Forwarded headers may carry a chain "client, proxy1, proxy2";
+                // the left-most entry is the originating client.
+                $ips = explode(',', $value);
+
+                return trim($ips[0]);
             }
         }
 

--- a/src/Http/Middleware/RateLimitMiddleware.php
+++ b/src/Http/Middleware/RateLimitMiddleware.php
@@ -93,7 +93,7 @@ class RateLimitMiddleware implements MiddlewareInterface
      * - `identifierCallback`: Closure|null to generate custom identifier, overrides `identifier` option
      * - `limitCallback`: Closure|null to determine dynamic limits based on request/identifier
      * - `ipHeader`: Header name(s) to check for client IP (default: 'remote_addr'). If your application
-     *    is behind a loadbalance or CDN, you may need to use `x-forwarded-for` to get the original
+     *    is behind a load balancer or CDN, you may need to use `x-forwarded-for` to get the original
      *    client IP.
      * - `includeRetryAfter`: Whether to include Retry-After header (default: true)
      * - `keyGenerator`: Closure|null to generate custom cache keys for rate limiting

--- a/src/Http/Middleware/RateLimitMiddleware.php
+++ b/src/Http/Middleware/RateLimitMiddleware.php
@@ -23,6 +23,7 @@ use Cake\Http\RateLimit\FixedWindowRateLimiter;
 use Cake\Http\RateLimit\RateLimiterInterface;
 use Cake\Http\RateLimit\SlidingWindowRateLimiter;
 use Cake\Http\RateLimit\TokenBucketRateLimiter;
+use Cake\Http\ServerRequest;
 use Closure;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -92,7 +93,9 @@ class RateLimitMiddleware implements MiddlewareInterface
      * - `costCallback`: Closure|null to calculate custom cost for requests (default: 1 per request)
      * - `identifierCallback`: Closure|null to generate custom identifier, overrides `identifier` option
      * - `limitCallback`: Closure|null to determine dynamic limits based on request/identifier
-     * - `ipHeader`: Header name(s) to check for client IP (default: 'x-forwarded-for')
+     * - `ipHeader`: Header name(s) to check for client IP (default: 'remote_addr'). If your application
+     *    is behind a loadbalance or CDN, you may need to use `x-forwarded-for` to get the original
+     *    client IP.
      * - `includeRetryAfter`: Whether to include Retry-After header (default: true)
      * - `keyGenerator`: Closure|null to generate custom cache keys for rate limiting
      * - `tokenHeaders`: Array of headers to check for API tokens (default: ['Authorization', 'X-API-Key'])
@@ -114,7 +117,7 @@ class RateLimitMiddleware implements MiddlewareInterface
         'costCallback' => null,
         'identifierCallback' => null,
         'limitCallback' => null,
-        'ipHeader' => 'x-forwarded-for',
+        'ipHeader' => 'remote_addr',
         'includeRetryAfter' => true,
         'keyGenerator' => null,
         'tokenHeaders' => ['Authorization', 'X-API-Key'],
@@ -279,7 +282,7 @@ class RateLimitMiddleware implements MiddlewareInterface
         if (is_array($this->config['ipHeader'])) {
             foreach ($this->config['ipHeader'] as $header) {
                 $value = $request->getHeaderLine($header);
-                if ($value !== null) {
+                if ($value !== '') {
                     return $value;
                 }
             }

--- a/src/Http/Middleware/RateLimitMiddleware.php
+++ b/src/Http/Middleware/RateLimitMiddleware.php
@@ -278,19 +278,15 @@ class RateLimitMiddleware implements MiddlewareInterface
 
         if (is_array($this->config['ipHeader'])) {
             foreach ($this->config['ipHeader'] as $header) {
-                $headerKey = 'HTTP_' . strtoupper(str_replace('-', '_', $header));
-                if (!empty($params[$headerKey])) {
-                    $ips = explode(',', $params[$headerKey]);
-
-                    return trim($ips[0]);
+                $value = $request->getHeaderLine($header);
+                if ($value !== null) {
+                    return $value;
                 }
             }
         } elseif (is_string($this->config['ipHeader'])) {
-            $headerKey = 'HTTP_' . strtoupper(str_replace('-', '_', $this->config['ipHeader']));
-            if (!empty($params[$headerKey])) {
-                $ips = explode(',', $params[$headerKey]);
-
-                return trim($ips[0]);
+            $value = $request->getHeaderLine($this->config['ipHeader']);
+            if ($value !== '') {
+                return $value;
             }
         }
 

--- a/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
@@ -385,5 +385,19 @@ class RateLimitMiddlewareTest extends TestCase
         } catch (TooManyRequestsException $e) {
             $this->assertStringContainsString('limit exceeded', $e->getMessage());
         }
+
+        // Remote-Addr as a header is also ignored.
+        $request = new ServerRequest([
+            'environment' => [
+                'REMOTE_ADDR' => '127.0.0.1',
+                'HTTP_REMOTE_ADDR' => '192.168.1.101',
+            ],
+        ]);
+        try {
+            $middleware->process($request, $this->handler);
+            $this->fail('should raise');
+        } catch (TooManyRequestsException $e) {
+            $this->assertStringContainsString('limit exceeded', $e->getMessage());
+        }
     }
 }

--- a/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
@@ -324,25 +324,31 @@ class RateLimitMiddlewareTest extends TestCase
             'cache' => 'rate_limit_test',
             'ipHeader' => 'x-forwarded-for',
         ]);
-        // Prime the ratelimiter
+        // Prime the ratelimiter for the client (left-most entry of the chain).
         $request = new ServerRequest([
-            'environment' => [
-                'REMOTE_ADDR' => '127.0.0.1',
-            ],
-        ]);
-        $resp = $middleware->process($request, $this->handler);
-        $this->assertEquals($resp->getStatusCode(), 200);
-
-        // Test X-Forwarded-For
-        $request2 = new ServerRequest([
             'environment' => [
                 'REMOTE_ADDR' => '127.0.0.1',
                 'HTTP_X_FORWARDED_FOR' => '192.168.1.101, 10.0.0.1',
             ],
         ]);
-        $resp = $middleware->process($request2, $this->handler);
-        // Different IPs should work
-        $this->assertEquals($resp->getStatusCode(), 200);
+        $resp = $middleware->process($request, $this->handler);
+        $this->assertSame(200, $resp->getStatusCode());
+
+        // Same client IP, different downstream proxy hop must resolve to the same
+        // identifier and exceed the limit. Guards against keying on the full chain,
+        // which an attacker could vary to bypass the limit.
+        $request = new ServerRequest([
+            'environment' => [
+                'REMOTE_ADDR' => '127.0.0.1',
+                'HTTP_X_FORWARDED_FOR' => '192.168.1.101, 10.9.9.9',
+            ],
+        ]);
+        try {
+            $middleware->process($request, $this->handler);
+            $this->fail('should raise');
+        } catch (TooManyRequestsException $e) {
+            $this->assertStringContainsString('limit exceeded', $e->getMessage());
+        }
     }
 
     /**
@@ -364,7 +370,7 @@ class RateLimitMiddlewareTest extends TestCase
             ],
         ]);
         $resp = $middleware->process($request, $this->handler);
-        $this->assertEquals($resp->getStatusCode(), 200);
+        $this->assertSame(200, $resp->getStatusCode());
 
         // X-Forwarded-For is not considered by default as it can be spoofed trivially.
         $request = new ServerRequest([

--- a/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
@@ -316,22 +316,22 @@ class RateLimitMiddlewareTest extends TestCase
      *
      * @return void
      */
-    public function testProxyHeaders(): void
+    public function testProxyHeadersWithTrustProxy(): void
     {
         $middleware = new RateLimitMiddleware([
             'limit' => 1,
             'window' => 60,
             'cache' => 'rate_limit_test',
+            'ipHeader' => 'x-forwarded-for',
         ]);
-
-        // Test Cloudflare header
+        // Prime the ratelimiter
         $request = new ServerRequest([
             'environment' => [
                 'REMOTE_ADDR' => '127.0.0.1',
-                'HTTP_CF_CONNECTING_IP' => '192.168.1.100',
             ],
         ]);
-        $middleware->process($request, $this->handler);
+        $resp = $middleware->process($request, $this->handler);
+        $this->assertEquals($resp->getStatusCode(), 200);
 
         // Test X-Forwarded-For
         $request2 = new ServerRequest([
@@ -340,9 +340,44 @@ class RateLimitMiddlewareTest extends TestCase
                 'HTTP_X_FORWARDED_FOR' => '192.168.1.101, 10.0.0.1',
             ],
         ]);
-        $middleware->process($request2, $this->handler);
-
+        $resp = $middleware->process($request2, $this->handler);
         // Different IPs should work
-        $this->assertTrue(true);
+        $this->assertEquals($resp->getStatusCode(), 200);
+    }
+
+    /**
+     * Test proxy headers for IP detection
+     *
+     * @return void
+     */
+    public function testProxyHeadersNoTrustProxy(): void
+    {
+        $middleware = new RateLimitMiddleware([
+            'limit' => 1,
+            'window' => 60,
+            'cache' => 'rate_limit_test',
+        ]);
+        // Prime the ratelimiter
+        $request = new ServerRequest([
+            'environment' => [
+                'REMOTE_ADDR' => '127.0.0.1',
+            ],
+        ]);
+        $resp = $middleware->process($request, $this->handler);
+        $this->assertEquals($resp->getStatusCode(), 200);
+
+        // X-Forwarded-For is not considered by default as it can be spoofed trivially.
+        $request = new ServerRequest([
+            'environment' => [
+                'REMOTE_ADDR' => '127.0.0.1',
+                'HTTP_X_FORWARDED_FOR' => '192.168.1.101, 10.0.0.1',
+            ],
+        ]);
+        try {
+            $middleware->process($request, $this->handler);
+            $this->fail('should raise');
+        } catch (TooManyRequestsException $e) {
+            $this->assertStringContainsString('limit exceeded', $e->getMessage());
+        }
     }
 }


### PR DESCRIPTION
Trusting the `x-forwarded-for` header by default is an unsafe default value. In many environments this header is trivial to spoof, allowing total rate-limit bypass.

I think the correct action here is to break current behavior. This is a new feature and now is the time to make the change.

Thank you to `@yousukezan` for reporting this issue through our security mailing list.