### PR TITLE
Add charset attribute to MySQL columns

### DIFF
--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -49,6 +49,7 @@ class Column
      * @param string|null $geometryType Geometry type for geometry fields (e.g., Point, Polygon)
      * @param string|null $baseType The basic schema type if the column type is a complex/custom type.
      * @param bool|null $fixed Whether the column is fixed-length (BINARY vs VARBINARY)
+     * @param string|null $charset Character set for the column
      */
     public function __construct(
         protected string $name,
@@ -69,6 +70,7 @@ class Column
         protected ?string $geometryType = null,
         protected ?string $baseType = null,
         protected ?bool $fixed = null,
+        protected ?string $charset = null,
     ) {
     }
 
@@ -102,6 +104,7 @@ class Column
         $this->geometryType ??= null;
         $this->baseType ??= null;
         $this->fixed ??= null;
+        $this->charset ??= null;
     }
 
     /**
@@ -517,6 +520,29 @@ class Column
     }
 
     /**
+     * Sets the column character set.
+     *
+     * @param string $charset Character set
+     * @return $this
+     */
+    public function setCharset(string $charset)
+    {
+        $this->charset = $charset;
+
+        return $this;
+    }
+
+    /**
+     * Gets the column character set.
+     *
+     * @return string|null
+     */
+    public function getCharset(): ?string
+    {
+        return $this->charset;
+    }
+
+    /**
      * Sets the column SRID for geometry fields.
      *
      * @param int $srid SRID
@@ -617,6 +643,7 @@ class Column
             'unsigned',
             'type',
             'properties',
+            'charset',
             'collate',
             'srid',
             'geometryType',
@@ -655,7 +682,7 @@ class Column
     /**
      * Convert an index into an array that is compatible with the Column constructor.
      *
-     * @return array{name: ?string, baseType: ?string, type: string, length: ?int, null: ?bool, default: mixed, generated: ?string, unsigned: ?bool, onUpdate: ?string, collate: ?string, precision: ?int, srid: ?int, comment: ?string, autoIncrement: bool, identity: bool, fixed: ?bool, geometryType?: ?string}
+     * @return array{name: ?string, baseType: ?string, type: string, length: ?int, null: ?bool, default: mixed, generated: ?string, unsigned: ?bool, onUpdate: ?string, charset: ?string, collate: ?string, precision: ?int, srid: ?int, comment: ?string, autoIncrement: bool, identity: bool, fixed: ?bool, geometryType?: ?string}
      */
     public function toArray(): array
     {
@@ -680,6 +707,7 @@ class Column
             'generated' => $this->getGenerated(),
             'unsigned' => $this->getUnsigned(),
             'onUpdate' => $this->getOnUpdate(),
+            'charset' => $this->getCharset(),
             'collate' => $this->getCollate(),
             'precision' => $precision,
             'srid' => $this->getSrid(),

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -850,8 +850,13 @@ SQL;
             TableSchemaInterface::TYPE_STRING,
             TableSchemaInterface::TYPE_UUID,
         ];
