### PR TITLE
Fix typos in docblocks and warning message

### DIFF
--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -413,7 +413,7 @@ abstract class Driver implements LoggerAwareInterface
     }
 
     /**
-     * Returns the decorators to be applied to the result set incase of a SelectQuery.
+     * Returns the decorators to be applied to the result set in case of a SelectQuery.
      *
      * @param \Cake\Database\Query|string $query The query to be decorated.
      * @return array<\Closure>

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -483,7 +483,7 @@ class QueryCompiler
     /**
      * Builds the optimizer hint comment part.
      *
-     * @param list<string> $parts The optmizer hints
+     * @param list<string> $parts The optimizer hints
      * @param \Cake\Database\Query $query The query that is being compiled
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string Optimizer hint comment
@@ -515,7 +515,7 @@ class QueryCompiler
     }
 
     /**
-     * Helper function used to covert ExpressionInterface objects inside an array
+     * Helper function used to convert ExpressionInterface objects inside an array
      * into their string representation.
      *
      * @param array $expressions list of strings and ExpressionInterface objects

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -470,7 +470,7 @@ abstract class SchemaDialect
      * - null : boolean indicating whether the column can be null.
      * - comment : the column comment or null.
      *
-     * Additionaly the `autoIncrement` key will be set for columns that are a primary key.
+     * Additionally the `autoIncrement` key will be set for columns that are a primary key.
      *
      * @param string $tableName The name of the table to describe columns on.
      * @return array

--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -228,7 +228,7 @@ interface TableSchemaInterface extends SchemaInterface
     public const TYPE_LINESTRING = 'linestring';
 
     /**
-     * Polgon column type
+     * Polygon column type
      *
      * @var string
      */

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -580,7 +580,7 @@ abstract class Association
             && in_array($this->_propertyName, $this->_sourceTable->getSchema()->columns(), true)
         ) {
             $msg = 'Association property name `%s` clashes with field of same name of table `%s`.' .
-                ' You should specify an alterate name using the `propertyName` option or `setProperty()` method.';
+                ' You should specify an alternate name using the `propertyName` option or `setProperty()` method.';
             trigger_error(
                 sprintf($msg, $this->_propertyName, $this->_sourceTable->getTable()),
                 E_USER_WARNING,


### PR DESCRIPTION
Fixes several small typos found in docblock comments and one user-facing warning message across the Database and ORM packages:

- `Database\Driver`: "incase" → "in case"
- `Database\QueryCompiler`: "optmizer" → "optimizer", "covert" → "convert"
- `Database\Schema\SchemaDialect`: "Additionaly" → "Additionally"
- `Database\Schema\TableSchemaInterface`: "Polgon" → "Polygon"
- `ORM\Association`: "alterate" → "alternate" (in the property name clash warning message)

