### PR TITLE
Fix nested matching condition leak and LIMIT handling in subquery eager loading

### DIFF
--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -244,6 +244,9 @@ class EagerLoader
 
         $options += ['joinType' => SelectQuery::JOIN_TYPE_INNER];
         $sharedOptions = ['negateMatch' => false, 'matching' => true] + $options;
+        // The builder belongs to the last association in the path. Inheriting it would
+        // apply the target's conditions to every association leading up to it as well.
+        unset($sharedOptions['queryBuilder']);
 
         $contains = [];
         $nested = &$contains;
@@ -658,6 +661,8 @@ class EagerLoader
             return $results;
         }
 
+        $this->correctSubqueryStrategy($external, $query);
+
         $collected = $this->_collectKeys($external, $query, $results);
 
         foreach ($external as $meta) {
@@ -793,6 +798,43 @@ class EagerLoader
             'forMatching' => $asMatching,
             'targetProperty' => $targetProperty ?: $assoc->getProperty(),
         ]);
+    }
+
+    /**
+     * Switches associations away from the subquery strategy when the subquery filter
+     * would not describe the rows the query returned.
+     *
+     * The filter groups by the source binding key and inherits the query's LIMIT, so
+     * the limit cuts the distinct keys instead of the rows. Both sets only coincide
+     * while the association is owned by the query's own repository. As soon as it hangs
+     * off another association, many rows share one key and the filter returns a
+     * different, largely disjoint set of keys.
+     *
+     * @param array<\Cake\ORM\EagerLoadable> $external The list of external associations to be loaded.
+     * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface|array> $query The query the associations are loaded for.
+     * @return void
+     */
+    protected function correctSubqueryStrategy(array $external, SelectQuery $query): void
+    {
+        if ($query->clause('limit') === null) {
+            return;
+        }
+
+        $primaryAlias = $query->getRepository()->getAlias();
+        foreach ($external as $meta) {
+            $config = $meta->getConfig();
+            $instance = $meta->instance();
+            $strategy = $config['strategy'] ?? $instance->getStrategy();
+            if (
+                $strategy !== Association::STRATEGY_SUBQUERY ||
+                $instance->getSource()->getAlias() === $primaryAlias
+            ) {
+                continue;
+            }
+
+            $config['strategy'] = Association::STRATEGY_SELECT;
+            $meta->setConfig($config);
+        }
     }
 
     /**

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -54,6 +54,7 @@ class QueryRegressionTest extends TestCase
         'core.AuthorsTags',
         'core.Comments',
         'core.FeaturedTags',
+        'core.Profiles',
         'core.SpecialTags',
         'core.TagsTranslations',
         'core.Translates',
@@ -2018,5 +2019,92 @@ class QueryRegressionTest extends TestCase
         $sql = array_pop($grouped);
         $this->assertSame(1, preg_match('/GROUP BY (.+?)(?= ORDER BY| HAVING| LIMIT|\))/', $sql, $matches), $sql);
         $this->assertStringContainsString('name', $matches[1], $sql);
+    }
+
+    /**
+     * Test for https://github.com/cakephp/cakephp/issues/19608
+     *
+     * The conditions of a nested innerJoinWith() belong to that association's join only.
+     * Databases that do not resolve the ON clause strictly, such as SQLite, accept the
+     * misplaced reference, so the condition has to be counted in the generated SQL.
+     */
+    public function testNestedMatchingConditionsStayOnTheirOwnJoin(): void
+    {
+        $logger = new class extends AbstractLogger {
+            /**
+             * @var array<string>
+             */
+            public array $messages = [];
+
+            /**
+             * @inheritDoc
+             */
+            public function log($level, string|Stringable $message, array $context = []): void
+            {
+                $this->messages[] = (string)$message;
+            }
+        };
+
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->hasMany('Comments');
+        $articles->Comments->getTarget()->belongsTo('Profiles', ['foreignKey' => 'user_id']);
+        $articles->belongsToMany('Tags', ['strategy' => Association::STRATEGY_SUBQUERY]);
+
+        $driver = $articles->getConnection()->getDriver();
+        $previousLogger = $driver->getLogger();
+        $driver->setLogger($logger);
+
+        try {
+            $articles->find()
+                ->contain(['Tags'])
+                ->innerJoinWith('Comments', fn(SelectQuery $q): SelectQuery => $q->innerJoinWith(
+                    'Profiles',
+                    fn(SelectQuery $q): SelectQuery => $q->where(['Profiles.last_name' => 'iglesias']),
+                ))
+                ->all()
+                ->toArray();
+        } finally {
+            if ($previousLogger) {
+                $driver->setLogger($previousLogger);
+            } else {
+                $driver->disableQueryLogging();
+            }
+        }
+
+        // The filtering subquery built for Tags is the only grouped statement the query above runs.
+        $grouped = array_filter(
+            $logger->messages,
+            fn(string $message): bool => str_contains($message, 'GROUP BY'),
+        );
+        $this->assertCount(1, $grouped, implode("\n", $logger->messages));
+
+        $sql = array_pop($grouped);
+        $this->assertSame(1, substr_count($sql, 'last_name'), $sql);
+    }
+
+    /**
+     * Test for https://github.com/cakephp/cakephp/issues/19609
+     *
+     * The subquery filter groups by the source binding key and inherits the query's LIMIT,
+     * so for an association that hangs off another association it describes a different set
+     * of keys than the rows the query returned.
+     */
+    public function testLimitedQueryLoadsNestedAssociationOfJoinedTable(): void
+    {
+        $comments = $this->getTableLocator()->get('Comments');
+        $comments->belongsTo('Articles');
+        $comments->Articles->getTarget()
+            ->belongsToMany('Tags', ['strategy' => Association::STRATEGY_SUBQUERY]);
+
+        $comment = $comments->find()
+            ->contain(['Articles' => ['Tags']])
+            ->orderBy(['Articles.id' => 'ASC'])
+            ->limit(1)
+            ->offset(1)
+            ->all()
+            ->first();
+
+        $this->assertSame(1, $comment->article->id);
+        $this->assertCount(2, $comment->article->tags);
     }
 }


