### PR TITLE
Fix rector CI step broken by phpstan 2.2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -143,7 +143,7 @@
         "psalm-baseline": "tools/psalm --set-baseline=psalm-baseline.xml",
         "lowest": "validate-prefer-lowest",
         "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json",
-        "rector-setup": "cp composer.json composer.backup && composer require --dev rector/rector:\"~2.4.0\" && mv composer.backup composer.json",
+        "rector-setup": "cp composer.json composer.backup && composer require --dev rector/rector:\"~2.5.0\" && mv composer.backup composer.json",
         "rector-check": "vendor/bin/rector process --dry-run",
         "rector-fix": "vendor/bin/rector process",
         "test": "phpunit",

--- a/rector.php
+++ b/rector.php
@@ -136,4 +136,23 @@ return RectorConfig::configure()
         \Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector::class,
         // and rewrites `$x ?: []` in ways that can change behavior on undefined/empty values.
         \Rector\DeadCode\Rector\Ternary\RemoveUselessTernaryRector::class,
+
+        // New in rector 2.5 - skipped to keep the version bump behavior-neutral.
+        // Together these touch ~226 files, mostly docblock removal. Whether to apply
+        // them is a separate decision from getting CI green again.
+        \Rector\CodeQuality\Rector\BooleanNot\NegatedAndsToPositiveOrsRector::class,
+        \Rector\CodeQuality\Rector\Property\FixClassCaseSensitivityVarDocblockRector::class,
+        \Rector\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector::class,
+        \Rector\DeadCode\Rector\ClassMethod\RemoveMixedDocblockOverruledByNativeTypeRector::class,
+        \Rector\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector::class,
+        \Rector\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector::class,
+        \Rector\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector::class,
+        \Rector\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector::class,
+        \Rector\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector::class,
+        \Rector\Php80\Rector\NotIdentical\MbStrContainsRector::class,
+        \Rector\TypeDeclaration\Rector\ClassMethod\ArrayParamTypeByMethodCallTypeRector::class,
+        \Rector\TypeDeclaration\Rector\ClassMethod\ScalarParamTypeByMethodCallTypeRector::class,
+        \Rector\TypeDeclaration\Rector\Closure\ClosureReturnTypeFromAssertInstanceOfRector::class,
+        \Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector::class,
+        \Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector::class,
     ]);


### PR DESCRIPTION
The `Coding Standard & Static Analysis` job has been red on every PR since 2026-07-26, and it is not caused by any of those PRs.

## What breaks

`composer rector-check` dies before it analyzes anything:

```
PHP Fatal error:  Uncaught Rector\Exception\Reflection\MissingPrivatePropertyException:
Property "$container" was not found in "PHPStan\Parser\RichParser" class
in vendor/rector/rector/src/Util/Reflection/PrivatesAccessor.php:82
Script vendor/bin/rector process --dry-run handling the rector-check event returned with error code 255
```

## Why

`rector-setup` pins `rector/rector:"~2.4.0"`. Rector 2.4.6 requires `phpstan/phpstan: ^2.2.2` and reaches into a private `RichParser::$container` property via `PHPStanContainerMemento::removeRichVisitors()`. PHPStan 2.2.6, released 2026-07-26, no longer has that property, so the unpinned resolution of `^2.2.2` now picks a PHPStan that Rector 2.4.x cannot boot against.

Verified locally:

- rector 2.4.6 + phpstan 2.2.5 - exits 0
- rector 2.4.6 + phpstan 2.2.6 - the fatal above
- rector 2.5.8 + phpstan 2.2.6 - boots and analyzes fine

Upstream fixed this in rector 2.5.7/2.5.8, which raise the requirement to `phpstan/phpstan: ^2.2.6`.

## The change

- `rector-setup` now installs `rector/rector:"~2.5.0"`.
- Rector 2.5 adds a batch of new rules to the sets we enable. They fire across ~226 files, dominated by docblock removal (`RemoveUselessUnionReturnDocblockRector`, `RemoveMixedDocblockOverruledByNativeTypeRector`, `RemoveDuplicatedReturnSelfDocblockRector`) plus `RemoveDefaultValueFromAssignedPropertyRector`. They are skipped here, same way the 2.4 bump handled `SafeDeclareStrictTypesRector` and `RemoveUselessTernaryRector`, so this PR only unblocks CI and changes no `src/` code.

Whether to actually apply any of those rules is worth its own PR - I did not want to bury a 226-file sweep inside a CI fix.

## Alternative considered

Keeping rector on `~2.4.0` and pinning `phpstan/phpstan` below 2.2.6 also makes CI green with a smaller diff, but it freezes a transitive tool at an exact patch to work around a bug upstream has already fixed. Happy to switch if the team prefers that.

Two pre-existing skips are now reported as deprecated by rector 2.5 (`JoinStringConcatRector`, `StrictStringParamConcatRector`). Left them in place to keep this diff focused; they can be pruned separately.
