### PR TITLE
Guard Cache::pool() against reentrant construction of the same pool

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -91,6 +91,14 @@ class Cache
     protected static bool $_enabled = true;
 
     /**
+     * Names of the pools currently being constructed, used to detect reentrant calls.
+     *
+     * @see \Cake\Cache\Cache::pool()
+     * @var array<string, true>
+     */
+    protected static array $_building = [];
+
+    /**
      * Group to Config mapping
      *
      * @var array<string, array>
@@ -211,7 +219,21 @@ class Cache
             return $registry->get($config);
         }
 
-        static::_buildEngine($config);
+        if (isset(static::$_building[$config])) {
+            // Reentered while this pool is still being constructed. An engine that cannot reach
+            // its backend may log that failure, and the logger may in turn ask for a cache pool -
+            // for example one that stores database schema metadata. Nothing is registered yet at
+            // that point, so without this check the two would call each other until the process
+            // runs out of memory. Degrade to a null engine instead.
+            return new NullEngine();
+        }
+
+        static::$_building[$config] = true;
+        try {
+            static::_buildEngine($config);
+        } finally {
+            unset(static::$_building[$config]);
+        }
 
         return $registry->get($config);
     }

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -96,7 +96,7 @@ class Cache
      * @see \Cake\Cache\Cache::pool()
      * @var array<string, true>
      */
-    protected static array $_building = [];
+    protected static array $building = [];
 
     /**
      * Group to Config mapping
@@ -219,7 +219,7 @@ class Cache
             return $registry->get($config);
         }
 
-        if (isset(static::$_building[$config])) {
+        if (isset(static::$building[$config])) {
             // Reentered while this pool is still being constructed. An engine that cannot reach
             // its backend may log that failure, and the logger may in turn ask for a cache pool -
             // for example one that stores database schema metadata. Nothing is registered yet at
@@ -228,11 +228,11 @@ class Cache
             return new NullEngine();
         }
 
-        static::$_building[$config] = true;
+        static::$building[$config] = true;
         try {
             static::_buildEngine($config);
         } finally {
-            unset(static::$_building[$config]);
+            unset(static::$building[$config]);
         }
 
         return $registry->get($config);

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -29,6 +29,7 @@ use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\SimpleCache\CacheInterface as SimpleCacheInterface;
 use stdClass;
+use TestApp\Cache\Engine\ReentrantCacheEngine;
 use TestApp\Cache\Engine\TestAppCacheEngine;
 use TestPlugin\Cache\Engine\TestPluginCacheEngine;
 
@@ -900,5 +901,63 @@ class CacheTest extends TestCase
         Cache::disable();
         $pool = Cache::pool('tests');
         $this->assertInstanceOf(SimpleCacheInterface::class, $pool);
+    }
+
+    /**
+     * A pool asked for again while it is still being constructed must not recurse.
+     *
+     * An engine that cannot reach its backend may log that failure, and the logger may in turn
+     * ask for a cache pool - a database schema metadata cache, for instance. Nothing is
+     * registered for the pool at that point, so the two would otherwise call each other until
+     * the process runs out of memory.
+     */
+    public function testPoolReentrantBuildDoesNotRecurse(): void
+    {
+        ReentrantCacheEngine::reset();
+        Cache::setConfig('reentrant', [
+            'className' => ReentrantCacheEngine::class,
+            'reentrantTarget' => 'reentrant',
+        ]);
+
+        $pool = Cache::pool('reentrant');
+
+        $this->assertSame(1, ReentrantCacheEngine::$initCount, 'The engine should be built once.');
+        $this->assertInstanceOf(ReentrantCacheEngine::class, $pool);
+        $this->assertInstanceOf(
+            NullEngine::class,
+            ReentrantCacheEngine::$reentrantPool,
+            'The reentrant call should degrade to a null engine.',
+        );
+
+        ReentrantCacheEngine::reset();
+        Cache::drop('reentrant');
+    }
+
+    /**
+     * The in-flight marker must be cleared once construction finishes, so a later call to the
+     * same pool still builds normally rather than being treated as reentrant forever.
+     */
+    public function testPoolIsBuildableAgainAfterReentrantBuild(): void
+    {
+        ReentrantCacheEngine::reset();
+        Cache::setConfig('reentrant', [
+            'className' => ReentrantCacheEngine::class,
+            'reentrantTarget' => 'reentrant',
+        ]);
+
+        Cache::pool('reentrant');
+        Cache::drop('reentrant');
+
+        Cache::setConfig('reentrant', [
+            'className' => ReentrantCacheEngine::class,
+            'reentrantTarget' => 'reentrant',
+        ]);
+        $pool = Cache::pool('reentrant');
+
+        $this->assertInstanceOf(ReentrantCacheEngine::class, $pool);
+        $this->assertSame(2, ReentrantCacheEngine::$initCount);
+
+        ReentrantCacheEngine::reset();
+        Cache::drop('reentrant');
     }
 }