### PR DESCRIPTION
Fixes #19608
Fixes #19609

Two defects in the eager loading subquery strategy, both surfacing since 5.4 made `subquery` the default for `hasMany`/`belongsToMany`.

### Nested matching conditions leaked into the parent join

`EagerLoader::setMatching()` spreads its shared options over every segment of the association path. When a nested matching is rebound from a surrogate query (`Association::_bindNewAssociations()`), those options carry the target's `queryBuilder`, so the parent association applied the target's conditions to its own join as well:

```sql
INNER JOIN comments Comments ON (Profiles.last_name = 'iglesias' AND Articles.id = Comments.article_id)
INNER JOIN profiles Profiles ON (Profiles.last_name = 'iglesias' AND Profiles.id = Comments.user_id)
```

The first build of a query escaped it, so it only surfaced once the query was cloned, which is what building a subquery strategy filter does. MySQL rejects the ON clause; SQLite resolves it and returns rows, which is why the regression test asserts on the generated SQL.

The builder now stays on the last association of the path.

### The subquery filter applied LIMIT to the grouped keys

The filter groups by the source binding key and inherits the query's `LIMIT`, so the limit cuts the distinct keys rather than the rows the query returned:

```sql
SELECT Comments.* FROM comments Comments
INNER JOIN (
  SELECT Authors.id AS Authors__id FROM articles Articles
  LEFT JOIN authors Authors ON Authors.id = Articles.author_id
  GROUP BY Authors.id LIMIT 10
) Authors ON Comments.user_id = Authors.Authors__id
```

Both sets only coincide while the association is owned by the query's own repository. Where it hangs off another association, many rows share one key, the derived table answers with a largely disjoint set of keys, and the association comes back empty with no error. Such loaders now fall back to the select strategy, which filters on the keys of the rows that were actually returned. The ordinary paginated listing case, where the association belongs to the primary table, keeps the subquery strategy.

This does not address #19595, which is a MariaDB optimizer issue with a different remedy.
