### PR TITLE
DeleteStrategy fixture strategy

### DIFF
--- a/src/TestSuite/Fixture/DeleteStrategy.php
+++ b/src/TestSuite/Fixture/DeleteStrategy.php
@@ -29,9 +29,10 @@ namespace Cake\TestSuite\Fixture;
  * a lot cheaper, so test suites with many fixtures can spend noticeably less time in
  * teardown with this strategy.
  *
- * The trade off is that `DELETE` does not reset auto increment counters. Tests that
- * assert on generated primary keys, or fixtures whose records rely on the counter
- * starting from 1 for each test, need `TruncateStrategy` instead.
+ * The trade off is that `DELETE` does not reset auto increment counters. Fixtures
+ * whose records omit their primary key, and which other fixtures or assertions then
+ * refer to by id, need that counter to start from 1 in every test and have to keep
+ * using `TruncateStrategy`.
  */
 class DeleteStrategy implements FixtureStrategyInterface
 {

--- a/src/TestSuite/Fixture/DeleteStrategy.php
+++ b/src/TestSuite/Fixture/DeleteStrategy.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite\Fixture;
+
+/**
+ * Fixture strategy that deletes all rows from the fixture tables at the end of test.
+ *
+ * A drop-in alternative to {@link \Cake\TestSuite\Fixture\TruncateStrategy}: fixtures are
+ * inserted before each test and the tables are emptied afterwards, without a wrapping
+ * transaction, so `afterCommit` listeners behave as they do in the application.
+ *
+ * `TRUNCATE` is a DDL statement, and on most database servers it does more work than
+ * removing the rows - InnoDB for example drops and recreates the tablespace of every
+ * table it is issued against. Deleting the handful of rows a fixture holds is usually
+ * a lot cheaper, so test suites with many fixtures can spend noticeably less time in
+ * teardown with this strategy.
+ *
+ * The trade off is that `DELETE` does not reset auto increment counters. Tests that
+ * assert on generated primary keys, or fixtures whose records rely on the counter
+ * starting from 1 for each test, need `TruncateStrategy` instead.
+ */
+class DeleteStrategy implements FixtureStrategyInterface
+{
+    /**
+     * @var \Cake\TestSuite\Fixture\FixtureHelper
+     */
+    protected FixtureHelper $helper;
+
+    /**
+     * @var array<\Cake\Datasource\FixtureInterface>
+     */
+    protected array $fixtures = [];
+
+    /**
+     * Initialize strategy.
+     */
+    public function __construct()
+    {
+        $this->helper = new FixtureHelper();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setupTest(array $fixtureNames): void
+    {
+        if (!$fixtureNames) {
+            return;
+        }
+
+        $this->fixtures = $this->helper->loadFixtures($fixtureNames);
+        $this->helper->insert($this->fixtures);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function teardownTest(): void
+    {
+        $this->helper->delete($this->fixtures);
+    }
+}

--- a/src/TestSuite/Fixture/DeleteStrategy.php
+++ b/src/TestSuite/Fixture/DeleteStrategy.php
@@ -34,12 +34,9 @@ namespace Cake\TestSuite\Fixture;
  * refer to by id, need that counter to start from 1 in every test and have to keep
  * using `TruncateStrategy`.
  *
- * Because `DELETE` is subject to foreign keys, the tables are emptied in the reverse of
- * the order the fixtures are inserted in. That order is not a topological sort of the
- * schema: it only separates the tables which have foreign keys from the tables which do
- * not. Whenever one of the fixture tables references another fixture table which itself
- * has foreign keys the order is abandoned and the rows are deleted with the constraints
- * disabled, exactly like `TruncateStrategy` does.
+ * Unlike `TRUNCATE`, `DELETE` is subject to foreign keys on every driver, so the rows
+ * are removed with the constraints disabled and the order of the fixtures does not
+ * matter.
  */
 class DeleteStrategy implements FixtureStrategyInterface
 {

--- a/src/TestSuite/Fixture/DeleteStrategy.php
+++ b/src/TestSuite/Fixture/DeleteStrategy.php
@@ -33,6 +33,13 @@ namespace Cake\TestSuite\Fixture;
  * whose records omit their primary key, and which other fixtures or assertions then
  * refer to by id, need that counter to start from 1 in every test and have to keep
  * using `TruncateStrategy`.
+ *
+ * Because `DELETE` is subject to foreign keys, the tables are emptied in the reverse of
+ * the order the fixtures are inserted in. That order is not a topological sort of the
+ * schema: it only separates the tables which have foreign keys from the tables which do
+ * not. Whenever one of the fixture tables references another fixture table which itself
+ * has foreign keys the order is abandoned and the rows are deleted with the constraints
+ * disabled, exactly like `TruncateStrategy` does.
  */
 class DeleteStrategy implements FixtureStrategyInterface
 {

--- a/src/TestSuite/Fixture/FixtureHelper.php
+++ b/src/TestSuite/Fixture/FixtureHelper.php
@@ -227,6 +227,65 @@ class FixtureHelper
     }
 
     /**
+     * Deletes the rows of the fixture tables.
+     *
+     * @param array<\Cake\Datasource\FixtureInterface> $fixtures Test fixtures
+     * @return void
+     * @since 5.5.0
+     * @internal
+     */
+    public function delete(array $fixtures): void
+    {
+        $this->runPerConnection(function (ConnectionInterface $connection, array $groupFixtures): void {
+            if (!$connection instanceof Connection) {
+                $this->truncateConnection($connection, $groupFixtures);
+
+                return;
+            }
+
+            // Unlike truncate, delete is subject to foreign keys on every driver, so the
+            // fixtures can be emptied in the reverse of their insertion order whenever
+            // they can be sorted. Constraints are only disabled when they cannot be.
+            $sortedFixtures = $this->sortByConstraint($connection, $groupFixtures);
+            if ($sortedFixtures !== null) {
+                $this->deleteConnection($connection, array_reverse($sortedFixtures));
+            } else {
+                ConnectionHelper::runWithoutConstraints(
+                    $connection,
+                    fn(Connection $connection) => $this->deleteConnection($connection, $groupFixtures),
+                );
+            }
+        }, $fixtures);
+    }
+
+    /**
+     * Deletes the rows of all fixtures for a connection and provides friendly errors for bad data.
+     *
+     * @param \Cake\Database\Connection $connection Fixture connection
+     * @param array<\Cake\Datasource\FixtureInterface> $fixtures Connection fixtures
+     * @return void
+     */
+    protected function deleteConnection(Connection $connection, array $fixtures): void
+    {
+        foreach ($fixtures as $fixture) {
+            try {
+                $connection->deleteQuery()
+                    ->delete($fixture->sourceName())
+                    ->execute()
+                    ->closeCursor();
+            } catch (PDOException $exception) {
+                $message = sprintf(
+                    'Unable to delete rows from table `%s`.'
+                        . " Fixture records might have invalid data or unknown constraints.\n%s",
+                    $fixture->sourceName(),
+                    $exception->getMessage(),
+                );
+                throw new CakeException($message);
+            }
+        }
+    }
+
+    /**
      * Sort fixtures with foreign constraints last if possible, otherwise returns null.
      *
      * @param \Cake\Database\Connection $connection Database connection

--- a/src/TestSuite/Fixture/FixtureHelper.php
+++ b/src/TestSuite/Fixture/FixtureHelper.php
@@ -244,8 +244,10 @@ class FixtureHelper
             }
 
             // Unlike truncate, delete is subject to foreign keys on every driver, so the
-            // fixtures can be emptied in the reverse of their insertion order whenever
-            // they can be sorted. Constraints are only disabled when they cannot be.
+            // fixtures are emptied in the reverse of the order they are inserted in.
+            // That order only covers foreign keys pointing at tables which have none of
+            // their own; sortByConstraint() gives up on anything deeper and the delete
+            // runs with the constraints disabled instead.
             $sortedFixtures = $this->sortByConstraint($connection, $groupFixtures);
             if ($sortedFixtures !== null) {
                 $this->deleteConnection($connection, array_reverse($sortedFixtures));
@@ -287,6 +289,13 @@ class FixtureHelper
 
     /**
      * Sort fixtures with foreign constraints last if possible, otherwise returns null.
+     *
+     * This is not a topological sort. The fixtures are only split into the tables which
+     * have foreign keys and the tables which do not, which is enough to order inserts as
+     * long as every foreign key points at a table without foreign keys of its own. As
+     * soon as one constrained table references another constrained table null is returned
+     * instead, even when the dependency graph is acyclic, and callers are expected to fall
+     * back to disabling the constraints.
      *
      * @param \Cake\Database\Connection $connection Database connection
      * @param array<\Cake\Datasource\FixtureInterface> $fixtures Database fixtures

--- a/src/TestSuite/Fixture/FixtureHelper.php
+++ b/src/TestSuite/Fixture/FixtureHelper.php
@@ -243,20 +243,12 @@ class FixtureHelper
                 return;
             }
 
-            // Unlike truncate, delete is subject to foreign keys on every driver, so the
-            // fixtures are emptied in the reverse of the order they are inserted in.
-            // That order only covers foreign keys pointing at tables which have none of
-            // their own; sortByConstraint() gives up on anything deeper and the delete
-            // runs with the constraints disabled instead.
-            $sortedFixtures = $this->sortByConstraint($connection, $groupFixtures);
-            if ($sortedFixtures !== null) {
-                $this->deleteConnection($connection, array_reverse($sortedFixtures));
-            } else {
-                ConnectionHelper::runWithoutConstraints(
-                    $connection,
-                    fn(Connection $connection) => $this->deleteConnection($connection, $groupFixtures),
-                );
-            }
+            // Unlike truncate, delete is subject to foreign keys on every driver, so
+            // the constraints are disabled rather than the fixtures ordered.
+            ConnectionHelper::runWithoutConstraints(
+                $connection,
+                fn(Connection $connection) => $this->deleteConnection($connection, $groupFixtures),
+            );
         }, $fixtures);
     }
 
@@ -289,13 +281,6 @@ class FixtureHelper
 
     /**
      * Sort fixtures with foreign constraints last if possible, otherwise returns null.
-     *
-     * This is not a topological sort. The fixtures are only split into the tables which
-     * have foreign keys and the tables which do not, which is enough to order inserts as
-     * long as every foreign key points at a table without foreign keys of its own. As
-     * soon as one constrained table references another constrained table null is returned
-     * instead, even when the dependency graph is acyclic, and callers are expected to fall
-     * back to disabling the constraints.
      *
      * @param \Cake\Database\Connection $connection Database connection
      * @param array<\Cake\Datasource\FixtureInterface> $fixtures Database fixtures

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -262,18 +262,25 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testGetTimestamp(): void
     {
-        $table = $this->getTableInstance();
-        $behavior = new TimestampBehavior($table);
+        $previousTestNow = DateTime::getTestNow();
+        $now = new DateTime('2026-01-01 12:00:00');
+        DateTime::setTestNow($now);
 
-        $return = $behavior->timestamp();
-        $this->assertInstanceOf(
-            DateTime::class,
-            $return,
-            'Should return a timestamp object',
-        );
+        try {
+            $table = $this->getTableInstance();
+            $behavior = new TimestampBehavior($table);
 
-        // Compare timestamps within tolerance to avoid flaky tests during slow CI runs
-        $this->assertEqualsWithDelta(time(), $return->getTimestamp(), 120);
+            $return = $behavior->timestamp();
+            $this->assertInstanceOf(
+                DateTime::class,
+                $return,
+                'Should return a timestamp object',
+            );
+
+            $this->assertSame($now->getTimestamp(), $return->getTimestamp());
+        } finally {
+            DateTime::setTestNow($previousTestNow);
+        }
     }
 
     /**

--- a/tests/TestCase/TestSuite/Fixture/DeleteStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/DeleteStrategyTest.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\TestSuite\Fixture;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\Fixture\DeleteStrategy;
+use Cake\TestSuite\TestCase;
+
+class DeleteStrategyTest extends TestCase
+{
+    protected array $fixtures = ['core.Articles'];
+
+    /**
+     * Tests delete strategy.
+     */
+    public function testStrategy(): void
+    {
+        /**
+         * @var \Cake\Database\Connection $connection
+         */
+        $connection = ConnectionManager::get('test');
+        $connection->deleteQuery()->delete('articles')->execute()->closeCursor();
+        $rows = $connection->selectQuery()->select('*')->from('articles')->execute();
+        $this->assertEmpty($rows->fetchAll());
+        $rows->closeCursor();
+
+        $strategy = new DeleteStrategy();
+        $strategy->setupTest(['core.Articles']);
+        $rows = $connection->selectQuery()->select('*')->from('articles')->execute();
+        $this->assertNotEmpty($rows->fetchAll());
+        $rows->closeCursor();
+
+        $strategy->teardownTest();
+        $rows = $connection->selectQuery()->select('*')->from('articles')->execute();
+        $this->assertEmpty($rows->fetchAll());
+        $rows->closeCursor();
+    }
+
+    /**
+     * Tests that tables referenced by other fixtures can be emptied.
+     */
+    public function testStrategyWithConstraints(): void
+    {
+        /**
+         * @var \Cake\Database\Connection $connection
+         */
+        $connection = ConnectionManager::get('test');
+
+        $strategy = new DeleteStrategy();
+        $strategy->setupTest(['core.Articles', 'core.ArticlesTags', 'core.Tags']);
+        $strategy->teardownTest();
+
+        foreach (['articles', 'articles_tags', 'tags'] as $table) {
+            $rows = $connection->selectQuery()->select('*')->from($table)->execute();
+            $this->assertEmpty($rows->fetchAll(), sprintf('Table `%s` was not emptied.', $table));
+            $rows->closeCursor();
+        }
+    }
+
+    /**
+     * Tests that no fixtures is a no-op.
+     */
+    public function testStrategyWithoutFixtures(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $strategy = new DeleteStrategy();
+        $strategy->setupTest([]);
+        $strategy->teardownTest();
+    }
+}

--- a/tests/TestCase/TestSuite/Fixture/DeleteStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/DeleteStrategyTest.php
@@ -16,63 +16,64 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\TestSuite\Fixture;
 
+use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\DeleteStrategy;
 use Cake\TestSuite\TestCase;
 
 class DeleteStrategyTest extends TestCase
 {
-    protected array $fixtures = ['core.Articles'];
+    /**
+     * The tables the strategy is exercised against are declared as fixtures so that
+     * the default truncate strategy resets their identity counters once the test is
+     * done. Deleting rows does not reset them, and the records of these fixtures
+     * have no explicit ids.
+     *
+     * @var array<string>
+     */
+    protected array $fixtures = ['core.Articles', 'core.Products', 'core.Orders'];
 
     /**
      * Tests delete strategy.
      */
     public function testStrategy(): void
     {
-        /**
-         * @var \Cake\Database\Connection $connection
-         */
         $connection = ConnectionManager::get('test');
-        $connection->deleteQuery()->delete('articles')->execute()->closeCursor();
-        $rows = $connection->selectQuery()->select('*')->from('articles')->execute();
-        $this->assertEmpty($rows->fetchAll());
-        $rows->closeCursor();
+        assert($connection instanceof Connection);
+        $this->emptyTables($connection);
 
         $strategy = new DeleteStrategy();
         $strategy->setupTest(['core.Articles']);
-        $rows = $connection->selectQuery()->select('*')->from('articles')->execute();
-        $this->assertNotEmpty($rows->fetchAll());
-        $rows->closeCursor();
+        $this->assertNotEmpty($this->readTable($connection, 'articles'));
 
         $strategy->teardownTest();
-        $rows = $connection->selectQuery()->select('*')->from('articles')->execute();
-        $this->assertEmpty($rows->fetchAll());
-        $rows->closeCursor();
+        $this->assertEmpty($this->readTable($connection, 'articles'));
     }
 
     /**
-     * Tests that tables referenced by other fixtures can be emptied.
+     * Tests that fixtures referencing each other can be emptied.
      */
     public function testStrategyWithConstraints(): void
     {
-        /**
-         * @var \Cake\Database\Connection $connection
-         */
         $connection = ConnectionManager::get('test');
+        assert($connection instanceof Connection);
+        $this->emptyTables($connection);
 
+        // Orders has a foreign key to products, so it has to be emptied first.
         $strategy = new DeleteStrategy();
-        $strategy->setupTest(['core.Articles', 'core.ArticlesTags', 'core.Tags']);
-        $strategy->teardownTest();
+        $strategy->setupTest(['core.Orders', 'core.Products']);
+        foreach (['products', 'orders'] as $table) {
+            $this->assertNotEmpty($this->readTable($connection, $table), "Table `{$table}` has no rows.");
+        }
 
-        foreach (['articles', 'articles_tags', 'tags'] as $table) {
-            $rows = $connection->selectQuery()->select('*')->from($table)->execute();
-            $this->assertEmpty($rows->fetchAll(), sprintf('Table `%s` was not emptied.', $table));
-            $rows->closeCursor();
+        $strategy->teardownTest();
+        foreach (['products', 'orders'] as $table) {
+            $this->assertEmpty($this->readTable($connection, $table), "Table `{$table}` was not emptied.");
         }
     }
 
     /**
-     * Tests that no fixtures is a no-op.
+     * Tests that a test without fixtures is a no-op.
      */
     public function testStrategyWithoutFixtures(): void
     {
@@ -81,5 +82,33 @@ class DeleteStrategyTest extends TestCase
         $strategy = new DeleteStrategy();
         $strategy->setupTest([]);
         $strategy->teardownTest();
+    }
+
+    /**
+     * Removes the rows inserted by this test case's fixtures, children first.
+     *
+     * @param \Cake\Database\Connection $connection Test connection
+     * @return void
+     */
+    protected function emptyTables(Connection $connection): void
+    {
+        foreach (['orders', 'products', 'articles'] as $table) {
+            $connection->deleteQuery()->delete($table)->execute()->closeCursor();
+            $this->assertEmpty($this->readTable($connection, $table));
+        }
+    }
+
+    /**
+     * @param \Cake\Database\Connection $connection Test connection
+     * @param string $table Table name
+     * @return array
+     */
+    protected function readTable(Connection $connection, string $table): array
+    {
+        $statement = $connection->selectQuery()->select('*')->from($table)->execute();
+        $rows = $statement->fetchAll();
+        $statement->closeCursor();
+
+        return $rows;
     }
 }

--- a/tests/TestCase/TestSuite/Fixture/DeleteStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/DeleteStrategyTest.php
@@ -85,6 +85,87 @@ class DeleteStrategyTest extends TestCase
     }
 
     /**
+     * Deleting rows does not reset identity counters, so fixtures which omit their
+     * primary key get fresh ids on every cycle. This is the documented trade off of
+     * the strategy, and the reason `TruncateStrategy` stays the default.
+     */
+    public function testStrategyDoesNotResetIdentityCounters(): void
+    {
+        $connection = ConnectionManager::get('test');
+        assert($connection instanceof Connection);
+        $this->emptyTables($connection);
+
+        // The articles fixture records have no explicit ids.
+        $strategy = new DeleteStrategy();
+        $strategy->setupTest(['core.Articles']);
+        $firstIds = $this->readIds($connection, 'articles');
+        $strategy->teardownTest();
+
+        $strategy->setupTest(['core.Articles']);
+        $secondIds = $this->readIds($connection, 'articles');
+
+        $this->assertCount(3, $firstIds);
+        $this->assertCount(3, $secondIds);
+        $this->assertGreaterThan(
+            max($firstIds),
+            min($secondIds),
+            'The identity counter is expected to keep counting across setup cycles.',
+        );
+
+        // A row inserted without an id during the test continues from there rather
+        // than colliding with the fixture records.
+        $connection->insertQuery()
+            ->insert(['author_id', 'title', 'body', 'published'])
+            ->into('articles')
+            ->values(['author_id' => 1, 'title' => 'Fourth', 'body' => 'Body', 'published' => 'Y'])
+            ->execute()
+            ->closeCursor();
+
+        $ids = $this->readIds($connection, 'articles');
+        $this->assertCount(4, $ids);
+        $this->assertGreaterThan(max($secondIds), max($ids));
+
+        $strategy->teardownTest();
+        $this->assertEmpty($this->readTable($connection, 'articles'));
+    }
+
+    /**
+     * Fixtures whose records carry explicit ids are unaffected, and come back
+     * unchanged on every cycle.
+     */
+    public function testStrategyKeepsExplicitIdsStable(): void
+    {
+        $connection = ConnectionManager::get('test');
+        assert($connection instanceof Connection);
+        $this->emptyTables($connection);
+
+        $strategy = new DeleteStrategy();
+        $strategy->setupTest(['core.Products']);
+        $firstIds = $this->readIds($connection, 'products');
+        $strategy->teardownTest();
+
+        $strategy->setupTest(['core.Products']);
+        $secondIds = $this->readIds($connection, 'products');
+        $strategy->teardownTest();
+
+        $this->assertSame([1, 2, 3], $firstIds);
+        $this->assertSame($firstIds, $secondIds);
+    }
+
+    /**
+     * @param \Cake\Database\Connection $connection Test connection
+     * @param string $table Table name
+     * @return array<int>
+     */
+    protected function readIds(Connection $connection, string $table): array
+    {
+        $ids = array_map(intval(...), array_column($this->readTable($connection, $table), 'id'));
+        sort($ids);
+
+        return $ids;
+    }
+
+    /**
      * Removes the rows inserted by this test case's fixtures, children first.
      *
      * @param \Cake\Database\Connection $connection Test connection
@@ -106,7 +187,7 @@ class DeleteStrategyTest extends TestCase
     protected function readTable(Connection $connection, string $table): array
     {
         $statement = $connection->selectQuery()->select('*')->from($table)->execute();
-        $rows = $statement->fetchAll();
+        $rows = $statement->fetchAll('assoc');
         $statement->closeCursor();
 
         return $rows;

--- a/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\TestSuite\Fixture;
 
 use Cake\Core\Exception\CakeException;
 use Cake\Database\Connection;
+use Cake\Database\Query\DeleteQuery;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
@@ -76,6 +77,7 @@ class FixtureHelperTest extends TestCase
         ConnectionManager::dropAlias('test1');
         ConnectionManager::dropAlias('test2');
         ConnectionManager::drop('fake');
+        ConnectionManager::drop('failing');
         $this->dropNestedTables();
     }
 
@@ -329,15 +331,31 @@ class FixtureHelperTest extends TestCase
 
     /**
      * Tests handling PDO errors when deleting rows.
+     *
+     * The error is raised by the connection rather than by deleting from a table which
+     * does not exist, the way the insert and truncate tests above raise theirs from the
+     * fixture. Postgres can only defer constraints inside a transaction, and a statement
+     * failing there aborts it, so restoring the constraints afterwards would fail too and
+     * mask the error this is about.
      */
     public function testDeleteFixturesException(): void
     {
+        ConnectionManager::setConfig('failing', new class (ConnectionManager::get('test')->config()) extends Connection {
+            public function deleteQuery(
+                ?string $table = null,
+                array $conditions = [],
+                array $types = [],
+            ): DeleteQuery {
+                throw new PDOException('Missing key');
+            }
+        });
+
         $fixture = new class extends TestFixture {
-            public string $table = 'this_table_does_not_exist';
+            public string $table = 'articles';
 
             public function connection(): string
             {
-                return 'test';
+                return 'failing';
             }
 
             protected function _schemaFromReflection(): void
@@ -346,7 +364,7 @@ class FixtureHelperTest extends TestCase
         };
 
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('Unable to delete rows from table `this_table_does_not_exist`.');
+        $this->expectExceptionMessage('Unable to delete rows from table `articles`.');
         (new FixtureHelper())->delete([$fixture]);
     }
 

--- a/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
@@ -42,6 +42,15 @@ class FixtureHelperTest extends TestCase
     public const SELF_REFERENCING_TABLE = 'fixture_selves';
 
     /**
+     * The primary key of those tables.
+     *
+     * Deliberately not named `id`: every dialect turns a lone integer primary key which
+     * is named `id` into an auto increment column, and sqlserver then rejects the
+     * explicit keys these fixtures carry unless IDENTITY_INSERT is switched on.
+     */
+    public const PRIMARY_KEY = 'pk';
+
+    /**
      * The chain of tables created on demand by the delete tests, parents first.
      *
      * @var array<string>
@@ -500,8 +509,8 @@ class FixtureHelperTest extends TestCase
             public string $table = FixtureHelperTest::SELF_REFERENCING_TABLE;
 
             public array $records = [
-                ['id' => 1, 'parent_id' => null],
-                ['id' => 2, 'parent_id' => 1],
+                [FixtureHelperTest::PRIMARY_KEY => 1, 'parent_id' => null],
+                [FixtureHelperTest::PRIMARY_KEY => 2, 'parent_id' => 1],
             ];
 
             public function connection(): string
@@ -529,13 +538,13 @@ class FixtureHelperTest extends TestCase
         $schemas = [];
         $parent = null;
         foreach ($this->nestedTables as $table) {
-            $columns = ['id' => ['type' => 'integer']];
+            $columns = [static::PRIMARY_KEY => ['type' => 'integer', 'null' => false]];
             if ($parent !== null) {
                 $columns['parent_id'] = ['type' => 'integer', 'null' => false];
             }
 
             $schema = new TableSchema($table, $columns);
-            $schema->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']]);
+            $schema->addConstraint('primary', ['type' => 'primary', 'columns' => [static::PRIMARY_KEY]]);
             if ($parent !== null) {
                 // No cascades: sqlserver rejects them on self references, and the
                 // point of these tables is that the rows cannot go unless the
@@ -543,7 +552,7 @@ class FixtureHelperTest extends TestCase
                 $schema->addConstraint("{$table}_parent_id_fk", [
                     'type' => 'foreign',
                     'columns' => ['parent_id'],
-                    'references' => [$parent, 'id'],
+                    'references' => [$parent, static::PRIMARY_KEY],
                     'update' => 'noAction',
                     'delete' => 'noAction',
                 ]);
@@ -555,14 +564,14 @@ class FixtureHelperTest extends TestCase
 
         // A table referencing itself, the other shape a fixture order cannot cover.
         $self = new TableSchema(static::SELF_REFERENCING_TABLE, [
-            'id' => ['type' => 'integer'],
+            static::PRIMARY_KEY => ['type' => 'integer', 'null' => false],
             'parent_id' => ['type' => 'integer', 'null' => true],
         ]);
-        $self->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']]);
+        $self->addConstraint('primary', ['type' => 'primary', 'columns' => [static::PRIMARY_KEY]]);
         $self->addConstraint(static::SELF_REFERENCING_TABLE . '_parent_id_fk', [
             'type' => 'foreign',
             'columns' => ['parent_id'],
-            'references' => [static::SELF_REFERENCING_TABLE, 'id'],
+            'references' => [static::SELF_REFERENCING_TABLE, static::PRIMARY_KEY],
             'update' => 'noAction',
             'delete' => 'noAction',
         ]);
@@ -616,7 +625,7 @@ class FixtureHelperTest extends TestCase
         $fixtures = [];
         $parent = null;
         foreach ($this->nestedTables as $table) {
-            $record = ['id' => 1];
+            $record = [static::PRIMARY_KEY => 1];
             if ($parent !== null) {
                 $record['parent_id'] = 1;
             }

--- a/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\TestSuite\Fixture;
 
 use Cake\Core\Exception\CakeException;
 use Cake\Database\Connection;
+use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\Test\Fixture\ArticlesFixture;
@@ -26,6 +27,7 @@ use Cake\TestSuite\Fixture\TestFixture;
 use Cake\TestSuite\TestCase;
 use Company\TestPluginThree\Test\Fixture\ArticlesFixture as CompanyArticlesFixture;
 use PDOException;
+use TestApp\Datasource\FakeConnection;
 use TestApp\Test\Fixture\ArticlesFixture as AppArticlesFixture;
 use TestPlugin\Test\Fixture\ArticlesFixture as PluginArticlesFixture;
 use TestPlugin\Test\Fixture\Blog\CommentsFixture as PluginCommentsFixture;
@@ -33,7 +35,36 @@ use UnexpectedValueException;
 
 class FixtureHelperTest extends TestCase
 {
-    protected array $fixtures = ['core.Articles'];
+    /**
+     * A table holding a foreign key to itself, created on demand by the delete tests.
+     */
+    public const SELF_REFERENCING_TABLE = 'fixture_selves';
+
+    /**
+     * The chain of tables created on demand by the delete tests, parents first.
+     *
+     * @var array<string>
+     */
+    protected array $nestedTables = [
+        'fixture_grandparents',
+        'fixture_parents',
+        'fixture_children',
+    ];
+
+    /**
+     * Whether those tables have to be dropped on teardown.
+     */
+    protected bool $nestedTablesCreated = false;
+
+    /**
+     * `Orders` and `Products` are only used by the delete tests below, but they are
+     * declared here so that the default truncate strategy resets their identity
+     * counters afterwards. Deleting rows does not reset them, and the records of the
+     * orders fixture have no explicit ids.
+     *
+     * @var array<string>
+     */
+    protected array $fixtures = ['core.Articles', 'core.Products', 'core.Orders'];
 
     /**
      * Clean up after test.
@@ -44,6 +75,8 @@ class FixtureHelperTest extends TestCase
         $this->clearPlugins();
         ConnectionManager::dropAlias('test1');
         ConnectionManager::dropAlias('test2');
+        ConnectionManager::drop('fake');
+        $this->dropNestedTables();
     }
 
     /**
@@ -272,5 +305,390 @@ class FixtureHelperTest extends TestCase
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Unable to truncate table `');
         $helper->truncate([$fixture]);
+    }
+
+    /**
+     * Tests deleting the rows of fixtures.
+     */
+    public function testDeleteFixtures(): void
+    {
+        /**
+         * @var \Cake\Database\Connection $connection
+         */
+        $connection = ConnectionManager::get('test');
+        $rows = $connection->selectQuery()->select('*')->from('articles')->execute();
+        $this->assertNotEmpty($rows->fetchAll());
+        $rows->closeCursor();
+
+        $helper = new FixtureHelper();
+        $helper->delete($helper->loadFixtures(['core.Articles']));
+        $rows = $connection->selectQuery()->select('*')->from('articles')->execute();
+        $this->assertEmpty($rows->fetchAll());
+        $rows->closeCursor();
+    }
+
+    /**
+     * Tests handling PDO errors when deleting rows.
+     */
+    public function testDeleteFixturesException(): void
+    {
+        $fixture = new class extends TestFixture {
+            public string $table = 'this_table_does_not_exist';
+
+            public function connection(): string
+            {
+                return 'test';
+            }
+
+            protected function _schemaFromReflection(): void
+            {
+            }
+        };
+
+        $helper = new class extends FixtureHelper {
+            protected function sortByConstraint(Connection $connection, array $fixtures): ?array
+            {
+                return $fixtures;
+            }
+        };
+
+        $this->expectException(CakeException::class);
+        $this->expectExceptionMessage('Unable to delete rows from table `this_table_does_not_exist`.');
+        $helper->delete([$fixture]);
+    }
+
+    /**
+     * Connections which are not database connections have no delete query builder,
+     * so they keep going through FixtureInterface::truncate().
+     */
+    public function testDeleteFixturesWithoutDatabaseConnection(): void
+    {
+        ConnectionManager::setConfig('fake', ['className' => FakeConnection::class]);
+
+        $fixture = new class extends TestFixture {
+            public bool $truncated = false;
+
+            public function connection(): string
+            {
+                return 'fake';
+            }
+
+            protected function _schemaFromReflection(): void
+            {
+            }
+
+            public function truncate(ConnectionInterface $connection): bool
+            {
+                $this->truncated = true;
+
+                return true;
+            }
+        };
+
+        (new FixtureHelper())->delete([$fixture]);
+        $this->assertTrue($fixture->truncated);
+    }
+
+    /**
+     * Tests that fixtures are deleted once per connection.
+     */
+    public function testDeleteFixturesPerConnection(): void
+    {
+        ConnectionManager::alias('test', 'test1');
+        ConnectionManager::alias('test', 'test2');
+
+        $articles = new class extends TestFixture {
+            public string $table = 'articles';
+
+            public function connection(): string
+            {
+                return 'test1';
+            }
+        };
+        $orders = new class extends TestFixture {
+            public string $table = 'orders';
+
+            public function connection(): string
+            {
+                return 'test2';
+            }
+        };
+
+        /**
+         * @var \Cake\Database\Connection $connection
+         */
+        $connection = ConnectionManager::get('test');
+        foreach (['articles', 'orders'] as $table) {
+            $this->assertNotEmpty($this->readTable($connection, $table), "Table `{$table}` has no rows.");
+        }
+
+        (new FixtureHelper())->delete([$articles, $orders]);
+        foreach (['articles', 'orders'] as $table) {
+            $this->assertEmpty($this->readTable($connection, $table), "Table `{$table}` was not emptied.");
+        }
+    }
+
+    /**
+     * Tests that fixture tables referencing a table without foreign keys of its own
+     * are emptied in the reverse of their insertion order, constraints left enabled.
+     */
+    public function testDeleteFixturesWithConstraints(): void
+    {
+        /**
+         * @var \Cake\Database\Connection $connection
+         */
+        $connection = ConnectionManager::get('test');
+        foreach (['products', 'orders'] as $table) {
+            $this->assertNotEmpty($this->readTable($connection, $table), "Table `{$table}` has no rows.");
+        }
+
+        // Orders references products, which references nothing, so the fixtures sort.
+        $helper = new FixtureHelper();
+        $helper->delete($helper->loadFixtures(['core.Orders', 'core.Products']));
+        foreach (['products', 'orders'] as $table) {
+            $this->assertEmpty($this->readTable($connection, $table), "Table `{$table}` was not emptied.");
+        }
+    }
+
+    /**
+     * sortByConstraint() only separates the tables which have foreign keys from the
+     * tables which do not, so a table referencing another constrained table cannot be
+     * ordered even though the graph is acyclic.
+     */
+    public function testSortByConstraintGivesUpOnNestedConstraints(): void
+    {
+        /**
+         * @var \Cake\Database\Connection $connection
+         */
+        $connection = ConnectionManager::get('test');
+        $this->createNestedTables($connection);
+
+        $helper = $this->sortingHelper();
+        $fixtures = $this->nestedFixtures();
+        $this->assertNull(
+            $helper->sortFixtures($connection, $fixtures),
+            'Nested constraints are expected to be reported as unsortable.',
+        );
+
+        // The same fixtures without the deepest table are one level only, and do sort.
+        array_pop($fixtures);
+        $this->assertNotNull($helper->sortFixtures($connection, $fixtures));
+    }
+
+    /**
+     * Tests that fixtures which cannot be sorted are deleted with the constraints
+     * disabled instead.
+     */
+    public function testDeleteFixturesWithNestedConstraints(): void
+    {
+        /**
+         * @var \Cake\Database\Connection $connection
+         */
+        $connection = ConnectionManager::get('test');
+        $this->createNestedTables($connection);
+
+        $helper = new FixtureHelper();
+        $fixtures = $this->nestedFixtures();
+        $helper->insert($fixtures);
+        foreach ($this->nestedTables as $table) {
+            $this->assertNotEmpty($this->readTable($connection, $table), "Table `{$table}` has no rows.");
+        }
+
+        $helper->delete($fixtures);
+        foreach ($this->nestedTables as $table) {
+            $this->assertEmpty($this->readTable($connection, $table), "Table `{$table}` was not emptied.");
+        }
+    }
+
+    /**
+     * A table holding a foreign key to itself cannot be sorted either, so its rows are
+     * deleted with the constraints disabled.
+     */
+    public function testDeleteFixturesWithSelfReferencingConstraint(): void
+    {
+        /**
+         * @var \Cake\Database\Connection $connection
+         */
+        $connection = ConnectionManager::get('test');
+        $this->createNestedTables($connection);
+
+        $table = static::SELF_REFERENCING_TABLE;
+        $fixture = new class extends TestFixture {
+            public string $table = FixtureHelperTest::SELF_REFERENCING_TABLE;
+
+            public array $records = [
+                ['id' => 1, 'parent_id' => null],
+                ['id' => 2, 'parent_id' => 1],
+            ];
+
+            public function connection(): string
+            {
+                return 'test';
+            }
+        };
+
+        $this->assertNull(
+            $this->sortingHelper()->sortFixtures($connection, [$fixture]),
+            'A self referencing table is expected to be reported as unsortable.',
+        );
+
+        $helper = new FixtureHelper();
+        $helper->insert([$fixture]);
+        $this->assertCount(2, $this->readTable($connection, $table));
+
+        $helper->delete([$fixture]);
+        $this->assertEmpty($this->readTable($connection, $table), "Table `{$table}` was not emptied.");
+    }
+
+    /**
+     * A helper exposing the protected sorting used to decide whether the constraints
+     * have to be disabled.
+     *
+     * @return \Cake\TestSuite\Fixture\FixtureHelper
+     */
+    protected function sortingHelper(): FixtureHelper
+    {
+        return new class extends FixtureHelper {
+            public function sortFixtures(Connection $connection, array $fixtures): ?array
+            {
+                return $this->sortByConstraint($connection, $fixtures);
+            }
+        };
+    }
+
+    /**
+     * Builds a three level chain of tables, so that the middle table both has a foreign
+     * key and is referenced by one, plus a table holding a foreign key to itself.
+     *
+     * @return array<\Cake\Database\Schema\TableSchema>
+     */
+    protected function nestedTableSchemas(): array
+    {
+        $schemas = [];
+        $parent = null;
+        foreach ($this->nestedTables as $table) {
+            $columns = ['id' => ['type' => 'integer']];
+            if ($parent !== null) {
+                $columns['parent_id'] = ['type' => 'integer', 'null' => false];
+            }
+
+            $schema = new TableSchema($table, $columns);
+            $schema->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']]);
+            if ($parent !== null) {
+                // No cascades: sqlserver rejects them on self references, and the
+                // point of these tables is that the rows cannot go without the
+                // constraints being disabled.
+                $schema->addConstraint("{$table}_parent_id_fk", [
+                    'type' => 'foreign',
+                    'columns' => ['parent_id'],
+                    'references' => [$parent, 'id'],
+                    'update' => 'noAction',
+                    'delete' => 'noAction',
+                ]);
+            }
+
+            $schemas[] = $schema;
+            $parent = $table;
+        }
+
+        // A table referencing itself is reported as unsortable for the same reason.
+        $self = new TableSchema(static::SELF_REFERENCING_TABLE, [
+            'id' => ['type' => 'integer'],
+            'parent_id' => ['type' => 'integer', 'null' => true],
+        ]);
+        $self->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']]);
+        $self->addConstraint(static::SELF_REFERENCING_TABLE . '_parent_id_fk', [
+            'type' => 'foreign',
+            'columns' => ['parent_id'],
+            'references' => [static::SELF_REFERENCING_TABLE, 'id'],
+            'update' => 'noAction',
+            'delete' => 'noAction',
+        ]);
+        $schemas[] = $self;
+
+        return $schemas;
+    }
+
+    /**
+     * @param \Cake\Database\Connection $connection Test connection
+     * @return void
+     */
+    protected function createNestedTables(Connection $connection): void
+    {
+        foreach ($this->nestedTableSchemas() as $schema) {
+            foreach ($schema->createSql($connection) as $sql) {
+                $connection->execute($sql);
+            }
+        }
+        $this->nestedTablesCreated = true;
+    }
+
+    /**
+     * @return void
+     */
+    protected function dropNestedTables(): void
+    {
+        if (!$this->nestedTablesCreated) {
+            return;
+        }
+
+        /**
+         * @var \Cake\Database\Connection $connection
+         */
+        $connection = ConnectionManager::get('test');
+        foreach (array_reverse($this->nestedTableSchemas()) as $schema) {
+            foreach ($schema->dropSql($connection) as $sql) {
+                $connection->execute($sql);
+            }
+        }
+        $this->nestedTablesCreated = false;
+    }
+
+    /**
+     * One fixture per nested table, parents first.
+     *
+     * @return array<\Cake\Datasource\FixtureInterface>
+     */
+    protected function nestedFixtures(): array
+    {
+        $fixtures = [];
+        $parent = null;
+        foreach ($this->nestedTables as $table) {
+            $record = ['id' => 1];
+            if ($parent !== null) {
+                $record['parent_id'] = 1;
+            }
+
+            $fixtures[] = new class ($table, $record) extends TestFixture {
+                public function __construct(string $table, array $record)
+                {
+                    $this->table = $table;
+                    $this->records = [$record];
+                    parent::__construct();
+                }
+
+                public function connection(): string
+                {
+                    return 'test';
+                }
+            };
+            $parent = $table;
+        }
+
+        return $fixtures;
+    }
+
+    /**
+     * @param \Cake\Database\Connection $connection Test connection
+     * @param string $table Table name
+     * @return array
+     */
+    protected function readTable(Connection $connection, string $table): array
+    {
+        $statement = $connection->selectQuery()->select('*')->from($table)->execute();
+        $rows = $statement->fetchAll('assoc');
+        $statement->closeCursor();
+
+        return $rows;
     }
 }

--- a/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
@@ -345,16 +345,9 @@ class FixtureHelperTest extends TestCase
             }
         };
 