--- a/tests/test_app/TestApp/Cache/Engine/ReentrantCacheEngine.php
+++ b/tests/test_app/TestApp/Cache/Engine/ReentrantCacheEngine.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Cache\Engine;
+
+use Cake\Cache\Cache;
+use Cake\Cache\Engine\ArrayEngine;
+
+/**
+ * Asks for a cache pool from inside its own init(), the way an engine that logs a failed
+ * connection does when the logger reaches for a cache-backed resource.
+ */
+class ReentrantCacheEngine extends ArrayEngine
+{
+    /**
+     * @var int
+     */
+    public static int $initCount = 0;
+
+    /**
+     * What the reentrant Cache::pool() call handed back.
+     *
+     * @var \Psr\SimpleCache\CacheInterface|null
+     */
+    public static $reentrantPool = null;
+
+    /**
+     * @param array<string, mixed> $config
+     * @return bool
+     */
+    public function init(array $config = []): bool
+    {
+        parent::init($config);
+
+        static::$initCount++;
+        static::$reentrantPool = Cache::pool($config['reentrantTarget']);
+
+        return true;
+    }
+
+    /**
+     * @return void
+     */
+    public static function reset(): void
+    {
+        static::$initCount = 0;
+        static::$reentrantPool = null;
+    }
+}

--- a/tests/test_app/TestApp/Cache/Engine/ReentrantCacheEngine.php
+++ b/tests/test_app/TestApp/Cache/Engine/ReentrantCacheEngine.php
@@ -34,7 +34,7 @@ class ReentrantCacheEngine extends ArrayEngine
      *
      * @var \Psr\SimpleCache\CacheInterface|null
      */
-    public static $reentrantPool = null;
+    public static $reentrantPool;
 
     /**
      * @param array<string, mixed> $config


### PR DESCRIPTION
Asking for a cache pool that is still being constructed recurses without bound.

## The cycle

`Cache::pool()` returns early only once the registry holds the engine, and the registry is populated by `_buildEngine()` after `$registry->load()` returns. A call that arrives while that build is still in progress therefore finds nothing registered, starts another build, and repeats.

The reachable path is a cache engine that cannot connect and logs it. `RedisEngine::init()` calls `Log::error()` from inside its connect path, and if a configured log engine reaches for a cache-backed resource on the way to writing that message, it lands back in `Cache::pool()` for the pool that is mid-build. A schema metadata cache is the usual way this closes, because a log engine writing to a table goes through the connection's schema collection:

```
Cache::pool('_cake_model_')
  -> Cache::_buildEngine('_cake_model_')
    -> $registry->load(...)
      -> RedisEngine::init()
        -> Log::error('RedisEngine could not connect...')
          -> log engine writing to a table
            -> Connection::getSchemaCollection()
              -> Connection::getCacher()
                -> Cache::pool('_cake_model_')   // still nothing registered, so again
```

The `NullEngine` fallback already in `_buildEngine()` does not help. It runs from the `catch` around `$registry->load()`, and the recursion happens *inside* that call, before the `RuntimeException` can propagate out of it.

Each round allocates, so the process grows until it dies. With a small stack it segfaults first.

## The change

Track which pools are mid-build, and hand reentrant callers a `NullEngine` instead of starting another build:

```php
if (isset(static::$_building[$config])) {
    return new NullEngine();
}

static::$_building[$config] = true;
try {
    static::_buildEngine($config);
} finally {
    unset(static::$_building[$config]);
}
```

The inner consumer degrades to an uncached lookup, which is the correct outcome when the cache backend is unreachable anyway. The outer build continues and registers whatever it resolves to, so the caller that actually asked for the pool is unaffected.

Clearing the marker in a `finally` matters: a build that throws must not leave the pool permanently unbuildable for the rest of the process. There is a test for that case specifically.

## Notes

- Nothing changes for any pool that builds normally. The guard is only reachable from inside a build of the same pool name.
- I considered fixing this in `RedisEngine` instead by not logging from `init()`, but that only covers the one engine that happens to do it today and removes log output people may rely on. Guarding the construction path covers any engine and keeps the logging.
- Verified the test is a real regression test: with the `Cache.php` change reverted, `tests/TestCase/Cache/CacheTest.php --filter Reentrant` crashes the PHP process rather than failing an assertion.
- This came out of a production incident where a Redis unit failed to start after a reboot. PHP processes grew by GB per minute across every site on the host, the page cache was evicted, and per-minute cron jobs stacked up to 638 stuck processes at load average 257. The site that lost its cache should have degraded on its own instead of taking the machine with it.
