### PR TITLE
Strip new from multipart Content-Disposition attributes

### DIFF
--- a/src/Http/Client/FormDataPart.php
+++ b/src/Http/Client/FormDataPart.php
@@ -223,7 +223,7 @@ class FormDataPart implements Stringable
      */
     protected function _headerParameterToString(string $name, string $value): string
     {
-        $transliterated = Text::transliterate(str_replace('"', '', $value));
+        $transliterated = Text::transliterate(str_replace(['"', "\r", "\n"], '', $value));
         $return = sprintf('%s="%s"', $name, $transliterated);
         if ($this->charset !== null && $value !== $transliterated) {
             $return .= sprintf("; %s*=%s''%s", $name, strtolower($this->charset), rawurlencode($value));

--- a/tests/TestCase/Http/Client/FormDataTest.php
+++ b/tests/TestCase/Http/Client/FormDataTest.php
@@ -209,6 +209,30 @@ class FormDataTest extends TestCase
             '',
         ];
         $this->assertSame(implode("\r\n", $expected), $result);
+
+        $file = new UploadedFile(
+            CORE_PATH . 'VERSION.txt',
+            filesize(CORE_PATH . 'VERSION.txt'),
+            0,
+            "VERSION.txt\r\nRCPT TO:test@example.com",
+            'text/plain',
+        );
+
+        $data = new FormData();
+        $data->add("upload\r\nSEND TO:foo@example.com", $file);
+        $boundary = $data->boundary();
+        $result = (string)$data;
+
+        $expected = [
+            '--' . $boundary,
+            'Content-Disposition: form-data; name="uploadSEND TO:foo@example.com"; filename="VERSION.txtRCPT TO:test@example.com"',
+            'Content-Type: text/plain',
+            '',
+            (string)$file->getStream(),
+            '--' . $boundary . '--',
+            '',
+        ];
+        $this->assertSame(implode("\r\n", $expected), $result);
     }
 
     /**


### PR DESCRIPTION
Strip out CRLF and LF from name and filename attributes of Content-Disposition headers. Thes character sequences are not allowed in attribute values as per RFC5987 Sec 3.2.1, and can leveraged for header injection in contrived scenarios.