### PR TITLE
Add DriverFeatureEnum for recently added driver specific behavior

### DIFF
--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -321,6 +321,8 @@ class Mysql extends Driver
             DriverFeatureEnum::CHECK_CONSTRAINTS => $versionCompare(),
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => true,
             DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => true,
+            DriverFeatureEnum::CASE_SENSITIVE_QUOTED_IDENTIFIERS => false,
+            DriverFeatureEnum::SUBQUERY_FILTER_DISTINCT => $this->isMariaDb(),
         };
     }
 

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -217,6 +217,8 @@ class Postgres extends Driver
             DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION => false,
             DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => true,
             DriverFeatureEnum::CHECK_CONSTRAINTS => true,
+            DriverFeatureEnum::CASE_SENSITIVE_QUOTED_IDENTIFIERS => true,
+            DriverFeatureEnum::SUBQUERY_FILTER_DISTINCT => false,
         };
     }
 

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -215,6 +215,8 @@ class Sqlite extends Driver
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => false,
             DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => false,
             DriverFeatureEnum::CHECK_CONSTRAINTS => true,
+            DriverFeatureEnum::CASE_SENSITIVE_QUOTED_IDENTIFIERS => false,
+            DriverFeatureEnum::SUBQUERY_FILTER_DISTINCT => false,
         };
     }
 

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -295,6 +295,8 @@ class Sqlserver extends Driver
             DriverFeatureEnum::SET_OPERATIONS_ORDER_BY => false,
             DriverFeatureEnum::OPTIMIZER_HINT_COMMENT => false,
             DriverFeatureEnum::CHECK_CONSTRAINTS => false,
+            DriverFeatureEnum::CASE_SENSITIVE_QUOTED_IDENTIFIERS => false,
+            DriverFeatureEnum::SUBQUERY_FILTER_DISTINCT => false,
         };
     }
 

--- a/src/Database/DriverFeatureEnum.php
+++ b/src/Database/DriverFeatureEnum.php
@@ -92,4 +92,18 @@ enum DriverFeatureEnum: string
      * String aggregation via GROUP_CONCAT support.
      */
     case GROUP_CONCAT = 'group-concat';
+
+    /**
+     * Whether or not the driver uses case sensitive quoted identifiers
+     *
+     * Postgres driver requires uses this.
+     */
+    case CASE_SENSITIVE_QUOTED_IDENTIFIERS = 'case-sensitive-quoted-identifier';
+
+    /**
+     * Whether the driver requires DISTINCT on grouped filtering sub-queries
+     *
+     * Mysql + MariaDB use this.
+     */
+    case SUBQUERY_FILTER_DISTINCT = 'subquery-fitler-distinct';
 }

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Association\Loader;
 
-use Cake\Database\Driver\Mysql;
+use Cake\Database\DriverFeatureEnum;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\AggregateExpression;
 use Cake\Database\Expression\FieldInterface;
@@ -24,7 +24,6 @@ use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\ExpressionInterface;
-use Cake\Database\PostgresCompiler;
 use Cake\Database\ValueBinder;
 use Cake\ORM\Association;
 use Cake\ORM\Query\SelectQuery;
@@ -364,7 +363,7 @@ class SelectLoader
         if (
             $selectAlias !== null &&
             !$driver->isAutoQuotingEnabled() &&
-            $driver->newCompiler() instanceof PostgresCompiler
+            $driver->supports(DriverFeatureEnum::CASE_SENSITIVE_QUOTED_IDENTIFIERS)
         ) {
             $identifier = $aliasedTable . '.' . $driver->quoteIdentifier($selectAlias);
         }
@@ -486,9 +485,7 @@ class SelectLoader
         }
 
         $driver = $filterQuery->getDriver();
-        $useDistinct = !$filterQuery->clause('group')
-            && $driver instanceof Mysql
-            && $driver->isMariadb();
+        $useDistinct = !$filterQuery->clause('group') && $driver->supports(DriverFeatureEnum::SUBQUERY_FILTER_DISTINCT);
         $fields = $this->_subqueryFields($query, $useDistinct);
         $filterQuery->select($fields['select'], true);
         if ($useDistinct) {


### PR DESCRIPTION
Add new cases to DriverFeatureEnum for recently added driver specific behavior related to subquery association loading. I'd like to avoid having driver specific logic in the ORM layer. We have Driver::supports() which allows us to model this driver specific behavior like we do for other driver/dialect specific feature support.

Refs #19596
Refs #19552