### PR TITLE
Preserve PHP 8.5 fatal error backtraces

### DIFF
--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -260,7 +260,17 @@ class ExceptionTrap
         if ($megabytes > 0) {
             $this->increaseMemoryLimit($megabytes * 1024);
         }
-        $error = error_get_last();
+        $this->handleLastError(error_get_last());
+    }
+
+    /**
+     * Handle the last PHP error captured during shutdown.
+     *
+     * @param array<string, mixed>|null $error The last PHP error.
+     * @return void
+     */
+    protected function handleLastError(?array $error): void
+    {
         if (!is_array($error)) {
             return;
         }
@@ -273,9 +283,16 @@ class ExceptionTrap
         if (!in_array($error['type'], $fatals, true)) {
             return;
         }
+        $description = $error['message'];
+        $trace = $error['trace'] ?? [];
+        if (is_array($trace) && $trace) {
+            $formattedTrace = Debugger::formatTrace($trace, ['format' => 'text', 'args' => false]);
+            assert(is_string($formattedTrace));
+            $description .= "\nStack Trace:\n" . $formattedTrace;
+        }
         $this->handleFatalError(
             $error['type'],
-            $error['message'],
+            $description,
             $error['file'],
             $error['line'],
         );

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -350,6 +350,47 @@ class ExceptionTrapTest extends TestCase
         $this->assertSame('', $out);
     }
 
+    public function testHandleLastErrorIncludesFatalErrorTrace(): void
+    {
+        $trap = new class extends ExceptionTrap {
+            public ?array $fatalError = null;
+
+            public function processLastError(?array $error): void
+            {
+                $this->handleLastError($error);
+            }
+
+            public function handleFatalError(int $code, string $description, string $file, int $line): void
+            {
+                $this->fatalError = compact('code', 'description', 'file', 'line');
+            }
+        };
+
+        $trap->processLastError([
+            'type' => E_ERROR,
+            'message' => 'Allowed memory size exhausted',
+            'file' => '/app/query.php',
+            'line' => 42,
+            'trace' => [
+                [
+                    'file' => '/app/query.php',
+                    'line' => 42,
+                    'class' => 'App\\Service\\ReportService',
+                    'type' => '->',
+                    'function' => 'generate',
+                    'args' => ['secret value'],
+                ],
+            ],
+        ]);
+
+        $this->assertSame(E_ERROR, $trap->fatalError['code']);
+        $this->assertSame('/app/query.php', $trap->fatalError['file']);
+        $this->assertSame(42, $trap->fatalError['line']);
+        $this->assertStringContainsString('Stack Trace:', $trap->fatalError['description']);
+        $this->assertStringContainsString('App\\Service\\ReportService->generate()', $trap->fatalError['description']);
+        $this->assertStringNotContainsString('secret value', $trap->fatalError['description']);
+    }
+
     public function testHandleFatalErrorText(): void
     {
         $trap = new ExceptionTrap([


### PR DESCRIPTION
Fixes #19571.

## Summary

- Preserve the fatal-error trace supplied by `error_get_last()` on PHP 8.5+.
- Format the trace without arguments so sensitive values are not exposed.
- Keep the existing output on PHP 8.2–8.4, where no fatal-error trace is available.

## Tests

- `vendor/bin/phpunit tests/TestCase/Error/ExceptionTrapTest.php`
- `php -l src/Error/ExceptionTrap.php`
- `php -l tests/TestCase/Error/ExceptionTrapTest.php`
- `git diff --check`