### PR TITLE
Remove explicit schema in postgreschema

### DIFF
--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -123,7 +123,7 @@ class PostgresSchemaDialect extends SchemaDialect
                 f_{$postgisType}_column AS name,
                 type,
                 srid
-            FROM public.{$postgisType}_columns
+            FROM {$postgisType}_columns
             WHERE f_table_name = ? AND f_table_schema = ? AND f_table_catalog = ?
             SQL;
 


### PR DESCRIPTION
Remove the hardcoded `public` schema from postgis column reflection. Adding a test seemed more complex than it would provide value.

Fixes #19604