-        $helper = new class extends FixtureHelper {
-            protected function sortByConstraint(Connection $connection, array $fixtures): ?array
-            {
-                return $fixtures;
-            }
-        };
-
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Unable to delete rows from table `this_table_does_not_exist`.');
-        $helper->delete([$fixture]);
+        (new FixtureHelper())->delete([$fixture]);
     }
 
     /**
@@ -429,8 +422,7 @@ class FixtureHelperTest extends TestCase
     }
 
     /**
-     * Tests that fixture tables referencing a table without foreign keys of its own
-     * are emptied in the reverse of their insertion order, constraints left enabled.
+     * Tests that fixture tables referencing each other are emptied.
      */
     public function testDeleteFixturesWithConstraints(): void
     {
@@ -442,7 +434,7 @@ class FixtureHelperTest extends TestCase
             $this->assertNotEmpty($this->readTable($connection, $table), "Table `{$table}` has no rows.");
         }
 
-        // Orders references products, which references nothing, so the fixtures sort.
+        // Orders references products, so the rows cannot go in fixture order.
         $helper = new FixtureHelper();
         $helper->delete($helper->loadFixtures(['core.Orders', 'core.Products']));
         foreach (['products', 'orders'] as $table) {
@@ -451,33 +443,7 @@ class FixtureHelperTest extends TestCase
     }
 
     /**
-     * sortByConstraint() only separates the tables which have foreign keys from the
-     * tables which do not, so a table referencing another constrained table cannot be
-     * ordered even though the graph is acyclic.
-     */
-    public function testSortByConstraintGivesUpOnNestedConstraints(): void
-    {
-        /**
-         * @var \Cake\Database\Connection $connection
-         */
-        $connection = ConnectionManager::get('test');
-        $this->createNestedTables($connection);
-
-        $helper = $this->sortingHelper();
-        $fixtures = $this->nestedFixtures();
-        $this->assertNull(
-            $helper->sortFixtures($connection, $fixtures),
-            'Nested constraints are expected to be reported as unsortable.',
-        );
-
-        // The same fixtures without the deepest table are one level only, and do sort.
-        array_pop($fixtures);
-        $this->assertNotNull($helper->sortFixtures($connection, $fixtures));
-    }
-
-    /**
-     * Tests that fixtures which cannot be sorted are deleted with the constraints
-     * disabled instead.
+     * Tests that a chain of foreign keys deeper than one level is emptied too.
      */
     public function testDeleteFixturesWithNestedConstraints(): void
     {
@@ -501,8 +467,7 @@ class FixtureHelperTest extends TestCase
     }
 
     /**
-     * A table holding a foreign key to itself cannot be sorted either, so its rows are
-     * deleted with the constraints disabled.
+     * Tests that a table holding a foreign key to itself is emptied too.
      */
     public function testDeleteFixturesWithSelfReferencingConstraint(): void
     {
@@ -527,33 +492,12 @@ class FixtureHelperTest extends TestCase
             }
         };
 
