### PR TITLE
Group the subquery filter by the columns it is ordered on

### DIFF
--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -18,6 +18,7 @@ namespace Cake\ORM\Association\Loader;
 
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\AggregateExpression;
+use Cake\Database\Expression\FieldInterface;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
@@ -492,9 +493,10 @@ class SelectLoader
     /**
      * Calculate the fields that need to participate in a subquery.
      *
-     * Normally this includes the binding key columns. If there is a an ORDER BY,
-     * those columns are also included as the fields may be calculated or constant values,
-     * that need to be present to ensure the correct association data is loaded.
+     * Normally this includes the binding key columns. If the subquery keeps an ORDER BY,
+     * whatever it sorts on joins the GROUP BY as well, and aliased columns are additionally
+     * kept in the SELECT list as they may be calculated or constant values, that need to be
+     * present to ensure the correct association data is loaded.
      *
      * When a HAVING clause is present the original SELECT aliases are preserved as
      * well, since HAVING may reference computed aliases that would otherwise be
@@ -519,13 +521,31 @@ class SelectLoader
 
         /** @var \Cake\Database\Expression\QueryExpression|null $order */
         $order = $query->clause('order');
-        if ($order) {
+        // _buildSubquery() only keeps the ORDER BY when the query is limited. Its columns then have
+        // to take part in the GROUP BY as well, or strict databases such as Postgres reject the
+        // reduced subquery with a grouping error.
+        if ($order && $query->clause('limit') !== null) {
             // iterateParts() rebuilds the expression from the callback's return value, so each part
             // has to be handed back. Returning nothing would strip the ORDER BY from $query itself,
             // which is the caller's query, not a clone of it.
-            $order->iterateParts(function ($direction, $field) use (&$fields, $columns) {
-                if (isset($columns[$field])) {
-                    $fields[$field] = $columns[$field];
+            $order->iterateParts(function ($direction, $field) use (&$fields, &$group, $columns) {
+                // Only named parts can reference a SELECT alias. A numeric key means the part
+                // carries its own column, and must not be looked up as a SELECT offset.
+                if (is_string($field) && isset($columns[$field])) {
+                    $column = $columns[$field];
+                    $fields[$field] = $column;
+                } else {
+                    $column = $this->_orderColumn($field, $direction);
+                }
+
+                // Constant SELECT values, as in `select(['score' => 100])`, are not columns and
+                // neither can nor need to be grouped.
+                if (!is_string($column) && !$column instanceof ExpressionInterface) {
+                    return $direction;
+                }
+
+                if (!$this->_isAggregate($column) && !in_array($column, $group, true)) {
+                    $group[] = $column;
                 }
 
                 return $direction;
@@ -553,21 +573,69 @@ class SelectLoader
                 }
                 $fields[$alias] = $column;
 
-                $isAggregate = $column instanceof AggregateExpression;
-                if (!$isAggregate && $column instanceof ExpressionInterface) {
-                    $column->traverse(function ($sub) use (&$isAggregate): void {
-                        if ($sub instanceof AggregateExpression) {
-                            $isAggregate = true;
-                        }
-                    });
-                }
-                if (!$isAggregate) {
+                if (!$this->_isAggregate($column)) {
                     $group[] = $column;
                 }
             }
         }
 
         return ['select' => $fields, 'group' => $group];
+    }
+
+    /**
+     * Resolves the column an ORDER BY part sorts on, so it can join the subquery GROUP BY.
+     *
+     * Associative parts (`['Articles.title' => 'ASC']`) carry the column as their key, while
+     * orderByAsc()/orderByDesc() and raw expressions keep it in the value instead. Parts that
+     * are plain SQL fragments (`orderBy('Articles.title DESC')`) cannot be told apart from their
+     * sort direction and are left untouched.
+     *
+     * @param mixed $field The key of the ORDER BY part.
+     * @param mixed $direction The value of the ORDER BY part.
+     * @return \Cake\Database\ExpressionInterface|string|null The column, or null if it cannot be resolved.
+     */
+    protected function _orderColumn(mixed $field, mixed $direction): ExpressionInterface|string|null
+    {
+        if (is_string($field)) {
+            return $field;
+        }
+
+        if ($direction instanceof FieldInterface) {
+            $field = $direction->getField();
+
+            return is_string($field) || $field instanceof ExpressionInterface ? $field : null;
+        }
+
+        if ($direction instanceof ExpressionInterface) {
+            return $direction;
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks whether a SELECT column aggregates rows, in which case it must stay out of the GROUP BY.
+     *
+     * @param mixed $column The column to check.
+     * @return bool
+     */
+    protected function _isAggregate(mixed $column): bool
+    {
+        if (!$column instanceof ExpressionInterface) {
+            return false;
+        }
+        if ($column instanceof AggregateExpression) {
+            return true;
+        }
+
+        $isAggregate = false;
+        $column->traverse(function ($sub) use (&$isAggregate): void {
+            if ($sub instanceof AggregateExpression) {
+                $isAggregate = true;
+            }
+        });
+
+        return $isAggregate;
     }
 
     /**

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -493,10 +493,9 @@ class SelectLoader
     /**
      * Calculate the fields that need to participate in a subquery.
      *
-     * Normally this includes the binding key columns. If the subquery keeps an ORDER BY,
-     * whatever it sorts on joins the GROUP BY as well, and aliased columns are additionally
-     * kept in the SELECT list as they may be calculated or constant values, that need to be
-     * present to ensure the correct association data is loaded.
+     * Normally this includes the binding key columns. If the subquery keeps an ORDER BY, whatever
+     * it sorts on joins the GROUP BY too, and aliased columns additionally stay in the SELECT list
+     * as they may be calculated or constant values needed to load the correct association data.
      *
      * When a HAVING clause is present the original SELECT aliases are preserved as
      * well, since HAVING may reference computed aliases that would otherwise be
@@ -521,30 +520,26 @@ class SelectLoader
 
         /** @var \Cake\Database\Expression\QueryExpression|null $order */
         $order = $query->clause('order');
-        // _buildSubquery() only keeps the ORDER BY when the query is limited. Its columns then have
-        // to take part in the GROUP BY as well, or strict databases such as Postgres reject the
-        // reduced subquery with a grouping error.
+        // _buildSubquery() only keeps the ORDER BY when the query is limited.
         if ($order && $query->clause('limit') !== null) {
             // iterateParts() rebuilds the expression from the callback's return value, so each part
             // has to be handed back. Returning nothing would strip the ORDER BY from $query itself,
             // which is the caller's query, not a clone of it.
             $order->iterateParts(function ($direction, $field) use (&$fields, &$group, $columns) {
-                // Only named parts can reference a SELECT alias. A numeric key means the part
-                // carries its own column, and must not be looked up as a SELECT offset.
+                // A numeric key carries its own column and must not be read as a SELECT offset.
                 if (is_string($field) && isset($columns[$field])) {
                     $column = $columns[$field];
                     $fields[$field] = $column;
                 } else {
-                    $column = $this->_orderColumn($field, $direction);
+                    $column = $this->orderColumn($field, $direction);
                 }
 
-                // Constant SELECT values, as in `select(['score' => 100])`, are not columns and
-                // neither can nor need to be grouped.
+                // Constant values such as `select(['score' => 100])` are not columns.
                 if (!is_string($column) && !$column instanceof ExpressionInterface) {
                     return $direction;
                 }
 
-                if (!$this->_isAggregate($column) && !in_array($column, $group, true)) {
+                if (!$this->isAggregate($column) && !in_array($column, $group, true)) {
                     $group[] = $column;
                 }
 
@@ -573,7 +568,7 @@ class SelectLoader
                 }
                 $fields[$alias] = $column;
 
-                if (!$this->_isAggregate($column)) {
+                if (!$this->isAggregate($column)) {
                     $group[] = $column;
                 }
             }
@@ -585,16 +580,15 @@ class SelectLoader
     /**
      * Resolves the column an ORDER BY part sorts on, so it can join the subquery GROUP BY.
      *
-     * Associative parts (`['Articles.title' => 'ASC']`) carry the column as their key, while
-     * orderByAsc()/orderByDesc() and raw expressions keep it in the value instead. Parts that
-     * are plain SQL fragments (`orderBy('Articles.title DESC')`) cannot be told apart from their
-     * sort direction and are left untouched.
+     * Associative parts (`['Articles.title' => 'ASC']`) carry it as their key, orderByAsc()/
+     * orderByDesc() and raw expressions in the value. Plain SQL fragments such as
+     * `orderBy('Articles.title DESC')` cannot be told apart from their direction.
      *
      * @param mixed $field The key of the ORDER BY part.
      * @param mixed $direction The value of the ORDER BY part.
      * @return \Cake\Database\ExpressionInterface|string|null The column, or null if it cannot be resolved.
      */
-    protected function _orderColumn(mixed $field, mixed $direction): ExpressionInterface|string|null
+    protected function orderColumn(mixed $field, mixed $direction): ExpressionInterface|string|null
     {
         if (is_string($field)) {
             return $field;
@@ -614,12 +608,12 @@ class SelectLoader
     }
 
     /**
-     * Checks whether a SELECT column aggregates rows, in which case it must stay out of the GROUP BY.
+     * Checks whether a column aggregates rows, in which case it must stay out of the GROUP BY.
      *
      * @param mixed $column The column to check.
      * @return bool
      */
-    protected function _isAggregate(mixed $column): bool
+    protected function isAggregate(mixed $column): bool
     {
         if (!$column instanceof ExpressionInterface) {
             return false;

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -20,9 +20,12 @@ use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\ComparisonExpression;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\Log\QueryLogger;
+use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\I18n\DateTime;
+use Cake\Log\Log;
 use Cake\ORM\Association;
 use Cake\ORM\Entity;
 use Cake\ORM\Query\SelectQuery;
@@ -1907,5 +1910,100 @@ class QueryRegressionTest extends TestCase
         $this->assertCount(1, $results[1]->articles);
         $this->assertSame('Second Article', $results[1]->articles[0]->title);
         $this->assertEmpty($results[1]->comments);
+    }
+
+    /**
+     * Ordering on a column other than the binding key must not produce an invalid subquery.
+     *
+     * The filtering subquery reduces its SELECT to the binding key and groups by it. Sorting it by
+     * a column that takes part in neither is rejected by Postgres with a grouping error, so the
+     * ordered columns have to join the GROUP BY.
+     */
+    public function testSubqueryStrategyOrderedByNonKeyColumn(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->belongsTo('Authors');
+        $articles->hasMany('Comments', ['strategy' => Association::STRATEGY_SUBQUERY]);
+
+        $results = $articles->find()
+            ->contain(['Comments'])
+            ->innerJoinWith('Authors')
+            ->orderBy(['Authors.name' => 'ASC', 'Articles.id' => 'ASC'])
+            ->limit(2)
+            ->all()
+            ->toArray();
+
+        $this->assertSame([2, 1], array_map(fn(EntityInterface $article) => $article->id, $results));
+
+        // Only reachable when the subquery kept the same ordered window as the parent query.
+        $this->assertCount(2, $results[0]->comments);
+        $this->assertCount(4, $results[1]->comments);
+    }
+
+    /**
+     * orderByAsc()/orderByDesc() store the column inside an OrderClauseExpression under a numeric
+     * key instead of using the column as the key, and have to reach the GROUP BY just the same.
+     */
+    public function testSubqueryStrategyOrderedByExpression(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->belongsTo('Authors');
+        $articles->hasMany('Comments', ['strategy' => Association::STRATEGY_SUBQUERY]);
+
+        $results = $articles->find()
+            ->contain(['Comments'])
+            ->innerJoinWith('Authors')
+            ->orderByAsc('Authors.name')
+            ->orderByAsc('Articles.id')
+            ->limit(2)
+            ->all()
+            ->toArray();
+
+        $this->assertSame([2, 1], array_map(fn(EntityInterface $article) => $article->id, $results));
+        $this->assertCount(2, $results[0]->comments);
+        $this->assertCount(4, $results[1]->comments);
+    }
+
+    /**
+     * Databases that do not enforce grouping, such as SQLite, accept the invalid subquery, so the
+     * GROUP BY has to be asserted on the generated SQL as well.
+     */
+    public function testSubqueryStrategyGroupsByOrderedColumns(): void
+    {
+        Log::setConfig('queries', ['className' => 'Array']);
+        $driver = ConnectionManager::get('test')->getDriver();
+        $previousLogger = $driver->getLogger();
+        $driver->setLogger(new QueryLogger());
+
+        try {
+            $articles = $this->getTableLocator()->get('Articles');
+            $articles->belongsTo('Authors');
+            $articles->hasMany('Comments', ['strategy' => Association::STRATEGY_SUBQUERY]);
+
+            $articles->find()
+                ->contain(['Comments'])
+                ->innerJoinWith('Authors')
+                ->orderBy(['Authors.name' => 'ASC', 'Articles.id' => 'ASC'])
+                ->limit(2)
+                ->all()
+                ->toArray();
+
+            $messages = array_filter(
+                Log::engine('queries')->read(),
+                fn(string $message): bool => str_contains($message, 'FROM comments'),
+            );
+            $this->assertNotEmpty($messages);
+
+            $sql = array_pop($messages);
+            $this->assertSame(1, preg_match('/GROUP BY (.+?)(?= ORDER BY| HAVING| LIMIT|\))/', $sql, $matches), $sql);
+            $this->assertStringContainsString('name', $matches[1], $sql);
+        } finally {
+            if ($previousLogger) {
+                $driver->setLogger($previousLogger);
+            } else {
+                $driver->disableQueryLogging();
+            }
+            Log::reset();
+        }
     }
 }

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -20,12 +20,9 @@ use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\ComparisonExpression;
 use Cake\Database\Expression\QueryExpression;
-use Cake\Database\Log\QueryLogger;
-use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\I18n\DateTime;
-use Cake\Log\Log;
 use Cake\ORM\Association;
 use Cake\ORM\Entity;
 use Cake\ORM\Query\SelectQuery;
@@ -33,6 +30,8 @@ use Cake\TestSuite\TestCase;
 use DateTime as NativeDateTime;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Log\AbstractLogger;
+use Stringable;
 use TestApp\Model\Table\ArticlesTable;
 use TestApp\Model\Table\TagsTable;
 use function Cake\Collection\collection;
@@ -1970,13 +1969,27 @@ class QueryRegressionTest extends TestCase
      */
     public function testSubqueryStrategyGroupsByOrderedColumns(): void
     {
-        Log::setConfig('queries', ['className' => 'Array']);
-        $driver = ConnectionManager::get('test')->getDriver();
+        $logger = new class extends AbstractLogger {
+            /**
+             * @var array<string>
+             */
+            public array $messages = [];
+
+            /**
+             * @inheritDoc
+             */
+            public function log($level, string|Stringable $message, array $context = []): void
+            {
+                $this->messages[] = (string)$message;
+            }
+        };
+
+        $articles = $this->getTableLocator()->get('Articles');
+        $driver = $articles->getConnection()->getDriver();
         $previousLogger = $driver->getLogger();
-        $driver->setLogger(new QueryLogger());
+        $driver->setLogger($logger);
 
         try {
-            $articles = $this->getTableLocator()->get('Articles');
             $articles->belongsTo('Authors');
             $articles->hasMany('Comments', ['strategy' => Association::STRATEGY_SUBQUERY]);
 
@@ -1987,23 +2000,23 @@ class QueryRegressionTest extends TestCase
                 ->limit(2)
                 ->all()
                 ->toArray();
-
-            $messages = array_filter(
-                Log::engine('queries')->read(),
-                fn(string $message): bool => str_contains($message, 'FROM comments'),
-            );
-            $this->assertNotEmpty($messages);
-
-            $sql = array_pop($messages);
-            $this->assertSame(1, preg_match('/GROUP BY (.+?)(?= ORDER BY| HAVING| LIMIT|\))/', $sql, $matches), $sql);
-            $this->assertStringContainsString('name', $matches[1], $sql);
         } finally {
             if ($previousLogger) {
                 $driver->setLogger($previousLogger);
             } else {
                 $driver->disableQueryLogging();
             }
-            Log::reset();
         }
+
+        // The filtering subquery is the only grouped statement the query above runs.
+        $grouped = array_filter(
+            $logger->messages,
+            fn(string $message): bool => str_contains($message, 'GROUP BY'),
+        );
+        $this->assertCount(1, $grouped, implode("\n", $logger->messages));
+
+        $sql = array_pop($grouped);
+        $this->assertSame(1, preg_match('/GROUP BY (.+?)(?= ORDER BY| HAVING| LIMIT|\))/', $sql, $matches), $sql);
+        $this->assertStringContainsString('name', $matches[1], $sql);
     }
 }


### PR DESCRIPTION
Follow-up to #19538.

The filtering subquery of the `subquery` strategy reduces its SELECT to the binding key and groups by it. Since 5.3 it keeps the ORDER BY when the source query is limited, and since #19538 that ORDER BY actually reaches the generated SQL - it used to be wiped as a side effect of `iterateParts()`. Ordering the subquery by a column that is in neither the GROUP BY nor an aggregate is invalid on Postgres:

```sql
SELECT Countries.iso2 FROM countries Countries
WHERE Countries.id = 1
GROUP BY Countries.iso2
ORDER BY Countries.sort DESC
LIMIT 1
```

```
SQLSTATE[42803]: Grouping error: 7 ERROR: column "Countries.sort" must appear in the GROUP BY clause or be used in an aggregate function
```

Grouping by a primary key hides it, because Postgres then resolves the remaining columns of that table through functional dependency. That is exactly what the existing coverage does (`orderBy(['Authors.id' => 'DESC'])`), so CI stayed green. It breaks as soon as the binding key is not the primary key, or the ORDER BY points at a joined table.

Real-world report: a `hasMany` with `'bindingKey' => 'iso2'` plus a default table order started erroring on Postgres the day 5.4.0 was released, on plugin code that had not changed.

## What changed

`_subqueryFields()` now adds the ordered columns to the GROUP BY, and only looks at the ORDER BY when the subquery is actually going to keep it (`_buildSubquery()` drops it when there is no limit, and the columns would then be dead weight in the reduced SELECT).

Left out of the GROUP BY on purpose:

- aggregates, which must not be grouped
- constant SELECT values such as `select(['score' => 100])`, which are not columns
- plain SQL fragments such as `orderBy('Articles.title DESC')`, where the column cannot be told apart from the sort direction

Named parts, `orderByAsc()`/`orderByDesc()` and expression parts are all covered.

Grouping by additional columns can only split groups, never merge them, so the first N groups still cover the N rows the parent query matched - the filtered key set stays complete.

The aggregate detection that the HAVING branch already carried is extracted into `isAggregate()` and shared.