### PR TITLE
Added methods for absolute path handling in `Path` utility class

### DIFF
--- a/src/Utility/Fs/Path.php
+++ b/src/Utility/Fs/Path.php
@@ -67,26 +67,63 @@ class Path
     }
 
     /**
-     * Makes a path absolute, using a base path if the given path is not already absolute.
+     * Resolves `.` and `..` segments in an absolute, forward-slash-normalized path.
      *
-     * Note that the resulting path is not resolved: any `..` or `.` segments in $path
-     * are preserved as-is, consistent with join() and normalize().
+     * Segments that would go above the root (e.g. an extra `..` at the root level)
+     * are simply dropped, since there is nothing above the root to resolve to.
+     *
+     * @param string $path The absolute path to resolve
+     * @return string The resolved path
+     */
+    protected static function resolveDotSegments(string $path): string
+    {
+        $root = '';
+
+        if (preg_match('/^[A-Za-z]:\//', $path) === 1) {
+            $root = substr($path, 0, 3);
+            $path = substr($path, 3);
+        } elseif (str_starts_with($path, '/')) {
+            $root = '/';
+            $path = substr($path, 1);
+        }
+
+        $resolved = [];
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '' || $segment === '.') {
+                continue;
+            }
+
+            if ($segment === '..') {
+                array_pop($resolved);
+
+                continue;
+            }
+
+            $resolved[] = $segment;
+        }
+
+        return $root . implode('/', $resolved);
+    }
+
+    /**
+     * Makes a path absolute, using a base path if the given path is not already absolute,
+     * and resolves any `.` and `..` segments in the result.
      *
      * @param string $path The path to make absolute
      * @param string $from The base path to use when $path is relative. Expected to already be absolute.
-     * @return string The absolute path
+     * @return string The absolute, resolved path
      */
     public static function makeAbsolute(string $path, string $from): string
     {
         if (static::isAbsolute($path)) {
-            return str_replace('\\', '/', $path);
+            $absolute = str_replace('\\', '/', $path);
+        } elseif ($path === '') {
+            $absolute = str_replace('\\', '/', $from);
+        } else {
+            $absolute = static::join($from, $path);
         }
 
-        if ($path === '') {
-            return str_replace('\\', '/', $from);
-        }
-
-        return static::join($from, $path);
+        return static::resolveDotSegments($absolute);
     }
 
     /**

--- a/src/Utility/Fs/Path.php
+++ b/src/Utility/Fs/Path.php
@@ -54,6 +54,42 @@ class Path
     }
 
     /**
+     * Checks if a path is absolute.
+     *
+     * @param string $path The path to check
+     * @return bool True if the path is absolute
+     */
+    public static function isAbsolute(string $path): bool
+    {
+        $path = str_replace('\\', '/', $path);
+
+        return str_starts_with($path, '/') || preg_match('/^[A-Za-z]:\//', $path) === 1;
+    }
+
+    /**
+     * Makes a path absolute, using a base path if the given path is not already absolute.
+     *
+     * Note that the resulting path is not resolved: any `..` or `.` segments in $path
+     * are preserved as-is, consistent with join() and normalize().
+     *
+     * @param string $path The path to make absolute
+     * @param string $from The base path to use when $path is relative. Expected to already be absolute.
+     * @return string The absolute path
+     */
+    public static function makeAbsolute(string $path, string $from): string
+    {
+        if (static::isAbsolute($path)) {
+            return str_replace('\\', '/', $path);
+        }
+
+        if ($path === '') {
+            return str_replace('\\', '/', $from);
+        }
+
+        return static::join($from, $path);
+    }
+
+    /**
      * Makes a path relative to a base path.
      *
      * @param string $path The absolute path to make relative

--- a/tests/TestCase/Utility/Fs/PathTest.php
+++ b/tests/TestCase/Utility/Fs/PathTest.php
@@ -46,6 +46,7 @@ class PathTest extends TestCase
         $this->assertTrue(Path::isAbsolute('/'));
         $this->assertTrue(Path::isAbsolute('C:/Windows'));
         $this->assertTrue(Path::isAbsolute('C:\\Windows'));
+        $this->assertTrue(Path::isAbsolute('/../src/Model'));
 
         $this->assertFalse(Path::isAbsolute('src/Model'));
         $this->assertFalse(Path::isAbsolute('./src/Model'));
@@ -87,6 +88,11 @@ class PathTest extends TestCase
         $this->assertSame(
             'C:/project/src/file.php',
             Path::makeAbsolute('src/file.php', 'C:/project'),
+        );
+
+        $this->assertSame(
+            '/src/Model',
+            Path::makeAbsolute('/../src/Model', '/var/www'),
         );
     }
 

--- a/tests/TestCase/Utility/Fs/PathTest.php
+++ b/tests/TestCase/Utility/Fs/PathTest.php
@@ -40,6 +40,72 @@ class PathTest extends TestCase
         $this->assertSame('', Path::normalize('/'));
     }
 
+    public function testIsAbsolute(): void
+    {
+        $this->assertTrue(Path::isAbsolute('/var/www'));
+        $this->assertTrue(Path::isAbsolute('/'));
+        $this->assertTrue(Path::isAbsolute('C:/Windows'));
+        $this->assertTrue(Path::isAbsolute('C:\\Windows'));
+
+        $this->assertFalse(Path::isAbsolute('src/Model'));
+        $this->assertFalse(Path::isAbsolute('./src/Model'));
+        $this->assertFalse(Path::isAbsolute('../src/Model'));
+        $this->assertFalse(Path::isAbsolute(''));
+
+        // Lowercase drive letters are valid too
+        $this->assertTrue(Path::isAbsolute('d:/folder'));
+
+        // A drive letter without a following slash is drive-relative on Windows, not absolute
+        $this->assertFalse(Path::isAbsolute('C:folder'));
+
+        // UNC paths are absolute
+        $this->assertTrue(Path::isAbsolute('\\\\server\\share'));
+    }
+
+    public function testMakeAbsolute(): void
+    {
+        $this->assertSame(
+            '/var/www/src/file.php',
+            Path::makeAbsolute('src/file.php', '/var/www'),
+        );
+
+        $this->assertSame(
+            '/var/www/src/file.php',
+            Path::makeAbsolute('/var/www/src/file.php', '/tmp'),
+        );
+
+        $this->assertSame(
+            '/var/www',
+            Path::makeAbsolute('', '/var/www'),
+        );
+
+        $this->assertSame(
+            '/var/www/src/../config',
+            Path::makeAbsolute('../config', '/var/www/src'),
+        );
+
+        $this->assertSame(
+            'C:/project/src/file.php',
+            Path::makeAbsolute('src/file.php', 'C:/project'),
+        );
+    }
+
+    public function testMakeAbsoluteWithBackslashes(): void
+    {
+        // Absolute path with backslashes: base is ignored, separators are normalized.
+        // This is the one branch not exercised by the existing tests.
+        $this->assertSame(
+            'C:/other/file.php',
+            Path::makeAbsolute('C:\\other\\file.php', '/var/www'),
+        );
+
+        // Relative path with backslashes joined with a Unix base
+        $this->assertSame(
+            '/var/www/src/file.php',
+            Path::makeAbsolute('src\\file.php', '/var/www'),
+        );
+    }
+
     public function testMakeRelative(): void
     {
         $this->assertSame('src/Model/Table.php', Path::makeRelative('/var/www/src/Model/Table.php', '/var/www'));

--- a/tests/TestCase/Utility/Fs/PathTest.php
+++ b/tests/TestCase/Utility/Fs/PathTest.php
@@ -80,7 +80,7 @@ class PathTest extends TestCase
         );
 
         $this->assertSame(
-            '/var/www/src/../config',
+            '/var/www/config',
             Path::makeAbsolute('../config', '/var/www/src'),
         );
 
@@ -103,6 +103,51 @@ class PathTest extends TestCase
         $this->assertSame(
             '/var/www/src/file.php',
             Path::makeAbsolute('src\\file.php', '/var/www'),
+        );
+    }
+
+    public function testMakeAbsoluteResolvesDotSegments(): void
+    {
+        // Multiple ".." segments walk up more than one level
+        $this->assertSame(
+            '/var/etc/passwd',
+            Path::makeAbsolute('../../etc/passwd', '/var/www/src'),
+        );
+
+        // "." segments are simply dropped
+        $this->assertSame(
+            '/var/www/src/file.php',
+            Path::makeAbsolute('./src/./file.php', '/var/www'),
+        );
+
+        // ".." segments that would go above the root are dropped, not an error
+        $this->assertSame(
+            '/etc',
+            Path::makeAbsolute('../../../../etc', '/var/www'),
+        );
+
+        // Already-absolute paths are resolved too, not just the joined ones
+        $this->assertSame(
+            '/var/etc/passwd',
+            Path::makeAbsolute('/var/www/../etc/passwd', '/tmp'),
+        );
+
+        // Resolution also works on Windows-style drive paths
+        $this->assertSame(
+            'C:/var/www/config',
+            Path::makeAbsolute('..\\config', 'C:\\var\\www\\src'),
+        );
+
+        // A single "." resolves to just the base
+        $this->assertSame(
+            '/var/www',
+            Path::makeAbsolute('.', '/var/www'),
+        );
+
+        // ".." at the root stays at the root
+        $this->assertSame(
+            '/',
+            Path::makeAbsolute('..', '/'),
         );
     }
 


### PR DESCRIPTION
- Introduced `isAbsolute()` to check for absolute paths.
- Added `makeAbsolute()` to construct absolute paths based on a base path.
- Included extensive test coverage for the new methods in `PathTest`.

## Implementation notes / discussion points

**Path separators are always normalized, regardless of OS.**
`isAbsolute()` and `makeAbsolute()` follow the existing behaviour of `normalize()`/`join()`: backslashes are always treated as path separators and Windows drive letters are always recognized, independent of the OS the code happens to run on.

~~**`makeAbsolute()` does not resolve `.`/`..` segments.**
The result is a plain concatenation of `$from` and `$path` (see the `../config` case in `testMakeAbsolute`), not a canonical path. This is consistent with the rest of the class: neither `join()` nor `normalize()` resolve dot segments either.
Flagging this so it reads as a scope decision, not an oversight — a proper canonicalization method would be a separate, larger addition.~~

**`$from` is not validated as absolute.**
Passing a relative `$from` to `makeAbsolute()` will silently produce a result that looks absolute but isn't. No other method in this class throws on invalid input, so this PR keeps that behaviour and documents the expectation in the docblock instead of adding validation/exceptions. Happy to add a guard if reviewers prefer stricter behaviour.

**Edge case: bare drive letter (`"C:"`, no trailing separator).**
`isAbsolute()` requires a separator after the colon (`"C:/"`), so `isAbsolute('C:')` is `false`. A bare `"C:"` conventionally refers to the *current directory* on that drive rather than its root, so treating it as non-absolute seemed the safer default — open to discussion if a different convention is preferred.

**Test coverage suggestions**, if useful:
- `makeAbsolute()` with an already-absolute `$path` containing backslashes  (e.g. `C:\other\file.php`), to exercise the "already absolute, normalize separators" branch explicitly.
- `isAbsolute()` with a lowercase drive letter and a drive-relative path (`C:folder`).

P.S. I rightly maintained the same "style" in the tests.
However, from now on, I would really encourage the use of the `DataProvider` and (especially) `TestWith` attributes whenever possible (I can do another PR for this).