### PR TITLE
Stop a logger from reentering itself while it is dispatching

### DIFF
--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -131,6 +131,15 @@ class Log
     protected static bool $_dirtyConfig = false;
 
     /**
+     * Loggers currently dispatching a message, keyed by stream name.
+     *
+     * Used to detect a logger reentering itself, see {@link \Cake\Log\Log::write()}.
+     *
+     * @var array<string, true>
+     */
+    protected static array $writing = [];
+
+    /**
      * LogEngineRegistry class
      *
      * @var \Cake\Log\LogEngineRegistry
@@ -332,6 +341,16 @@ class Log
      * then the logged message will be ignored and silently dropped. You can check if this has happened
      * by inspecting the return of write(). If false the message was not handled.
      *
+     * ### Reentrant log messages
+     *
+     * A logger that writes through a subsystem which logs its own failures can end up being asked
+     * to write again while it is still handling a message. A logger storing rows in a table is the
+     * usual example: the insert is picked up by the query logger, which writes a log message, which
+     * reaches the same logger. Left alone this repeats until the process runs out of memory.
+     *
+     * While a logger is dispatching, it will not be handed another message. The nested message goes
+     * to `error_log()` instead so it is not lost, and the other configured loggers still receive it.
+     *
      * @param string|int $level The severity level of the message being written.
      *    The value must be an integer or string matching a known level.
      * @param \Stringable|string $message Message content to log
@@ -377,7 +396,23 @@ class Log
                 is_array($scopes) && array_intersect((array)$context['scope'], $scopes);
 
             if ($correctLevel && $inScope) {
-                $logger->log($level, $message, $context);
+                if (isset(static::$writing[$streamName])) {
+                    error_log(sprintf(
+                        '[cake][%s] %s (dropped: logger `%s` reentered while writing)',
+                        $level,
+                        $message,
+                        $streamName,
+                    ));
+
+                    continue;
+                }
+
+                static::$writing[$streamName] = true;
+                try {
+                    $logger->log($level, $message, $context);
+                } finally {
+                    unset(static::$writing[$streamName]);
+                }
                 $logged = true;
             }
         }

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -17,11 +17,15 @@ namespace Cake\Test\TestCase\Log;
 
 use BadMethodCallException;
 use Cake\Core\Exception\CakeException;
+use Cake\Log\Engine\BaseLog;
 use Cake\Log\Engine\FileLog;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
+use RuntimeException;
+use Stringable;
+use TestApp\Log\Engine\ReentrantLog;
 use TestApp\Log\Engine\TestAppLog;
 use TestPlugin\Log\Engine\TestPluginLog;
 
@@ -30,6 +34,11 @@ use TestPlugin\Log\Engine\TestPluginLog;
  */
 class LogTest extends TestCase
 {
+    /**
+     * @var string|null
+     */
+    protected ?string $errorLogBackup = null;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -41,6 +50,29 @@ class LogTest extends TestCase
     {
         parent::tearDown();
         Log::reset();
+
+        if ($this->errorLogBackup !== null) {
+            ini_set('error_log', $this->errorLogBackup);
+            $this->errorLogBackup = null;
+        }
+    }
+
+    /**
+     * Sends error_log() output to a file for the duration of the test, so a suppressed
+     * reentrant message does not end up in the test runner's output.
+     */
+    protected function captureErrorLog(): string
+    {
+        $file = TMP . 'error_log_capture.log';
+        if (file_exists($file)) {
+            unlink($file);
+        }
+
+        $previous = ini_get('error_log');
+        $this->errorLogBackup = $previous === false ? '' : $previous;
+        ini_set('error_log', $file);
+
+        return $file;
     }
 
     /**
@@ -670,5 +702,105 @@ class LogTest extends TestCase
             return $instance;
         });
         $this->assertSame($instance, Log::engine('default'));
+    }
+
+    /**
+     * A logger that writes a log message from inside its own log() must not be handed that
+     * message while it is still dispatching, or it calls itself until the process dies.
+     */
+    public function testWriteDoesNotReenterTheSameLogger(): void
+    {
+        $file = $this->captureErrorLog();
+        $logger = new ReentrantLog();
+        Log::setConfig('reentrant', $logger);
+
+        Log::write('error', 'the original problem');
+
+        $this->assertSame(['the original problem'], $logger->messages);
+        $this->assertStringContainsString(
+            'dropped: logger `reentrant` reentered while writing',
+            (string)file_get_contents($file),
+            'The suppressed message should still be recorded somewhere.',
+        );
+    }
+
+    /**
+     * The nested message still reaches the other configured loggers. Only the one that is already
+     * dispatching is skipped, so a per-logger cycle does not silence the rest of the stack.
+     */
+    public function testWriteStillDispatchesNestedMessageToOtherLoggers(): void
+    {
+        $this->captureErrorLog();
+        $reentrant = new ReentrantLog();
+        $bystander = new class extends BaseLog {
+            public array $messages = [];
+
+            public function log($level, Stringable|string $message, array $context = []): void
+            {
+                $this->messages[] = (string)$message;
+            }
+        };
+        Log::setConfig('reentrant', $reentrant);
+        Log::setConfig('bystander', $bystander);
+
+        Log::write('error', 'the original problem');
+
+        $this->assertSame(['the original problem'], $reentrant->messages);
+        $this->assertSame(
+            ['INSERT INTO logs ...', 'the original problem'],
+            $bystander->messages,
+            'The bystander should have received the nested message as well as the original.',
+        );
+    }
+
+    /**
+     * The marker is cleared once dispatch finishes, so a later write is handled normally rather
+     * than being mistaken for a reentrant one forever.
+     */
+    public function testLoggerIsWritableAgainAfterReentrantWrite(): void
+    {
+        $this->captureErrorLog();
+        $logger = new ReentrantLog();
+        Log::setConfig('reentrant', $logger);
+
+        Log::write('error', 'first');
+        Log::write('error', 'second');
+
+        $this->assertSame(['first', 'second'], $logger->messages);
+    }
+
+    /**
+     * A logger that throws must not leave itself marked as dispatching, otherwise one failure
+     * would silence it for the rest of the process.
+     */
+    public function testMarkerIsClearedWhenTheLoggerThrows(): void
+    {
+        $logger = new class extends BaseLog {
+            public bool $explode = true;
+
+            public array $messages = [];
+
+            public function log($level, Stringable|string $message, array $context = []): void
+            {
+                if ($this->explode) {
+                    throw new RuntimeException('logger blew up');
+                }
+
+                $this->messages[] = (string)$message;
+            }
+        };
+        Log::setConfig('exploding', $logger);
+
+        try {
+            Log::write('error', 'first');
+            $this->fail('Expected the logger failure to propagate.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('logger blew up', $e->getMessage());
+        }
+
+        $logger->explode = false;
+        Log::write('error', 'second');
+
+        $this->assertSame(['second'], $logger->messages);
     }
 }

--- a/tests/test_app/TestApp/Log/Engine/ReentrantLog.php
+++ b/tests/test_app/TestApp/Log/Engine/ReentrantLog.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Log\Engine;
+
+use Cake\Log\Engine\BaseLog;
+use Cake\Log\Log;
+use Stringable;
+
+/**
+ * Writes a log message from inside its own log(), the way a table-backed logger does when the
+ * insert it performs is picked up by the query logger.
+ */
+class ReentrantLog extends BaseLog
+{
+    /**
+     * Messages this logger was handed.
+     *
+     * @var array<string>
+     */
+    public array $messages = [];
+
+    /**
+     * Guards the stub against running away if the reentrancy check ever stops working.
+     *
+     * @var int
+     */
+    public int $limit = 20;
+
+    /**
+     * @param mixed $level
+     * @param \Stringable|string $message
+     * @param array $context
+     * @return void
+     */
+    public function log($level, Stringable|string $message, array $context = []): void
+    {
+        $this->messages[] = (string)$message;
+
+        if (count($this->messages) >= $this->limit) {
+            return;
+        }
+
+        Log::write('debug', 'INSERT INTO logs ...', [
+            'scope' => ['queriesLog', 'cake.database.queries'],
+        ]);
+    }
+}


### PR DESCRIPTION
The general fix discussed in #19588. Targets 5.next because it changes observable behavior for third-party loggers, which is not something I would put in a patch release. #19587 handles the cache route on 5.x and is independent of this.

## The problem

`Log::write()` has nothing that notices a logger being asked to write while it is already writing. A logger that goes through a subsystem which logs its own failures therefore calls itself until the process runs out of memory.

The route I did not expect needs no exotic configuration at all. `Cake\Database\Log\QueryLogger::log()` ends in:

```php
Log::write('debug', (string)$message, $context);
```

So for a logger that stores rows in a table:

```
Log::write('error', ...)
  -> table-backed logger
    -> INSERT INTO ...
      -> QueryLogger::log()
        -> Log::write('debug', ...)
          -> same table-backed logger
            -> INSERT INTO ...        // and around again
```

I reproduced this against a stub standing in for the table write. It went 40 levels deep and was still descending when the probe cut it off.

Scopes do not save you, which was my first assumption. `BaseLog` defaults to:

```php
protected array $_defaultConfig = [
    'levels' => [],
    'scopes' => [],
];
```

and `Log::write()` matches with:

```php
$inScope = $scopes === null && empty($context['scope']) || $scopes === [] ||
    is_array($scopes) && array_intersect((array)$context['scope'], $scopes);
```

`$scopes === []` matches everything, scoped messages included. A logger configured with nothing but a `className` is exposed. Only one that explicitly sets `'scopes' => null` is excluded.

The other route is the cache one from #19588: an engine that cannot reach its backend logs the failure, and a table-backed logger asking for schema metadata lands back in the pool that is still being built.

## The change

Track which streams are dispatching, and skip a stream that is already inside a write:

```php
if (isset(static::$writing[$streamName])) {
    error_log(sprintf(
        '[cake][%s] %s (dropped: logger `%s` reentered while writing)',
        $level,
        $message,
        $streamName,
    ));

    continue;
}

static::$writing[$streamName] = true;
try {
    $logger->log($level, $message, $context);
} finally {
    unset(static::$writing[$streamName]);
}
```

Keyed per stream rather than one global flag on purpose. A global flag would suppress every logger for the duration of any nested write, which is far broader than the problem calls for. Here the nested message still reaches every other configured logger, so one logger looping does not silence the rest of the stack. There is a test for that specifically.

The nested message goes to `error_log()` rather than disappearing, and the marker is cleared in a `finally` so a logger that throws does not disable itself for the rest of the process.

## What this does not cover

A cycle that runs across two different streams, where A's logger triggers a message only B handles and B's triggers one only A handles. That needs a depth counter, and I did not think the complexity was worth it before someone hits it. Happy to change that if you disagree.

The flag is process-global. Nothing in core logs from concurrent fibers today, but if that changes, one fiber's write could suppress another's.

## Verification notes

The full suite passes with no new failures. I compared against the base branch by test identity from the JUnit output rather than by count, because the totals move between runs on identical code. The 22 problem cases in both runs are the same set, and they are artifacts of my local setup (21 separate-process `SessionTest` cases where the child does not inherit a CLI `zend.assertions=1`, plus one stdin-dependent `ConsoleInputTest`), not anything this touches.

Worth stating plainly: no core logger calls `Log::` at all, and `RedisEngine` is the only core cache engine that logs while connecting. Core cannot reach either cycle on its own, so a green suite here means "nothing regressed", not "this is safe for every third-party logger". That limit is the main thing I would want a second opinion on.
