### PR TITLE
Initialize Client\Response::$reasonPhrase

### DIFF
--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -103,7 +103,7 @@ class Response extends Message implements ResponseInterface
      *
      * @var string
      */
-    protected string $reasonPhrase;
+    protected string $reasonPhrase = '';
 
     /**
      * Cached decoded XML data.

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -26,6 +26,21 @@ use PHPUnit\Framework\Attributes\DataProvider;
 class ResponseTest extends TestCase
 {
     /**
+     * A response built without a status line still has a usable reason phrase.
+     *
+     * `_parseHeaders()` only assigns the reason phrase when it encounters an
+     * `HTTP/x.y NNN` status line, so without one the property stayed
+     * uninitialized and `getReasonPhrase()` raised an Error despite its
+     * `string` return type.
+     */
+    public function testGetReasonPhraseWithoutStatusLine(): void
+    {
+        $response = new Response([], 'Okay body.');
+
+        $this->assertSame('', $response->getReasonPhrase());
+    }
+
+    /**
      * Test parsing headers and reading with PSR7 methods.
      */
     public function testHeaderParsingPsr7(): void


### PR DESCRIPTION
Fixes #19576.

`Cake\Http\Client\Response::$reasonPhrase` is assigned in only two places: `_parseHeaders()`, when a header line matches an `HTTP/x.y NNN` status line, and `withStatus()`. Construct a response without a status line and neither runs, so the property stays uninitialized:

```php
$response = new Cake\Http\Client\Response([], 'Okay body.');
$response->getReasonPhrase();
// Error: Typed property Cake\Http\Client\Response::$reasonPhrase
//        must not be accessed before initialization
```

A method declared `: string` should not fatal, and PSR-7 requires `getReasonPhrase()` to return a string.

Defaulting the property to `''` is what PSR-7 allows when no reason phrase is known, and matches the reporter's suggestion.

## Not a 5.x regression

Worth noting for triage: this is not new. `52104f3` ("Add native type hints for Http properties") changed `protected $reasonPhrase;` to `protected string $reasonPhrase;`, but `getReasonPhrase(): string` already carried the string return type before that commit. So the untyped default was `null` and the same call raised `TypeError: Return value must be of type string, null returned`. The typed property only changed the error message.

## Left out on purpose

The related inconsistency in the issue thread is not addressed here, since it is a behavior change rather than a fix:

| | default status | default phrase | `withStatus(404)` phrase |
|---|---|---|---|
| `Http\Response` | `200` | `'OK'` | `'Not Found'` |
| `Http\Client\Response` | `0` | `''` (after this PR) | `''` |

`Http\Response::_setStatus()` fills an empty reason phrase from its `$_statusCodes` map; the client class has no such map and stores whatever it is given. Making the two consistent would change output for existing `withStatus()` callers, so it seems better suited to 5.next if wanted at all. Happy to follow up.
