### PR TITLE
Fix paginated association subqueries on MariaDB

### DIFF
--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Association\Loader;
 
+use Cake\Database\Driver\Mysql;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\AggregateExpression;
 use Cake\Database\Expression\FieldInterface;
@@ -484,8 +485,18 @@ class SelectLoader
             }
         }
 
-        $fields = $this->_subqueryFields($query);
-        $filterQuery->select($fields['select'], true)->groupBy($fields['group']);
+        $driver = $filterQuery->getDriver();
+        $useDistinct = !$filterQuery->clause('group')
+            && $driver instanceof Mysql
+            && $driver->isMariadb();
+        $fields = $this->_subqueryFields($query, $useDistinct);
+        $filterQuery->select($fields['select'], true);
+        if ($useDistinct) {
+            // DISTINCT deduplicates joined rows without triggering MariaDB's lateral GROUP BY optimization.
+            $filterQuery->distinct();
+        } else {
+            $filterQuery->groupBy($fields['group']);
+        }
 
         return $filterQuery;
     }
@@ -502,9 +513,10 @@ class SelectLoader
      * dropped from the reduced subquery SELECT list.
      *
      * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array> $query The query to get fields from.
+     * @param bool $includeOrderFields Whether ordered fields should be included in the SELECT list.
      * @return array<string, array> The list of fields for the subquery.
      */
-    protected function _subqueryFields(SelectQuery $query): array
+    protected function _subqueryFields(SelectQuery $query, bool $includeOrderFields = false): array
     {
         $keys = (array)$this->bindingKey;
 
@@ -525,7 +537,15 @@ class SelectLoader
             // iterateParts() rebuilds the expression from the callback's return value, so each part
             // has to be handed back. Returning nothing would strip the ORDER BY from $query itself,
             // which is the caller's query, not a clone of it.
-            $order->iterateParts(function ($direction, $field) use (&$fields, &$group, $columns) {
+            $order->iterateParts(function (
+                $direction,
+                $field,
+            ) use (
+                &$fields,
+                &$group,
+                $columns,
+                $includeOrderFields,
+            ) {
                 // A numeric key carries its own column and must not be read as a SELECT offset.
                 if (is_string($field) && isset($columns[$field])) {
                     $column = $columns[$field];
@@ -537,6 +557,16 @@ class SelectLoader
                 // Constant values such as `select(['score' => 100])` are not columns.
                 if (!is_string($column) && !$column instanceof ExpressionInterface) {
                     return $direction;
+                }
+
+                $selectColumn = $column;
+                // Auto-quoting may have already converted the order field to SQL. Keep that form
+                // as an expression so aliasFields() does not quote it a second time.
+                if (is_string($column) && $column !== '' && str_contains('`"[', $column[0])) {
+                    $selectColumn = new QueryExpression($column);
+                }
+                if ($includeOrderFields && !in_array($selectColumn, $fields, true)) {
+                    $fields[] = $selectColumn;
                 }
 
                 if (!$this->isAggregate($column) && !in_array($column, $group, true)) {

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM\Query;
 
+use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\ComparisonExpression;
@@ -1964,10 +1965,13 @@ class QueryRegressionTest extends TestCase
     }
 
     /**
-     * Databases that do not enforce grouping, such as SQLite, accept the invalid subquery, so the
-     * GROUP BY has to be asserted on the generated SQL as well.
+     * MariaDB filtering subqueries should use DISTINCT for deduplication.
+     *
+     * A GROUP BY combined with ORDER BY, LIMIT, and OFFSET triggers MariaDB's lateral-derived
+     * optimization, which can apply the page window per joined row and return incorrect associations.
+     * Other drivers retain the existing GROUP BY behavior.
      */
-    public function testSubqueryStrategyGroupsByOrderedColumns(): void
+    public function testSubqueryStrategyDeduplicatesPaginatedResults(): void
     {
         $logger = new class extends AbstractLogger {
             /**
@@ -2008,15 +2012,22 @@ class QueryRegressionTest extends TestCase
             }
         }
 
-        // The filtering subquery is the only grouped statement the query above runs.
-        $grouped = array_filter(
+        $subqueries = array_filter(
             $logger->messages,
-            fn(string $message): bool => str_contains($message, 'GROUP BY'),
+            fn(string $message): bool => str_contains($message, 'INNER JOIN (SELECT'),
         );
-        $this->assertCount(1, $grouped, implode("\n", $logger->messages));
+        $this->assertCount(1, $subqueries, implode("\n", $logger->messages));
 
-        $sql = array_pop($grouped);
-        $this->assertSame(1, preg_match('/GROUP BY (.+?)(?= ORDER BY| HAVING| LIMIT|\))/', $sql, $matches), $sql);
-        $this->assertStringContainsString('name', $matches[1], $sql);
+        $sql = array_pop($subqueries);
+        if ($driver instanceof Mysql && $driver->isMariadb()) {
+            $this->assertStringContainsString('INNER JOIN (SELECT DISTINCT', $sql);
+            $this->assertStringNotContainsString('GROUP BY', $sql);
+            $this->assertMatchesRegularExpression('/SELECT DISTINCT .+name.+ FROM/', $sql);
+
+            return;
+        }
+
+        $this->assertStringNotContainsString('SELECT DISTINCT', $sql);
+        $this->assertMatchesRegularExpression('/GROUP BY .+name/', $sql);
     }
 }

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -1997,11 +1997,12 @@ class QueryRegressionTest extends TestCase
             $articles->belongsTo('Authors');
             $articles->hasMany('Comments', ['strategy' => Association::STRATEGY_SUBQUERY]);
 
-            $articles->find()
+            $results = $articles->find()
                 ->contain(['Comments'])
                 ->innerJoinWith('Authors')
                 ->orderBy(['Authors.name' => 'ASC', 'Articles.id' => 'ASC'])
-                ->limit(2)
+                ->limit(1)
+                ->offset(1)
                 ->all()
                 ->toArray();
         } finally {
@@ -2011,6 +2012,10 @@ class QueryRegressionTest extends TestCase
                 $driver->disableQueryLogging();
             }
         }
+
+        $this->assertCount(1, $results);
+        $this->assertSame(1, $results[0]->id);
+        $this->assertCount(4, $results[0]->comments);
 
         $subqueries = array_filter(
             $logger->messages,


### PR DESCRIPTION
Use `SELECT DISTINCT` to deduplicate ungrouped MariaDB association-filter subqueries without triggering the lateral `GROUP BY` optimization that can apply pagination per joined row.

Explicit grouping semantics and other database drivers retain `GROUP BY`. Ordered columns are included in the reduced select list where MariaDB requires them.

The regression coverage verifies both the generated SQL and the contained results from a page with a nonzero offset.

Fixes #19595.