### PR TITLE
Fix Container 6.x branch alias

### DIFF
--- a/src/Container/composer.json
+++ b/src/Container/composer.json
@@ -46,7 +46,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-5.next": "5.5.x-dev"
+            "6.x-dev": "6.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
Fixes standalone split-package Composer resolution on 6.x.

cakephp/container exposes its 6.x branch as 6.x-dev, but its package manifest still aliases dev-5.next to 5.5.x-dev. Core and dependent split packages require cakephp/container: 6.0.*@dev, which Composer cannot resolve.

Update the alias to map 6.x-dev to 6.0.x-dev.