-        $this->assertNull(
-            $this->sortingHelper()->sortFixtures($connection, [$fixture]),
-            'A self referencing table is expected to be reported as unsortable.',
-        );
-
         $helper = new FixtureHelper();
         $helper->insert([$fixture]);
         $this->assertCount(2, $this->readTable($connection, $table));
 
         $helper->delete([$fixture]);
         $this->assertEmpty($this->readTable($connection, $table), "Table `{$table}` was not emptied.");
-    }
-
-    /**
-     * A helper exposing the protected sorting used to decide whether the constraints
-     * have to be disabled.
-     *
-     * @return \Cake\TestSuite\Fixture\FixtureHelper
-     */
-    protected function sortingHelper(): FixtureHelper
-    {
-        return new class extends FixtureHelper {
-            public function sortFixtures(Connection $connection, array $fixtures): ?array
-            {
-                return $this->sortByConstraint($connection, $fixtures);
-            }
-        };
     }
 
     /**
@@ -576,8 +520,8 @@ class FixtureHelperTest extends TestCase
             $schema->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']]);
             if ($parent !== null) {
                 // No cascades: sqlserver rejects them on self references, and the
-                // point of these tables is that the rows cannot go without the
-                // constraints being disabled.
+                // point of these tables is that the rows cannot go unless the
+                // constraints are disabled.
                 $schema->addConstraint("{$table}_parent_id_fk", [
                     'type' => 'foreign',
                     'columns' => ['parent_id'],
@@ -591,7 +535,7 @@ class FixtureHelperTest extends TestCase
             $parent = $table;
         }
 
-        // A table referencing itself is reported as unsortable for the same reason.
+        // A table referencing itself, the other shape a fixture order cannot cover.
         $self = new TableSchema(static::SELF_REFERENCING_TABLE, [
             'id' => ['type' => 'integer'],
             'parent_id' => ['type' => 'integer', 'null' => true],


### PR DESCRIPTION
## What

Adds `Cake\TestSuite\Fixture\DeleteStrategy`, a drop-in alternative to `TruncateStrategy` that empties fixture tables with `DELETE FROM` instead of `TRUNCATE`, backed by a new `FixtureHelper::delete()`. Opt in via `TestSuite.fixtureStrategy`; `TruncateStrategy` stays the default.

## Why

`TRUNCATE` is DDL and is much more expensive than deleting a few rows (InnoDB drops and recreates the tablespace). It runs once per fixture per test, so on suites with many fixtures it dominates teardown. Switching to `DELETE` removed a large part of our application's test run time.

## How

`FixtureHelper::delete()` mirrors `truncate()`, but runs inside `ConnectionHelper::runWithoutConstraints()` because `DELETE` is subject to foreign keys on every driver. Fixture order therefore does not matter and no ordering is attempted.

Non-`Cake\Database\Connection` connections still go through `FixtureInterface::truncate()`. As with `TruncateStrategy` there is no wrapping transaction, so `afterCommit` listeners keep firing.

## Trade off

`DELETE` does not reset auto increment counters. Fixtures that omit their primary keys and are referenced by id elsewhere (e.g. core `TagsFixture` / `ArticlesTagsFixture`) must keep using `TruncateStrategy`.

## Open questions

- Should the SQL live in the strategy instead of `FixtureHelper::delete()`?
- Worth a `DriverFeatureEnum` opt out for drivers where `DELETE` has no advantage?
- Should the strategy reset auto increment counters (`ALTER SEQUENCE ... RESTART` / `AUTO_INCREMENT = 1`) instead of documenting the caveat?
- Docs PR to follow if the approach is accepted.

## Testing

`DeleteStrategyTest` and `FixtureHelperTest` cover the error path, non-database connections, multiple connections, multi-level and self-referencing foreign keys, and identity counters across setup/teardown cycles. CI is green on SQLite, MySQL, MariaDB, PostgreSQL and SQL Server.

Also fixes `TimestampBehaviorTest::testGetTimestamp()`, which compared the clock frozen in `tests/bootstrap.php` against `time()` and failed once the coverage run exceeded its 120s tolerance. It now freezes the clock inside the test. Happy to split this out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsnYRGVfNH35sAjvEZy1G9
