### PR TITLE
Fix count with unbuffered queries

### DIFF
--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1467,10 +1467,14 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
                 ->execute();
         }
 
-        $result = $statement->fetch(PDO::FETCH_ASSOC);
-        // A count always returns a single row, and leaving an unbuffered statement open
-        // would keep the connection busy until the statement is garbage collected.
-        $statement->closeCursor();
+        try {
+            $result = $statement->fetch(PDO::FETCH_ASSOC);
+        } finally {
+            // A count always returns a single row, and leaving an unbuffered statement
+            // open would keep the connection busy until the statement is garbage
+            // collected.
+            $statement->closeCursor();
+        }
 
         return $result === false ? 0 : (int)$result['count'];
     }

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1462,15 +1462,15 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
         } else {
             $query->getEagerLoader()->disableAutoFields();
             $statement = $query
-                // A count always returns a single row, and leaving it unbuffered would
-                // keep the connection busy until the statement is garbage collected.
-                ->enableBufferedResults()
                 ->select($count, true)
                 ->disableAutoFields()
                 ->execute();
         }
 
         $result = $statement->fetch(PDO::FETCH_ASSOC);
+        // A count always returns a single row, and leaving an unbuffered statement open
+        // would keep the connection busy until the statement is garbage collected.
+        $statement->closeCursor();
 
         return $result === false ? 0 : (int)$result['count'];
     }

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1462,6 +1462,9 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
         } else {
             $query->getEagerLoader()->disableAutoFields();
             $statement = $query
+                // A count always returns a single row, and leaving it unbuffered would
+                // keep the connection busy until the statement is garbage collected.
+                ->enableBufferedResults()
                 ->select($count, true)
                 ->disableAutoFields()
                 ->execute();

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -1722,6 +1722,36 @@ class SelectQueryTest extends TestCase
     }
 
     /**
+     * Tests that counting a query with buffered results disabled does not leave the
+     * connection busy for the queries that follow it.
+     */
+    public function testCountWithBufferedResultsDisabled(): void
+    {
+        $this->skipIf(!$this->connection->getDriver() instanceof Mysql);
+
+        $table = $this->getTableLocator()->get('Articles');
+        $table->belongsTo('Authors');
+
+        // Behaviors such as TranslateBehavior configure associations with closures that
+        // reference the query they are given. That reference cycle keeps the query used
+        // for counting, and its statement, alive until the cycle collector runs.
+        $table->getEventManager()
+            ->on('Model.beforeFind', function (EventInterface $event, SelectQuery $query): void {
+                $query->contain([
+                    'Authors' => [
+                        'queryBuilder' => function (SelectQuery $q) use ($query): SelectQuery {
+                            return $q->where([$query->getRepository()->aliasField('id') . ' IS NOT' => null]);
+                        },
+                    ],
+                ]);
+            });
+
+        $query = $table->find()->disableBufferedResults();
+        $this->assertSame(3, $query->count());
+        $this->assertCount(3, $query->all()->toArray());
+    }
+
+    /**
      * Tests that beforeFind is only ever called once, even if you trigger it again in the beforeFind
      */
     public function testBeforeFindCalledOnce(): void


### PR DESCRIPTION
Fixes: ``SQLSTATE[HY000]: General error: 2014 Cannot execute queries while other unbuffered queries are active.``
with unbuffered queries.

An alternative would be to always enable buffered queries in cleanCopy() but it would be a breaking change.