-        if (in_array($column['type'], $hasCollate, true) && isset($column['collate']) && $column['collate'] !== '') {
-            $out .= ' COLLATE ' . $column['collate'];
+        if (in_array($column['type'], $hasCollate, true)) {
+            if (isset($column['charset']) && $column['charset'] !== '') {
+                $out .= ' CHARACTER SET ' . $column['charset'];
+            }
+            if (isset($column['collate']) && $column['collate'] !== '') {
+                $out .= ' COLLATE ' . $column['collate'];
+            }
         }
 
         if (isset($column['null']) && $column['null'] === false) {

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -136,15 +136,19 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     protected static array $_columnExtras = [
         'string' => [
+            'charset' => null,
             'collate' => null,
         ],
         'char' => [
+            'charset' => null,
             'collate' => null,
         ],
         'text' => [
+            'charset' => null,
             'collate' => null,
         ],
         'uuid' => [
+            'charset' => null,
             'collate' => null,
         ],
         'tinyinteger' => [

--- a/tests/TestCase/Database/Schema/ColumnTest.php
+++ b/tests/TestCase/Database/Schema/ColumnTest.php
@@ -231,6 +231,7 @@ class ColumnTest extends TestCase
             'length' => 255,
             'null' => false,
             'default' => 'default_value',
+            'charset' => 'utf8mb4',
             'collate' => 'utf8mb4_general_ci',
         ];
         $column->setAttributes($options);
@@ -238,6 +239,7 @@ class ColumnTest extends TestCase
         $this->assertSame(255, $column->getLength());
         $this->assertFalse($column->isNull());
         $this->assertSame('default_value', $column->getDefault());
+        $this->assertSame('utf8mb4', $column->getCharset());
         $this->assertSame('utf8mb4_general_ci', $column->getCollate());
     }
 

--- a/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaDialectTest.php
@@ -446,6 +446,7 @@ SQL;
                 'length' => 20,
                 'precision' => null,
                 'comment' => 'A title',
+                'charset' => null,
                 'collate' => 'utf8_general_ci',
             ],
             'body' => [
@@ -455,6 +456,7 @@ SQL;
                 'length' => null,
                 'precision' => null,
                 'comment' => null,
+                'charset' => null,
                 'collate' => 'utf8_general_ci',
             ],
             'author_id' => [
@@ -559,6 +561,7 @@ SQL;
             $expected['config']['type'] = 'text';
             $expected['config']['length'] = 4294967295;
             $expected['config']['comment'] = '';
+            $expected['config']['charset'] = null;
             $expected['config']['collate'] = 'utf8mb4_bin';
         }
         // MariaDB 10.5+ and MySQL 8.0.30+ use utf8mb3 alias instead of utf8
@@ -1190,6 +1193,16 @@ SQL;
                 'title',
                 ['type' => 'string', 'length' => 255, 'null' => false, 'collate' => 'utf8_unicode_ci'],
                 '`title` VARCHAR(255) COLLATE utf8_unicode_ci NOT NULL',
+            ],
+            [
+                'title',
+                ['type' => 'string', 'null' => false, 'charset' => 'ascii'],
+                '`title` VARCHAR(255) CHARACTER SET ascii NOT NULL',
+            ],
+            [
+                'title',
+                ['type' => 'string', 'charset' => 'ascii', 'collate' => 'ascii_bin'],
+                '`title` VARCHAR(255) CHARACTER SET ascii COLLATE ascii_bin',
             ],
             // Text
             [

--- a/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaDialectTest.php
@@ -408,6 +408,7 @@ SQL;
                 'length' => 20,
                 'precision' => null,
                 'comment' => 'a title',
+                'charset' => null,
                 'collate' => null,
             ],
             'body' => [
@@ -417,6 +418,7 @@ SQL;
                 'length' => null,
                 'precision' => null,
                 'comment' => null,
+                'charset' => null,
                 'collate' => null,
             ],
             'author_id' => [
@@ -673,6 +675,7 @@ SQL;
                 'length' => 50,
                 'precision' => null,
                 'comment' => null,
+                'charset' => null,
                 'collate' => null,
             ],
             'bio' => [

--- a/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaDialectTest.php
@@ -427,6 +427,7 @@ SQL;
                 'length' => 20,
                 'precision' => null,
                 'comment' => null,
+                'charset' => null,
                 'collate' => null,
             ],
             'body' => [
@@ -436,6 +437,7 @@ SQL;
                 'length' => null,
                 'precision' => null,
                 'comment' => null,
+                'charset' => null,
                 'collate' => null,
             ],
             'author_id' => [
@@ -481,6 +483,7 @@ SQL;
                 'length' => 10,
                 'precision' => null,
                 'comment' => null,
+                'charset' => null,
                 'collate' => null,
             ],
             'field2' => [
@@ -490,6 +493,7 @@ SQL;
                 'length' => 10,
                 'precision' => null,
                 'comment' => null,
+                'charset' => null,
                 'collate' => null,
             ],
             'location' => [
@@ -529,6 +533,7 @@ SQL;
                 'length' => null,
                 'null' => true,
                 'default' => null,
+                'charset' => null,
                 'collate' => null,
                 'precision' => null,
                 'comment' => null,

--- a/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaDialectTest.php
@@ -413,6 +413,7 @@ SQL;
                 'length' => 20,
                 'precision' => null,
                 'comment' => null,
+                'charset' => null,
                 'collate' => 'Japanese_Unicode_CI_AI',
             ],
             'body' => [
@@ -422,6 +423,7 @@ SQL;
                 'length' => 1000,
                 'precision' => null,
                 'comment' => null,
+                'charset' => null,
                 'collate' => 'SQL_Latin1_General_CP1_CI_AS',
             ],
             'author_id' => [
@@ -516,6 +518,7 @@ SQL;
                 'length' => 10,
                 'precision' => null,
                 'comment' => null,
+                'charset' => null,
                 'collate' => 'SQL_Latin1_General_CP1_CI_AS',
             ],
             'field2' => [
@@ -525,6 +528,7 @@ SQL;
                 'length' => 10,
                 'precision' => null,
                 'comment' => null,
+                'charset' => null,
                 'collate' => 'SQL_Latin1_General_CP1_CI_AS',
             ],
             'field3' => [
@@ -534,6 +538,7 @@ SQL;
                 'length' => 10,
                 'precision' => null,
                 'comment' => null,
+                'charset' => null,
                 'collate' => 'SQL_Latin1_General_CP1_CI_AS',
             ],
         ];

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -264,6 +264,7 @@ class TableSchemaTest extends TestCase
             'default' => null,
             'null' => null,
             'comment' => null,
+            'charset' => null,
             'collate' => null,
         ];
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
Adds a per-column `charset` attribute for `string`, `char`, `text` and `uuid` columns on MySQL. It renders as `CHARACTER SET` ahead of `COLLATE`, mirroring the table-level `charset` option.

The `Column` object and `TableSchema` column extras learn the key so it round-trips through `addColumn()`. Reflection is untouched, `SHOW FULL COLUMNS` only exposes the collation.

Needed for cakephp/migrations#1112, whose `encoding` column option is accepted and documented but currently never reaches the SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpXY8G8bDZdga92LvMaVho
