### PR TITLE
Add missing add() method to NullEngine to prevent undefined prefix key error

### DIFF
--- a/src/Cache/Engine/NullEngine.php
+++ b/src/Cache/Engine/NullEngine.php
@@ -31,7 +31,7 @@ class NullEngine extends CacheEngine
      */
     public function init(array $config = []): bool
     {
-        return true;
+        return parent::init($config);
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/NullEngineTest.php
+++ b/tests/TestCase/Cache/Engine/NullEngineTest.php
@@ -41,6 +41,12 @@ class NullEngineTest extends TestCase
         ]);
     }
 
+    public function testAdd(): void
+    {
+        $result = Cache::add('test_key', 'test_value', 'null');
+        $this->assertTrue($result);
+    }
+
     public function testReadMany(): void
     {
         $keys = [


### PR DESCRIPTION
When Cache::add() is called with NullEngine, it falls through to the parent CacheEngine::add() which calls $this->_key(). That method accesses $this->_config['prefix'], but NullEngine does not populate _config with defaults since it skips the standard init() setup.

This results in: "Undefined array key prefix" in CacheEngine.php

The fix adds an add() method to NullEngine that simply returns true, consistent with how set(), get(), delete(), and other methods already work in NullEngine (they all no-op and return the expected default).

Reproducible when any code calls Cache::add() on a cache config using NullEngine, for example queue workers using unique job deduplication via Cache::add().