### PR TITLE
Harden client IP resolution in RateLimitMiddleware

### DIFF
--- a/src/Http/Middleware/RateLimitMiddleware.php
+++ b/src/Http/Middleware/RateLimitMiddleware.php
@@ -93,8 +93,10 @@ class RateLimitMiddleware implements MiddlewareInterface
      * - `identifierCallback`: Closure|null to generate custom identifier, overrides `identifier` option
      * - `limitCallback`: Closure|null to determine dynamic limits based on request/identifier
      * - `ipHeader`: Header name(s) to check for client IP (default: 'remote_addr'). If your application
-     *    is behind a load balancer or CDN, you may need to use `x-forwarded-for` to get the original
-     *    client IP.
+     *    is behind a load balancer or CDN, set this to the forwarded header (e.g. `x-forwarded-for`) to
+     *    get the original client IP. The left-most entry of a comma-separated chain is used. WARNING:
+     *    forwarded headers are client-supplied and trivially spoofable unless a trusted proxy overwrites
+     *    them. Only opt in when a proxy you control sets the header; otherwise rate limits can be bypassed.
      * - `includeRetryAfter`: Whether to include Retry-After header (default: true)
      * - `keyGenerator`: Closure|null to generate custom cache keys for rate limiting
      * - `tokenHeaders`: Array of headers to check for API tokens (default: ['Authorization', 'X-API-Key'])
@@ -278,17 +280,23 @@ class RateLimitMiddleware implements MiddlewareInterface
     {
         $params = $request->getServerParams();
 
-        if (is_array($this->config['ipHeader'])) {
-            foreach ($this->config['ipHeader'] as $header) {
-                $value = $request->getHeaderLine($header);
-                if ($value !== '') {
-                    return $value;
+        foreach ((array)$this->config['ipHeader'] as $header) {
+            // 'remote_addr' is a sentinel for the connecting IP, not an HTTP header.
+            if (strtolower($header) === 'remote_addr') {
+                if (!empty($params['REMOTE_ADDR'])) {
+                    return $params['REMOTE_ADDR'];
                 }
+
+                continue;
             }
-        } elseif (is_string($this->config['ipHeader'])) {
-            $value = $request->getHeaderLine($this->config['ipHeader']);
+
+            $value = $request->getHeaderLine($header);
             if ($value !== '') {
-                return $value;
+                // Forwarded headers may carry a chain "client, proxy1, proxy2";
+                // the left-most entry is the originating client.
+                $ips = explode(',', $value);
+
+                return trim($ips[0]);
             }
         }
 

--- a/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/RateLimitMiddlewareTest.php
@@ -324,25 +324,31 @@ class RateLimitMiddlewareTest extends TestCase
             'cache' => 'rate_limit_test',
             'ipHeader' => 'x-forwarded-for',
         ]);
-        // Prime the ratelimiter
+        // Prime the ratelimiter for the client (left-most entry of the chain).
         $request = new ServerRequest([
-            'environment' => [
-                'REMOTE_ADDR' => '127.0.0.1',
-            ],
-        ]);
-        $resp = $middleware->process($request, $this->handler);
-        $this->assertEquals($resp->getStatusCode(), 200);
-
-        // Test X-Forwarded-For
-        $request2 = new ServerRequest([
             'environment' => [
                 'REMOTE_ADDR' => '127.0.0.1',
                 'HTTP_X_FORWARDED_FOR' => '192.168.1.101, 10.0.0.1',
             ],
         ]);
-        $resp = $middleware->process($request2, $this->handler);
-        // Different IPs should work
-        $this->assertEquals($resp->getStatusCode(), 200);
+        $resp = $middleware->process($request, $this->handler);
+        $this->assertSame(200, $resp->getStatusCode());
+
+        // Same client IP, different downstream proxy hop must resolve to the same
+        // identifier and exceed the limit. Guards against keying on the full chain,
+        // which an attacker could vary to bypass the limit.
+        $request = new ServerRequest([
+            'environment' => [
+                'REMOTE_ADDR' => '127.0.0.1',
+                'HTTP_X_FORWARDED_FOR' => '192.168.1.101, 10.9.9.9',
+            ],
+        ]);
+        try {
+            $middleware->process($request, $this->handler);
+            $this->fail('should raise');
+        } catch (TooManyRequestsException $e) {
+            $this->assertStringContainsString('limit exceeded', $e->getMessage());
+        }
     }
 
     /**
@@ -364,7 +370,7 @@ class RateLimitMiddlewareTest extends TestCase
             ],
         ]);
         $resp = $middleware->process($request, $this->handler);
-        $this->assertEquals($resp->getStatusCode(), 200);
+        $this->assertSame(200, $resp->getStatusCode());
 
         // X-Forwarded-For is not considered by default as it can be spoofed trivially.
         $request = new ServerRequest([


### PR DESCRIPTION
Follow-up to #19565, targeting that branch.

The default change from `x-forwarded-for` to `remote_addr` is the right fix. This adds three hardening/correctness follow-ups on top of it.

### 1. Restore left-most IP extraction (behavior regression)

#19565 replaced the `explode(',', ...)` + `trim($ips[0])` extraction with the raw `getHeaderLine()` value. For anyone opting back into `ipHeader => 'x-forwarded-for'`, the rate-limit identifier became the **entire** forwarded chain (`192.168.1.101, 10.0.0.1`) instead of the client IP.

That is a bypass: an attacker who controls XFF can vary the downstream hops (`client, junk1`, `client, junk2`, ...) and get a fresh key each request. This restores taking the left-most (originating client) entry.

### 2. Explicit `remote_addr` handling

The new default only worked because `getHeaderLine('remote_addr')` returns `''` and falls through to `$params['REMOTE_ADDR']`. That is implicit - any nonexistent header name behaves the same. Handle the `remote_addr` sentinel explicitly so intent is clear.

### 3. Docs + tests

- Docblock now warns that forwarded headers are client-supplied and spoofable unless a trusted proxy overwrites them.
- `testProxyHeadersWithTrustProxy` now asserts the resolved identifier: it primes on client `192.168.1.101` via the chain, then re-requests with the same client but a different proxy hop and asserts the limit is hit. The previous version only asserted `200` twice and would have passed even with the chain-keying bug.
- Status assertions switched to `assertSame(200, ...)` (expected-first, type-strict).

Gates: `RateLimitMiddlewareTest` 10/10 green, phpstan clean, phpcs clean.
