### PR TITLE
Add schema to postgis column reflection

### DIFF
--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -123,7 +123,7 @@ class PostgresSchemaDialect extends SchemaDialect
                 f_{$postgisType}_column AS name,
                 type,
                 srid
-            FROM {$postgisType}_columns
+            FROM {$schema}.{$postgisType}_columns
             WHERE f_table_name = ? AND f_table_schema = ? AND f_table_catalog = ?
             SQL;
 


### PR DESCRIPTION
In #19606, I removed the hard-coded `public`. I should have also added the connection schema as we can't rely on SEARCH_PATH being set.